### PR TITLE
Bootstrapping Wolfi / Chainguard Images documentation

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -43,6 +43,12 @@
   name = "Sigstore"
   url = "/open-source/sigstore/"
   parent = "menu-oss"
+  weight = 10
+
+[[main]]
+  name = "Wolfi"
+  url = "/open-source/wolfi/"
+  parent = "menu-oss"
   weight = 15
 
 [[main]]
@@ -56,12 +62,6 @@
   url = "/open-source/melange/"
   parent = "menu-oss"
   weight = 30
-
-[[main]]
-  name = "Wolfi"
-  url = "/open-source/wolfi/"
-  parent = "menu-oss"
-  weight = 40
 
 [[main]]
   name = "Software Security"

--- a/content/chainguard/chainguard-images/_index.md
+++ b/content/chainguard/chainguard-images/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Chainguard Images"
+description: ""
+type: "article"
+date: 2022-09-05T08:49:15+00:00
+lastmod: 2022-09-05T08:49:15+00:00
+draft: false
+images: []
+---
+
+Minimalist, distroless container images powered by Wolfi to secure your software supply chain.

--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -1,0 +1,35 @@
+---
+title: "FAQ"
+type: "article"
+description: "Frequently asked questions about Chainguard Images"
+date: 2022-09-01T08:49:31+00:00
+lastmod: 2022-09-01T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 500
+toc: true
+---
+
+### Are Chainguard Images based on Alpine?
+Some of our images are still based on Alpine, but going forward the majority will be based on  [Wolfi](/open-source/wolfi/), a Linux _undistro_ we built specifically to address software supply chain security issues.
+
+### What is an "undistro"?
+We call Wolfi an undistro because unlike a typical Linux distribution, Wolfi is a stripped-down distribution designed for the cloud-native era. Most notably, we don’t include a Linux kernel, instead relying on the environment (such as the container runtime) to provide this.
+
+### Which images are available?
+You can check which images are already available at our [GitHub Repository](https://github.com/chainguard-images).
+
+### What is an SBOM and why is it important?
+An SBOM is a Software Bill of Materials, which is a list containing detailed information about all software that is included within a software artifact, whether it's an application, a container image, or a physical appliance.
+
+SBOMs provide visibility into the software you depend on. They can allow automated systems to quickly identify issues such as unpatched vulnerabilities, since SBOMs typically include the version of each dependency listed.
+
+### Who maintains Chainguard Images?
+Chainguard Images are officially maintained by [Chainguard](https://chainguard.dev) employees, but they are also open source, which means any community member is welcome to suggest improvements.
+
+### Can I simply replace my current base image with a Chainguard Image and it will work out of the box?
+Chainguard Images are distroless, which means they are minimalist and most of them don't come with a package manager. Depending on your stack, you may need to include additional software by copying artifacts from multi-stage builds.
+

--- a/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
@@ -1,0 +1,145 @@
+---
+title: "How to Use Chainguard Images"
+type: "article"
+description: "A primer on how to migrate to Chainguard Images"
+lead: "A primer on how to migrate to Chainguard Images"
+date: 2022-09-01T08:49:31+00:00
+lastmod: 2022-09-01T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 300
+toc: true
+---
+Chainguard Images are distroless images based on [Wolfi](/open-source/wolfi/overview/), our Linux _undistro_. You can have a look at [Chainguard Image's GitHub org](https://github.com/chainguard-images) in order to find out which images are already available for general usage.
+
+Each image has its own usage instructions, which is detailed in their READMEs. All images are hosted on the `cgr.dev` registry.
+
+In this guide, you'll learn how to get started using Chainguard Images and how to migrate existing container-based workflows to use our images.
+
+## Getting Started
+Chainguard Images are fully OCI compatible, which means they work seamlessly with any system that supports that standard, including Docker.
+
+Most Chainguard Images do not include a package manager such as `apt` or `apk`. This is by design to keep images minimal, following the distroless approach.
+
+There are a few different ways to include additional software on distroless images, depending on your use case. If you are using Chainguard Images with  Dockerfile pipelines, you can add artifacts from a multi-stage Docker build. Alternatively, you can use Chainguard’s [apko](/open-source/apko/getting-started-with-apko/) and [melange](/open-source/melange/getting-started-with-melange/) tooling to add extra software (this will also give you some extra features like build-time SBOM support).
+
+### Using the Distroless Base Images
+
+Many of the images are intended as platforms for running compiled binaries in as minimal an environment as possible. In the case of languages that can compile completely static binaries (such as C and Rust), the static base image can be used.
+
+The following example Dockerfile builds a hello-world program in C and copies it on top of the `cgr.dev/chainguard/static:latest` base image:
+
+```dockerfile
+# syntax=docker/dockerfile:1.4
+FROM cgr.dev/chainguard/gcc-musl:latest as build
+
+COPY <<EOF /hello.c
+#include <stdio.h>
+int main() { printf("Hello Distroless!"); }
+EOF
+RUN cc -static /hello.c -o /hello
+
+FROM cgr.dev/chainguard/static:latest
+
+COPY --from=build /hello /hello
+CMD ["/hello"]
+```
+
+Run the following command to build the demo image and tag it as `c-distroless`:
+
+```shell
+docker build -t c-distroless  .
+```
+
+Now you can run the image with:
+
+```shell
+docker run c-distroless
+```
+
+You should get output like this:
+
+```
+Hello Distroless!
+```
+
+It’s worth noting how small the resulting image is:
+
+```shell
+docker images c-distroless
+```
+
+```
+REPOSITORY     TAG       IMAGE ID       CREATED              SIZE
+c-distroless   latest    de04a116ff9d   18 seconds ago   1.57MB
+```
+
+If your binary is dependent on `glibc` or `musl`, take a look at the [glibc-dynamic](https://github.com/chainguard-images/glibc-dynamic) and [musl-dynamic](https://github.com/chainguard-images/musl-dynamic) images.
+
+We are working on similar images for runtimes such as the JVM.
+
+### Extending Chainguard Base Images
+
+It often happens that you want a distroless image with one or two extra packages, for example you may have a binary with a dependency on `curl` or `git`. Ideally you’d like a base image with this dependency already installed. There are a few options here:
+
+1. Compile the dependency from source and use a multi-stage Dockerfile to create a new base image. This works, but may require considerable effort to get the dependency compiling and to keep it up to date. This process quickly becomes untenable if you require several dependencies.
+2. Use the `wolfi-base` image that includes apk tools to install the package in the traditional Dockerfile manner. This works but sacrifices a lot of the advantages of the “distroless” philosophy.
+3. Use Chainguard’s [melange and apko tooling to create a custom base image](/open-source/melange/getting-started-with-melange/). This keeps the image as minimal as possible without sacrificing maintainability.
+
+### Using the wolfi-base Image
+The `wolfi-base` image is a good starting point to try out Chainguard Images. Unlike most of the other images, which are strictly distroless, `wolfi-base` includes the `apk` package manager, which facilitates composing additional software into it. Just keep in mind that the resulting image will be a little larger due to the extra software and won't have a comprehensive SBOM that covers all your dependencies, since the new software will be added as a layer on top of `wolfi-base`.
+
+The following command will pull the `wolfi-base` image to your local system and run an interactive shell that you can use to explore the image features:
+
+```shell
+docker run -it --rm cgr.dev/chainguard/wolfi-base /bin/sh -l
+```
+
+First you will need to update the list of packages available in Wolfi:
+
+```shell
+apk update
+```
+
+Now you can use `apk search` to search for packages that are already available on Wolfi repositories:
+
+```shell
+apk search curl
+```
+
+More packages will be added with time, as the ecosystem matures and drives community involvement.
+
+_Looking for a specific package that is not yet available? Feel free to open an issue on the [wolfi-os](https://github.com/chainguard-dev/wolfi-os) GitHub repository._
+
+### Using the wolfi-base Image within Dockerfiles
+
+Following, you can see an example of a Dockerfile that uses `wolfi-base` as base image, installing the packages `curl` and `jq` in order to make a query to the [advice slip](https://api.adviceslip.com/) API:
+
+```dockerfile
+FROM cgr.dev/chainguard/wolfi-base
+
+RUN apk update && apk add --no-cache --update-cache curl jq
+
+CMD curl -s https://api.adviceslip.com/advice --http1.1 | jq .slip.advice
+```
+
+You can build this Dockerfile as usual:
+
+```shell
+docker build . -t advice-slip:test
+```
+
+Then, execute the image with:
+
+```shell
+docker run -it --rm advice-slip:test
+```
+
+You should get output like this, with a random piece of advice:
+
+```
+"Big things have small beginnings."
+```

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -1,0 +1,38 @@
+---
+title: "Overview"
+type: "article"
+description: "Chainguard Images Overview"
+lead: "A primer on Chainguard Images and the distroless approach"
+date: 2022-09-01T08:49:31+00:00
+lastmod: 2022-09-01T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 100
+toc: true
+---
+
+Chainguard Images is a collection of container images designed for minimalism and security.
+
+Many of the images are distroless; they contain only an application and its runtime dependencies. These images do not even contain a shell or package manager.
+
+Most of the images are built with [Wolfi](/open-source/wolfi/getting-started-with-wolfi), our Linux _undistro_ designed from the ground up to produce container images that meet the requirements of a secure software supply chain.
+
+Main features include:
+
+- Minimalist design, no bloating from unnecessary software
+- Build-time SBOMs (software bill of materials) attesting the provenance of all artifacts within the image
+- Verifiable signatures provided by [Sigstore](/open-source/sigstore/cosign/an-introduction-to-cosign/)
+- Automated nightly builds to ensure images are completely up-to-date and contain all available security patches
+
+Chainguard Images are available [on Github](https://github.com/chainguard-images) and the `cgr.dev` registry.
+
+## Why Distroless
+
+[Distroless images](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) are the result of pushing minimalism in containers to the next level. When compared to traditional base images such as [alpine](https://hub.docker.com/_/alpine) or [debian](https://hub.docker.com/_/debian), they are more stripped back, lacking even a shell or package managers. However, compared to the empty “scratch” image, they do contain structure essential for the majority of Linux applications such as root certificates for TLS and core files like `/etc/passwd`.
+
+The major advantage of distroless images is the reduced size and complexity, which results in a vastly reduced attack surface. This is evidenced by the results from security scanners, which detect far fewer potential vulnerabilities in Chainguard Images. The following graph shows a comparison between the official Nginx image and Chainguard's Nginx image, based on the number of CVEs (common vulnerabilities and exposures) detected by Trivy:
+
+{{< rumble left="nginx:latest" right="distroless.dev/nginx:latest" >}}

--- a/content/open-source/wolfi/_index.md
+++ b/content/open-source/wolfi/_index.md
@@ -1,9 +1,11 @@
 ---
-title : "Wolfi"
-description: "Coming soon"
-date: 2020-10-06T08:48:23+00:00
-lastmod: 2020-10-06T08:48:23+00:00
+title: "Wolfi"
+description: "Linux undistro and build toolkit for secure container images"
+type: "article"
+date: 2022-09-05T08:49:15+00:00
+lastmod: 2022-09-05T08:49:15+00:00
 draft: false
 images: []
 ---
 
+Wolfi is a Linux undistro and build toolkit for building container images that meet the requirements of a secure software supply chain.

--- a/content/open-source/wolfi/faq.md
+++ b/content/open-source/wolfi/faq.md
@@ -1,0 +1,29 @@
+---
+title: "FAQ"
+type: "article"
+description: "Frequently asked questions about Wolfi"
+date: 2022-09-01T08:49:31+00:00
+lastmod: 2022-09-01T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "wolfi"
+weight: 300
+toc: true
+---
+### What is Wolfi and how does it compare to Alpine?
+Wolfi is our Linux _undistro_  designed from the ground up to support newer computing paradigms such as containers. Although Wolfi has a few similar design principles as Alpine (such as using apk), it is a different distribution that is  focused on supply chain security. Unlike Alpine, Wolfi does not currently build its own Linux kernel, instead relying on the host environment (e.g. a container runtime) to provide one.
+
+### Is Wolfi free to use?
+Yes, Wolfi is free and will always be.
+
+### Can I use Wolfi on the Desktop?
+No. Wolfi is an un-distro, or distroless base to be used within the container / OCI ecosystem. Desktop distributions require additional software that is out of scope for Wolfi's roadmap.
+
+### Who maintains Wolfi?
+Wolfi was created and is currently maintained by [Chainguard](https://chainguard.dev).
+
+### What are the plans for long-term Wolfi governance?
+We intend for Wolfi to be a community-driven project, which means over time it will have multi-vendor governance and maintainers. For now we're focused on building the project and community, and will revisit this in several months when a community has formed.
+

--- a/content/open-source/wolfi/overview.md
+++ b/content/open-source/wolfi/overview.md
@@ -1,0 +1,36 @@
+---
+title: "Overview"
+type: "article"
+description: "Getting started with Wolfi, the Linux undistro for secure container images"
+lead: "Introducing Wolfi, the Linux undistro for secure container images"
+date: 2022-09-01T08:49:31+00:00
+lastmod: 2022-09-01T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "wolfi"
+weight: 100
+toc: true
+---
+[Wolfi](https://github.com/wolfi-dev) is a community Linux [undistro](#why-undistro) designed for the container and cloud-native era. Chainguard started the Wolfi project to enable building  [Chainguard Images](/chainguard/chainguard-images/overview), our collection of curated [distroless]( https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/)  images that meet the requirements of a secure software supply chain. This required a Linux distribution with components at the appropriate granularity and with support for both [glibc](https://www.gnu.org/software/libc/) and [musl](https://www.musl-libc.org/), something that was not yet available in the cloud-native Linux ecosystem.
+
+Building our own undistro also allows us to ensure packages have full provenance and metadata for supporting modern supply-chain security needs.
+
+## Why Undistro
+
+We call Wolfi an undistro because unlike a [typical Linux distribution](https://en.wikipedia.org/wiki/Linux_distribution) designed to run on bare-metal, Wolfi is a stripped-down distro designed for the cloud-native era. It doesn't have a kernel of its own, instead relying on the environment (such as the container runtime) to provide one. This separation of concerns in Wolfi means it is adaptable to a range of environments.
+
+Wolfi is the base we use to build [Chainguard Images](/chainguard/chainguard-images/overview), our open source distroless images that are available free of charge.
+
+## Wolfi Features
+
+Wolfi, whose name was inspired by the [world's smallest octopus](https://en.wikipedia.org/wiki/Octopus_wolfi), has some key features that differentiates it from other distributions that focus on container/cloud-native environments:
+
+- Provides a high-quality, build-time SBOM as standard for all packages
+- Packages are designed to be granular and independent, to support minimal images
+- Uses the proven and reliable apk package format
+- Fully declarative and reproducible build system
+- Designed to support glibc and musl
+
+Wolfi enables Chainguard to solve the software supply chain security problem from the outside in. It gives developers the secure-by-default base they need to build software, it scales to support organizations running massive environments and provides the control needed to fix most modern supply chain threats. Wolfi builds all packages directly from source, allowing us to fix vulnerabilities or apply customizations that improve the supply chain security posture of everything from compilers to language package managers.


### PR DESCRIPTION
Wolfi and Chainguard Images documentation for Chainguard Academy.

I will rebase when we finish all review cycles :)

### Preview

Chainguard Images Docs Preview: https://deploy-preview-89--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/overview/

Wolfi Docs Preview: https://deploy-preview-89--ornate-narwhal-088216.netlify.app/open-source/wolfi/overview/

## Suggesting changes
Draft Doc Wolfi: https://docs.google.com/document/d/1n13jteqj2RZtTo5ADo2M2o9j2FhIQ6ApA4jGZdSGhm0/edit#

Draft Doc Chainguard Images: https://docs.google.com/document/d/1VAyGmjSSG0PF29-f-szfskFTI4B3qNCywVW_AkeqnTg/edit#