### PR TITLE
update download links to use dl.enforce.dev

### DIFF
--- a/content/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl.md
@@ -24,19 +24,10 @@ Before we begin, let’s move into a temporary directory that we can work in. Be
 mkdir ~/tmp && cd $_
 ```
 
-To install `chainctl`, create variables that simplify the commands and export them to be used by child processes.
+To install `chainctl`, we’ll use the `curl` command to pull the application down.
 
 ```sh
-export BUCKET="us.artifacts.prod-enforce-fabc.appspot.com"
-export BASE_URL="https://storage.googleapis.com/${BUCKET}"
-```
-
-Here, we are using the bucket our Chainguard Enforce tool is hosted in, and calling that bucket within the base URL of our application hosted by Google.
-
-We’ll use the `curl` command to pull the application down.
-
-```sh
-curl -o chainctl "$BASE_URL/chainctl_$(uname -s)_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl_$(uname -s)_$(uname -m)"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory.

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -48,19 +48,10 @@ Before we begin, let’s move into a directory that we can work in. For our exam
 mkdir ~/enforce-demo && cd $_
 ```
 
-To install `chainctl`, let’s create variables that simplify our commands and export them to be used by child processes.
+To install `chainctl`, we’ll use the `curl` command to pull the application down.
 
 ```sh
-export BUCKET="us.artifacts.prod-enforce-fabc.appspot.com"
-export BASE_URL="https://storage.googleapis.com/${BUCKET}"
-```
-
-Here, we are using the bucket our Chainguard Enforce tool is hosted in, and calling that bucket within the base URL of our application hosted by Google.
-
-We’ll use the `curl` command to pull the application down.
-
-```sh
-curl -o chainctl "$BASE_URL/chainctl_$(uname -s)_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl_$(uname -s)_$(uname -m)"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory.

--- a/content/ui/enforce-onboarding-quickstart.md
+++ b/content/ui/enforce-onboarding-quickstart.md
@@ -20,17 +20,10 @@ Create a new directory called `enforce-demo`.
 mkdir ~/enforce-demo && cd $_
 ```
 
-To simplify later commands, create the following variables and export them to be used by child processes.
+To install `chainctl`, we’ll use the `curl` command to pull the application down.
 
 ```sh
-export BUCKET="us.artifacts.prod-enforce-fabc.appspot.com"
-export BASE_URL="https://storage.googleapis.com/${BUCKET}"
-```
-
-Then use `curl` to pull the application down.
-
-```sh
-curl -o chainctl "$BASE_URL/chainctl_$(uname -s)_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl_$(uname -s)_$(uname -m)"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory.


### PR DESCRIPTION
## Type of change

Purely cosmetic. 💄 

### What should this PR do?

Updates the `chainctl` download URL to a prettier one at https://dl.enforce.dev

### Why are we making this change?

It makes a slightly more polished experience.

If we decide to change the storage backend in the future we can do it without changing this user-visible URL.

### What are the acceptance criteria? 

The installation instructions continue to work.

### How should this PR be tested?

```
curl -o chainctl "https://dl.enforce.dev/chainctl_$(uname -s)_$(uname -m)"
```