### PR TITLE
Fix port in redirected URLs, move rewrites to a map

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,12 +11,19 @@ http {
     keepalive_timeout  65;
     gzip  on;
 
+    # add URLs after the `default` line that are moved and aren't redirecting via Hugo aliases
+    map $request_uri $redirect_url {
+        default "";
+        "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl/;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
 
-	location ~* ^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.*) {
-	    return 301 /chainguard/chainguard-enforce/how-to-install-chainctl/;
+        # process $request_uri -> $redirect_url, preserving https, and ensure URLs don't have any ports in them
+        if ($redirect_url != "") {
+            rewrite ^(.*)$ $scheme://$http_host$redirect_url permanent;
         }
 
         location / {


### PR DESCRIPTION
## Type of change
Bug fix 

### What should this PR do?
The redirect in #212 has ended up returning URLs with the backend container's `listen       8080;` port in them e.g. 

```
curl -sI https://edu.chainguard.dev/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl/

HTTP/2 301
content-type: text/html
location: http://edu.chainguard.dev:8080/chainguard/chainguard-enforce/how-to-install-chainctl/
x-cloud-trace-context: bb1cc4a237af84f2c84d8c5259aedbcf;o=1
content-length: 169
date: Fri, 09 Dec 2022 19:42:56 GMT
server: Google Frontend
```

This PR ensures that redirects don't add a port, and instead preserve the request scheme and hostname.

Additionally, it gives a single place to add future rewrite rules as needed.