### PR TITLE
Fix #122: hide h2 elements on chainctl pages

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -47,3 +47,7 @@ blockquote > p {
 .chainguard-med {
   color: #8087fc;
 }
+
+h2#chainctl, h2[id^="chainctl"] {
+  display: none;
+}


### PR DESCRIPTION
## Type of change
Enhancement

### What should this PR do?
This PR hides any `h2` with an `id` matching `chainctl` using a CSS selector.

### Why are we making this change?
Fixes #122 - the header repetition is redundant and clutters up the page.

### What are the acceptance criteria? 
Any page under https://edu.chainguard.dev/chainguard/chainguard-enforce/chainctl-docs/ should only have an `h1` matching the command name.