### PR TITLE
fix chainctl curl command

### DIFF
--- a/content/ui/install.md
+++ b/content/ui/install.md
@@ -9,7 +9,7 @@ mkdir ~/enforce-demo && cd $_
 To install `chainctl`, we’ll use the `curl` command to pull the application down.
 
 ```sh
-curl -o chainctl "https://dl.enforce.dev/chainctl_$(uname -s)_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
old path points to dated 0.1.44, point to latest

matches the path here, https://github.com/chainguard-dev/edu/blob/b5b223538769c5624fbbb233c0e113e888e9d831/content/chainguard/chainguard-enforce/how-to-install-chainctl.md?plain=1#L52

fix: https://github.com/chainguard-dev/mono/issues/7664

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
fix incorrect download command

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->