### PR TITLE
Fixed typo in python image docs

### DIFF
--- a/content/chainguard/chainguard-images/reference/python/overview.md
+++ b/content/chainguard/chainguard-images/reference/python/overview.md
@@ -36,7 +36,7 @@ These images are available on `cgr.dev`:
 
 ```
 docker pull cgr.dev/chainguard/python:latest
-docker pull cgr.dev/chainguard/python:dev-latest
+docker pull cgr.dev/chainguard/python:latest-dev
 ```
 
 ## Usage
@@ -44,7 +44,7 @@ docker pull cgr.dev/chainguard/python:dev-latest
 The python image can be used directly for simple cases, or with a multi-stage build using python-dev as the build container.
 
 ```Dockerfile
-FROM cgr.dev/chainguard/python:dev-latest AS builder
+FROM cgr.dev/chainguard/python:latest-dev AS builder
 COPY . /app
 RUN cd /app && pip install -r requirements.txt
 


### PR DESCRIPTION
## Type of change
Fixed documentation to include the correct name of the image tag for python dev.

### What should this PR do?
The tag for the dev version of the python image is called `latest-dev` not `dev-latest`

### Why are we making this change?
If a user tries to pull `cgr.dev/chainguard/python:dev-latest` it will not work.

### What are the acceptance criteria? 
-

### How should this PR be tested?
-