### PR TITLE
Update images reference workflow - fixes #274

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -25,7 +25,7 @@ jobs:
         run: mkdir -p "${{ github.workspace }}/${{ env.WORKDIR }}" && chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: "Update the reference docs for Chainguard Images"
-        uses: chainguard-dev/deved-autodocs@e60c80e90e429ac5306447e5a1b2d84ba9cf3647 # v1.0.3
+        uses: chainguard-dev/deved-autodocs@1.0.4
         with:
           command: build images
         env:


### PR DESCRIPTION
Updating the images reference action version. This update fixes #274 

The new overview page has a table exhibiting the image tags with information obtained by a JSON file. Example: https://github.com/chainguard-dev/deved-autodocs/pull/10/files#diff-0b359d83768563ba64efc5d825da82b824c1860372d9e4465a3cbb19b0ad3e00

I am changing this workflow to use a tag instead of a commit because this Github Action comes from a trusted source: it's repository we own, inside our org, it has CODEOWNERS in place, and I'll only use tagged releases for it. Using a specific commit hash is a lot harder specially because this action is under active development.

I will still need to update this workflow when there's a new version, but it will be easier to update.