### PR TITLE
Fix typo on tutorial that should be consistent using docker-username

### DIFF
--- a/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
@@ -119,7 +119,7 @@ If you receive an error message or a “failed” message, check that your user 
 You should get guidance in the output that your build was successful when you receive no errors.
 
 ```
-=> => naming to docker.io/library/hello-container    
+=> => naming to docker.io/docker-username/hello-container    
 ```
 
 At this point your container is built and you can verify that the container is working as expected by running the container. 


### PR DESCRIPTION
## Type of change
I was going through the [How to Sign a Container with Cosign tutorial](https://edu.chainguard.dev/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign/). Along the tutorial it was mentioned that the image tag used is `docker-username/hello-container` but the output expected was written `library` instead. 
![image](https://user-images.githubusercontent.com/7043511/200180652-bba1701e-163c-4fbb-89e8-da2fba6ea005.png)

### What should this PR do?
Issue is not created since it is a minor change.

### Why are we making this change?
The tutorial mentioned that the image tag is `docker-username/hello-container` and the output got changed to `naming to docker.io/library/hello-container` which is `library` instead. 

### What are the acceptance criteria? 
Consistent naming of the image tag across the tutorial post. 

### How should this PR be tested?
Checking directly on Netlify deploy preview.