### PR TITLE
docs: switch distroless image references to chainguard registry

### DIFF
--- a/content/chainguard/chainguard-images/images-compared.md
+++ b/content/chainguard/chainguard-images/images-compared.md
@@ -15,6 +15,6 @@ toc: true
 
 On this page you can find comparison graphs showing the number of CVEs (common vulnerabilities and exposures) detected by [Trivy](https://github.com/aquasecurity/trivy) on popular official base images versus Chainguard Images.
 
-{{< rumble title="Nginx" description="Comparing the latest official Nginx image with distroless.dev/nginx" left="nginx:latest" right="distroless.dev/nginx:latest" >}}
+{{< rumble title="Nginx" description="Comparing the latest official Nginx image with cgr.dev/chainguard/nginx" left="nginx:latest" right="cgr.dev/chainguard/nginx:latest" >}}
 
-{{< rumble title="PHP" description="Comparing the latest official PHP image with distroless.dev/php" left="php:latest" right="distroless.dev/php:latest" >}}
+{{< rumble title="PHP" description="Comparing the latest official PHP image with cgr.dev/chainguard/php" left="php:latest" right="cgr.dev/chainguard/php:latest" >}}

--- a/content/open-source/apko/getting-started-with-apko.md
+++ b/content/open-source/apko/getting-started-with-apko.md
@@ -37,7 +37,7 @@ The instructions in this document were validated on an Ubuntu 22.04 workstation 
 Start by pulling the official apko image into your local system:
 
 ```shell
-docker pull distroless.dev/apko
+docker pull cgr.dev/chainguard/apko
 ```
 
 This will download the latest version of the distroless apko image, which is rebuilt every night for extra freshness.
@@ -45,7 +45,7 @@ This will download the latest version of the distroless apko image, which is reb
 Check that you're able to run apko with:
 
 ```shell
-docker run --rm distroless.dev/apko version
+docker run --rm cgr.dev/chainguard/apko version
 ```
 
 You should get output similar to this:
@@ -113,10 +113,10 @@ Save and close the file after you're done including these contents. With `nano`,
 The only thing left to do now is run apko to build this image. The following build command will:
 
 - set up a volume share in the current directory, synchronizing its contents with apko's image workdir; this way, the generated artifacts will be available on your host system.
-- execute the `distroless.dev/apko` image with the `build` command, tagging the image as `alpine-base:test` and saving the build as `alpine-test.rar`.
+- execute the `cgr.dev/chainguard/apko` image with the `build` command, tagging the image as `alpine-base:test` and saving the build as `alpine-test.rar`.
 
 ```shell
-docker run --rm -v ${PWD}:/work distroless.dev/apko build /work/alpine-base.yaml alpine-base:test /work/alpine-test.tar
+docker run --rm -v ${PWD}:/work cgr.dev/chainguard/apko build /work/alpine-base.yaml alpine-base:test /work/alpine-test.tar
 ```
 
 You should get output similar to this:

--- a/content/open-source/apko/troubleshooting.md
+++ b/content/open-source/apko/troubleshooting.md
@@ -20,7 +20,7 @@ toc: true
 To include debug-level information on apko builds, add `--debug` to your build command:
 
 ```shell
-docker run --rm -v ${PWD}:/work distroless.dev/apko build --debug \
+docker run --rm -v ${PWD}:/work cgr.dev/chainguard/apko build --debug \
   apko.yaml hello-minicli:test hello-minicli.tar \
   -k melange.rsa.pub
 ```

--- a/content/open-source/melange/getting-started-with-melange.md
+++ b/content/open-source/melange/getting-started-with-melange.md
@@ -49,7 +49,7 @@ You should now be able to build apks for all architectures that melange supports
 The fastest way to get melange up and running on your system is by using the [official melange image](https://github.com/distroless/melange) with Docker. Start by pulling the official melange image into your local system:
 
 ```shell
-docker pull distroless.dev/melange:latest
+docker pull cgr.dev/chainguard/melange:latest
 ```
 
 This will download the latest version of the distroless melange image, which is rebuilt every night for extra freshness.
@@ -57,7 +57,7 @@ This will download the latest version of the distroless melange image, which is 
 Check that you're able to run melange with `docker run`.
 
 ```shell
-docker run --rm distroless.dev/melange version
+docker run --rm cgr.dev/chainguard/melange version
 ```
 
 You should get output similar to the following:
@@ -272,7 +272,7 @@ First make sure you're at the `~/hello-minicli` directory.
 To get started, create a temporary keypair to sign your melange packages:
 
 ```shell
-docker run --rm -v "${PWD}":/work distroless.dev/melange keygen
+docker run --rm -v "${PWD}":/work cgr.dev/chainguard/melange keygen
 ```
 This will generate a `melange.rsa` and `melange.rsa.pub` files in the current directory.
 
@@ -286,7 +286,7 @@ Next, build the apk defined in the `melange.yaml` file with the following comman
 
 ```shell
 docker run --privileged --rm -v "${PWD}":/work \
-  distroless.dev/melange build melange.yaml \
+  cgr.dev/chainguard/melange build melange.yaml \
   --arch x86,amd64,aarch64,armv7 \
   --signing-key melange.rsa
 ```
@@ -357,7 +357,7 @@ Save and close the file when you're done. You are now ready to build your contai
 The following command will set up a volume sharing your current folder with the location `/work` in the apko container, running the `apko build` command to generate an image based on your `apko.yaml` definition file.
 
 ```shell
-docker run --rm -v ${PWD}:/work distroless.dev/apko \
+docker run --rm -v ${PWD}:/work cgr.dev/chainguard/apko \
   build apko.yaml hello-minicli:test hello-minicli.tar \
   -k melange.rsa.pub
 ```


### PR DESCRIPTION
Signed-off-by: James Rawlings <jrawlings@chainguard.dev>

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
renames distroless image references to chainguards container registry 

### Why are we making this change?
distroless images have moved to cgr.dev, this PR updates the references

### What are the acceptance criteria? 

### How should this PR be tested?

Could verify new image references used in the PR exist..
```
docker pull cgr.dev/chainguard/nginx:latest
docker pull cgr.dev/chainguard/php:latest
docker pull cgr.dev/chainguard/apko:latest
docker pull cgr.dev/chainguard/melange:latest
```