### PR TITLE
Fix unlisting for more deeply nested articles

### DIFF
--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -20,7 +20,7 @@
                   </button>
                   <div class="collapse{{ if $active }} show{{ end }}" id="section-{{ md5 .Title }}">
                     <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                      {{ range .Pages }}
+                      {{ range where .Pages ".Params.unlisted" "!=" "true" }}
                         {{ if .IsNode }}
                           {{ $active := in $currentPage.RelPermalink .RelPermalink }}
                           <li class="my-1 ms-3">
@@ -29,7 +29,7 @@
                             </button>
                             <div class="collapse{{ if $active }} show{{ end }}" id="section-{{ md5 .Title }}">
                               <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                                {{ range .Pages }}
+                                {{ range where .Pages ".Params.unlisted" "!=" "true" }}
                                   {{ $active := in $currentPage.RelPermalink .RelPermalink }}
                                   <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a></li>
                                 {{ end }}


### PR DESCRIPTION
Fixes #79. We've moved the enforce kubernetes articles on level lower and this broke the way we unlisted these articles. This work makes unlisting articles work for all nesting levels.