### PR TITLE
Feature: document the `cluster-{name,description}` fields.

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
@@ -53,6 +53,12 @@ metadata:
   namespace: gulfstream
 stringData:
   code: $INVITE_CODE
+
+  # Optionally, add some descriptive metadata that will be applied to your
+  # cluster upon initial registration.  Note that this will not update existing
+  # clusters, which can be done via chainctl.
+  cluster-name: "my-cluster"
+  cluster-description: "a more detailed description of this cluster."
 EOF
 ```
 
@@ -73,6 +79,12 @@ stringData:
   gcp-svc-acct-path: "/var/run/sts/gcp.json"
   gcp-svc-acct-name: $GSA_NAME
   gcp.json: $GSA_KEY
+
+  # Optionally, add some descriptive metadata that will be applied to your
+  # cluster upon initial registration.  Note that this will not update existing
+  # clusters, which can be done via chainctl.
+  cluster-name: "my-cluster"
+  cluster-description: "a more detailed description of this cluster."
 EOF
 ```
 


### PR DESCRIPTION
## Type of change
/kind feature

### What should this PR do?
Document a recently added feature

### Why are we making this change?
:gift: This documents the recently added `cluster-{name,description}` fields, which optionally attach friendly descriptor metadata to clusters at registration.

### What are the acceptance criteria? 
Clusters show up with the desired name.

### How should this PR be tested?
The steps can be run using the latest `chainctl`