### PR TITLE
Add terminal back to melange getting started guide

### DIFF
--- a/content/open-source/melange/getting-started-with-melange.md
+++ b/content/open-source/melange/getting-started-with-melange.md
@@ -13,6 +13,7 @@ menu:
     parent: "melange"
 weight: 100
 toc: true
+terminalImage: gcloud:latest
 ---
 
 [melange](https://github.com/chainguard-dev/melange) is an [apk](https://wiki.alpinelinux.org/wiki/Package_management) builder tool that uses declarative pipelines to create apk packages. From a single YAML file, users are able to generate multi-architecture apks that can be injected directly into [apko](https://github.com/chainguard-dev/apko) builds, which renders apko and melange a [powerful combination for any container image factory](https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/).


### PR DESCRIPTION
## Type of change
Bug/Documentation

### What should this PR do?
This PR adds the interactive terminal back to the Getting Started with Melange tutorial.

### Why are we making this change?
With the 0.2.2 release of [minicli/curly](https://github.com/minicli/curly/releases/tag/0.2.2) the `hello-minicli:test` image at the end of the tutorial now runs as expected. 

### How should this PR be tested?
Test the tutorial and look for output like the following:

```
docker run --rm hello-minicli:test


Work is never as important as you think it is.
```