### PR TITLE
Removing robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-
-Disallow: /


### PR DESCRIPTION
Removing old `robots.txt` that disallowed indexing on the main site.