### PR TITLE
Update frame-src CSP to allow terminal.inky.wtf

### DIFF
--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -1,7 +1,7 @@
 <meta http-equiv="Content-Security-Policy"
       content="
        default-src 'self';
-       frame-src 'self' edu.chainguard.dev https://player.vimeo.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://syndication.twitter.com https://visualization-ui.chainguard.app;
+       frame-src 'self' edu.chainguard.dev https://player.vimeo.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://syndication.twitter.com https://visualization-ui.chainguard.app https://terminal.inky.wtf;
        style-src 'self' edu.chainguard.dev 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com;
        form-action 'self';
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net;


### PR DESCRIPTION
This PR adds `https://terminal.inky.wtf` to the `frame-src` portion of the Content Security Policy.