### PR TITLE
fix: bump module version in cloud account assoc article

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
@@ -60,7 +60,7 @@ provider "aws" {}
 
 module "chainguard-account-association" {
   source  = "chainguard-dev/chainguard-account-association/aws"
-  version = "0.0.4"
+  version = "0.0.5"
 
   enforce_group_id = "$ENFORCE_GROUP_ID"
 }
@@ -122,7 +122,7 @@ provider "google-beta" {
 
 module "chainguard-account-association" {
   source  = "chainguard-dev/chainguard-account-association/google"
-  version = "0.0.1-alpha"
+  version = "0.0.2"
 
   enforce_group_id  = "$ENFORCE_GROUP_ID"
   google_project_id = "$PROJECT_ID"


### PR DESCRIPTION
The module now points to enforce.dev instead of the, now dead, guak.dev environment!