### PR TITLE
Add try_files directive to nginx.conf to fix invalid redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,3 @@
-
 worker_processes 2;
 
 events {
@@ -17,8 +16,9 @@ http {
         server_name  localhost;
 
         location / {
-            root   html;
-            index  index.html index.htm;
+            root   /var/lib/nginx/html/;
+	    index  index.html index.htm;
+            try_files $uri $uri/index.html =404;
         }
 
         # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
This PR adds a `try_files...` directive to `nginx.conf`.

Without it, nginx redirects pages without a trailing slash to invalid URLs.