### PR TITLE
Add Dockerfiles for interactive terminal images

### DIFF
--- a/terminal-images/README.md
+++ b/terminal-images/README.md
@@ -1,0 +1,5 @@
+## Interactive Terminal Dockerfiles
+
+The directories and files in here are used to generate container images on the Academy site. Images are derived from the `academy-base` image, which includes things like `curl`, `tmux`, `jq`, and `nano`. 
+
+Derived images only need to set a Docker `CMD` to override the default `sleep 3600` command that is passed to the image on start up.

--- a/terminal-images/academy-base/Dockerfile
+++ b/terminal-images/academy-base/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3
+
+RUN apk add curl bash tmux sudo tini nano jq && rm -rf /tmp/* /var/cache/apk/*
+
+RUN addgroup inky \
+      --gid 1000 && \
+    adduser inky \
+      --ingroup inky \
+      --uid 1000 \
+      --system \
+      -s /bin/bash
+RUN adduser inky wheel
+
+RUN printf "inky:secret" |chpasswd
+RUN echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel
+
+WORKDIR /home/inky
+USER inky
+
+ENV COSIGN_EXPERIMENTAL=1
+ENTRYPOINT ["/usr/bin/sudo", "/sbin/tini", "--"]
+CMD ["/bin/sleep", "3600"]

--- a/terminal-images/apko/Dockerfile
+++ b/terminal-images/apko/Dockerfile
@@ -1,0 +1,6 @@
+FROM academy-base:latest
+
+RUN sudo apk add docker && rm -rf /tmp/* /var/cache/apk/*
+RUN sudo adduser inky docker
+
+CMD ["/usr/bin/dockerd"]

--- a/terminal-images/cosign/Dockerfile
+++ b/terminal-images/cosign/Dockerfile
@@ -1,0 +1,6 @@
+FROM academy-base:latest
+
+RUN sudo apk add docker cosign && rm -rf /tmp/* /var/cache/apk/*
+RUN sudo adduser inky docker
+
+CMD ["/usr/bin/dockerd"]

--- a/terminal-images/rekor/Dockerfile
+++ b/terminal-images/rekor/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=linux/amd64 golang:1.19 as builder
+
+RUN GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go install -v github.com/sigstore/rekor/cmd/rekor-cli@latest
+
+FROM --platform=linux/amd64 academy-base:latest
+
+COPY --from=builder /go/bin/rekor-cli /usr/local/bin/


### PR DESCRIPTION
### What should this PR do?
This PR adds Dockerfiles for the images that run on terminal.inky.wtf. It includes an `academy-base` image with a user and various tools, and then derived images for pages like How To Query Rekor etc.

### What are the acceptance criteria? 
N/A - these are a capture of the Dockerfiles that comprise the already running images on the associated Academy pages.

### How should this PR be tested?
Build the `academy-base:latest` image first:
```
cd academy-base
docker build --platform linux/amd64 . -t academy-base:latest
```

Then build an image like `cosign:latest`:

```
cd cosign
docker build --platform linux/amd64 . -t cosign:latest
```

To build Rekor takes a while since it is compiled with Go.