### PR TITLE
Add pull-request permission for autodocs-enforce gh token

### DIFF
--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'


### PR DESCRIPTION
This PR addresses (hopefully) the error here: https://github.com/chainguard-dev/edu/actions/runs/3968970051/jobs/6802834106#step:9:45

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

My fork of the repo didn't need this permission, but I think we have more restrictive actions here so adding it. 