### PR TITLE
Add download commands for mac and linux

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -59,6 +59,23 @@ Here, we are using the bucket our Chainguard Enforce tool is hosted in, and call
 
 We’ll use the `curl` command to pull the application down.
 
+* **Darwin ARM 64**
+  ```sh
+  curl "${BASE_URL}/chainctl_Darwin_arm64" --output ./chainctl
+  ```
+* **Darwin Intel 64**
+    ```sh
+    curl "${BASE_URL}/chainctl_Darwin_x86_64" --output ./chainctl
+    ```
+* **Linux ARM 64**
+    ```sh
+    curl "${BASE_URL}/chainctl_Linux_arm64" --output ./chainctl
+    ```
+* **Linux Intel 64**
+    ```sh
+    curl "${BASE_URL}/chainctl_Linux_x86_64" --output ./chainctl
+    ```
+
 Move `chainctl` into your `/usr/local/bin` directory.
 
 ```sh


### PR DESCRIPTION
## Type of change
docs

### What should this PR do?
Adds chainctl binary retrieval commands to the guide

### Why are we making this change?
Missing information

### What are the acceptance criteria? 
Readers can download the chainctl binary from commands specified in the guide.

### How should this PR be tested?
Use the commands added to retrieve the chainctl binary for each platform type

![image](https://user-images.githubusercontent.com/2406847/191945760-b84561cc-f874-40c0-b4b0-e46613a3af60.png)
