### PR TITLE
Remove breadcrumbs on page

### DIFF
--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -15,15 +15,6 @@
     {{ else -}}
     <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
       {{ end -}}
-      {{ if .Site.Params.options.breadCrumb -}}
-      <!-- https://discourse.gohugo.io/t/breadcrumb-navigation-for-highly-nested-content/27359/6 -->
-      <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
-          {{ partial "main/breadcrumb" . -}}
-          <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
-        </ol>
-      </nav>
-      {{ end }}
       <h1>{{ .Title }}</h1>
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
       <p class="contributors">


### PR DESCRIPTION
It looks like there is a sitemap issue because we still had breadcrumbs appearing on the HTML page despite removing it from the config file. I removed it now to support analytics. 

Signed-off-by: Lisa Tagliaferri 