### PR TITLE
Change menu link

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -4,6 +4,7 @@
 title = "Chainguard Academy"
 titleSeparator = "—"
 titleAddition = "Software Supply Chain Security Knowledge Base"
+subTitle = "Chainguard"
 description = "Learn how to make your software supply chain secure by default"
 
 ## Documentation
@@ -54,10 +55,10 @@ lqipWidth = "20x"
 smallLimit = "300"
 
 # Footer
-footer = "©2022 <a class=\"text-muted\" href=\"https://www.chainguard.dev\">Chainguard</a>, <a class=\"text-muted\" href=\"https://creativecommons.org/licenses/by-nc-sa/4.0\">CC BY-NC-SA 4.0</a>"
+footer = "©2023 <a class=\"text-muted\" href=\"https://www.chainguard.dev\">Chainguard</a>, <a class=\"text-muted\" href=\"https://creativecommons.org/licenses/by-nc-sa/4.0\">CC BY-NC-SA 4.0</a>"
 
 # Feed
-copyRight = "Copyright (c) 2022 Chainguard"
+copyRight = "Copyright (c) 2023 Chainguard"
 
 # Alert
 alert = false

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -11,8 +11,8 @@
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
   <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main navigation">
 
-    <a class="navbar-brand order-0" href="{{ "/" | relLangURL }}" aria-label="{{ .Site.Params.Title }}">
-      {{ .Site.Params.Title }}
+    <a class="navbar-brand order-0" href="{{ "https://chainguard.dev" | relLangURL }}" aria-label="{{ .Site.Params.subTitle }}">
+      {{ .Site.Params.subTitle }}
     </a>
 
     {{ if (in .Site.Params.sections.sectionNav .Section) -}}


### PR DESCRIPTION
I updated the menu bar so that it points to "Chainguard" and the www site rather than Academy. Do we think this looks ok following discussions from yesterday cc @sheesh @SharpRake ?

Also updated the year in the footer

Signed-off-by: ltagliaferri 