### PR TITLE
Updates to onboarding and chainctl

### DIFF
--- a/content/chainguard/chainguard-enforce/chainctl-docs/_index.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/_index.md
@@ -11,3 +11,5 @@ weight: 003
 ---
 
 The CLI tool `chainctl` helps you interact with the account model that Chainguard Enforce provides, and enables you to make queries into the state of your clusters and policies registered with the platform. The tool uses the familiar `<context> <noun> <verb>` style of CLI interactions. Below find the current reference for `chainctl`.
+
+To install `chainctl`, follow the [installation guide](https://edu.chainguard.dev/chainguard/chainguard-enforce/how-to-install-chainctl/).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -198,7 +198,7 @@ We have confirmed that we’ve created the **sample-policy** based on the `sampl
 chainctl policies ls
 ```
 
-Here, you’ll get output on the policy you created as well as other policies that come with Chainguard Enforce. 
+Here, you’ll get output on the policy you created. If you were to have another policy applied to this cluster, you would receive that output as well. 
 
 You should now be able to review the policy that you set up. With this policy described and connected to our group, we are ready to install Chainguard Enforce into our cluster to gain insight into where our cluster currently stands from a security perspective.
 

--- a/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
@@ -1,7 +1,7 @@
 ---
-title: "How to Install chainctl for Chainguard Enforce"
+title: "How to Install chainctl"
 type: "article"
-description: "Install the chainctl command line tool to work with Chainguard Enforce"
+description: "Install the chainctl command line tool to work with Chainguard Enforce and Images"
 date: 2022-09-22T15:56:52-07:00
 lastmod: 2022-12-06T15:56:52-07:00
 draft: false


### PR DESCRIPTION
Signed-off-by: ltagliaferri

Resolves #102 and also takes in the feedback on `chainctl`, adding the installation onto the landing page, and making the installation title more generic