### PR TITLE
Auto-generated melange pipeline docs, reorganizing docs structure

### DIFF
--- a/content/open-source/melange/melange-pipelines/_index.md
+++ b/content/open-source/melange/melange-pipelines/_index.md
@@ -1,0 +1,12 @@
+---
+title: "melange Pipelines"
+description: "Built-in melange pipelines reference"
+lead: "The declarative APK builder"
+type: "article"
+date: 2022-11-28T08:49:15+00:00
+lastmod: 2022-11-28T08:49:15+00:00
+draft: false
+images: []
+---
+
+melange has several built-in pipelines to facilitate repeating common tasks.

--- a/content/open-source/melange/melange-pipelines/autoconf/configure.md
+++ b/content/open-source/melange/melange-pipelines/autoconf/configure.md
@@ -1,0 +1,37 @@
+---
+title: "autoconf/configure"
+type: "article"
+description: "Reference docs for the autoconf/configure melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Run the autoconf configure script
+
+### Dependencies
+None
+
+### Reference
+| Input | Description                                                          |
+|-------|----------------------------------------------------------------------|
+| `dir` | The directory containing the configure script. Default is set to `.` |
+
+
+### Example
+```yaml
+- uses: autoconf/configure
+  with:
+    opts: |
+      PYTHON=/usr/bin/python3 \
+      --with-lzma \
+      --with-zlib
+
+```

--- a/content/open-source/melange/melange-pipelines/autoconf/make-install.md
+++ b/content/open-source/melange/melange-pipelines/autoconf/make-install.md
@@ -1,0 +1,33 @@
+---
+title: "autoconf/make-install"
+type: "article"
+description: "Reference docs for the autoconf/make-install melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Run autoconf make install
+
+### Dependencies
+- make
+
+
+### Reference
+| Input | Description                                                  |
+|-------|--------------------------------------------------------------|
+| `dir` | The directory containing the Makefile. Default is set to `.` |
+
+
+### Example
+```yaml
+- uses: autoconf/make-install
+
+```

--- a/content/open-source/melange/melange-pipelines/autoconf/make.md
+++ b/content/open-source/melange/melange-pipelines/autoconf/make.md
@@ -1,0 +1,34 @@
+---
+title: "autoconf/make"
+type: "article"
+description: "Reference docs for the autoconf/make melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Run autoconf make
+
+### Dependencies
+- make
+
+
+### Reference
+| Input  | Description                                                  |
+|--------|--------------------------------------------------------------|
+| `dir`  | The directory containing the Makefile. Default is set to `.` |
+| `opts` | Options to pass to the make command. Default is set to ``    |
+
+
+### Example
+```yaml
+- uses: autoconf/make
+
+```

--- a/content/open-source/melange/melange-pipelines/cmake/build.md
+++ b/content/open-source/melange/melange-pipelines/cmake/build.md
@@ -1,0 +1,34 @@
+---
+title: "cmake/build"
+type: "article"
+description: "Reference docs for the cmake/build melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Build a CMake project
+
+### Dependencies
+- cmake
+- ninja
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the CMake build. Default is set to `output` |
+
+
+### Example
+```yaml
+uses: cmake/build
+
+```

--- a/content/open-source/melange/melange-pipelines/cmake/configure.md
+++ b/content/open-source/melange/melange-pipelines/cmake/configure.md
@@ -1,0 +1,35 @@
+---
+title: "cmake/configure"
+type: "article"
+description: "Reference docs for the cmake/configure melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Configure a CMake project
+
+### Dependencies
+- cmake
+- ninja
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the CMake build. Default is set to `output` |
+| `opts`       | Compile options for the CMake build.                                 |
+
+
+### Example
+```yaml
+uses: cmake/configure
+
+```

--- a/content/open-source/melange/melange-pipelines/cmake/install.md
+++ b/content/open-source/melange/melange-pipelines/cmake/install.md
@@ -1,0 +1,34 @@
+---
+title: "cmake/install"
+type: "article"
+description: "Reference docs for the cmake/install melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Build a CMake project
+
+### Dependencies
+- cmake
+- ninja
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the CMake build. Default is set to `output` |
+
+
+### Example
+```yaml
+uses: cmake/install
+
+```

--- a/content/open-source/melange/melange-pipelines/fetch.md
+++ b/content/open-source/melange/melange-pipelines/fetch.md
@@ -1,0 +1,41 @@
+---
+title: "fetch"
+type: "article"
+description: "Reference docs for the fetch melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Fetch and extract external object into workspace
+
+### Dependencies
+- wget
+
+
+### Reference
+| Input              | Description                                                                              |
+|--------------------|------------------------------------------------------------------------------------------|
+| `strip-components` | The number of path components to strip while extracting. Default is set to `1`           |
+| `extract`          | Whether to extract the downloaded artifact as a source tarball. Default is set to `true` |
+| `expected-sha256`  | The expected SHA256 of the downloaded artifact.                                          |
+| `expected-sha512`  | The expected SHA512 of the downloaded artifact.                                          |
+| `uri`*             | The URI to fetch as an artifact.                                                         |
+
+
+### Example
+```yaml
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
+      expected-sha256: 3660e8408321149f5d382bb8eeb9ea7b12ea8dd7ea66069da33f6f7383750ab2
+
+```

--- a/content/open-source/melange/melange-pipelines/git-checkout.md
+++ b/content/open-source/melange/melange-pipelines/git-checkout.md
@@ -1,0 +1,39 @@
+---
+title: "git-checkout"
+type: "article"
+description: "Reference docs for the git-checkout melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Check out sources from git
+
+### Dependencies
+- git
+
+
+### Reference
+| Input         | Description                                                 |
+|---------------|-------------------------------------------------------------|
+| `repository`* | The repository to check out sources from.                   |
+| `destination` | The path to check out the sources to. Default is set to `.` |
+| `depth`       | The depth to use when cloning. Default is set to `50`       |
+| `branch`      | The branch to check out, otherwise HEAD is checked out.     |
+
+
+### Example
+```yaml
+- uses: git-checkout
+  with:
+    repository: https://github.com/envoyproxy/envoy
+    branch: v${{package.version}}
+    destination: envoy
+```

--- a/content/open-source/melange/melange-pipelines/meson/compile.md
+++ b/content/open-source/melange/melange-pipelines/meson/compile.md
@@ -1,0 +1,33 @@
+---
+title: "meson/compile"
+type: "article"
+description: "Reference docs for the meson/compile melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Compile project with meson
+
+### Dependencies
+- meson
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the Meson build. Default is set to `output` |
+
+
+### Example
+```yaml
+uses: meson/compile
+
+```

--- a/content/open-source/melange/melange-pipelines/meson/configure.md
+++ b/content/open-source/melange/melange-pipelines/meson/configure.md
@@ -1,0 +1,34 @@
+---
+title: "meson/configure"
+type: "article"
+description: "Reference docs for the meson/configure melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Configure project with meson
+
+### Dependencies
+- meson
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the Meson build. Default is set to `output` |
+| `opts`       | Compile options for the Meson build.                                 |
+
+
+### Example
+```yaml
+uses: meson/configure
+
+```

--- a/content/open-source/melange/melange-pipelines/meson/install.md
+++ b/content/open-source/melange/melange-pipelines/meson/install.md
@@ -1,0 +1,33 @@
+---
+title: "meson/install"
+type: "article"
+description: "Reference docs for the meson/install melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Install project with meson
+
+### Dependencies
+- meson
+
+
+### Reference
+| Input        | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `output-dir` | The output directory for the Meson build. Default is set to `output` |
+
+
+### Example
+```yaml
+uses: meson/install
+
+```

--- a/content/open-source/melange/melange-pipelines/patch.md
+++ b/content/open-source/melange/melange-pipelines/patch.md
@@ -1,0 +1,35 @@
+---
+title: "patch"
+type: "article"
+description: "Reference docs for the patch melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Apply patches
+
+### Dependencies
+- patch
+
+
+### Reference
+| Input              | Description                                                                    |
+|--------------------|--------------------------------------------------------------------------------|
+| `strip-components` | The number of path components to strip while extracting. Default is set to `1` |
+| `patches`*         | A list of patches to apply, as a whitespace delimited string.                  |
+
+
+### Example
+```yaml
+- uses: patch
+    with:
+      patches: libtool-fix-cross-compile.patch
+```

--- a/content/open-source/melange/melange-pipelines/split/dev.md
+++ b/content/open-source/melange/melange-pipelines/split/dev.md
@@ -1,0 +1,29 @@
+---
+title: "split/dev"
+type: "article"
+description: "Reference docs for the split/dev melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Split development files
+
+### Dependencies
+None
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: split/dev
+
+```

--- a/content/open-source/melange/melange-pipelines/split/infodir.md
+++ b/content/open-source/melange/melange-pipelines/split/infodir.md
@@ -1,0 +1,29 @@
+---
+title: "split/infodir"
+type: "article"
+description: "Reference docs for the split/infodir melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Split GNU info pages
+
+### Dependencies
+None
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: split/infodir
+
+```

--- a/content/open-source/melange/melange-pipelines/split/locales.md
+++ b/content/open-source/melange/melange-pipelines/split/locales.md
@@ -1,0 +1,29 @@
+---
+title: "split/locales"
+type: "article"
+description: "Reference docs for the split/locales melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Split locales
+
+### Dependencies
+None
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: split/locales
+
+```

--- a/content/open-source/melange/melange-pipelines/split/manpages.md
+++ b/content/open-source/melange/melange-pipelines/split/manpages.md
@@ -1,0 +1,29 @@
+---
+title: "split/manpages"
+type: "article"
+description: "Reference docs for the split/manpages melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Split manpages
+
+### Dependencies
+None
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: split/manpages
+
+```

--- a/content/open-source/melange/melange-pipelines/split/static.md
+++ b/content/open-source/melange/melange-pipelines/split/static.md
@@ -1,0 +1,29 @@
+---
+title: "split/static"
+type: "article"
+description: "Reference docs for the split/static melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Split static library files
+
+### Dependencies
+None
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: split/static
+
+```

--- a/content/open-source/melange/melange-pipelines/strip.md
+++ b/content/open-source/melange/melange-pipelines/strip.md
@@ -1,0 +1,30 @@
+---
+title: "strip"
+type: "article"
+description: "Reference docs for the strip melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Strip binaries
+
+### Dependencies
+- binutils
+- scanelf
+
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+```yaml
+uses: strip
+```

--- a/content/open-source/melange/tutorials/_index.md
+++ b/content/open-source/melange/tutorials/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "melange"
-description: "An apk builder tool"
+title: "melange Tutorials"
+description: "Tutorials on how to use melange"
 lead: "The declarative APK builder"
 type: "article"
 date: 2020-10-06T08:49:15+00:00

--- a/content/open-source/melange/tutorials/getting-started-with-melange.md
+++ b/content/open-source/melange/tutorials/getting-started-with-melange.md
@@ -10,7 +10,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "melange"
+    parent: "melange-tutorials"
 weight: 100
 toc: true
 terminalImage: gcloud:latest


### PR DESCRIPTION
This PR brings a first version of the auto-generated melange pipeline docs to EDU and reorganizes melange docs structure to keep tutorials on a separate menu.

Ideally, these docs should not be manually edited, since our plan is to create a GitHub Action to periodically update them. The [deved-autodocs](https://github.com/chainguard-dev/deved-autodocs) repository has the source files to generate these docs, so for long term changes we should edit those sources.

Preview: https://deploy-preview-203--ornate-narwhal-088216.netlify.app/open-source/melange/melange-pipelines/git-checkout/