### PR TITLE
issuer/subject="*" should use issuer/subjectRegExp

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-user-onboarding.md
@@ -171,8 +171,8 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
-        - issuer: "*"
-          subject: "*"
+        - issuerRegExp: ".*"
+          subjectRegExp: ".*"
 EOF
 ```
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/connecting-to-private-registries.md
@@ -63,8 +63,8 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
-        - issuer: "*"
-          subject: "*"
+        - issuerRegExp: ".*"
+          subjectRegExp: ".*"
     source:
     - oci: "registry.example.com"
       signaturePullSecrets:
@@ -90,8 +90,8 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
-        - issuer: "*"
-          subject: "*"
+        - issuerRegExp: ".*"
+          subjectRegExp: ".*"
     source:
     - oci: "index.docker.io/privatenamespace/$image"
       signaturePullSecrets:
@@ -138,8 +138,8 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
-        - issuer: "*"
-          subject: "*"
+        - issuerRegExp: ".*"
+          subjectRegExp: ".*"
 ```
 
 Be sure to replace `$your-gcp-project` with your relevant project name. 
@@ -172,8 +172,8 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
-        - issuer: "*"
-          subject: "*"
+        - issuerRegExp: ".*"
+          subjectRegExp: ".*"
 ```
 
 Be sure to replace the variable next to glob with your relevant account information, within the double quotes.

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/detect-log4shell-demo/index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/detect-log4shell-demo/index.md
@@ -140,8 +140,8 @@ spec:
     keyless:
         url: "https://fulcio.sigstore.dev"
         identities:
-          - issuer: "*"
-            subject: "*"
+          - issuerRegExp: ".*"
+            subjectRegExp: ".*"
     attestations:
     - predicateType: cyclonedx
       name: log4shellcyclonedx

--- a/log4shell-demo-policy.yaml
+++ b/log4shell-demo-policy.yaml
@@ -10,8 +10,8 @@ spec:
     keyless:
         url: "https://fulcio.sigstore.dev"
         identities:
-          - issuer: "*"
-            subject: "*"
+          - issuerRegExp: ".*"
+            subjectRegExp: ".*"
     attestations:
     - predicateType: cyclonedx
       name: log4shellcyclonedx


### PR DESCRIPTION
## Type of change
Bug: issuer/subject="*" should use issuer/subjectRegExp

### What should this PR do?
Change issuer/subject="*" to use issuer/subjectRegExp

### Why are we making this change?
issuer/subject="*" should use issuer/subjectRegExp

### What are the acceptance criteria? 
cc @k4leung4 @hectorj2f 

### How should this PR be tested?
By applying the given policies.