### PR TITLE
Updated iframe URL for rumble and added option to shortcode

### DIFF
--- a/layouts/shortcodes/rumble.html
+++ b/layouts/shortcodes/rumble.html
@@ -1,8 +1,7 @@
 {{ if isset .Params "title"}}<h3>{{ .Get "title"}}</h3>{{ end }}
 {{ if isset .Params "description"}}<p>{{ .Get "description"}}</p>{{ end }}
-
 <iframe scrolling="no"
         style="width:100%; min-height:400px; border: none; overflow: hidden"
-        src="https://visualization-ui.chainguard.app/?left={{ .Get "left" }}&right={{ .Get "right"}}">
+        src="https://visualization-ui.chainguard.app/{{ if isset .Params "type" }}{{ .Get "type" }}{{ else }}bar{{ end }}?left={{ .Get "left" }}&right={{ .Get "right"}}">
 
 </iframe>


### PR DESCRIPTION
This PR fixes the URL for rumble graphs and adds a new parameter to the `rumble` shortcode.


Now you can specify which type of graph you want (for now either `bar` or `line`). Default is set to `bar` at least for now.

Preview: https://deploy-preview-117--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/images-compared/

### Example usage (bar)

```markdown
{{< rumble title="Nginx" description="Comparing the latest official Nginx image with distroless.dev/nginx" left="nginx:latest" right="distroless.dev/nginx:latest" >}}
```

### Example usage (line)

```markdown
{{< rumble type="line" title="Nginx" description="Comparing the latest official Nginx image with distroless.dev/nginx" left="nginx:latest" right="distroless.dev/nginx:latest" >}}
```