### PR TITLE
add project images issue sync

### DIFF
--- a/.github/workflows/add-issues-to-project-images.yaml
+++ b/.github/workflows/add-issues-to-project-images.yaml
@@ -1,0 +1,18 @@
+name: Add new and labeled issues to Images project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/chainguard-dev/projects/22
+          github-token: ${{ secrets.PROJECT_WRITER }}
+          labeled: images


### PR DESCRIPTION
Adding an issue syncer to our images project board.

Signed-off-by: Patrick Flynn <patrick@chainguard.dev>

