### PR TITLE
content/chainguard: fix quotes in sample policy

### DIFF
--- a/content/chainguard/enforce/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/enforce/chainguard-enforce-user-onboarding.md
@@ -195,7 +195,7 @@ metadata:
 spec:
   images:
   - glob: "gcr.io/chainguard-demo/*"
-  - glob: “ttl.sh/*”
+  - glob: "ttl.sh/*"
   - glob: "index.docker.io/*"
   - glob: "index.docker.io/*/*"
   authorities:


### PR DESCRIPTION
Wrong type of quotes meant this policy was broken and didn't work