### PR TITLE
Feature: Document the need to instantiate regional AWS audit logs.

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
@@ -60,10 +60,21 @@ this:
 cat  <<EOF > main.tf
 provider "aws" {}
 
-module "chainguard-account-association" {
+module "aws-impersonation" {
   source  = "chainguard-dev/chainguard-account-association/aws"
 
   enforce_group_ids = ["$ENFORCE_GROUP_ID"]
+}
+
+# While the above configures global IAM bindings, this module contains
+# regional resources that let Chainguard Enforce monitor audit logs that
+# let us discover infrastructure changes immediately.
+#
+# This module must be applied to each region containing resources you would like
+# Chainguard Enforce to monitor in near real time.
+module "aws-auditlogs" {
+  # Note the // is semantic and tells terraform that auditlogs is a directory.
+  source = "chainguard-dev/chainguard-account-association/aws//auditlogs"
 }
 EOF
 ```
@@ -121,7 +132,7 @@ provider "google-beta" {
   project = "$PROJECT_ID"
 }
 
-module "chainguard-account-association" {
+module "gcp-impersonation" {
   source  = "chainguard-dev/chainguard-account-association/google"
 
   enforce_group_ids  = ["$ENFORCE_GROUP_ID"]


### PR DESCRIPTION
:gift: This documents the separate module needed to instantiate the per-region resources for Enforce's audit log integration.

/kind feature

### What should this PR do?
This documents the need for a second module for AWS that must be instantiated regionally.

### Why are we making this change?
The best practices for the AWS provider discourage folks from having modules that perform operations across many regions at once (with the exception of global resources like IAM), so we split a submodule that folks can apply regionally.

### What are the acceptance criteria? 
Users are able to apply the new terraform cleanly.

### How should this PR be tested?
Attempt to instantiate the new terraform locally, a `terraform init -upgrade` may be required.
