### PR TITLE
Update Enforce changelog and chainctl docs

### DIFF
--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl"
 slug: chainctl
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl/
@@ -15,13 +15,14 @@ Chainguard Control
 ### Options
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-  -h, --help              help for chainctl
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+  -h, --help                         help for chainctl
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO
@@ -32,5 +33,6 @@ Chainguard Control
 * [chainctl events](/chainguard/chainguard-enforce/chainctl-docs/chainctl_events/)	 - Events related commands for the Chainguard platform.
 * [chainctl iam](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/)	 - IAM related commands for the Chainguard platform.
 * [chainctl policies](/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/)	 - Policy related commands for the Chainguard platform.
+* [chainctl update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_update/)	 - Update chainctl.
 * [chainctl version](/chainguard/chainguard-enforce/chainctl-docs/chainctl_version/)	 - Prints the version
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl auth"
 slug: chainctl_auth
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/
@@ -21,17 +21,19 @@ Auth related commands for the Chainguard platform.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO
 
 * [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
 * [chainctl auth login](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login/)	 - Login to the Chainguard platform.
+* [chainctl auth logout](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_logout/)	 - Logout from the Chainguard platform.
 * [chainctl auth status](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status/)	 - Inspect the local Chainguard Token.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl auth login"
 slug: chainctl_auth_login
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_login/
@@ -13,26 +13,29 @@ toc: true
 Login to the Chainguard platform.
 
 ```
-chainctl auth login [--identity-token TOKEN] [--invite-code INVITE_CODE | --register] [--create-group] [--cluster CLUSTER_ID] [--refresh] [flags]
+chainctl auth login [--identity-token TOKEN] [--invite-code INVITE_CODE | --register] [--cluster CLUSTER_ID] [--refresh]
 ```
 
 ### Examples
 
 ```
-
-# Default auth login flow:
-chainctl auth login
-
-# Refreshing a token within a Kubernetes context:
-chainctl auth login --identity-token=PATH_TO_TOKEN --refresh
-
+  # Default auth login flow:
+  chainctl auth login
+  
+  # Refreshing a token within a Kubernetes context:
+  chainctl auth login --identity-token=PATH_TO_TOKEN --refresh
+  
+  # Register and create a new root group
+  chainctl auth login --register
+  
+  # Register by accepting an invite to an existing group
+  chainctl auth login --invite-code eyJncnAiOiI5MzA...
 ```
 
 ### Options
 
 ```
       --cluster string          UID of the Cluster.
-      --create-group            Whether a new root group should be created if an invite code is not specified. (default true)
   -h, --help                    help for login
       --identity-token string   Use an explicit passed identity token or token path.
       --invite-code string      Registration invite code.
@@ -43,12 +46,13 @@ chainctl auth login --identity-token=PATH_TO_TOKEN --refresh
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_logout.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_logout.md
@@ -1,27 +1,25 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl auth logout"
+slug: chainctl_auth_logout
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_logout/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl auth logout
 
-Delete invite codes
+Logout from the Chainguard platform.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl auth logout
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for logout
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +36,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl auth](/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth/)	 - Auth related commands for the Chainguard platform.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl auth status"
 slug: chainctl_auth_status
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_auth_status/
@@ -19,18 +19,21 @@ chainctl auth status [--output table|json] [flags]
 ### Options
 
 ```
-  -h, --help   help for status
+  -h, --help                    help for status
+      --identity-token string   Use an explicit passed identity token or token path.
+      --quick                   Whether to perform quick offline token checks (vs. calling the Validate API).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters"
 slug: chainctl_clusters
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/
@@ -21,21 +21,26 @@ Cluster related commands for the Chainguard platform.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO
 
 * [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
+* [chainctl clusters describe](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_describe/)	 - Describe a cluster.
 * [chainctl clusters install](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install/)	 - Install Chainguard into the current kubernetes context.
 * [chainctl clusters list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list/)	 - List clusters.
 * [chainctl clusters open](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open/)	 - Open the console for a cluster.
+* [chainctl clusters print-config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_print-config/)	 - Print the tenant configuration in YAML.
+* [chainctl clusters profiles](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles/)	 - Profile related commands.
 * [chainctl clusters records](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records/)	 - Interact with cluster records.
 * [chainctl clusters uninstall](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall/)	 - Uninstalls Chainguard from the current kubernetes context.
 * [chainctl clusters update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update/)	 - Update the name or description of a cluster.
+* [chainctl clusters workloads](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads/)	 - Interact with cluster workloads.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_describe.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_describe.md
@@ -1,0 +1,64 @@
+---
+date: 2022-12-15T19:03:53-05:00
+title: "chainctl clusters describe"
+slug: chainctl_clusters_describe
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_describe/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## chainctl clusters describe
+
+Describe a cluster.
+
+```
+chainctl clusters describe CLUSTER_NAME | CLUSTER_ID [--active-within DURATION] [--all] [--images] [--packages] [--policies] [--output |json]
+```
+
+### Examples
+
+```
+  # Describe a cluster
+  chainctl cluster describe my-cluster
+  
+  # Display just the records of images that have been seen in the past 6 hours.
+  chainctl cluster describe --active-within 6h
+  
+  # Display just policy information about a cluster
+  chainctl cluster describe my-cluster --policies
+  
+  # Display package and image information, and include all records
+  chainctl cluster describe my-cluster --images --packages --all
+  
+  # Including all three flags is the same as the default behavior with no flags.
+  chainctl cluster describe my-cluster --images --packages --policies
+```
+
+### Options
+
+```
+      --active-within duration   How recently a cluster must have been active to be listed. Zero will return all clusters. (default 24h0m0s)
+      --all                      Whether to include all records in the output, even for large collections.
+  -h, --help                     help for describe
+      --images                   Include images data in output. Use with --packages and/or --policies to filter output. If all three are omitted, all categories are included by default.
+      --packages                 Include package data in output. Use with --images and/or --policies to filter output. If all three are omitted, all categories are included by default.
+      --policies                 Include policy data in output. Use with --packages and/or --images to filter output. If all three are omitted, all categories are included by default.
+```
+
+### Options inherited from parent commands
+
+```
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
+```
+
+### SEE ALSO
+
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters install"
 slug: chainctl_clusters_install
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_install/
@@ -13,7 +13,7 @@ toc: true
 Install Chainguard into the current kubernetes context.
 
 ```
-chainctl clusters install [--name NAME] [--description DESCRIPTION] [--group GROUP_NAME|GROUP_ID | --invite-code INVITE_CODE | --skip-invite | --managed=PROVIDER --cluster=CLUSTER_NAME | --private] [flags]
+chainctl clusters install [--name NAME] [--description DESCRIPTION] [--group GROUP_NAME|GROUP_ID | --invite-code INVITE_CODE | --skip-invite | --managed={eks,gke} --cluster=CLUSTER_NAME | --private]
 ```
 
 ### Examples
@@ -47,24 +47,26 @@ chainctl clusters install [--name NAME] [--description DESCRIPTION] [--group GRO
       --context string                   Indicates the name of the context (in kubectl) to be connect to Chainguard.
   -d, --description string               The description of the resource.
       --gcp-serviceaccount-file string   The path to a GCP service account JSON key file.
-      --group string                     The group under which to create a temporary invite code.
+      --group string                     The group under which to create a temporary invite code and install the cluster.
   -h, --help                             help for install
       --invite-code string               An invite code to use for joining this cluster into the IAM hierarchy.
       --managed string                   Indicates the cluster's agent should be managed by Chainguard.  The value indicates the provider of the cluster, e.g. gke
   -n, --name string                      Given name of the resource.
-      --private                          Kubernetes API endpoint isn't publically accessible. Cannot be used with managed clusters
+      --private                          Kubernetes API endpoint isn't publicly accessible. Cannot be used with managed clusters.
+      --profiles stringArray             The names of Chainguard profiles to install into the cluster.
       --skip-invite                      When specified we perform installation without an invite code.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters list"
 slug: chainctl_clusters_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_list/
@@ -13,19 +13,26 @@ toc: true
 List clusters.
 
 ```
-chainctl clusters list [--name NAME] [--active-within DURATION] [--group GROUP_ID|GROUP_NAME] [--output table|json] [flags]
+chainctl clusters list [--name NAME] [--active-within DURATION] [--group GROUP_ID|GROUP_NAME] [--output table|json]
 ```
 
 ### Examples
 
 ```
+  # List all clusters visible to the current user.
   chainctl cluster list
+  
+  # List all clusters in the group "my-group"
+  chainctl cluster list --group my-group
+  
+  # List all clusters that have some recorded activity within the last 6 hours
+  chainctl cluster list --active-within 6h
 ```
 
 ### Options
 
 ```
-      --active-within duration   How recently a cluster must have been active to be listed (zero will return all clusters). (default 168h0m0s)
+      --active-within duration   How recently a cluster must have been active to be listed. Zero will return all clusters. (default 24h0m0s)
       --group string             The name or id of the parent group to list clusters from.
   -h, --help                     help for list
   -n, --name string              The given name of the resource.
@@ -34,12 +41,13 @@ chainctl clusters list [--name NAME] [--active-within DURATION] [--group GROUP_I
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters open"
 slug: chainctl_clusters_open
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_open/
@@ -13,7 +13,7 @@ toc: true
 Open the console for a cluster.
 
 ```
-chainctl clusters open [CLUSTER_ID] [--output table|json] [flags]
+chainctl clusters open [CLUSTER_ID] [--output table|json]
 ```
 
 ### Options
@@ -25,12 +25,13 @@ chainctl clusters open [CLUSTER_ID] [--output table|json] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_print-config.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_print-config.md
@@ -1,27 +1,26 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl clusters print-config"
+slug: chainctl_clusters_print-config
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_print-config/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl clusters print-config
 
-Delete invite codes
+Print the tenant configuration in YAML.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl clusters print-config
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help                   help for print-config
+      --profiles stringArray   The names of Chainguard profiles to install into the cluster.
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +37,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles.md
@@ -1,27 +1,21 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl clusters profiles"
+slug: chainctl_clusters_profiles
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl clusters profiles
 
-Delete invite codes
-
-```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
-```
+Profile related commands.
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for profiles
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +32,6 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+* [chainctl clusters profiles list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles_list/)	 - List cluster profiles.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles_list.md
@@ -1,27 +1,25 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl clusters profiles list"
+slug: chainctl_clusters_profiles_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles_list/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl clusters profiles list
 
-Delete invite codes
+List cluster profiles.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl clusters profiles list [--output table|json|wide]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +36,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl clusters profiles](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_profiles/)	 - Profile related commands.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters records"
 slug: chainctl_clusters_records
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records/
@@ -21,12 +21,13 @@ Interact with cluster records.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters records list"
 slug: chainctl_clusters_records_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_records_list/
@@ -13,25 +13,26 @@ toc: true
 List cluster records.
 
 ```
-chainctl clusters records list [CLUSTER_ID] [--active-within DURATION] [--output table|json|wide] [flags]
+chainctl clusters records list [CLUSTER_NAME|CLUSTER_ID] [--active-within DURATION] [--output table|json|wide]
 ```
 
 ### Options
 
 ```
-      --active-within duration   How recently a record must have been created to be listed (zero will return all records). (default 168h0m0s)
+      --active-within duration   How recently a record must have been active to be listed. Zero will return all records. (default 24h0m0s)
   -h, --help                     help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters uninstall"
 slug: chainctl_clusters_uninstall
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_uninstall/
@@ -13,36 +13,42 @@ toc: true
 Uninstalls Chainguard from the current kubernetes context.
 
 ```
-chainctl clusters uninstall [--context CONTEXT_NAME | --inactive DURATION | --inactive DURATION --group GROUP_NAME|GROUP_ID] [flags]
+chainctl clusters uninstall [--group GROUP_NAME|GROUP_ID] [--context CONTEXT_NAME | --inactive DURATION] [--yes]
 ```
 
 ### Examples
 
 ```
+  # Uninstall a cluster and choose the context interactively
   chainctl cluster uninstall
   
   # Uninstall all clusters not seen in 7 days
   chainctl cluster uninstall --inactive 168h
+  
+  # Uninstall a cluster only if it is a member of a given group
+  chainctl cluster uninstall --group my-group --context my-context
 ```
 
 ### Options
 
 ```
       --context string      Indicates the name of the context (in kubectl) to disconnect from Chainguard.
-      --group string        Name or ID of a group to filter clusters not seen within the given duration.
+      --group string        Name or ID of a group to filter clusters by for uninstallation.
   -h, --help                help for uninstall
       --inactive duration   Delete all clusters that have not been seen within the given duration. (default 168h0m0s)
+  -y, --yes                 Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl clusters update"
 slug: chainctl_clusters_update
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_update/
@@ -43,12 +43,13 @@ chainctl clusters update CLUSTER_NAME|CLUSTER_ID [--name NAME] [--description DE
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads.md
@@ -1,27 +1,21 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl clusters workloads"
+slug: chainctl_clusters_workloads
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl clusters workloads
 
-Delete invite codes
-
-```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
-```
+Interact with cluster workloads.
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for workloads
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +32,6 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl clusters](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters/)	 - Cluster related commands for the Chainguard platform.
+* [chainctl clusters workloads list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads_list/)	 - List cluster workloads.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads_list.md
@@ -1,27 +1,27 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl clusters workloads list"
+slug: chainctl_clusters_workloads_list
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads_list/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl clusters workloads list
 
-Delete invite codes
+List cluster workloads.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl clusters workloads list [CLUSTER_ID] [--active-within DURATION] [--output tree|table|json|wide]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+      --active-within duration   How recently a workload must have been active to be listed. Zero will return all workloads. (default 24h0m0s)
+  -h, --help                     help for list
+  -n, --namespace string         The namespace whose workloads to list (default: all).
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +38,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl clusters workloads](/chainguard/chainguard-enforce/chainctl-docs/chainctl_clusters_workloads/)	 - Interact with cluster workloads.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl config"
 slug: chainctl_config
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config/
@@ -21,18 +21,20 @@ Local config file commands for chainctl.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO
 
 * [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
 * [chainctl config edit](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit/)	 - Edit the current chainctl config file.
+* [chainctl config reset](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_reset/)	 - Remove local chainctl config files and restore defaults.
 * [chainctl config save](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save/)	 - Save the current chainctl config to a config file.
 * [chainctl config view](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view/)	 - View the current chainctl config.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl config edit"
 slug: chainctl_config_edit
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_edit/
@@ -26,12 +26,13 @@ chainctl config edit [--config FILE] [--yes] [--output ] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_reset.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_reset.md
@@ -1,27 +1,26 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl config reset"
+slug: chainctl_config_reset
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_reset/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl config reset
 
-Delete invite codes
+Remove local chainctl config files and restore defaults.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl config reset [--yes]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for reset
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +37,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl config](/chainguard/chainguard-enforce/chainctl-docs/chainctl_config/)	 - Local config file commands for chainctl.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl config save"
 slug: chainctl_config_save
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_save/
@@ -26,12 +26,13 @@ chainctl config save [--config FILE] [--yes] [--output ] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl config view"
 slug: chainctl_config_view
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_config_view/
@@ -26,12 +26,13 @@ chainctl config view [--diff] [--output ] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl events"
 slug: chainctl_events
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events/
@@ -21,12 +21,13 @@ Events related commands for the Chainguard platform.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl events subscriptions"
 slug: chainctl_events_subscriptions
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions/
@@ -21,12 +21,13 @@ Subscription interactions.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl events subscriptions create"
 slug: chainctl_events_subscriptions_create
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_create/
@@ -27,12 +27,13 @@ chainctl events subscriptions create SINK_URL [--group GROUP_NAME|GROUP_ID] [--y
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl events subscriptions delete"
 slug: chainctl_events_subscriptions_delete
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_delete/
@@ -26,12 +26,13 @@ chainctl events subscriptions delete SUBSCRIPTION_ID [--yes] [--output id] [flag
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl events subscriptions list"
 slug: chainctl_events_subscriptions_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_events_subscriptions_list/
@@ -26,12 +26,13 @@ chainctl events subscriptions list [--group GROUP_NAME|GROUP_ID] [--output table
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam"
 slug: chainctl_iam
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam/
@@ -21,12 +21,13 @@ IAM related commands for the Chainguard platform.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups"
 slug: chainctl_iam_groups
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/
@@ -21,12 +21,13 @@ IAM Group resource interactions.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO
@@ -38,6 +39,8 @@ IAM Group resource interactions.
 * [chainctl iam groups delete](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete/)	 - Delete group
 * [chainctl iam groups describe](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe/)	 - Describe a group. (Experimental)
 * [chainctl iam groups list](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list/)	 - List groups.
+* [chainctl iam groups remove-aws](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-aws/)	 - Remove any configured AWS account association for this IAM Group.
+* [chainctl iam groups remove-gcp](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-gcp/)	 - Remove any configured GCP account association for this IAM Group.
 * [chainctl iam groups set-aws](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws/)	 - Set the AWS account association for this IAM Group.
 * [chainctl iam groups set-gcp](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp/)	 - Set the GCP project association for this IAM Group.
 * [chainctl iam groups update](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update/)	 - Update a group.

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups check-aws"
 slug: chainctl_iam_groups_check-aws
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-aws/
@@ -25,12 +25,13 @@ chainctl iam groups check-aws [GROUP_NAME | GROUP_ID] [--output TODO] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups check-gcp"
 slug: chainctl_iam_groups_check-gcp
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_check-gcp/
@@ -25,12 +25,13 @@ chainctl iam groups check-gcp [GROUP_NAME | GROUP_ID] [--output TODO] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups create"
 slug: chainctl_iam_groups_create
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_create/
@@ -30,12 +30,13 @@ chainctl iam groups create GROUP_NAME [--parent GROUP_NAME|GROUP_ID | --no-paren
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups delete"
 slug: chainctl_iam_groups_delete
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_delete/
@@ -42,12 +42,13 @@ chainctl iam group delete
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups describe"
 slug: chainctl_iam_groups_describe
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_describe/
@@ -13,24 +13,26 @@ toc: true
 Describe a group. (Experimental)
 
 ```
-chainctl iam groups describe [--output json] [flags]
+chainctl iam groups describe [--active-within DURATION] [--output json] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for describe
+      --active-within duration   How recently a record must have been active to be listed. Zero will return all records. (default 24h0m0s)
+  -h, --help                     help for describe
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups list"
 slug: chainctl_iam_groups_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_list/
@@ -33,12 +33,13 @@ chainctl iam group list
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-aws.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-aws.md
@@ -1,27 +1,28 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl iam groups remove-aws"
+slug: chainctl_iam_groups_remove-aws
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-aws/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl iam groups remove-aws
 
-Delete invite codes
+Remove any configured AWS account association for this IAM Group.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl iam groups remove-aws [GROUP_NAME | GROUP_ID][--output |json|table] [flags]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+      --account string       The AWS account ID.
+  -d, --description string   The description of the association.
+  -h, --help                 help for remove-aws
+  -n, --name string          The name of the association. (default: the group name)
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +39,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-gcp.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-gcp.md
@@ -1,27 +1,29 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl iam groups remove-gcp"
+slug: chainctl_iam_groups_remove-gcp
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_remove-gcp/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl iam groups remove-gcp
 
-Delete invite codes
+Remove any configured GCP account association for this IAM Group.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl iam groups remove-gcp [GROUP_NAME | GROUP_ID][--output |json|table] [flags]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -d, --description string      The description of the association.
+  -h, --help                    help for remove-gcp
+  -n, --name string             The name of the association. (default: the group name)
+      --project-id string       The GCP project ID.
+      --project-number string   The GCP project number.
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +40,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl iam groups](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups/)	 - IAM Group resource interactions.
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups set-aws"
 slug: chainctl_iam_groups_set-aws
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-aws/
@@ -13,7 +13,7 @@ toc: true
 Set the AWS account association for this IAM Group.
 
 ```
-chainctl iam groups set-aws [GROUP_NAME | GROUP_ID] [--account ACCOUNT_ID] [--output TODO] [flags]
+chainctl iam groups set-aws [GROUP_NAME | GROUP_ID] [--account ACCOUNT_ID] [--output |json|table] [flags]
 ```
 
 ### Options
@@ -28,12 +28,13 @@ chainctl iam groups set-aws [GROUP_NAME | GROUP_ID] [--account ACCOUNT_ID] [--ou
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups set-gcp"
 slug: chainctl_iam_groups_set-gcp
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_set-gcp/
@@ -13,7 +13,7 @@ toc: true
 Set the GCP project association for this IAM Group.
 
 ```
-chainctl iam groups set-gcp [GROUP_NAME | GROUP_ID] [--project-id PROJECT_ID] [--project-number PROJECT_NUMBER] [--output TODO] [flags]
+chainctl iam groups set-gcp [GROUP_NAME | GROUP_ID] [--project-id PROJECT_ID] [--project-number PROJECT_NUMBER] [--output |json|table] [flags]
 ```
 
 ### Options
@@ -29,12 +29,13 @@ chainctl iam groups set-gcp [GROUP_NAME | GROUP_ID] [--project-id PROJECT_ID] [-
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam groups update"
 slug: chainctl_iam_groups_update
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_groups_update/
@@ -41,12 +41,13 @@ chainctl iam groups update my-group --description ""
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam invites"
 slug: chainctl_iam_invites
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/
@@ -21,12 +21,13 @@ Manage invite codes that register identities or clusters with Chainguard.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam invites create"
 slug: chainctl_iam_invites_create
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_create/
@@ -13,7 +13,7 @@ toc: true
 Generate an invite code to identities or register clusters with Chainguard.
 
 ```
-chainctl iam invites create [GROUP_NAME | GROUP_ID] [--role ROLE_ID | --cluster] [--ttl TTL_DURATION] [--output json|table|id] [flags]
+chainctl iam invites create [GROUP_NAME | GROUP_ID] [--role ROLE_ID|ROLE_NAME | --cluster] [--ttl TTL_DURATION] [--output json|table|id] [flags]
 ```
 
 ### Examples
@@ -22,6 +22,10 @@ chainctl iam invites create [GROUP_NAME | GROUP_ID] [--role ROLE_ID | --cluster]
 
 # Create an invite that will be valid for 5 days:
 chainctl iam invite create GROUP_ID --role ROLE_ID --ttl 5d
+
+# Create an invite that only Kim can accept:
+chainctl iam invite create GROUP_ID --role ROLE_ID --email kim@example.com
+
 # Create an invite for a cluster:
 chainctl iam invite create GROUP_ID --cluster
 
@@ -31,6 +35,7 @@ chainctl iam invite create GROUP_ID --cluster
 
 ```
       --cluster        Default roles for cluster invites.
+      --email string   The email address that is allowed to accept this invite code.
   -h, --help           help for create
       --role string    Role is used to role-bind the invited to the associated group.
       --ttl duration   Duration the invite code will be valid. (default 168h0m0s)
@@ -39,12 +44,13 @@ chainctl iam invite create GROUP_ID --cluster
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam invites list"
 slug: chainctl_iam_invites_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_list/
@@ -25,12 +25,13 @@ chainctl iam invites list [--output table|json|id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam role-bindings"
 slug: chainctl_iam_role-bindings
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings/
@@ -21,12 +21,13 @@ IAM role bindings resource interactions.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam role-bindings list"
 slug: chainctl_iam_role-bindings_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_role-bindings_list/
@@ -33,12 +33,13 @@ chainctl iam role-bindings list
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam roles"
 slug: chainctl_iam_roles
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles/
@@ -21,12 +21,13 @@ IAM role resource interactions.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl iam roles list"
 slug: chainctl_iam_roles_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_roles_list/
@@ -33,12 +33,13 @@ chainctl iam role list
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies"
 slug: chainctl_policies
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies/
@@ -21,12 +21,13 @@ Policy related commands for the Chainguard platform.
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies apply"
 slug: chainctl_policies_apply
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_apply/
@@ -30,12 +30,13 @@ chainctl policies apply [--group GROUP_NAME|GROUP_ID] [--description DESCRIPTION
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies delete"
 slug: chainctl_policies_delete
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_delete/
@@ -26,12 +26,13 @@ chainctl policies delete POLICY_ID|POLICY_NAME [--yes] [--output id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies edit"
 slug: chainctl_policies_edit
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_edit/
@@ -26,12 +26,13 @@ chainctl policies edit [POLICY_ID|POLICY_NAME] [--yes] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies list"
 slug: chainctl_policies_list
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_list/
@@ -27,12 +27,13 @@ chainctl policies list [--group GROUP_NAME|GROUP_ID] [--output table|json|id] [f
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies update"
 slug: chainctl_policies_update
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_update/
@@ -20,10 +20,10 @@ chainctl policies update POLICY_NAME|POLICY_ID --description DESCRIPTION [--outp
 
 ```
   # Update a policy description by name.
-  chainctl iam policy update my-policy --description "A description of my policy."
+  chainctl policy update my-policy --description "A description of my policy."
   
   # Remove a policy description by ID.
-  chainctl iam policy update 617ec5ae5775e22fb52ec2d62398de1e7def7986/e74e9050df769110 --description ""
+  chainctl policy update 617ec5ae5775e22fb52ec2d62398de1e7def7986/e74e9050df769110 --description ""
 ```
 
 ### Options
@@ -36,12 +36,13 @@ chainctl policies update POLICY_NAME|POLICY_ID --description DESCRIPTION [--outp
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl policies view"
 slug: chainctl_policies_view
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_policies_view/
@@ -25,12 +25,13 @@ chainctl policies view [POLICY_ID|POLICY_NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_update.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_update.md
@@ -1,27 +1,26 @@
 ---
 date: 2022-12-15T19:03:53-05:00
-title: "chainctl iam invites delete"
-slug: chainctl_iam_invites_delete
-url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites_delete/
+title: "chainctl update"
+slug: chainctl_update
+url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_update/
 draft: false
 images: []
 type: "article"
 toc: true
 ---
-## chainctl iam invites delete
+## chainctl update
 
-Delete invite codes
+Update chainctl.
 
 ```
-chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
+chainctl update [--yes]
 ```
 
 ### Options
 
 ```
-      --expired   When true, delete all expired invite codes.
-  -h, --help      help for delete
-  -y, --yes       Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
+  -h, --help   help for update
+  -y, --yes    Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively.
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +37,5 @@ chainctl iam invites delete {INVITE_ID... | --expired} [--yes] [flags]
 
 ### SEE ALSO
 
-* [chainctl iam invites](/chainguard/chainguard-enforce/chainctl-docs/chainctl_iam_invites/)	 - Manage invite codes that register identities or clusters with Chainguard.
+* [chainctl](/chainguard/chainguard-enforce/chainctl-docs/chainctl/)	 - Chainguard Control
 

--- a/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_version.md
+++ b/content/chainguard/chainguard-enforce/chainctl-docs/chainctl_version.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-29T10:58:14-04:00
+date: 2022-12-15T19:03:53-05:00
 title: "chainctl version"
 slug: chainctl_version
 url: /chainguard/chainguard-enforce/chainctl-docs/chainctl_version/
@@ -26,12 +26,13 @@ chainctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --api string        The url of the Chainguard platform API. (default "http://api.api-system.svc")
-      --audience string   The Chainguard token audience to request. (default "http://api.api-system.svc")
-      --config string     A specific chainctl config file.
-      --console string    The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
-      --issuer string     The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
-  -o, --output string     Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --api string                   The url of the Chainguard platform API. (default "http://api.api-system.svc")
+      --audience string              The Chainguard token audience to request. (default "http://api.api-system.svc")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
+      --issuer string                The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
+  -o, --output string                Output format. One of: ["", "table", "tree", "json", "id", "wide"]
+      --timestamp_authority string   The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
 ```
 
 ### SEE ALSO

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog.md
@@ -2,14 +2,91 @@
 title : "Chainguard Enforce Changelog"
 description: "Chainguard Enforce Changelog"
 type: "article"
-date: 2022-12-07 20:35:46 +0000 UTC
+date: 2023-01-10 10:56:36 +0000 UTC
 draft: false
 images: []
 weight: 799
 ---
 
 ## Introduction
-Any customer facing changes to Chainguard Enforce or [`chainctl`](/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl/) are highlighted in the following notes. Any new features, bug fixes, or general ease of use improvments will be listed under the corresponding release version.
+Any customer facing changes to Chainguard Enforce or [`chainctl`](/chainguard/chainguard-enforce/how-to-install-chainctl/) are highlighted in the following notes. Any new features, bug fixes, or general ease of use improvements will be listed under the corresponding release version.
+
+### v0.1.51
+Release date: 2023-01-10
+#### Feature
+- We will now observe and model Tekton resources, when they are installed.
+- terraform-provider now default's to the enforce.dev production environment instead of the decomissioned guak.dev environment
+- non-Kubernetes GCP runtimes can now take advantage of GCP audit logs to react in near real-time to deployment events (similar to Kubernetes informers).  This needs the latest release of https://github.com/chainguard-dev/terraform-google-chainguard-account-association to be applied.
+
+
+### v0.1.50
+Release date: 2023-01-06
+#### Feature
+- Agent-based cluster installation now surfaces cluster created events (like agentless installs)
+- Allow customers coming from gitlab to to authorize with Chainguard APIs until gitlab supports customizing the audience claim.
+- `chainctl` notifies the user when there is a an update available.
+
+
+### v0.1.49
+Release date: 2023-01-05
+
+Customer facing changes: N/A
+
+### v0.1.48
+Release date: 2023-01-05
+
+Customer facing changes: N/A
+
+### v0.1.47
+Release date: 2023-01-03
+#### Feature
+- Introduce a "chainctl cluster discover" command for automatically discovering (and enrolling) clusters.
+- Search for packages within your clusters with `chainctl cluster search`
+#### Bug or Regression
+- Fix authentication for fetchConfigFile with private images (multi-arch images are still broken pending an upstream fix)
+- image references should now use a consistently normalized form with a hostname and no tag.  DockerHub references will always get prefixed with index.docker.io (even if written without a host, or with docker.io), and "official" images will have the prefix: index.docker.io/library.  Tags will be stripped, even if specified alongside a digest.  For example, ubuntu:latest@sha256:deadbeef will become: index.docker.io/library/ubuntu@sha256:deadbeef
+
+
+### v0.1.46
+Release date: 2022-12-16
+
+Customer facing changes: N/A
+
+### v0.1.45
+Release date: 2022-12-15
+
+Customer facing changes: N/A
+
+### v0.1.44
+Release date: 2022-12-14
+#### Feature
+- Enforce will now detect Knative resource types, if they are installed, and model them in our resource hierarchy.
+
+
+### v0.1.43
+Release date: 2022-12-13
+
+Customer facing changes: N/A
+
+### v0.1.42
+Release date: 2022-12-12
+
+Customer facing changes: N/A
+
+### v0.1.41
+Release date: 2022-12-12
+
+Customer facing changes: N/A
+
+### v0.1.40
+Release date: 2022-12-12
+#### Documentation
+- generate a release changelog for Enforce and `chainctl` changes, accessible at [https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog/](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog/)
+#### Bug or Regression
+- Bugfix: allow rerunning of `chainctl cluster install --private`
+#### Other (Cleanup or Flake)
+- Activity in chainctl will now show up as monitor -> observer, and policy -> enforcer
+
 
 ### v0.1.39
 Release date: 2022-12-05
@@ -53,12 +130,12 @@ Release date: 2022-11-19
 Customer facing changes: N/A
 
 ### v0.1.33
-Release date: 2022-11-18
+Release date: 2022-11-19
 
 Customer facing changes: N/A
 
-### v0.1.18
-Release date: 2022-11-28
+### v0.1.32
+Release date: 2022-11-19
 
 Customer facing changes: N/A
 
@@ -78,7 +155,7 @@ Release date: 2022-11-17
 - `chainctl iam groups describe` now supports filtering cluster records with `--active-within`.
 
 ### v0.1.28
-Release date: 2022-11-16
+Release date: 2022-11-17
 
 Customer facing changes: N/A
 
@@ -190,7 +267,7 @@ Release date: 2022-10-13
 
 
 ### v0.1.9
-Release date: 2022-10-11
+Release date: 2022-10-12
 
 Customer facing changes: N/A
 
@@ -243,7 +320,7 @@ Release date: 2022-09-21
 
 
 ### v0.0.24
-Release date: 2022-09-20
+Release date: 2022-09-21
 
 Customer facing changes: N/A
 
@@ -253,7 +330,7 @@ Release date: 2022-09-19
 Customer facing changes: N/A
 
 ### v0.0.22
-Release date: 2022-09-17
+Release date: 2022-09-18
 
 Customer facing changes: N/A
 
@@ -275,7 +352,7 @@ Release date: 2022-09-14
 
 
 ### v0.0.18
-Release date: 2022-09-13
+Release date: 2022-09-14
 
 Customer facing changes: N/A
 
@@ -295,7 +372,7 @@ Release date: 2022-09-12
 Customer facing changes: N/A
 
 ### v0.0.14
-Release date: 2022-09-09
+Release date: 2022-09-10
 #### Feature
 - Customize some colors used across chainctl with `CHAINGUARD_OUTPUT_COLOR_PASS`, `CHAINGUARD_OUTPUT_COLOR_WARN`, and `CHAINGUARD_OUTPUT_COLOR_FAIL`. Highlight important images when reviewing cluster records with `CHAINGUARD_OUTPUT_RECORDS_NOTABLE` and `CHAINGUARD_OUTPUT_RECORDS_COLOR`.
 #### Other (Cleanup or Flake)


### PR DESCRIPTION
## Type of change
Docs update for Enforce changelog and `chainctl`

### What are the acceptance criteria? 
* Enforce changelog should show latest v0.1.51 release
* chainctl docs should show a new page under `/chainguard/chainguard-enforce/chainctl-docs/chainctl_config_reset/`

### How should this PR be tested?
The netlify preview site should show the new pages.