### PR TITLE
Oci note

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
@@ -4,7 +4,7 @@ type: "article"
 lead: ""
 description: "How to connect Chainguard Enforce to a private container registry"
 date: 2022-09-02T15:56:52-07:00
-lastmod: 2022-09-02T15:56:52-07:00
+lastmod: 2022-11-18T15:56:52-07:00
 draft: false
 images: []
 menu:

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
@@ -29,7 +29,10 @@ To support the widest set of private registries, you can authenticate using a Ku
 
 ### Configuring your image pull secret
 
-To verify policies using attestation and signatures for images in a private registry, create an image pull secret in the `cosign-system` namespace of your cluster, filling in your own details for the private registry, username, password, and email:
+To verify policies using attestation and signatures for images in a private registry, create an image pull secret in the `cosign-system` namespace of your cluster. The following example creates a secret named `regcreds`, but you could provide a different name if you like. Additionally, the `docker-registry` subcommand creates a secret that is specifically for use with a Docker registry.
+
+In the next lines, fill in your own details for the private registry, username, password, and email, substituting those values for the variables.
+
 
 ```sh
 kubectl create secret docker-registry regcreds \
@@ -68,7 +71,8 @@ spec:
       - name: regcreds
 ```
 
-In this example, add the name of your private registry directory in `glob` and include the name of the private registry in `oci`. Note that the value you pass to the `oci` key cannot be a glob pattern and must be a valid repository name. Also, be aware that you will have set up `regcreds` in the previous `kubectl create secret` command. 
+In this example, add the name of your private registry directory in `glob` and include the name of the private registry in `oci`. Note that the value you pass to the `oci` key cannot be a glob pattern and must be a valid repository name. Also, be aware that you will have set up `regcreds` in the previous `kubectl create secret` command; be sure to change this value if you gave your secret a different name.
+
 
 ### Scoping image pull secret credentials to a registry namespace
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
@@ -21,21 +21,15 @@ Chainguard Enforce supports two methods of authenticating to private registries:
 - Using image pull secrets in your tenant clusters
 - Using cloud account associations to the cloud provider running your registry
 
-Depending on your organization’s setup, you may leverage one or both of the
-supported authentication strategies.
+Depending on your organization’s setup, you may leverage one or both of the supported authentication strategies.
 
 ## Image Pull Secrets
 
-To support the widest set of private registries, you can authenticate using a
-Kubernetes image pull secret. This is configured on a per-policy basis, and
-applies to all the images scoped to that policy. 
+To support the widest set of private registries, you can authenticate using a Kubernetes image pull secret. This is configured on a per-policy basis, and applies to all the images scoped to that policy. 
 
 ### Configuring your image pull secret
 
-To verify policies using attestation and signatures for images in a private
-registry, create an image pull secret in the `cosign-system` namespace of your
-cluster, filling in your own details for the private registry, username,
-password, and email:
+To verify policies using attestation and signatures for images in a private registry, create an image pull secret in the `cosign-system` namespace of your cluster, filling in your own details for the private registry, username, password, and email:
 
 ```sh
 kubectl create secret docker-registry regcreds \
@@ -46,19 +40,13 @@ kubectl create secret docker-registry regcreds \
     --docker-email=$email
 ```
 
-> **Note**: It is important to ensure the secret is created in the `cosign-system`
-> namespace, as this ensures the Chainguard Enforce agent can use this secret
-> to authenticate images from all namespaces in the cluster.
+> **Note**: It is important to ensure the secret is created in the `cosign-system` namespace, as this ensures the Chainguard Enforce agent can use this secret to authenticate images from all namespaces in the cluster.
 
-The same image pull secret must be added to the `cosign-system` namespace of
-every cluster that you’d like to enforce policies in.
+The same image pull secret must be added to the `cosign-system` namespace of every cluster that you’d like to enforce policies in.
 
 ### Using your image pull secret in a policy
 
-Once you’ve created your image pull secret, you can reference it in a cluster
-image policy using the authority’s source specification. This example requires
-all containers from a private registry with hostname `registry.example.com` to be
-signed by the public Fulcio instance:
+Once you’ve created your image pull secret, you can reference it in a cluster image policy using the authority’s source specification. This example requires all containers from a private registry with hostname `registry.example.com` to be signed by the public Fulcio instance:
 
 ```yaml
 apiVersion: policy.sigstore.dev/v1alpha1
@@ -80,17 +68,11 @@ spec:
       - name: regcreds
 ```
 
-In this example, add the name of your private registry directory in `glob` and
-include the name of the private registry in `oci`. You will have set up
-`regcreds` in the previous `kubectl create secret` command. 
+In this example, add the name of your private registry directory in `glob` and include the name of the private registry in `oci`. Note that the value you pass to the `oci` key cannot be a glob pattern and must be a valid repository name. Also, be aware that you will have set up `regcreds` in the previous `kubectl create secret` command. 
 
 ### Scoping image pull secret credentials to a registry namespace
 
-Some registries, like Docker Hub, can issue credentials that are scoped to a
-particular private namespace in the registry. To use these namespace scoped
-credentials in a cluster image policy, modify the authority’s source
-specification to include the namespace. This example uses credentials scoped to
-the Docker hub namespace `"privatenamespace"`:
+Some registries, like Docker Hub, can issue credentials that are scoped to a particular private namespace in the registry. To use these namespace scoped credentials in a cluster image policy, modify the authority’s source specification to include the namespace. This example uses credentials scoped to the Docker hub namespace `"privatenamespace"`:
 
 ```yaml
 apiVersion: policy.sigstore.dev/v1alpha1
@@ -112,31 +94,21 @@ spec:
       - name: regcreds
 ```
 
-Replace the variables pointing to your private Docker namespace next to `glob`
-and `oci`. 
+Replace the variables pointing to your private Docker namespace next to `glob` and `oci`. 
 
-> **Note**: For legacy Docker Hub reasons that have propagated to how container
-> runtimes identify images, `privatenamespace/*` is equivalent to
-> `index.docker.io/privatenamespace/*` — both will work!
+> **Note**: For legacy Docker Hub reasons that have propagated to how container runtimes identify images, `privatenamespace/*` is equivalent to `index.docker.io/privatenamespace/*` — both will work!
 
 ## Cloud account associations
 
-If your private registry is either AWS’s Elastic Container Registry (ECR) or
-Google Cloud’s Google Container Registry (GCR), you can leverage Enforce for
-Kubernetes’ cloud account association feature to allow Enforce to authenticate
-to your registry. While support is limited to ECR and GCR, cloud account
-associations remove the need to maintain image pull secrets in all clusters and
-no long term access credentials are stored by our platform.
+If your private registry is either AWS’s Elastic Container Registry (ECR) or Google Cloud’s Google Container Registry (GCR), you can leverage Enforce for Kubernetes’ cloud account association feature to allow Enforce to authenticate to your registry. While support is limited to ECR and GCR, cloud account associations remove the need to maintain image pull secrets in all clusters and no long term access credentials are stored by our platform.
 
 ### Configuring your cloud account association
 
-Detailed instructions can be found in
-our dedicated article on [How to Set Up Chainguard Enforce Cloud Account Associations](../cloud-account-associations). Once you have a cloud account association configured at a specified group level, policies at or below that group can be verified against private registries in the associated cloud account. 
+Detailed instructions can be found in our dedicated article on [How to Set Up Chainguard Enforce Cloud Account Associations](../cloud-account-associations). Once you have a cloud account association configured at a specified group level, policies at or below that group can be verified against private registries in the associated cloud account. 
 
 ### Using Google Container Registry images in policies
 
-In GCP, you can verify that an account association is correctly configured by
-running:
+In GCP, you can verify that an account association is correctly configured by running:
 
 ```
 chainctl iam groups check-gcp $group_name
@@ -148,8 +120,7 @@ If successful, you will receive a message similar to the following:
 2022/09/01 11:26:47 GCP role impersonation was successful!
 ```
 
-You can now write policies under `$group_name` that refer to images in your
-associated GCP project:
+You can now write policies under `$group_name` that refer to images in your associated GCP project:
 
 ```yaml
 apiVersion: policy.sigstore.dev/v1alpha1
@@ -171,8 +142,7 @@ Be sure to replace `$your-gcp-project` with your relevant project name.
 
 ### Using AWS Elastic Container Registry Images in Policies
 
-In AWS, you can verify that an account association is correctly configured by
-running the following.
+In AWS, you can verify that an account association is correctly configured by running the following.
 
 ```sh
 chainctl iam groups check-aws $group_name
@@ -184,8 +154,7 @@ If successful, you will receive a message back that’s similar to this output:
 2022/09/01 11:26:47 AWS role impersonation was successful!
 ```
 
-You can now write policies under `$group_name` that refer to images in your
-associated AWS Account:
+You can now write policies under `$group_name` that refer to images in your associated AWS Account:
 
 ```yaml
 apiVersion: policy.sigstore.dev/v1alpha1
@@ -203,5 +172,4 @@ spec:
           subject: "*"
 ```
 
-Be sure to replace the variable next to glob with your relevant account
-information, within the double quotes.
+Be sure to replace the variable next to glob with your relevant account information, within the double quotes.


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This is a minor update to [How to Connect Chainguard Enforce to Private Container Registries](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries/). The goal is to add a clarifying point about what values are accepted by the `oci` key in CIPs.

Also, note that when I cloned the repo this doc had a lot of unnecessary line breaks throughout. I also removed those to ensure that it renders properly. 

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
This PR fulfills the request for documentation within [this issue](https://github.com/chainguard-dev/customer-issues/issues/68) (now closed)

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->