### PR TITLE
Add url handler for css files to app.yaml to fix GAE deploys

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -10,6 +10,11 @@ automatic_scaling:
   max_concurrent_requests: 50
 
 handlers:
+- url: /(.*\.css)
+  mime_type: text/css
+  static_files: public/\1
+  upload: public/(.*\.css)
+
 - url: /(.+)/
   static_files: public/\1/index.html
   upload: public/(.+)/index.html


### PR DESCRIPTION
This PR adds a URL handler for Hugo's `main.css` file that sets the `mime_type: text/css` explicitly. 

For some reason, App Engine arbitrarily decides to serve CSS files with `content-type: application/octet-stream` on some deploys, and with `text/css` on others. There's a bug about it that is supposedly resolved, but it definitely isn't:

https://issuetracker.google.com/issues/186012458

Testing the deploy manually with `gcloud app deploy` seems to work. [This file](https://chainguard-academy.uc.r.appspot.com/main.59bf7090f22462799325cbdc69fee5a21183a28eb64f942123f71834ed6033d817c5741201f2557034ddc8e266cf2afeafb9970599ef8eb1679c1480cd117411.css) used to show the wrong content type, but with the handler in place it gets rendered properly on https://chainguard-academy.uc.r.appspot.com/