### PR TITLE
Add terminal back to apko, cosign, and rekor pages

### DIFF
--- a/content/open-source/apko/getting-started-with-apko.md
+++ b/content/open-source/apko/getting-started-with-apko.md
@@ -12,7 +12,7 @@ menu:
   docs:
     parent: "apko"
 weight: 100
-# terminalImage: gcloud:latest
+terminalImage: academy/apko:latest
 toc: true
 ---
 

--- a/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
@@ -11,7 +11,7 @@ menu:
   docs:
     parent: "cosign"
 weight: 003
-# terminalImage: gcloud:latest
+terminalImage: academy/cosign:latest
 toc: true
 ---
 

--- a/content/open-source/sigstore/rekor/how-to-query-rekor.md
+++ b/content/open-source/sigstore/rekor/how-to-query-rekor.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "rekor"
-# terminalImage: gcloud:latest
+terminalImage: academy/rekor:latest
 weight: 003
 toc: true
 ---

--- a/content/open-source/sigstore/rekor/how-to-sign-and-upload-metadata-to-rekor.md
+++ b/content/open-source/sigstore/rekor/how-to-sign-and-upload-metadata-to-rekor.md
@@ -11,7 +11,7 @@ menu:
   docs:
     parent: "rekor"
 weight: 004
-# terminalImage: gcloud:latest
+terminalImage: academy/rekor:latest
 toc: true
 ---
 


### PR DESCRIPTION
### What should this PR do?
Fixes #269: This PR adds the interactive terminal back to apko, cosign, and rekor pages

### Why are we making this change?
The terminal was turned off in https://github.com/chainguard-dev/edu/commit/bcb5ec7b75a0b00c70f4f714745110a513f6177d so this turns it back on.

### What are the acceptance criteria? 
Terminal loads locally in dev. It likely won't in netlify, but should again in production.