### PR TITLE
fix: remove warning when applying policy

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-policy-examples.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-policy-examples.md
@@ -33,6 +33,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
 ```
 
 An example using Docker Hub images:

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -170,6 +170,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
 EOF
 ```
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
@@ -71,6 +71,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
     source:
     - oci: "registry.example.com"
       signaturePullSecrets:
@@ -100,6 +103,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
     source:
     - oci: "index.docker.io/privatenamespace/$image"
       signaturePullSecrets:
@@ -156,6 +162,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
 ```
 
 Be sure to replace `$your-gcp-project` with your relevant project name. 
@@ -189,6 +198,9 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+        - issuer: "*"
+          subject: "*"
 ```
 
 Be sure to replace the variable next to glob with your relevant account


### PR DESCRIPTION
## Type of change
Fix to sample policies to prevent warning being shown

### What should this PR do?
This removes a warning shown when applying a policy. Without a set identify the following is returned via `chainctl policies apply...`

**- WARNING: missing field(s): spec.authorities[0].keyless.identities**

### Why are we making this change?
This warning is coming from an upstream update in Sigstore and could confuse someone going through Enforce within the academy

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
I've completed the academy walkthrough with the branch locally, I can complete the workshop material, and no warning is shown during the process.