### PR TITLE
Edit alt methods guide

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/_index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/_index.md
@@ -11,3 +11,5 @@ weight: 001
 ---
 
 Chainguard Enforce is a comprehensive solution for software supply chain risk management.
+
+Stay up to date on Chainguard Enforce with the [Changelog](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog/).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
@@ -227,7 +227,7 @@ auth:
 EOF
 ```
 
-With the required authentication information inclyded in the `values.yaml` file, you can use the Chart to install the Chainguard Enforce Agent.
+With the required authentication information included in the `values.yaml` file, you can use the Chart to install the Chainguard Enforce Agent.
 
 ```bash
 helm upgrade -i enforce-agent chainguard/enforce-agent -f values.yaml

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
@@ -38,7 +38,13 @@ To install with `chainctl`, first authenticate into `chainctl` before running a 
 chainctl auth login
 ```
 
-With your cluster already set up, you'll install the Chainguard Enforce Agent with this `chainctl` command:
+With your cluster already set up, you'll install the Chainguard Enforce Agent with `chainctl`. For GKE, EKS, and AKS cloud infrastructure, use the next command. 
+
+```sh
+chainctl cluster install --group=$GROUP_ID --context $CLUSTER
+```
+
+If you are using a _private_ or on-prem cluster, run the command  with the `--private` flag as in the next command.
 
 ```sh
 chainctl cluster install --group=$GROUP_ID --private --context $CLUSTER

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods.md
@@ -1,10 +1,10 @@
 ---
-title: "Alternative Enforce Agent Installation Methods"
+title: "How to Install Chainguard Enforce"
 type: "article"
 lead: ""
-description: "Alternative installation methods and instructions."
+description: "Installing the Chainguard Enforce Agent with chainctl, YAML, Helm"
 date: 2022-11-04T15:56:52-07:00
-lastmod: 2022-12-01T15:56:52-07:00
+lastmod: 2022-12-20T15:56:52-07:00
 draft: false
 images: []
 menu:
@@ -16,33 +16,124 @@ toc: true
 
 > _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
 
-While the `chainctl` approach outlined in our [user onboarding documentation](../chainguard-enforce-user-onboarding/) is a valid and well supported method of installing the Chainguard Enforce Agent, some may prefer alternative methods to better align with their existing Kubernetes workflows.
+There are currently three recommended approaches to installing the Chainguard Enforce Agent. This guide will walk you through each of these approaches. 
 
-We'll refer to these alternative methods as various flavors of Declarative Installs. In other words, the entirety of the Chainguard Enforce Agent resources are defined as static Kubernetes manifests.
+Our [getting started guide](../chainguard-enforce-user-onboarding/) provides more detailed information on how to set up Chainguard Enforce, and this document provides a reference for three alternative methods to align best with your team's existing Kubernetes workflow. 
 
-Static manifests created for Declarative Installs allow for great flexibility for how they're ultimately applied to the cluster, and can be easily adapted to fit most Kubernetes deployment workflows.
+Our first method will be installation with `chainctl`, the command line tool for working with Chainguard products. 
 
-The two examples we'll cover are: "raw" yaml, and a helm chart.
+The second two methods are two approaches to declarative installs, which define the entirety of the Chainguard Enforce Agent resources as static Kubernetes manifests. Static manifests created for declarative installs allow for greater flexibility for how they're ultimately applied to the cluster, and can be adapted to fit most Kubernetes deployment workflows. These two examples we'll be covering are installation via "raw" YAML, and via a Helm Chart.
 
-## Raw YAML
+## Prerequisites
 
-First, we'll fetch the latest YAML representing the Chainguard Enforce Agent's Kubernetes resources:
+You'll need access to Chainguard Enforce (sign up via the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)), with a group and cluster already set up.
+
+Regardless of the method you choose, you'll need `chainctl` installed, which you can achieve by following our [How to Install `chainctl` tutorial](/chainguard/chainguard-enforce/how-to-install-chainctl/).
+
+## Install with `chainctl`
+
+To install with `chainctl`, first authenticate into `chainctl` before running a command.
+
+```sh
+chainctl auth login
+```
+
+With your cluster already set up, you'll install the Chainguard Enforce Agent with this `chainctl` command:
+
+```sh
+chainctl cluster install --group=$GROUP_ID --private --context $CLUSTER
+```
+
+Be sure to replace the `$GROUP_ID` and `$CLUSTER` variables with the appropriate IAM Group ID, and name of your Kubernetes cluster, respectively. To check the ID of your Chainguard Enforce group(s), you can list out relevant groups and thier IDs in a table.
+
+```sh
+chainctl iam groups ls -o table
+```
+
+The output will display the ID of the group you have been invited to or have created. To learn more about groups and permissions in Chainguard Enforce, reveiw our [How to Manage IAM Groups in Chainguard Enforce](../how-to-manage-iam-groups-in-chainguard-enforce/) guide.
+
+If you would like more detail about installing the Chainguard Enforce Agent with `chainctl`, or on getting onboarded to Chainguard Enforce, check out our [Getting Started guide](../chainguard-enforce-user-onboarding/).
+
+## Install with a Declarative Method
+
+The Chainguard Enforce Agent can be installed declaratively with either YAML or Helm. In order to install this way, you'll need to authenticate first.
+
+### Required Authentication for Declarative Installations
+
+When installing the Chainguard Enforce Agent declaratively, this step must be taken to set up the Agent's authentication and authorization to the Chainguard Enforce Platform. This step ensures the agent knows _how_ it should authenticate to the platform, and _where_ it should authenticate (which [group](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-manage-iam-groups-in-chainguard-enforce/)).
+
+Generate the relevant invite code(s) for your cluster or clusters using the following:
 
 ```bash
-# Option 1: chainctl
-chainctl cluster print-config > enforce-agent.yaml
+# $GROUP is the IAM group name where clusters using this code will register
+INVITE_CODE=$(chainctl iam invite create $GROUP --cluster -ojson | jq -r '.code')
+```
 
-# Option 2: remote
+For a full overview of the invite code, and how it relates to IAM in Chainguard Enforce, see [our guide on managing groups in Chainguard Enforce](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-manage-iam-groups-in-chainguard-enforce/).
+
+#### Additional Authentication for Private Clusters
+
+This step is only required if you're installing on a _private_ cluster. A _private_ cluster is one without a public issuer, which effectively means any cluster that is __not__ GKE, AKS, or EKS.
+
+If you're on a _private_ cluster and still want to use declarative installs (for example, to bulk install across a fleet of on-prem clusters), this step needs to be taken to fulfil the agent's authentication flow.
+
+Currently, the best supported method requires using GCP Service Accounts (GSA). To set up a minimally scoped GSA, follow the [GCP documentation on the subject](https://cloud.google.com/endpoints/docs/openapi/service-account-authentication#gcloud). This can also be done with standard IAC tooling.
+
+Using the created GSA, we'll collect the required information:
+
+```bash
+# This is the name of the GSA created in the previous step
+GSA_NAME="$SA_NAME:$PROJECT_ID.iam.gserviceaccount.com"
+
+# This is the GSA key file created in the previous step
+GSA_KEY=$(cat "$FILENAME.json")
+```
+
+This information will be used to configure your installation in later steps.
+
+### Declarative Option 1 — Install with YAML
+
+Defining Kubernetes manifests through YAML provides convenience of not needing to add parameters on the command line, more ease with maintenance through tracking changes in source control, and the ability to add more complexity. If you are already using YAML to deploy Kubernetes, you can install the Chainguard Enforce Agent directly through remotely fetching and modifying the Chainguard Enforce Agent manifest.
+
+You have two options to install the Enforce Agent with YAML, either using `chainctl` or `curl`.
+
+**Please note** that as you will be pulling down manifests, we recommend that you _always inspect_ the contents of these remotely fetched files!
+
+#### YAML Option 1 — Install with `chainctl`
+
+If you would like to work directly with the Chainguard command line tool, you can install the Agent directly into you cluster with `chainctl`. 
+
+Install `chainctl` if you have not done so already by following the [How to Install `chainctl` guide](/chainguard/chainguard-enforce/how-to-install-chainctl/). 
+
+With the tool installed, authenticate into `chainctl`.
+
+```sh
+chainctl auth login
+```
+
+Next, fetch the latest YAML representing the Enforce Agent's Kubernetes resources and save it to an `enforce-agent.yaml` file. Make sure you are in a relevant working directory. 
+
+```sh
+chainctl cluster print-config > enforce-agent.yaml
+```
+
+With this YAML fetched, you are ready to [add our authentication details](#add-authentication-details-to-yaml) to your config file.
+
+#### YAML Option 2 — Install with `curl`
+
+If you would like to use `curl` to install YAML, you can do so by pulling down the latest YAML that represents the Enforce Agent's Kubernetes resources, and saving it to a new `enforce-agent.yaml` file. Make sure you are in a relevant working directory. 
+
+```sh
 curl -s 'https://dl.enforce.dev/{mcp,tenant}.yaml' > enforce-agent.yaml
 ```
 
-> Note: We recommend that you always inspect the contents of remotely fetched manifests!
+With this YAML fetched, you are ready to [add our authentication details](#add-authentication-details-to-yaml) to your config file, in the next step.
 
-Before proceeding, we must first define how our agent should authenticate with the Chainguard Enforce Platform, and which [group](../how-to-manage-iam-groups-in-chainguard-enforce/) to register under. To do this, we first set up the [required authentication](#required-authentication).
+#### Add Authentication Details to YAML
 
-> Note: Before proceeding, ensure the [required authentication](#required-authentication) steps are completed.
+At this point, we can now define how our agent should authenticate with the Chainguard Enforce Platform, with the details we set up the [required authentication](#required-authentication-for-declarative-installations).
 
-Once the required authentication is pre-provisioned, append the following to the `enforce-agent.yaml` created in the previous step:
+With the required authentication pre-provisioned, append the following to the `enforce-agent.yaml` created in the previous step. This format is appropriate for a cluster in GKE, AKS, or EKS.
 
 ```bash
 cat >> enforce-agent.yaml <<EOF
@@ -62,9 +153,9 @@ stringData:
 EOF
 ```
 
-> Warning: `mcp-creds` contains sensitive information. If compromised it could allow unauthorized access to the Chainguard Enforce Platform. We recommend controlling access to it as you would with other platform secrets.
+> **Warning**: `mcp-creds` contains sensitive information. If compromised, it could allow unauthorized access to the Chainguard Enforce Platform. We recommend controlling access to it as you would with other platform secrets.
 
-Alternatively, if you're using an on-prem cluster, be sure to include the additional required `auth` components:
+If you're using a _private_ or on-prem cluster, be sure to include the required `auth` components that you set up in the [additional authentication step](#additional-authentication-for-private-clusters).
 
 ```bash
 cat >> enforce-agent.yaml <<EOF
@@ -88,29 +179,33 @@ stringData:
 EOF
 ```
 
-Once the required authentication is set up, the Chainguard Enforce Agent can be installed with any valid Kubernetes installer, we'll use `kubectl` to demonstrate:
+Once the required authentication is set up, the Chainguard Enforce Agent can be installed with any valid Kubernetes installer. We'll use `kubectl` to demonstrate:
 
 ```bash
 kubectl apply -f enforce-agent.yaml
 ```
 
-> Note: The `enforce-agent.yaml` includes CRDs, which when applied all in one shot with `kubectl` may fail to register before being applied. To "workaround" this you may need to run the command twice. In a "real world" scenario you should split the resources up, or rely on the applying agent (ie Flux or ArgoCD) to handle the ordering.
+> **Note**: The `enforce-agent.yaml` includes CRDs, which when applied simultaneously with `kubectl` may fail to register before being applied. As a workaround, you may need to run the command twice. In a production scenario, you should split the resources up, or rely on the applying agent (such as Flux or ArgoCD) to handle the ordering.
 
-Up until now we've demonstrated the declarative raw yaml install using a single file: `enforce-agent.yaml`. However, in practice the structure of this doesn't matter, and you should feel free to structure the manifests according to your existing Kubernetes deployment workflows.
+We've demonstrated the declarative raw YAML install using a single file `enforce-agent.yaml`. In practice, you should feel free to structure the manifests according to your existing Kubernetes deployment workflows.
 
-## Helm Chart
+### Declarative Option 2 — Install with a Helm Chart
 
-A [helm](https://helm.sh) chart is provided for those already comfortable with the helm ecosystem.
+If you are already comfortable with the [Helm](https://helm.sh) ecosystem, you may opt to install the Chainguard Enforce Agent with Helm.
 
-Begin by adding the cart repository and syncing it's contents:
+Begin by adding the Helm Chart repository.
 
 ```bash
 helm repo add chainguard https://chainguard-dev.github.io/helm-charts
+```
 
+Next, sync its contents.
+
+```bash
 helm repo update
 ```
 
-Before installing the chart, ensure that the [required authentication](#required-authentication) steps are completed. With the information in hand, create a new `values.yaml` with the required invite code:
+Before installing the Chart, ensure that the [required authentication](#required-authentication-for-declarative-installations) steps are completed. With your authentication information in hand, create a new `values.yaml` with the required invite code if you are using GKE, AKS, or EKS.
 
 ```bash
 cat > values.yaml <<EOF
@@ -118,7 +213,7 @@ inviteCode: $INVITE_CODE
 EOF
 ```
 
-Alternatively, if you're using an on-prem cluster, be sure to include the additional required `auth` components:
+If you're using a _private_ or on-prem cluster, be sure to include the additional required `auth` components.
 
 ```bash
 cat > values.yaml <<EOF
@@ -132,45 +227,14 @@ auth:
 EOF
 ```
 
-With the required authentication information in the `values.yaml`, the chart can then be installed using:
+With the required authentication information inclyded in the `values.yaml` file, you can use the Chart to install the Chainguard Enforce Agent.
 
 ```bash
 helm upgrade -i enforce-agent chainguard/enforce-agent -f values.yaml
 ```
 
-The full list of configuration options available are located in the [charts repo](https://github.com/chainguard-dev/helm-charts).
+The full list of configuration options available are located in the [Chainguard Helm Charts repository](https://github.com/chainguard-dev/helm-charts).
 
-### Required authentication
+## Next Steps
 
-When installing the Chainguard Enforce Agent declaratively, an additional step must be taken to set up the Agent's authentication and authorization to the Chainguard Enforce Platform. This step ensures the agent knows _how_ it should authenticate to the platform, and _where_ it should authenticate (which [group](../how-to-manage-iam-groups-in-chainguard-enforce/)).
-
-Depending on the destination cluster, the information required will vary.
-
-#### Required: The cluster invite code
-
-Generate the cluster(s) invite code using the following:
-
-```bash
-# $GROUP is the IAM group where clusters using this code will register
-INVITE_CODE=$(chainctl iam invite create $GROUP --cluster -ojson | jq -r '.code')
-```
-
-> Note: For a full overview of the invite code, and how it relates to IAM in Chainguard Enforce, see [our guide on managing groups in Chainguard Enforce](../how-to-manage-iam-groups-in-chainguard-enforce/).
-
-#### Optional: The issuer information
-
-This step is only required if you're installing on a "private" cluster. A private cluster is one without a public issuer, which effectively means any cluster that is __not__ GKE, AKS, or EKS.
-
-If you're on a "private" cluster and still want to use declarative installs (for example, to bulk install across a fleet of on-prem clusters), an additional step needs to be taken to fulfil the agent's authentication flow.
-
-Currently, the best supported method requires using GCP Service Accounts (GSA). To set up a minimally scoped GSA, follow the [GCP documentation on the subject](https://cloud.google.com/endpoints/docs/openapi/service-account-authentication#gcloud). This can also be done with standard IAC tooling.
-
-Using the created GSA, we'll collect the required information:
-
-```bash
-# This is the name of the GSA created in the previous step
-GSA_NAME="$SA_NAME:$PROJECT_ID.iam.gserviceaccount.com"
-
-# This is the GSA key file created in the previous step
-GSA_KEY=$(cat "$FILENAME.json")
-```
+With the Chainguard Enforce Agent installed in your cluster, continue learning about Enforce by reading the [Getting Started Guide](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding/), learn how to [manage policies with `chainctl`](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-policies-cli/), or follow the tutorial on [how to detect the Log4Shell vulnerability with Enforce](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/detect-log4shell-demo/).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -95,7 +95,7 @@ GitTreeState:  clean
 BuildDate:     <date here>
 GoVersion:     go1.19.4
 Compiler:      gc
-Platform:      darwin/arm64
+Platform:      <your platform>
 ```
 
 With `chainctl` successfully installed, we can continue through the demo. For more details on `chainctl` installation, please review [How to Install chainctl for Chainguard Enforce](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl/).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -92,7 +92,7 @@ chainctl: Chainguard Control
 GitVersion:    <semver version>
 GitCommit:     <commit hash>
 GitTreeState:  clean
-BuildDate:     2022-12-14T22:14:33Z
+BuildDate:     <date here>
 GoVersion:     go1.19.4
 Compiler:      gc
 Platform:      darwin/arm64

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -93,7 +93,7 @@ GitVersion:    <semver version>
 GitCommit:     <commit hash>
 GitTreeState:  clean
 BuildDate:     <date here>
-GoVersion:     go1.19.4
+GoVersion:     <compiler version>
 Compiler:      gc
 Platform:      <your platform>
 ```

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -1,9 +1,9 @@
 ---
-title: "Chainguard Enforce User Onboarding"
+title: "Getting Started with Chainguard Enforce for Kubernetes"
 type: "article"
-description: "Walkthrough of Chainguard Enforce"
+description: "Chainguard Enforce User Onboarding"
 date: 2022-07-15T15:22:20+01:00
-lastmod: 2022-11-29T15:22:20+01:00
+lastmod: 2022-12-15T15:22:20+01:00
 draft: false
 images: []
 menu:
@@ -89,11 +89,11 @@ You should receive output similar to the following.
   \____| |_| |_| /_/   \_\ |___| |_| \_|  \____|   |_|   |_____|
 chainctl: Chainguard Control
 
-GitVersion:    0.1.39
-GitCommit:     98f4b3bc8a1ef111777f797e8248b737643eedc6
+GitVersion:    0.1.44
+GitCommit:     dabc530b10168315afd1edf7f71df6a7ba1d844b
 GitTreeState:  clean
-BuildDate:     2022-12-05T14:04:10Z
-GoVersion:     go1.19.3
+BuildDate:     2022-12-14T22:14:33Z
+GoVersion:     go1.19.4
 Compiler:      gc
 Platform:      darwin/arm64
 ```
@@ -124,7 +124,7 @@ You’ll receive output in the form of a table of your current group (or groups)
 
 > **Note**: If you don't receive output like the above at all, you can create a new group by running `chainctl iam groups create --no-parent` to create a new group. After group creation, you can run `chainctl iam groups ls -o table` again.
 
-Let’s create a variable that stores that ID for later steps in the tutorial. Replace `$GROUP_ID` below with the relevant ID; for exmaple, in the case of `enforce-demo-group` above, you would enter `b9adda06841c1d34dfa73d5902ed44b5448b7958` instead of `$GROUP_ID` in the command below. 
+Let’s create a variable that stores that ID for later steps in the tutorial. Replace `$GROUP_ID` below with the relevant ID; for exmaple, in the case of `enforce-demo-group` above, you would enter `b9adda06841c1d34dfa73d5902ed44b5448b7958` instead of `$GROUP_ID` in the next command. 
 
 ```sh
 export GROUP=$GROUP_ID
@@ -140,10 +140,10 @@ In order to put Chainguard Enforce into action within a cluster, we’ll now cre
 kind create cluster --name enforce-demo
 ```
 
-Install the Chainguard Enforce agent in your cluster:
+Install the Chainguard Enforce Agent in your cluster:
 
 ```sh
-chainctl cluster install --group=$GROUP --private --context kind-enforce-demo
+chainctl cluster install --group=$GROUP_ID --private --context kind-enforce-demo
 ```
 
  Once everything is set up, your terminal output will indicate that the cluster was successfully configured. We now have a Kubernetes cluster setup that’s running an application.
@@ -181,7 +181,7 @@ This policy creates a cluster image policy with the Sigstore beta API, and with 
 We have already set up the `GROUP` variable in with the group we created above in Step 2. Let’s now associate this new policy with that group.
 
 ```sh
-chainctl policies apply -f sample-policy.yaml --group=$GROUP
+chainctl policies apply -f sample-policy.yaml --group=$GROUP_ID
 ```
 
 You should get feedback about the group selected and that the policy was applied, similar to the following.
@@ -219,7 +219,7 @@ sample-policy     68s
 
 Next, verify the compliance records of containers via the CLI.
 
-First, obtain the cluster ID and load it into a variable for usage. We are using `kubectl` to get an UUID (universally unique identifier) that Chainguard Enforce uses to identify the agent running on your cluster.
+First, obtain the cluster ID and load it into a variable for usage. We are using `kubectl` to get an UUID (universally unique identifier) that Chainguard Enforce uses to identify the Agent running on your cluster.
 
 ```sh
 export CLUSTER_ID=$(chainctl cluster list -o json | jq -r '.items[0].name')

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -89,7 +89,7 @@ You should receive output similar to the following.
   \____| |_| |_| /_/   \_\ |___| |_| \_|  \____|   |_|   |_____|
 chainctl: Chainguard Control
 
-GitVersion:    0.1.44
+GitVersion:    <semver version>
 GitCommit:     dabc530b10168315afd1edf7f71df6a7ba1d844b
 GitTreeState:  clean
 BuildDate:     2022-12-14T22:14:33Z

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -90,7 +90,7 @@ You should receive output similar to the following.
 chainctl: Chainguard Control
 
 GitVersion:    <semver version>
-GitCommit:     dabc530b10168315afd1edf7f71df6a7ba1d844b
+GitCommit:     <commit hash>
 GitTreeState:  clean
 BuildDate:     2022-12-14T22:14:33Z
 GoVersion:     go1.19.4


### PR DESCRIPTION
Edited the alternative installation guide to include all methods

Some initial feedback from Mark:

> Regarding the alternative installation methods thing, I think ultimately we're going to want a general "How to Install Chainguard Enforce" article that combines instructions for installing with chainctl, raw YAML, and a Helm Chart. That makes the most sense to me.
> Semi-related to that, I might advocate for retitling the Onboarding doc to "Getting Started with Chainguard Enforce for Kubernetes" at some point.

Signed-off-by: ltagliaferri