### PR TITLE
Added missing configuration for highlight.js - fixes #34

### DIFF
--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -1,0 +1,30 @@
+import hljs from 'highlight.js/lib/core';
+
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import bash from 'highlight.js/lib/languages/bash';
+import ini from 'highlight.js/lib/languages/ini';
+import yaml from 'highlight.js/lib/languages/yaml';
+import markdown from 'highlight.js/lib/languages/markdown';
+import shell from 'highlight.js/lib/languages/shell';
+import php from 'highlight.js/lib/languages/php';
+import python from 'highlight.js/lib/languages/python';
+import go from 'highlight.js/lib/languages/go';
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('ini', ini);
+hljs.registerLanguage('toml', ini);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('md', markdown);
+hljs.registerLanguage('shell', shell);
+hljs.registerLanguage('php', php);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('go', go);
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre code').forEach((block) => {
+    hljs.highlightElement(block);
+  });
+});

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -8,7 +8,7 @@
 @import "bootstrap/scss/bootstrap";
 
 /** Import highlight.js */
-// @import "highlight.js/scss/github-dark-dimmed";
+@import "highlight.js/scss/a11y-light";
 
 /** Import KaTeX */
 @import "katex/dist/katex";


### PR DESCRIPTION
### What should this PR do?
This PR resolves issue #34 , enabling syntax highlighting with the theme-included library `higlight.js`. The configuration sets the theme to `a11y-light` for more readability and compatibility with both light and dark theme. Support to additional languages can be added when necessary.

Preview: https://deploy-preview-47--ornate-narwhal-088216.netlify.app/open-source/melange/getting-started-with-melange/

(check the PHP code)