### PR TITLE
Add chainctl docs and Enforce OpenAPI shortcode+spec

### DIFF
--- a/content/chainguard/chainguard-enforce/chainctl-docs/_index.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/_index.md
@@ -1,0 +1,10 @@
+---
+title : "chainctl"
+lead: ""
+description: "chainctl Documentation"
+type: "article"
+date: 2020-10-06T08:48:45+00:00
+lastmod: 2020-10-06T08:48:45+00:00
+draft: false
+images: []
+---

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl.md
@@ -1,0 +1,36 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl"
+slug: chainctl
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl
+
+Chainguard Control
+
+### Options
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+  -h, --help              help for chainctl
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl auth](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/)	 - Auth related commands for the Chainguard platform.
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+* [chainctl config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config/)	 - Local config file commands for chainctl.
+* [chainctl events](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events/)	 - Events related commands for the Chainguard platform.
+* [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+* [chainctl version](/chainguard/chainguard-enforce/chainctl-docs/chainctl_version/)	 - Prints the version
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth.md
@@ -1,0 +1,37 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl auth"
+slug: chainctl_auth
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl auth
+
+Auth related commands for the Chainguard platform.
+
+### Options
+
+```
+  -h, --help   help for auth
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl auth login](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login/)	 - Login to the Chainguard platform.
+* [chainctl auth status](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status/)	 - Inspect the local Chainguard Token.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login.md
@@ -1,0 +1,57 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl auth login"
+slug: chainctl_auth_login
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl auth login
+
+Login to the Chainguard platform.
+
+```
+chainctl auth login [--identity-token TOKEN] [--invite-code INVITE_CODE | --register] [--create-group] [--cluster CLUSTER_ID] [--refresh] [flags]
+```
+
+### Examples
+
+```
+
+# Default auth login flow:
+chainctl auth login
+
+# Refreshing a token within a Kubernetes context:
+chainctl auth login --identity-token=PATH_TO_TOKEN --refresh
+
+```
+
+### Options
+
+```
+      --cluster string          UID of the Cluster.
+      --create-group            Whether a new root group should be created if an invite code is not specified. (default true)
+  -h, --help                    help for login
+      --identity-token string   Use an explicit passed identity token or token path.
+      --invite-code string      Registration invite code.
+      --refresh                 Enable auto refresh of the Chainguard token (for workloads).
+      --register                Register a new account if needed. Will create a new root group when an invite code is not specified.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl auth](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/)	 - Auth related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl auth status"
+slug: chainctl_auth_status
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl auth status
+
+Inspect the local Chainguard Token.
+
+```
+chainctl auth status [--output table|json] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl auth](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/)	 - Auth related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters.md
@@ -1,0 +1,41 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters"
+slug: chainctl_clusters
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters
+
+Cluster related commands for the Chainguard platform.
+
+### Options
+
+```
+  -h, --help   help for clusters
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl clusters install](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install/)	 - Install Chainguard into the current kubernetes context.
+* [chainctl clusters list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list/)	 - List clusters.
+* [chainctl clusters open](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open/)	 - Open the console for a cluster.
+* [chainctl clusters records](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records/)	 - Interact with cluster records.
+* [chainctl clusters uninstall](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall/)	 - Uninstalls Chainguard from the current kubernetes context.
+* [chainctl clusters update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update/)	 - Update the name or description of a cluster.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install.md
@@ -1,0 +1,73 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters install"
+slug: chainctl_clusters_install
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters install
+
+Install Chainguard into the current kubernetes context.
+
+```
+chainctl clusters install [--name NAME] [--description DESCRIPTION] [--group GROUP_NAME|GROUP_ID | --invite-code INVITE_CODE | --skip-invite | --managed=PROVIDER --cluster=CLUSTER_NAME | --private] [flags]
+```
+
+### Examples
+
+```
+  # Install Chainguard on a GKE cluster using a managed agent, and linking it
+  # under GROUP_ID in the Chainguard resource hierarchy.
+  chainctl cluster install --group=GROUP_ID --managed=gke --cluster=gke_project-id_us-central1_cluster-name
+  
+  # Install or Update the chainguard agent on a cluster.
+  chainctl cluster install --skip-invite
+  
+  # Install or Update the chainguard agent on a cluster with private API endpoint
+  chainctl cluster install --private
+  
+  # Install the Chainguard agent with an explicit invite code.
+  chainctl cluster install --invite-code=INVITE_CODE
+  
+  # Install the Chainguard agent using a temporary invite code under the group
+  # with ID "GROUP_ID".
+  chainctl cluster install --group=GROUP_ID
+  
+  # Install the Chainguard agent using a temporary invite code under a group
+  # determined via an interactive prompt.
+  chainctl cluster install
+```
+
+### Options
+
+```
+      --context string                   Indicates the name of the context (in kubectl) to be connect to Chainguard.
+  -d, --description string               The description of the resource.
+      --gcp-serviceaccount-file string   The path to a GCP service account JSON key file.
+      --group string                     The group under which to create a temporary invite code.
+  -h, --help                             help for install
+      --invite-code string               An invite code to use for joining this cluster into the IAM hierarchy.
+      --managed string                   Indicates the cluster's agent should be managed by Chainguard.  The value indicates the provider of the cluster, e.g. gke
+  -n, --name string                      Given name of the resource.
+      --private                          Kubernetes API endpoint isn't publically accessible. Cannot be used with managed clusters
+      --skip-invite                      When specified we perform installation without an invite code.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list.md
@@ -1,0 +1,48 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters list"
+slug: chainctl_clusters_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters list
+
+List clusters.
+
+```
+chainctl clusters list [--name NAME] [--active-within DURATION] [--group GROUP_ID|GROUP_NAME] [--output table|json] [flags]
+```
+
+### Examples
+
+```
+  chainctl cluster list
+```
+
+### Options
+
+```
+      --active-within duration   How recently a cluster must have been active to be listed (zero will return all clusters). (default 168h0m0s)
+      --group string             The name or id of the parent group to list clusters from.
+  -h, --help                     help for list
+  -n, --name string              The given name of the resource.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters open"
+slug: chainctl_clusters_open
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters open
+
+Open the console for a cluster.
+
+```
+chainctl clusters open [CLUSTER_ID] [--output table|json] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for open
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records.md
@@ -1,0 +1,36 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters records"
+slug: chainctl_clusters_records
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters records
+
+Interact with cluster records.
+
+### Options
+
+```
+  -h, --help   help for records
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+* [chainctl clusters records list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list/)	 - List cluster records.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters records list"
+slug: chainctl_clusters_records_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters records list
+
+List cluster records.
+
+```
+chainctl clusters records list [CLUSTER_ID] [--active-within DURATION] [--output table|json|wide] [flags]
+```
+
+### Options
+
+```
+      --active-within duration   How recently a record must have been created to be listed (zero will return all records). (default 168h0m0s)
+  -h, --help                     help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters records](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records/)	 - Interact with cluster records.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall.md
@@ -1,0 +1,51 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters uninstall"
+slug: chainctl_clusters_uninstall
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters uninstall
+
+Uninstalls Chainguard from the current kubernetes context.
+
+```
+chainctl clusters uninstall [--context CONTEXT_NAME | --inactive DURATION | --inactive DURATION --group GROUP_NAME|GROUP_ID] [flags]
+```
+
+### Examples
+
+```
+  chainctl cluster uninstall
+  
+  # Uninstall all clusters not seen in 7 days
+  chainctl cluster uninstall --inactive 168h
+```
+
+### Options
+
+```
+      --context string      Indicates the name of the context (in kubectl) to disconnect from Chainguard.
+      --group string        Name or ID of a group to filter clusters not seen within the given duration.
+  -h, --help                help for uninstall
+      --inactive duration   Delete all clusters that have not been seen within the given duration. (default 168h0m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update.md
@@ -1,0 +1,57 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl clusters update"
+slug: chainctl_clusters_update
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters update
+
+Update the name or description of a cluster.
+
+```
+chainctl clusters update CLUSTER_NAME|CLUSTER_ID [--name NAME] [--description DESCRIPTION] [--output table|wide|json]
+```
+
+### Examples
+
+```
+  # Update a cluster description by name
+  chainctl cluster update my-cluster --description "My development cluster."
+  
+  # Update a cluster name by name
+  chainctl cluster update my-cluster --name my-new-cluster
+  
+  # Update a cluster name by ID
+  chainctl cluster update 19d3a64f20c64ba3ccf1bc86ce59d03e705959ad/efb53f2857d567f2 --name new-cluster-name
+  
+  # Delete a cluster description by name
+  chainctl cluster update my-cluster --description ""
+```
+
+### Options
+
+```
+  -d, --description string   The description of the resource.
+  -h, --help                 help for update
+  -n, --name string          Given name of the resource.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config.md
@@ -1,0 +1,38 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl config"
+slug: chainctl_config
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl config
+
+Local config file commands for chainctl.
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl config edit](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit/)	 - Edit the current chainctl config file.
+* [chainctl config save](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save/)	 - Save the current chainctl config to a config file.
+* [chainctl config view](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view/)	 - View the current chainctl config.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl config edit"
+slug: chainctl_config_edit
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl config edit
+
+Edit the current chainctl config file.
+
+```
+chainctl config edit [--config FILE] [--yes] [--output ] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for edit
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config/)	 - Local config file commands for chainctl.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl config save"
+slug: chainctl_config_save
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl config save
+
+Save the current chainctl config to a config file.
+
+```
+chainctl config save [--config FILE] [--yes] [--output ] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for save
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config/)	 - Local config file commands for chainctl.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl config view"
+slug: chainctl_config_view
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl config view
+
+View the current chainctl config.
+
+```
+chainctl config view [--diff] [--output ] [flags]
+```
+
+### Options
+
+```
+      --diff   Show the difference between the local config file and the active configuration.
+  -h, --help   help for view
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config/)	 - Local config file commands for chainctl.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events.md
@@ -1,0 +1,36 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl events"
+slug: chainctl_events
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl events
+
+Events related commands for the Chainguard platform.
+
+### Options
+
+```
+  -h, --help   help for events
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl events subscriptions](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/)	 - Subscription interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions.md
@@ -1,0 +1,38 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl events subscriptions"
+slug: chainctl_events_subscriptions
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl events subscriptions
+
+Subscription interactions.
+
+### Options
+
+```
+  -h, --help   help for subscriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl events](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events/)	 - Events related commands for the Chainguard platform.
+* [chainctl events subscriptions create](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create/)	 - Subscribe to events under a group.
+* [chainctl events subscriptions delete](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete/)	 - Delete a subscription.
+* [chainctl events subscriptions list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list/)	 - List subscriptions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create.md
@@ -1,0 +1,41 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl events subscriptions create"
+slug: chainctl_events_subscriptions_create
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl events subscriptions create
+
+Subscribe to events under a group.
+
+```
+chainctl events subscriptions create SINK_URL [--group GROUP_NAME|GROUP_ID] [--yes] [--output table|json|id] [flags]
+```
+
+### Options
+
+```
+      --group string   The parent group id of the subscription.
+  -h, --help           help for create
+  -y, --yes            Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl events subscriptions](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/)	 - Subscription interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl events subscriptions delete"
+slug: chainctl_events_subscriptions_delete
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl events subscriptions delete
+
+Delete a subscription.
+
+```
+chainctl events subscriptions delete SUBSCRIPTION_ID [--yes] [--output id] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl events subscriptions](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/)	 - Subscription interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl events subscriptions list"
+slug: chainctl_events_subscriptions_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl events subscriptions list
+
+List subscriptions.
+
+```
+chainctl events subscriptions list [--group GROUP_NAME|GROUP_ID] [--output table|json|id] [flags]
+```
+
+### Options
+
+```
+      --group string   The parent group id of the subscription.
+  -h, --help           help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl events subscriptions](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/)	 - Subscription interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam"
+slug: chainctl_iam
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam
+
+IAM related commands for the Chainguard platform.
+
+### Options
+
+```
+  -h, --help   help for iam
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl iam role-bindings](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings/)	 - IAM role bindings resource interactions.
+* [chainctl iam roles](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles/)	 - IAM role resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups.md
@@ -1,0 +1,44 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups"
+slug: chainctl_iam_groups
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups
+
+IAM Group resource interactions.
+
+### Options
+
+```
+  -h, --help   help for groups
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
+* [chainctl iam groups check-aws](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws/)	 - Checks that the given group has been properly configured for OIDC federation with AWS.
+* [chainctl iam groups check-gcp](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp/)	 - Checks that the given group has been properly configured for OIDC federation with GCP.
+* [chainctl iam groups create](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create/)	 - Create a new group or add a group under an existing group.
+* [chainctl iam groups delete](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete/)	 - Delete group
+* [chainctl iam groups describe](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe/)	 - Describe a group. (Experimental)
+* [chainctl iam groups list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list/)	 - List groups.
+* [chainctl iam groups set-aws](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws/)	 - Set the AWS account association for this IAM Group.
+* [chainctl iam groups set-gcp](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp/)	 - Set the GCP project association for this IAM Group.
+* [chainctl iam groups update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update/)	 - Update a group.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups check-aws"
+slug: chainctl_iam_groups_check-aws
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups check-aws
+
+Checks that the given group has been properly configured for OIDC federation with AWS.
+
+```
+chainctl iam groups check-aws [GROUP_NAME | GROUP_ID] [--output TODO] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for check-aws
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups check-gcp"
+slug: chainctl_iam_groups_check-gcp
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups check-gcp
+
+Checks that the given group has been properly configured for OIDC federation with GCP.
+
+```
+chainctl iam groups check-gcp [GROUP_NAME | GROUP_ID] [--output TODO] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for check-gcp
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create.md
@@ -1,0 +1,44 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups create"
+slug: chainctl_iam_groups_create
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups create
+
+Create a new group or add a group under an existing group.
+
+```
+chainctl iam groups create GROUP_NAME [--parent GROUP_NAME|GROUP_ID | --no-parent] [--description DESCRIPTION] [--yes] [--skip-refresh] [flags]
+```
+
+### Options
+
+```
+  -d, --description string   The description of the group.
+  -h, --help                 help for create
+      --no-parent            The new group should be a new root group.
+      --parent string        The id, suffix, or name of the parent group for the new group.
+      --skip-refresh         Skips attempting to reauthenticate and refresh the Chainguard auth token if it becomes out of date.
+  -y, --yes                  Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete.md
@@ -1,0 +1,56 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups delete"
+slug: chainctl_iam_groups_delete
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups delete
+
+Delete group
+
+```
+chainctl iam groups delete [GROUP_NAME|GROUP_ID] [--yes] [--skip-refresh] [flags]
+```
+
+### Examples
+
+```
+
+# Delete a group by ID
+chainctl iam group delete e533448ca9770c46f99f2d86d60fc7101494e4a3
+
+# Delete a group by name
+chainctl iam group delete my-group
+
+# Delete a group to be selected interactively
+chainctl iam group delete
+
+```
+
+### Options
+
+```
+  -h, --help           help for delete
+      --skip-refresh   Skips attempting to reauthenticate and refresh the Chainguard auth token if it becomes out of date.
+  -y, --yes            Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups describe"
+slug: chainctl_iam_groups_describe
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups describe
+
+Describe a group. (Experimental)
+
+```
+chainctl iam groups describe [--output json] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list.md
@@ -1,0 +1,47 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups list"
+slug: chainctl_iam_groups_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups list
+
+List groups.
+
+```
+chainctl iam groups list [--output tree|table|json|id] [flags]
+```
+
+### Examples
+
+```
+
+chainctl iam group list
+
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws.md
@@ -1,0 +1,42 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups set-aws"
+slug: chainctl_iam_groups_set-aws
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups set-aws
+
+Set the AWS account association for this IAM Group.
+
+```
+chainctl iam groups set-aws [GROUP_NAME | GROUP_ID] [--account ACCOUNT_ID] [--output TODO] [flags]
+```
+
+### Options
+
+```
+      --account string       The AWS account ID.
+  -d, --description string   The description of the association.
+  -h, --help                 help for set-aws
+  -n, --name string          The name of the association. (default: the group name)
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp.md
@@ -1,0 +1,43 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups set-gcp"
+slug: chainctl_iam_groups_set-gcp
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups set-gcp
+
+Set the GCP project association for this IAM Group.
+
+```
+chainctl iam groups set-gcp [GROUP_NAME | GROUP_ID] [--project-id PROJECT_ID] [--project-number PROJECT_NUMBER] [--output TODO] [flags]
+```
+
+### Options
+
+```
+  -d, --description string      The description of the association.
+  -h, --help                    help for set-gcp
+  -n, --name string             The name of the association. (default: the group name)
+      --project-id string       The GCP project ID.
+      --project-number string   The GCP project number.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update.md
@@ -1,0 +1,55 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam groups update"
+slug: chainctl_iam_groups_update
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam groups update
+
+Update a group.
+
+```
+chainctl iam groups update GROUP_NAME|GROUP_ID [--name GROUP_NAME] [--description GROUP_DESCRIPTION] [flags]
+```
+
+### Examples
+
+```
+
+# Update a group's name
+chainctl iam groups update my-group --name new-group-name
+
+# Update a group's description
+chainctl iam groups update 19d3a64f20c64ba3ccf1bc86ce59d03e705959ad/efb53f2857d567f2 --description "A description of the group."
+
+# Remove a group's description
+chainctl iam groups update my-group --description ""
+```
+
+### Options
+
+```
+  -d, --description string   The updated description for the group.
+  -h, --help                 help for update
+  -n, --name string          The updated name for the group.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites.md
@@ -1,0 +1,38 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam invites"
+slug: chainctl_iam_invites
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam invites
+
+Manage invite codes that register identities or clusters with Chainguard.
+
+### Options
+
+```
+  -h, --help   help for invites
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
+* [chainctl iam invites create](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create/)	 - Generate an invite code to identities or register clusters with Chainguard.
+* [chainctl iam invites delete](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/)	 - Delete invite codes
+* [chainctl iam invites list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list/)	 - Show invites that are active.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create.md
@@ -1,0 +1,53 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam invites create"
+slug: chainctl_iam_invites_create
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam invites create
+
+Generate an invite code to identities or register clusters with Chainguard.
+
+```
+chainctl iam invites create [GROUP_NAME | GROUP_ID] [--role ROLE_ID | --cluster] [--ttl TTL_DURATION] [--output json|table|id] [flags]
+```
+
+### Examples
+
+```
+
+# Create an invite that will be valid for 5 days:
+chainctl iam invite create GROUP_ID --role ROLE_ID --ttl 5d
+# Create an invite for a cluster:
+chainctl iam invite create GROUP_ID --cluster
+
+```
+
+### Options
+
+```
+      --cluster        Default roles for cluster invites.
+  -h, --help           help for create
+      --role string    Role is used to role-bind the invited to the associated group.
+      --ttl duration   Duration the invite code will be valid. (default 168h0m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete.md
@@ -1,0 +1,41 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam invites delete"
+slug: chainctl_iam_invites_delete
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam invites delete
+
+Delete invite codes
+
+```
+chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+```
+
+### Options
+
+```
+      --expired   When true, delete all expired invite codes.
+  -h, --help      help for delete
+  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam invites list"
+slug: chainctl_iam_invites_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam invites list
+
+Show invites that are active.
+
+```
+chainctl iam invites list [--output table|json|id] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings.md
@@ -1,0 +1,36 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam role-bindings"
+slug: chainctl_iam_role-bindings
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam role-bindings
+
+IAM role bindings resource interactions.
+
+### Options
+
+```
+  -h, --help   help for role-bindings
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
+* [chainctl iam role-bindings list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list/)	 - List role bindings.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list.md
@@ -1,0 +1,47 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam role-bindings list"
+slug: chainctl_iam_role-bindings_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam role-bindings list
+
+List role bindings.
+
+```
+chainctl iam role-bindings list [--output table|tree|json] [flags]
+```
+
+### Examples
+
+```
+
+chainctl iam role-bindings list
+
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam role-bindings](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings/)	 - IAM role bindings resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles.md
@@ -1,0 +1,36 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam roles"
+slug: chainctl_iam_roles
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam roles
+
+IAM role resource interactions.
+
+### Options
+
+```
+  -h, --help   help for roles
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
+* [chainctl iam roles list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list/)	 - List roles.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list.md
@@ -1,0 +1,47 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl iam roles list"
+slug: chainctl_iam_roles_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl iam roles list
+
+List roles.
+
+```
+chainctl iam roles list NAME_FILTER [--output table|json] [flags]
+```
+
+### Examples
+
+```
+
+chainctl iam role list
+
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl iam roles](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles/)	 - IAM role resource interactions.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies.md
@@ -1,0 +1,41 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies"
+slug: chainctl_policies
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies
+
+Policy related commands for the Chainguard platform.
+
+### Options
+
+```
+  -h, --help   help for policies
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl policies apply](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply/)	 - Create or update a policy described by file or stdin.
+* [chainctl policies delete](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete/)	 - Delete a policy.
+* [chainctl policies edit](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit/)	 - Edit a policy document.
+* [chainctl policies list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list/)	 - List policies.
+* [chainctl policies update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update/)	 - Update the description of a policy.
+* [chainctl policies view](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view/)	 - View a policy.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply.md
@@ -1,0 +1,44 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies apply"
+slug: chainctl_policies_apply
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies apply
+
+Create or update a policy described by file or stdin.
+
+```
+chainctl policies apply [--group GROUP_NAME|GROUP_ID] [--description DESCRIPTION] [--filename FILENAME]... [--recursive] [--yes] [--output table|json|id] [flags]
+```
+
+### Options
+
+```
+  -d, --description string   The description of the policy.
+  -f, --filename strings     Filename, directory, or URL to files to use to create or update the resource
+      --group string         The parent group id of the policy.
+  -h, --help                 help for apply
+  -R, --recursive            Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+  -y, --yes                  Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies delete"
+slug: chainctl_policies_delete
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies delete
+
+Delete a policy.
+
+```
+chainctl policies delete POLICY_ID|POLICY_NAME [--yes] [--output id] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies edit"
+slug: chainctl_policies_edit
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies edit
+
+Edit a policy document.
+
+```
+chainctl policies edit [POLICY_ID|POLICY_NAME] [--yes] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for edit
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list.md
@@ -1,0 +1,41 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies list"
+slug: chainctl_policies_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies list
+
+List policies.
+
+```
+chainctl policies list [--group GROUP_NAME|GROUP_ID] [--output table|json|id] [flags]
+```
+
+### Options
+
+```
+      --group string   The name or id of the parent group to list policies from.
+  -h, --help           help for list
+  -y, --yes            Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update.md
@@ -1,0 +1,50 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies update"
+slug: chainctl_policies_update
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies update
+
+Update the description of a policy.
+
+```
+chainctl policies update POLICY_NAME|POLICY_ID --description DESCRIPTION [--output table|json|id] [flags]
+```
+
+### Examples
+
+```
+  # Update a policy description by name.
+  chainctl iam policy update my-policy --description "A description of my policy."
+  
+  # Remove a policy description by ID.
+  chainctl iam policy update 617ec5ae5775e22fb52ec2d62398de1e7def7986/e74e9050df769110 --description ""
+```
+
+### Options
+
+```
+  -d, --description string   New description for this policy.
+  -h, --help                 help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view.md
@@ -1,0 +1,39 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl policies view"
+slug: chainctl_policies_view
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl policies view
+
+View a policy.
+
+```
+chainctl policies view [POLICY_ID|POLICY_NAME] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for view
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_version.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_version.md
@@ -1,0 +1,40 @@
+---
+date: 2022-08-29T10:58:14-04:00
+title: "chainctl version"
+slug: chainctl_version
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_version/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl version
+
+Prints the version
+
+```
+chainctl version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+      --json   print JSON instead of text
+```
+
+### Options inherited from parent commands
+
+```
+      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string     A specific chainctl config file.
+      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+```
+
+### SEE ALSO
+
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-api/index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-api/index.md
@@ -1,0 +1,16 @@
+---
+title : "OpenAPI Specification"
+lead: ""
+date: 2020-10-06T08:48:23+00:00
+lastmod: 2020-10-06T08:48:23+00:00
+draft: false
+images: []
+type: "article"
+menu:
+  docs:
+    parent: "chainguard"
+weight: 620
+toc: true
+---
+
+{{< openapi spec-url="/api.yaml" >}}

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -1,0 +1,30 @@
+<script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+
+<elements-api
+      apiDescriptionUrl='{{ .Get "spec-url"}}'
+      router="hash"
+      hideTryIt="true"
+    />
+
+<style>
+  nav .nav-item svg {
+    display: inherit !important;
+  }
+  .docs-sidebar {
+    display: none !important;
+  }
+  main.docs-content {
+    width: 100% !important;
+  }
+  main h1 {
+    font-size: 2.5rem !important;
+    margin: 2rem 0 1rem;
+  }
+  nav.docs-toc {
+    display: none !important;
+  }
+  elements-api {
+    display: block;
+  }
+</style>

--- a/static/api.yaml
+++ b/static/api.yaml
@@ -1,0 +1,1898 @@
+consumes:
+  - application/json
+definitions:
+  AccountAssociationsAmazon:
+    properties:
+      account:
+        type: string
+    type: object
+  AccountAssociationsGoogle:
+    properties:
+      projectId:
+        type: string
+      projectNumber:
+        type: string
+    type: object
+  ClusterAuthInfo:
+    description: |-
+      This is based off of k8s.io/client-go/tools/clientcmd/api/v1.AuthInfo
+      This should only ever be used with KinD clusters during testing, it WILL
+      NOT be stored securely.
+    properties:
+      clientCertificateData:
+        description:
+          client_certificate_data contains PEM-encoded data from a client
+          cert file for TLS.
+        format: byte
+        type: string
+      clientKeyData:
+        description:
+          client_key_data contains PEM-encoded data from a client key file
+          for TLS.
+        format: byte
+        type: string
+    type: object
+  ClusterInfo:
+    properties:
+      CertificateAuthorityData:
+        format: byte
+        title: |-
+          CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+          Overrides CertificateAuthority
+        type: string
+      server:
+        description: Server is the address of the kubernetes cluster (https://hostname:port).
+        type: string
+    title: |-
+      This is based off of k8s.io/client-go/tools/clientcmd/api/v1.Cluster
+      This can be extracted from kubectl for a named cluster (replace CLUSTER_NAME) with:
+        kubectl config view \
+          --flatten -o jsonpath='{.clusters[?(@.name == "CLUSTER_NAME")].cluster}'
+    type: object
+  ClusterProvider:
+    default: UNKNOWN
+    description: " - KIND: For testing."
+    enum:
+      - UNKNOWN
+      - GKE
+      - EKS
+      - KIND
+    type: string
+  ContextAncestry:
+    description: |-
+      Ancestry relationships are added to records when a "base image"
+      relationship has been uncovered.  This context is added to BOTH
+      records with their respective roles.  The base image will get
+      the Role BASE, and the derivative image will get the Rile DERIVED.
+    properties:
+      id:
+        description: |-
+          The id of the other image's record in this ancestry relationship.
+          If our Role is BASE, then this will hold the ID of the DERIVED
+          image's record, and vice versa.
+        type: string
+      role:
+        $ref: "#/definitions/ContextAncestryRole"
+    type: object
+  ContextAncestryRole:
+    default: UNKNOWN
+    enum:
+      - UNKNOWN
+      - BASE
+      - DERIVED
+    type: string
+  ContextVariant:
+    description: |-
+      Variant relationships are added to records when we find an "index"
+      containing multiple different variations (typically os/arch) of the
+      same logical image.  These are referred to as "OCI Image Index",
+      "Docker Manifest List", and occasionally "fat images".  This context
+      is added to ALL records including the INDEX and all VARIANTs of that
+      index.  The INDEX will typically contain N contexts carrying the Role
+      INDEX, the id of the VARIANT's record, and the version information
+      that discriminates that VARIANT from other VARIANTs.  The VARIANT
+      will typically (but not always!) contain 1 context varrying the Role
+      VARIANT, the id of the INDEX's record, and the version information
+      that discriminates it among the other VARIANTs in the INDEX.
+    properties:
+      id:
+        description: |-
+          The id of the image index's record linking this
+          image (transitively) to the cluster.
+        type: string
+      role:
+        $ref: "#/definitions/ContextVariantRole"
+      version:
+        description: |-
+          The version information distinguishing this variant
+          from other possible variants of the index.
+        type: string
+    type: object
+  ContextVariantRole:
+    default: UNKNOWN
+    enum:
+      - UNKNOWN
+      - INDEX
+      - VARIANT
+    type: string
+  ContextWorkload:
+    description: |-
+      Workload contexts are added to existence records that have been
+      observed running on a cluster.
+    properties:
+      kind:
+        $ref: "#/definitions/tenantGroupVersionKind"
+      name:
+        type: string
+      namespace:
+        type: string
+      uid:
+        type: string
+    type: object
+  PolicyAttestation:
+    properties:
+      signature:
+        $ref: "#/definitions/PolicySignature"
+        description: The signature's ID serves as the attestation ID.
+    type: object
+  PolicyAttestations:
+    properties:
+      attestations:
+        items:
+          $ref: "#/definitions/PolicyAttestation"
+        type: array
+    title: |-
+      This mainly exists because you cannot have:
+         map<string, repeated Attestation>
+    type: object
+  PolicyAuthorityMatch:
+    properties:
+      attestations:
+        additionalProperties:
+          $ref: "#/definitions/PolicyAttestations"
+        description: |-
+          A mapping from the name of an attestation clause within the authority
+          to the attestations that match it.
+        type: object
+      signatures:
+        items:
+          $ref: "#/definitions/PolicySignature"
+        type: array
+    type: object
+  PolicySignature:
+    properties:
+      github:
+        $ref: "#/definitions/SignatureGithub"
+        description: |-
+          github holds the github-specific extensions encoded
+          into the certificate chain used to sign.
+      issuer:
+        description: issuer that was found to match on the Cert.
+        type: string
+      signatureId:
+        description: signature_id is a generated unique ID, output only.
+        type: string
+      subject:
+        description: subject that was found to match on the Cert.
+        type: string
+    type: object
+  RoleBindingListBinding:
+    properties:
+      email:
+        description: email of the bound identity.
+        type: string
+      group:
+        $ref: "#/definitions/iamGroup"
+        description: group of the bound role.
+      id:
+        description: id, the UID of this role binding.
+        type: string
+      identity:
+        description: identity, UID of the Identity bound.
+        type: string
+      role:
+        $ref: "#/definitions/iamRole"
+        description: role of the bound identity.
+    type: object
+  SignatureGithub:
+    properties:
+      workflowName:
+        title: "OID: 1.3.6.1.4.1.57264.1.4"
+        type: string
+      workflowRef:
+        title: "OID: 1.3.6.1.4.1.57264.1.6"
+        type: string
+      workflowRepo:
+        title: "OID: 1.3.6.1.4.1.57264.1.5"
+        type: string
+      workflowSha:
+        title: "OID: 1.3.6.1.4.1.57264.1.3"
+        type: string
+      workflowTrigger:
+        title: "OID: 1.3.6.1.4.1.57264.1.2"
+        type: string
+    type: object
+  StatusState:
+    default: UNKNOWN
+    enum:
+      - UNKNOWN
+      - Ready
+      - NotReady
+    type: string
+  authRegistrationRequest:
+    properties:
+      clusterId:
+        description: |-
+          cluster_id is an optional cluster id, which simultaneously registers
+          a Cluster with the Identity.  This path must specify an invite code, so
+          we know where in the IAM hierarchy to link the cluster.
+        type: string
+      code:
+        title: |-
+          code is an optional encoded invite code, which allows us to register
+          the caller's identity as a member of a particular group as a particular
+          role.
+          +optional
+        type: string
+      identityId:
+        title: |-
+          identity_id is an optional identity id. If the user already exists, this
+          by-passes identity registration and continues on to cluster registration
+          (if applicable)
+        type: string
+    type: object
+  authSession:
+    properties:
+      group:
+        description: |-
+          group, the group this identity has joined by invitation, when an invite
+          code was supplied.
+        type: string
+      identity:
+        description: identity, the Chainguard identity id.
+        type: string
+    type: object
+  authWhoAmI:
+    properties:
+      audience:
+        description: Audience is who the token is intended for.
+        items:
+          type: string
+        type: array
+      capabilities:
+        description: The capabilities referenced in the token.
+        items:
+          $ref: "#/definitions/authWhoAmICapability"
+        type: array
+      email:
+        description: The upstream email for this token.
+        type: string
+      expiry:
+        description: When the token expires.
+        format: date-time
+        type: string
+      issuedAt:
+        description: With the token was issued.
+        format: date-time
+        type: string
+      issuer:
+        description: Issuer is the issuer of the token.
+        type: string
+      subject:
+        description: The subject of the token.
+        type: string
+    type: object
+  authWhoAmICapability:
+    properties:
+      group:
+        $ref: "#/definitions/iamGroup"
+        description: group of the bound role.
+      role:
+        $ref: "#/definitions/iamRole"
+        description: role of the bound identity.
+    title: "--- Upstream fields ---"
+    type: object
+  commonUIDPFilter:
+    properties:
+      ancestorsOf:
+        description:
+          ancestors_of are groups reachable by repeated proceeding from
+          parent to child.
+        type: string
+      descendantsOf:
+        description:
+          descendants_of are groups reachable by repeated proceeding from
+          child to parent.
+        type: string
+    type: object
+  eventsIdentity:
+    properties:
+      expiration:
+        description: |-
+          Expiration of identity / issuer keys. After this date /time the issuer
+          keys will not be trusted. Defaults / maximum of 30 days after creation
+          time.
+        format: date-time
+        type: string
+      id:
+        description: id is unique identifier of this specific identity.
+        type: string
+      issuer:
+        description: |-
+          issuer of the OIDC ID tokens issued for this identity. Matches the `iss`
+          claim.
+        type: string
+      issuerKeys:
+        description: |-
+          Optional JWKS formatted public keys for the issuer. If supplied
+          verification of ID tokens is attempted using these keys instead of the
+          normal OIDC discovery path. This enables e.g clusters behing NAT to
+          authenticate.
+        type: string
+      subject:
+        description: |-
+          subject of OIDC ID tokens issued for this identity. Matchs the `sub`
+          claim.
+        type: string
+    type: object
+  eventsSubscription:
+    properties:
+      id:
+        description: id is identifier of this specific subscription.
+        type: string
+      sink:
+        description:
+          sink is the address to which events shall be delivered using
+          the selected protocol.
+        type: string
+    type: object
+  eventsSubscriptionList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/eventsSubscription"
+        type: array
+    type: object
+  googlerpcStatus:
+    properties:
+      code:
+        format: int32
+        type: integer
+      details:
+        items:
+          $ref: "#/definitions/protobufAny"
+        type: array
+      message:
+        type: string
+    type: object
+  iamAccountAssociations:
+    properties:
+      amazon:
+        $ref: "#/definitions/AccountAssociationsAmazon"
+        description:
+          amazon holds information associating an Amazon account with the
+          group.
+      description:
+        description: a short description of this association.
+        type: string
+      google:
+        $ref: "#/definitions/AccountAssociationsGoogle"
+        description:
+          google holds information associating a Google project with the
+          group.
+      group:
+        description: group is the group with which this account information is associated.
+        type: string
+      name:
+        description: name of the association.
+        type: string
+    type: object
+  iamAccountAssociationsList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/iamAccountAssociations"
+        type: array
+    type: object
+  iamGroup:
+    properties:
+      description:
+        description: description, human readable of group.
+        type: string
+      id:
+        description: id, The group UIDP under which this group resides.
+        type: string
+      name:
+        description: name, human readable name of group.
+        type: string
+    type: object
+  iamGroupInvite:
+    properties:
+      code:
+        description: code is the json-encoded authentication code.
+        type: string
+      expiration:
+        description: expiration, timestamp this invite becomes no longer valid.
+        format: date-time
+        type: string
+      id:
+        description: id, The group UIDP under which this invite resides.
+        type: string
+      keyId:
+        description: key_id is used to identify the verification key for this code.
+        type: string
+      role:
+        $ref: "#/definitions/iamRole"
+        description:
+          role is the role the invited identity will be role-bound to the
+          group with.
+    type: object
+  iamGroupInviteList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/iamStoredGroupInvite"
+        type: array
+    type: object
+  iamGroupList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/iamGroup"
+        type: array
+    type: object
+  iamPolicy:
+    properties:
+      description:
+        description: description, human readable description of policy.
+        type: string
+      document:
+        description: document, YAML encoded policy document.
+        type: string
+      id:
+        description: id is identifier of this specific policy.
+        type: string
+      name:
+        description: name, human readable name of policy.
+        type: string
+    type: object
+  iamPolicyList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/iamPolicy"
+        type: array
+    type: object
+  iamRole:
+    properties:
+      capabilities:
+        description:
+          capabilities, human readable list of capabilities supported by
+          the group.
+        items:
+          type: string
+        type: array
+      description:
+        description: description, human readable description of group.
+        type: string
+      id:
+        description: id, The Group path under which this Role resides.
+        type: string
+      name:
+        description: name, human readable name of group.
+        type: string
+    type: object
+  iamRoleBinding:
+    properties:
+      group:
+        description: group, UIDP of the group to bind.
+        type: string
+      id:
+        description: id, the UID of this role binding.
+        type: string
+      identity:
+        description: identity, UID of the Identity to bind.
+        type: string
+      role:
+        title: role, UIDP of the Role to bind
+        type: string
+    type: object
+  iamRoleBindingList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/RoleBindingListBinding"
+        type: array
+    type: object
+  iamRoleList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/iamRole"
+        type: array
+    type: object
+  iamStoredGroupInvite:
+    properties:
+      expiration:
+        description: expiration, timestamp this invite becomes no longer valid.
+        format: date-time
+        type: string
+      id:
+        description: id, The group UIDP under which this invite resides.
+        type: string
+      keyId:
+        description: key_id is used to identify the verification key for this code.
+        type: string
+      role:
+        $ref: "#/definitions/iamRole"
+        description:
+          role is the role the invited identity will be role-bound to the
+          group with.
+    type: object
+  oidcRawToken:
+    properties:
+      token:
+        type: string
+    type: object
+  protobufAny:
+    additionalProperties: {}
+    properties:
+      "@type":
+        type: string
+    type: object
+  rpcStatus:
+    properties:
+      code:
+        format: int32
+        type: integer
+      details:
+        items:
+          $ref: "#/definitions/protobufAny"
+        type: array
+      message:
+        type: string
+    type: object
+  tenantCluster:
+    properties:
+      activity:
+        additionalProperties:
+          $ref: "#/definitions/tenantClusterActivity"
+        description: |-
+          activity is a mapping from "Source" URLs to an activity record summarizing
+          recent activity from this source.
+        type: object
+      agentVersion:
+        description:
+          agent_version holds the version of the Chainguard agent last
+          reported by the cluster.
+        type: string
+      authInfo:
+        $ref: "#/definitions/ClusterAuthInfo"
+        description:
+          auth_info holds authentication details for connecting to KinD
+          in test scenarios.
+      description:
+        description: a short description of this cluster.
+        type: string
+      group:
+        $ref: "#/definitions/iamGroup"
+        title: group the cluster resides in
+      id:
+        description: id, The Cluster UIDP under which this Cluster resides.
+        type: string
+      info:
+        $ref: "#/definitions/ClusterInfo"
+        description: info contains the cluster information from the kubeconfig context.
+      issuer:
+        description: issuer is the identity issuer tied to this cluster.
+        type: string
+      lastSeen:
+        description:
+          last_seen tracks the timestamp at which this cluster was last
+          seen.
+        format: date-time
+        type: string
+      managedName:
+        description: |-
+          managed_name is the unique name we have given to this cluster's managed agent.
+          This field is output-only, and is populated only when this cluster is "managed".
+        type: string
+      name:
+        description: name of the cluster.
+        type: string
+      provider:
+        $ref: "#/definitions/ClusterProvider"
+        description: |-
+          provider holds the flavor of cluster provider, which is used to determine how we
+          authenticate with the cluster.
+      registered:
+        description: registered tracks the timestamp at which this cluster was registered.
+        format: date-time
+        type: string
+      remoteId:
+        description: remote_id is the remote ID of this cluster.
+        type: string
+      status:
+        $ref: "#/definitions/tenantClusterStatus"
+        description: status contains the managed cluster's status.
+      version:
+        description: version holds the Kubernetes version last reported by the cluster.
+        type: string
+    type: object
+  tenantClusterActivity:
+    properties:
+      controllerName:
+        description: |-
+          controller_name is the name of the Controller CRD which was the source of this
+          activity on the tenant cluster.
+        type: string
+      lastSeen:
+        description:
+          last_seen tracks the timestamp at which this source was last
+          active.
+        format: date-time
+        type: string
+      namespace:
+        description:
+          namespace is the namespace in which the source of this cluster
+          activity lives.
+        type: string
+      specHash:
+        description: |-
+          spec_hash is the hash of the Controller or Webhook CRD's spec, which forms a
+          loose form of versioning.
+        type: string
+      webhookName:
+        description: |-
+          webhook_name is the name of the Webhook CRD which was the source of this
+          activity on the tenant cluster.
+        type: string
+    type: object
+  tenantClusterList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/tenantCluster"
+        type: array
+    type: object
+  tenantClusterStatus:
+    properties:
+      message:
+        type: string
+      ready:
+        $ref: "#/definitions/StatusState"
+      reason:
+        type: string
+    type: object
+  tenantContext:
+    properties:
+      ancestry:
+        $ref: "#/definitions/ContextAncestry"
+      contextId:
+        description: context_id is a unique ID, output only.
+        type: string
+      lastSeen:
+        description: last_seen is the last time we've seen the image_id in this context.
+        format: date-time
+        type: string
+      variant:
+        $ref: "#/definitions/ContextVariant"
+      workload:
+        $ref: "#/definitions/ContextWorkload"
+    type: object
+  tenantGroupVersionKind:
+    description: "TODO: Replace with upstream proto messages wherever possible."
+    properties:
+      group:
+        type: string
+      kind:
+        type: string
+      version:
+        type: string
+    type: object
+  tenantPackage:
+    properties:
+      name:
+        type: string
+      purl:
+        type: string
+      version:
+        type: string
+    type: object
+  tenantPolicy:
+    properties:
+      authorityMatches:
+        additionalProperties:
+          $ref: "#/definitions/PolicyAuthorityMatch"
+        description: |-
+          This loosely tracks the policy-controller's PolicyResult type found here:
+          https://github.com/sigstore/policy-controller/blob/f777dcc2e/pkg/webhook/validator_result.go
+          The keys of this map are the authority names from within the policy.
+        type: object
+      diagnostic:
+        description: diagnostic holds any messages surfaced by the policy evaluation.
+        type: string
+      lastChecked:
+        description: last_checked holds when this policy was last evaluated.
+        format: date-time
+        type: string
+      valid:
+        description: valid holds whether the policy evaluation was successful.
+        type: boolean
+    type: object
+  tenantRecord:
+    properties:
+      cluster:
+        description: cluster identifies the specific cluster for the record.
+        type: string
+      contexts:
+        description: contexts in which we have seen this image id.
+        items:
+          $ref: "#/definitions/tenantContext"
+        type: array
+      id:
+        title: id holds the UIDP for this image's record
+        type: string
+      image:
+        description: image is the container image for the record.
+        type: string
+      lastRefreshed:
+        additionalProperties:
+          format: date-time
+          type: string
+        description: |-
+          last_refreshed will hold a PredicateType => Last time it was successfully
+          refreshed.
+        type: object
+      lastSeen:
+        description:
+          last_seen is the last time we've seen this image anywhere on
+          this cluster.
+        format: date-time
+        type: string
+      policies:
+        additionalProperties:
+          $ref: "#/definitions/tenantPolicy"
+        description: |-
+          policies will hold a policy name => policy struct, containing the
+          last time it was checked and whether it is pass or fail.
+          refreshed.
+        type: object
+      sboms:
+        items:
+          $ref: "#/definitions/tenantSbom"
+        type: array
+    type: object
+  tenantRecordList:
+    properties:
+      items:
+        items:
+          $ref: "#/definitions/tenantRecord"
+        type: array
+    type: object
+  tenantSbom:
+    properties:
+      packages:
+        items:
+          $ref: "#/definitions/tenantPackage"
+        type: array
+    type: object
+info:
+  title: Chainguard Enforce OpenAPI Specification
+  version: "v0.0.18"
+paths:
+  /auth/v1/ok:
+    get:
+      operationId: Auth_Validate
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/authWhoAmI"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Auth
+  /auth/v1/register:
+    post:
+      operationId: Auth_Register
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/authRegistrationRequest"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/authSession"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Auth
+  /tenant/v1/clusters:
+    get:
+      operationId: Clusters_List
+      parameters:
+        - description: id is the exact UID of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description: |-
+            active_since is the timestamp after which returned clusters should have been active.
+            This applies to both cluster registration and when it was "last seen".
+          format: date-time
+          in: query
+          name: activeSince
+          required: false
+          type: string
+        - description:
+            ancestors_of are groups reachable by repeated proceeding from
+            parent to child.
+          in: query
+          name: uidp.ancestorsOf
+          required: false
+          type: string
+        - description:
+            descendants_of are groups reachable by repeated proceeding from
+            child to parent.
+          in: query
+          name: uidp.descendantsOf
+          required: false
+          type: string
+        - description: remote_id is the remote ID of this cluster.
+          in: query
+          name: remoteId
+          required: false
+          type: string
+        - description: name is the exact name of the cluster.
+          in: query
+          name: name
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/tenantClusterList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/googlerpcStatus"
+      tags:
+        - Clusters
+  /tenant/v1/clusters/{id}:
+    delete:
+      operationId: Clusters_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/googlerpcStatus"
+      tags:
+        - Clusters
+    put:
+      operationId: Clusters_Update
+      parameters:
+        - description: id, The Cluster UIDP under which this Cluster resides.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              activity:
+                additionalProperties:
+                  $ref: "#/definitions/tenantClusterActivity"
+                description: |-
+                  activity is a mapping from "Source" URLs to an activity record summarizing
+                  recent activity from this source.
+                type: object
+              agentVersion:
+                description:
+                  agent_version holds the version of the Chainguard agent
+                  last reported by the cluster.
+                type: string
+              authInfo:
+                $ref: "#/definitions/ClusterAuthInfo"
+                description:
+                  auth_info holds authentication details for connecting to
+                  KinD in test scenarios.
+              description:
+                description: a short description of this cluster.
+                type: string
+              group:
+                $ref: "#/definitions/iamGroup"
+                title: group the cluster resides in
+              info:
+                $ref: "#/definitions/ClusterInfo"
+                description:
+                  info contains the cluster information from the kubeconfig
+                  context.
+              issuer:
+                description: issuer is the identity issuer tied to this cluster.
+                type: string
+              lastSeen:
+                description:
+                  last_seen tracks the timestamp at which this cluster was
+                  last seen.
+                format: date-time
+                type: string
+              managedName:
+                description: |-
+                  managed_name is the unique name we have given to this cluster's managed agent.
+                  This field is output-only, and is populated only when this cluster is "managed".
+                type: string
+              name:
+                description: name of the cluster.
+                type: string
+              provider:
+                $ref: "#/definitions/ClusterProvider"
+                description: |-
+                  provider holds the flavor of cluster provider, which is used to determine how we
+                  authenticate with the cluster.
+              registered:
+                description:
+                  registered tracks the timestamp at which this cluster was
+                  registered.
+                format: date-time
+                type: string
+              remoteId:
+                description: remote_id is the remote ID of this cluster.
+                type: string
+              status:
+                $ref: "#/definitions/tenantClusterStatus"
+                description: status contains the managed cluster's status.
+              version:
+                description:
+                  version holds the Kubernetes version last reported by the
+                  cluster.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/tenantCluster"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/googlerpcStatus"
+      tags:
+        - Clusters
+  /tenant/v1/clusters/{parentId}:
+    post:
+      operationId: Clusters_Create
+      parameters:
+        - description: parent_id, The Group under which this Cluster resides.
+          in: path
+          name: parentId
+          pattern: .+
+          required: true
+          type: string
+        - description: Cluster is the definition of the managed cluster to create.
+          in: body
+          name: cluster
+          required: true
+          schema:
+            $ref: "#/definitions/tenantCluster"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/tenantCluster"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/googlerpcStatus"
+      tags:
+        - Clusters
+  /tenant/v1/clusters/{cluster}/records:
+    get:
+      operationId: Records_List
+      parameters:
+        - description: |-
+            cluster is specified if restricting to a given cluster id.
+            This field is required.
+          in: path
+          name: cluster
+          required: true
+          type: string
+        - description: id is the exact UID of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description:
+            ancestors_of are groups reachable by repeated proceeding from
+            parent to child.
+          in: query
+          name: uidp.ancestorsOf
+          required: false
+          type: string
+        - description:
+            descendants_of are groups reachable by repeated proceeding from
+            child to parent.
+          in: query
+          name: uidp.descendantsOf
+          required: false
+          type: string
+        - description: image is specified if a specific Record is desired.
+          in: query
+          name: image
+          required: false
+          type: string
+        - description: |-
+            predicate specifies to fetch Records where either there's no
+            LastRefreshed for this predicate type, or if it needs to be refreshed.
+          in: query
+          name: predicate
+          required: false
+          type: string
+        - description: |-
+            active_since is the timestamp after which returned records should have been active.
+            This applies to when an image was "last seen".
+          format: date-time
+          in: query
+          name: activeSince
+          required: false
+          type: string
+        - description:
+            violations specifies to fetch Records where at least one policy
+            is not valid.
+          in: query
+          name: violations
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/tenantRecordList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Clusters
+  /iam/v1/account_associations:
+    get:
+      operationId: GroupAccountAssociations_List
+      parameters:
+        - description:
+            group is the exact UIDP of the group whose associations we want
+            to list.
+          in: query
+          name: group
+          required: false
+          type: string
+        - description: name is the exact name of the association.
+          in: query
+          name: name
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamAccountAssociationsList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupAccountAssociations
+  /iam/v1/account_associations/{group}:
+    delete:
+      operationId: GroupAccountAssociations_Delete
+      parameters:
+        - description:
+            group is the exact UIDP of the group whose associations we want
+            to delete.
+          in: path
+          name: group
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupAccountAssociations
+    post:
+      operationId: GroupAccountAssociations_Create
+      parameters:
+        - description: group is the group with which this account information is associated.
+          in: path
+          name: group
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              amazon:
+                $ref: "#/definitions/AccountAssociationsAmazon"
+                description:
+                  amazon holds information associating an Amazon account
+                  with the group.
+              description:
+                description: a short description of this association.
+                type: string
+              google:
+                $ref: "#/definitions/AccountAssociationsGoogle"
+                description:
+                  google holds information associating a Google project with
+                  the group.
+              name:
+                description: name of the association.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamAccountAssociations"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupAccountAssociations
+    put:
+      operationId: GroupAccountAssociations_Update
+      parameters:
+        - description: group is the group with which this account information is associated.
+          in: path
+          name: group
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              amazon:
+                $ref: "#/definitions/AccountAssociationsAmazon"
+                description:
+                  amazon holds information associating an Amazon account
+                  with the group.
+              description:
+                description: a short description of this association.
+                type: string
+              google:
+                $ref: "#/definitions/AccountAssociationsGoogle"
+                description:
+                  google holds information associating a Google project with
+                  the group.
+              name:
+                description: name of the association.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamAccountAssociations"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupAccountAssociations
+  /iam/v1/group_invites:
+    get:
+      operationId: GroupInvites_List
+      parameters:
+        - description: group is used to identify the group this record is rooted under.
+          in: query
+          name: group
+          required: false
+          type: string
+        - description: id is the exact UID of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description: key_id is the identify the verification key for this code.
+          in: query
+          name: keyId
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamGroupInviteList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupInvites
+  /iam/v1/group_invites/{group}:
+    post:
+      operationId: GroupInvites_Create
+      parameters:
+        - description: group, The Group UIDP path under which the new group Invite targets.
+          in: path
+          name: group
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              role:
+                description:
+                  role is the Role UIDP the invited identity will be role-bound
+                  to the group with.
+                type: string
+              ttl:
+                description: expiration, timestamp this invite becomes no longer valid.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamGroupInvite"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupInvites
+  /iam/v1/group_invites/{id}:
+    delete:
+      operationId: GroupInvites_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - GroupInvites
+  /iam/v1/groups:
+    get:
+      operationId: Groups_List
+      parameters:
+        - description: id is the exact UID of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description:
+            ancestors_of are groups reachable by repeated proceeding from
+            parent to child.
+          in: query
+          name: uidp.ancestorsOf
+          required: false
+          type: string
+        - description:
+            descendants_of are groups reachable by repeated proceeding from
+            child to parent.
+          in: query
+          name: uidp.descendantsOf
+          required: false
+          type: string
+        - description: name is the exact name of the record.
+          in: query
+          name: name
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamGroupList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Groups
+  /iam/v1/groups/{id}:
+    delete:
+      operationId: Groups_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Groups
+    put:
+      operationId: Groups_Update
+      parameters:
+        - description: id, The group UIDP under which this group resides.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              description:
+                description: description, human readable of group.
+                type: string
+              name:
+                description: name, human readable name of group.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamGroup"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Groups
+  /iam/v1/groups/{parent}:
+    post:
+      operationId: Groups_Create
+      parameters:
+        - description: |-
+            parent, The Group UIDP path under which the new Group resides.
+            This is effectively the iam_scope for Create requests, but because
+            we also allow users to create new "root" groups, we check the scoping
+            manually. Parent is allowed to be a prefix of a UIDP of a Group within
+            scope, or the name of a Group in scope.
+          in: path
+          name: parent
+          pattern: .+
+          required: true
+          type: string
+        - description: Group to create.
+          in: body
+          name: group
+          required: true
+          schema:
+            $ref: "#/definitions/iamGroup"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamGroup"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Groups
+  /iam/v1/identities:
+    post:
+      operationId: Identities_Create
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/eventsIdentity"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/eventsIdentity"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Identities
+  /iam/v1/policies:
+    get:
+      operationId: Policies_List
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description:
+            ancestors_of are groups reachable by repeated proceeding from
+            parent to child.
+          in: query
+          name: uidp.ancestorsOf
+          required: false
+          type: string
+        - description:
+            descendants_of are groups reachable by repeated proceeding from
+            child to parent.
+          in: query
+          name: uidp.descendantsOf
+          required: false
+          type: string
+        - description: name is the exact name of the record.
+          in: query
+          name: name
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamPolicyList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Policies
+  /iam/v1/policies/{id}:
+    delete:
+      operationId: Policies_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Policies
+    put:
+      operationId: Policies_Update
+      parameters:
+        - description: id is identifier of this specific policy.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              description:
+                description: description, human readable description of policy.
+                type: string
+              document:
+                description: document, YAML encoded policy document.
+                type: string
+              name:
+                description: name, human readable name of policy.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamPolicy"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Policies
+  /iam/v1/policies/{parentId}:
+    post:
+      operationId: Policies_Create
+      parameters:
+        - description:
+            parent_id, The Group UIDP path under which the new policy is
+            associated.
+          in: path
+          name: parentId
+          pattern: .+
+          required: true
+          type: string
+        - description: Policy is the policy to create;
+          in: body
+          name: policy
+          required: true
+          schema:
+            $ref: "#/definitions/iamPolicy"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamPolicy"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Policies
+  /iam/v1/rolebindings:
+    get:
+      operationId: RoleBindings_List
+      parameters:
+        - description: id is the exact UID of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRoleBindingList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - RoleBindings
+    post:
+      operationId: RoleBindings_Create
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/iamRoleBinding"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRoleBinding"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - RoleBindings
+  /iam/v1/rolebindings/{id}:
+    delete:
+      operationId: RoleBindings_Delete
+      parameters:
+        - description: id is the exact UID of the record.
+          in: path
+          name: id
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - RoleBindings
+    put:
+      operationId: RoleBindings_Update
+      parameters:
+        - description: id, the UID of this role binding.
+          in: path
+          name: id
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              group:
+                description: group, UIDP of the group to bind.
+                type: string
+              identity:
+                description: identity, UID of the Identity to bind.
+                type: string
+              role:
+                title: role, UIDP of the Role to bind
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRoleBinding"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - RoleBindings
+  /iam/v1/roles:
+    get:
+      operationId: Roles_List
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description: name is the exact name of the record
+          in: query
+          name: name
+          required: false
+          type: string
+        - description: parent is the exact UIDP of the parent, or / for root
+          in: query
+          name: parent
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRoleList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Roles
+  /iam/v1/roles/{id}:
+    delete:
+      operationId: Roles_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Roles
+    put:
+      operationId: Roles_Update
+      parameters:
+        - description: id, The Group path under which this Role resides.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            properties:
+              capabilities:
+                description:
+                  capabilities, human readable list of capabilities supported
+                  by the group.
+                items:
+                  type: string
+                type: array
+              description:
+                description: description, human readable description of group.
+                type: string
+              name:
+                description: name, human readable name of group.
+                type: string
+            type: object
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRole"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Roles
+  /iam/v1/roles/{parentId}:
+    post:
+      operationId: Roles_Create
+      parameters:
+        - description: parent_id, The Group UIDP path under which the new Role resides.
+          in: path
+          name: parentId
+          pattern: .+
+          required: true
+          type: string
+        - description: Role to create.
+          in: body
+          name: role
+          required: true
+          schema:
+            $ref: "#/definitions/iamRole"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/iamRole"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Roles
+  /sts/exchange:
+    post:
+      operationId: SecurityTokenService_Exchange
+      parameters:
+        - collectionFormat: multi
+          in: query
+          items:
+            type: string
+          name: aud
+          required: false
+          type: array
+        - in: query
+          name: scope
+          required: false
+          type: string
+        - in: query
+          name: cluster
+          required: false
+          type: string
+        - in: query
+          name: identity
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/oidcRawToken"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - SecurityTokenService
+  /events/v1/subscriptions:
+    get:
+      operationId: Subscriptions_List
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: query
+          name: id
+          required: false
+          type: string
+        - description:
+            ancestors_of are groups reachable by repeated proceeding from
+            parent to child.
+          in: query
+          name: uidp.ancestorsOf
+          required: false
+          type: string
+        - description:
+            descendants_of are groups reachable by repeated proceeding from
+            child to parent.
+          in: query
+          name: uidp.descendantsOf
+          required: false
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/eventsSubscriptionList"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Subscriptions
+  /events/v1/subscriptions/{id}:
+    delete:
+      operationId: Subscriptions_Delete
+      parameters:
+        - description: id is the exact UIDP of the record.
+          in: path
+          name: id
+          pattern: .+
+          required: true
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            properties: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Subscriptions
+  /events/v1/subscriptions/{parentId}:
+    post:
+      operationId: Subscriptions_Create
+      parameters:
+        - description:
+            parent_id, The Group UIDP path under which the new subscription
+            is associated.
+          in: path
+          name: parentId
+          pattern: .+
+          required: true
+          type: string
+        - description: Subscription is the subscription to create;
+          in: body
+          name: subscription
+          required: true
+          schema:
+            $ref: "#/definitions/eventsSubscription"
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/eventsSubscription"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - Subscriptions
+
+produces:
+  - application/json
+swagger: "2.0"


### PR DESCRIPTION
## Type of change
Docs

### What should this PR do?
This PR adds docs for `chainctl` and includes a shortcode plus `api.yaml` for the Enforce OpenAPI specification.

### Why are we making this change?
This addresses the requirement for docs in `mono` over in https://github.com/chainguard-dev/mono/issues/2858 

### What are the acceptance criteria? 
`chainctl` docs should be available in `/chainguard/chainguard-enforce/chainctl-docs/`
Enforce docs should be available in `/chainguard/chainguard-enforce/chainguard-enforce-api/`

### How should this PR be tested?
Check the above URLs on Netlify, or locally.

## Notes
These files are not completely automatically generated yet, but will eventually get created via Github Action. The Enforce `api.yaml` file needed some manual edits because the tool to generate it got a few things wrong. 