### PR TITLE
Add unpkg.com to style-src and script-src CSPs

### DIFF
--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -2,10 +2,10 @@
       content="
        default-src 'self';
        frame-src 'self' edu.chainguard.dev https://player.vimeo.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://syndication.twitter.com https://visualization-ui.chainguard.app https://terminal.inky.wtf;
-       style-src 'self' edu.chainguard.dev 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com;
+       style-src 'self' edu.chainguard.dev 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://unpkg.com;
        form-action 'self';
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net;
-       script-src 'self' edu.chainguard.dev *.googleapis.com cdn.jsdelivr.net *.googletagmanager.com 'sha256-vOgyKS2vkH4n5TxBJpeh9SgzrE6LVGsAeOAvEST6oCc=';
+       script-src 'self' edu.chainguard.dev *.googleapis.com cdn.jsdelivr.net *.googletagmanager.com 'sha256-vOgyKS2vkH4n5TxBJpeh9SgzrE6LVGsAeOAvEST6oCc=' 'sha256-R2OmoLN/NlJovrWBYuTwjPfAD+YHvBVdudGDjY2VLmI=' https://unpkg.com;
        connect-src 'self' edu.google-analytics.com;
        img-src 'self' edu.chainguard.dev data:;
        base-uri 'self';


### PR DESCRIPTION
The [OpenAPI page](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/api/) doesn't load because it calls JS/CSS from unpkg.com. This PR adds them, along with what I think is the SHA hash of the generated inline javascript for the page.

