### PR TITLE
Added workflow for autodocs - images reference

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -47,8 +47,3 @@ jobs:
             images
             automated
           assignees: erikaheidi
-          reviewers: |
-            erikaheidi
-            jamonation
-
-

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -13,7 +13,7 @@ jobs:
           path: edu
 
       - name: "Check out Images Monorepo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           repository: chainguard-images/images
           path: images

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out Destination Repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           path: edu
 

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -22,7 +22,7 @@ jobs:
         run: mkdir -p "${{ github.workspace }}/${{ env.WORKDIR }}" && chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: "Update the reference docs for Chainguard Images"
-        uses: chainguard-dev/deved-autodocs@1.0.2
+        uses: chainguard-dev/deved-autodocs@84badec14541d344c47d1a8435a8a214e72dbe95 # v1.0.2
         with:
           command: build images
         env:

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -1,0 +1,54 @@
+name: Build Images Reference Docs
+on:
+  workflow_dispatch:
+env:
+  WORKDIR: images
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out Destination Repo"
+        uses: actions/checkout@v2
+        with:
+          path: edu
+
+      - name: "Check out Images Monorepo"
+        uses: actions/checkout@v2
+        with:
+          repository: chainguard-images/images
+          path: images
+
+      - name: "Set up workdir"
+        run: mkdir -p "${{ github.workspace }}/${{ env.WORKDIR }}" && chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
+
+      - name: "Update the reference docs for Chainguard Images"
+        uses: chainguard-dev/deved-autodocs@1.0.2
+        with:
+          command: build images
+        env:
+          YAMLDOCS_SOURCE: "${{ github.workspace }}/images/images"
+          YAMLDOCS_OUTPUT: "${{ github.workspace }}/${{ env.WORKDIR }}"
+
+      - name: "Copy updates to main repo"
+        run: |
+          echo "Copying files..." && \
+          cp -R "${{ github.workspace }}/${{ env.WORKDIR }}" "${{ github.workspace }}/edu/content/chainguard/chainguard-images" && \
+          echo "Finished copy"
+
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          path: "${{ github.workspace }}/edu"
+          commit-message: Update Images Reference
+          title: "[AutoDocs] Update Images Reference Docs"
+          signoff: true
+          labels: |
+            documentation
+            images
+            automated
+          assignees: erikaheidi
+          reviewers: |
+            erikaheidi
+            jamonation
+
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @chainguard-dev/deved-team


### PR DESCRIPTION
This PR creates a workflow to run autodocs via manual trigger, from the GitHub Actions tab, so whenever there's an update to the source images READMEs, a new PR is created here bringing the changes.

We can later on add a schedule to run this periodically. To try it out first, I would prefer to run manually, that's why I didn't add the schedule yet.

Example of PR that will be created: https://github.com/chainguard-dev/deved-autodocs/pull/3