### PR TITLE
Add pages on verifying blob signatures with cosign or rekor-cli

### DIFF
--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -22,7 +22,7 @@ We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/
 
 All apko releases are released with [keyless signatures using Cosign](open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an apko release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
 
-If you would like to learn how to verify a binary using Rekor or curl, follow the steps in our guide [How to Verify File Signatures with Rekor or curl](open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl/).
+If you would like to learn how to verify a binary using Rekor or curl, follow the steps in our guide [How to Verify File Signatures with Rekor or curl](/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl/).
 
 We'll use the `apko_0.6.0_linux_arm64.tar.gz` tar archive from the apko [GitHub Release v0.6.0 page](https://github.com/chainguard-dev/apko/releases/tag/v0.6.0) in this example.
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -20,7 +20,7 @@ We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/
 
 ### Verifying a binary with Cosign keyless signatures
 
-All `apko` releases are released with [keyless signatures using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an `apko` release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
+All apko releases are released with [keyless signatures using Cosign](open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an apko release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
 
 If you would like to learn how to verify a binary using Rekor or curl, follow the steps in our guide [How to Verify File Signatures with Rekor or curl](open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl/).
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -63,7 +63,7 @@ curl -L -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_
   -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt
 ```
 
-Then you can verify the files that you downloaded using cosign:
+Then you can verify the files that you downloaded using Cosign:
 
 ```sh
 COSIGN_EXPERIMENTAL=1 cosign verify-blob \

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -14,7 +14,7 @@ weight: 005
 toc: true
 ---
 
-Cosign can verify more than just containers. Blobs, or binary large objects, and standard files can be verified in a similar way. You can publish a blob or other artifact to an OCI (Open Container Initiative) or elsewhere and then use Cosign to verify its signature. This tutorial assumes you have Cosign installed, which you can achieve by following our [How to Install Cosign guide](../how-to-install-cosign/).
+Cosign can be used to verify file signatures as these are binary artifacts, as long as these are published to an OCI registry. This tutorial assumes you have Cosign installed, which you can achieve by following our [How to Install Cosign guide](/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign/).
 
 We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/apko/overview/), which is a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file Cosign has signed with a keyless signature.
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -72,4 +72,4 @@ COSIGN_EXPERIMENTAL=1 cosign verify-blob \
    apko_0.6.0_linux_amd64.tar.gz
 ```
 
-If you receive an error while verifying a binary with cosign, then you know that there was a problem with creating the artifact, or that the file that you are verifying is corrupted or invalid. In any case, you should download a fresh copy and verify it again, or try a different version of the software with a working signature.
+If you receive an error while verifying a binary with Cosign, then you know that there was a problem with creating the artifact, or that the file that you are verifying is corrupted or invalid. If that is the case, you should download a fresh copy and verify it again, or try a different version of the software with a working signature.

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -1,0 +1,75 @@
+---
+title: "How to Verify File Signatures with Cosign"
+type: "article"
+description: "Use Cosign to verify non-container software artifacts"
+lead: "Cosign can verify software artifacts beyond containers"
+date: 2022-12-21T15:22:20+01:00
+lastmod: 2022-12-21T15:22:20+01:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "cosign"
+weight: 005
+toc: true
+---
+
+Cosign can verify more than just containers. Blobs, or binary large objects, and standard files can be verified in a similar way. You can publish a blob or other artifact to an OCI (Open Container Initiative) or elsewhere and then use Cosign to verify its signature. This tutorial assumes you have Cosign installed, which you can achieve by following our [How to Install Cosign guide](../how-to-install-cosign/).
+
+We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/apko/overview/), which is a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file Cosign has signed with a keyless signature.
+
+### Verifying a binary with Cosign keyless signatures
+
+All `apko` releases are released with [keyless signatures using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an `apko` release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
+
+If you would like to learn how to verify a binary using Rekor or curl, follow the steps in our guide [How to Verify File Signatures with Rekor or curl](open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl/).
+
+We'll use the `apko_0.6.0_linux_arm64.tar.gz` tar archive from the apko [GitHub Release v0.6.0 page](https://github.com/chainguard-dev/apko/releases/tag/v0.6.0) in this example.
+
+There are three URLs from the list of assets on that page that you will need to copy:
+
+1. The release itself: `https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz`
+2. The signature file: `https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.sig`
+3. The public certificate: `https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt`
+
+With these URLs, construct (or copy) the following command to verify the tar archive:
+
+```sh
+COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+   --signature https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.sig \
+   --certificate https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt \
+   https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz
+```
+
+Running the command may take a moment, but when it completes you will receive the following output:
+
+```
+tlog entry verified with uuid: 9ec23abb6326ebbaa6932f720847080e8f5e0b2925a1643b63962691917c8137 index: 8538988
+Verified OK
+```
+
+If any of the URLs are incorrect, of if there was a problem with the apko release file, a mismatching signature or certificate, or if the release file was not signed, you will receive an error like the following:
+
+```
+Error: verifying blob https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz: invalid signature when validating ASN.1 encoded signature
+main.go:62: error during command execution: verifying blob https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz: invalid signature when validating ASN.1 encoded signature
+```
+
+You can also download each or any of the files and verify them locally like this:
+
+```sh
+curl -L -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz \
+  -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.sig \
+  -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt
+```
+
+Then you can verify the files that you downloaded using cosign:
+
+```sh
+COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+   --signature apko_0.6.0_linux_amd64.tar.gz.sig \
+   --certificate apko_0.6.0_linux_amd64.tar.gz.crt \
+   apko_0.6.0_linux_amd64.tar.gz
+```
+
+If you receive an error while verifying a binary with cosign, then you know that there was a problem with creating the artifact, or that the file that you are verifying is corrupted or invalid. In any case, you should download a fresh copy and verify it again, or try a different version of the software with a working signature.

--- a/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
+++ b/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
@@ -1,0 +1,137 @@
+---
+title: "How to Verify File Signatures with Rekor or curl"
+type: "article"
+description: "Use Rekor or curl to verify non-container software artifacts"
+lead: "Rekor or curl can verify software artifacts beyond containers"
+date: 2022-12-21T15:22:20+01:00
+lastmod: 2022-12-21T15:22:20+01:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "rekor"
+weight: 005
+toc: true
+---
+
+The `rekor-cli` tool or `curl` can be used to verify anything with a signature on a [Rekor transparency log](/open-source/sigstore/rekor/an-introduction-to-rekor/#transparency-log). This tutorial assumes you have the `rekor-cli` tool installed, which you can achieve by following our [How to Install the Rekor CLI](/open-source/sigstore/rekor/how-to-install-rekor/) guide. When verifying a signature using either tool, ensure that you have the `jq` utility installed so that you can parse their output.
+
+We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/apko/overview/), which is a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file that Cosign has signed with a keyless signature.
+
+### Verifying a binary with rekor-cli
+
+All `apko` releases are released with [keyless signatures using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an `apko` release by searching for the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
+
+We'll use the `apko_0.6.0_linux_arm64.tar.gz` tar archive from the apko [GitHub Release v0.6.0 page](https://github.com/chainguard-dev/apko/releases/tag/v0.6.0) in this example.
+
+First, download the file using curl or your browser:
+
+```sh
+curl -L -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz
+```
+
+
+
+
+
+
+To search Rekor, set a shell variable to the SHA256 hash of the `apko_0.6.0_linux_amd64.tar.gz` release file:
+
+```sh
+SHASUM=$(shasum -a 256 apko_0.6.0_linux_amd64.tar.gz |awk '{print $1}')
+```
+
+If you are using the `rekor-cli` client, search for the hash with the following command:
+
+```sh
+rekor-cli search --sha "${SHASUM?}"
+```
+
+If you are using `curl`, run the following:
+
+```sh
+curl -X POST -H "Content-type: application/json" 'https://rekor.sigstore.dev/api/v1/index/retrieve' --data-raw "{\"hash\":\"sha256:$SHASUM\"}"
+```
+
+You will receive output like the following:
+
+```
+# rekor-cli output
+Found matching entries (listed by UUID):
+24296fb24b8ad77a9ec23abb6326ebbaa6932f720847080e8f5e0b2925a1643b63962691917c8137
+
+# curl output
+["24296fb24b8ad77a9ec23abb6326ebbaa6932f720847080e8f5e0b2925a1643b63962691917c8137"]
+```
+
+Set a shell variable called `UUID` to the returned entry:
+
+```sh
+UUID="24296fb24b8ad77a9ec23abb6326ebbaa6932f720847080e8f5e0b2925a1643b63962691917c8137"
+```
+
+Now you can use the returned UUID to retrieve the associated Rekor log entry. If you are using `rekor-cli` run the following:
+
+```sh
+rekor-cli get --uuid "${UUID?}"
+```
+
+If you are using `curl` then run this command:
+
+```sh
+curl -X GET "https://rekor.sigstore.dev/api/v1/log/entries/${UUID?}"
+```
+
+In both cases, if you would like to extract the signature and public key to verify your binary matches what is in the Rekor log, you will need to parse the output. You will need to use tools like `base64` to decode the data, `jq` to extract the relevant fields, and `openssl` to verify the signature. 
+
+##### Fetch a signature and public certificate using `rekor-cli`
+
+The following commands will fetch the Rekor entry for a release using `rekor-cli`, parse and extract the signature and public certificate using `jq`, and decode it using `base64`:
+
+```sh
+rekor-cli get --uuid "${UUID?}" --format json \
+  | jq -r '.Body .HashedRekordObj .signature .content' \
+  | base64 -d > apko_0.6.0_linux_amd64.tar.gz.sig
+rekor-cli get --uuid "${UUID?}" --format json \
+  | jq -r '.Body .HashedRekordObj .signature .publicKey .content' \
+  | base64 -d > apko_0.6.0_linux_amd64.tar.gz.crt
+```
+
+##### Fetch a signature and public certificate using `curl`
+
+The following commands will fetch the Rekor entry for a release using `curl`, parse and extract the signature and public certificate using `jq`, and decode it using `base64`:
+
+```sh
+curl -s -X GET "https://rekor.sigstore.dev/api/v1/log/entries/${UUID?}" \
+  | jq -r '.[] | .body' \
+  | base64 -d |jq -r '.spec .signature .content' \
+  | base64 -d > apko_0.6.0_linux_amd64.tar.gz.sig
+curl -s -X GET "https://rekor.sigstore.dev/api/v1/log/entries/${UUID?}" \
+  | jq -r '.[] | .body' \
+  | base64 -d |jq -r '.spec .signature .publicKey .content' \
+  | base64 -d > apko_0.6.0_linux_amd64.tar.gz.crt
+```
+
+##### Verifying a signature using `openssl`
+
+Now that you have downloaded the signature and public certificate corresponding to your `chainctl` version, you can verify the binary's signature using `openssl`.
+
+First, extract the public key portion of the `apko_0.6.0_linux_amd64.tar.gz.crt` certificate file:
+
+```sh
+openssl x509 -in apko_0.6.0_linux_amd64.tar.gz.crt -noout -pubkey > apko_0.6.0_linux_amd64.tar.gz.pubkey.crt
+```
+
+Now you can use `openssl` to verify the signature against your local `chainctl` binary. Run the following command:
+
+```sh
+openssl sha256 -verify apko_0.6.0_linux_amd64.tar.gz.pubkey.crt -signature apko_0.6.0_linux_amd64.tar.gz.sig apko_0.6.0_linux_amd64.tar.gz
+```
+
+If your `apko_0.6.0_linux_amd64.tar.gz` download matches the one that was signed using Cosign, you will receive the following line of output:
+
+```
+Verified OK
+```
+
+This output indicates that your `apko_0.6.0_linux_amd64.tar.gz` version is authentic and was signed by the ephemeral private key corresponding to the public certificate that you retrieved from the Rekor log.

--- a/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
+++ b/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
@@ -20,7 +20,7 @@ We’ll verify a binary artifact, in this case, a copy of [apko](/open-source/ap
 
 ### Verifying a binary with rekor-cli
 
-All `apko` releases are released with [keyless signatures using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an `apko` release by searching for the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
+All apko releases are released with [keyless signatures using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an apko release by searching for the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
 
 We'll use the `apko_0.6.0_linux_arm64.tar.gz` tar archive from the apko [GitHub Release v0.6.0 page](https://github.com/chainguard-dev/apko/releases/tag/v0.6.0) in this example.
 

--- a/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
+++ b/content/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl.md
@@ -16,7 +16,7 @@ toc: true
 
 The `rekor-cli` tool or `curl` can be used to verify anything with a signature on a [Rekor transparency log](/open-source/sigstore/rekor/an-introduction-to-rekor/#transparency-log). This tutorial assumes you have the `rekor-cli` tool installed, which you can achieve by following our [How to Install the Rekor CLI](/open-source/sigstore/rekor/how-to-install-rekor/) guide. When verifying a signature using either tool, ensure that you have the `jq` utility installed so that you can parse their output.
 
-We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/apko/overview/), which is a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file that Cosign has signed with a keyless signature.
+We’ll verify a binary artifact, in this case, a copy of [apko](/open-source/apko/overview/), which is a tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file that Cosign has signed with a keyless signature.
 
 ### Verifying a binary with rekor-cli
 


### PR DESCRIPTION
### What should this PR do?
This PR adds two pages that explain how to verify a cosign keyless signature on a binary artifact that is *not* a container image using `cosign` itself, or `rekor-cli`, or `curl`.

### Why are we making this change?
This is a longer form version of the steps to verify a `chainctl` binary on the [How to Install chainctl page](https://edu.chainguard.dev/chainguard/chainguard-enforce/how-to-install-chainctl/#verifying-the-chainctl-binary-with-cosign).

### How should this PR be tested?
The steps on each page should work with recent versions of cosign or rekor-cli.