### PR TITLE
Adding draft of signing doc

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-github/_index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-github/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Chainguard Enforce for Git"
+title: "Enforce for Git"
 lead: ""
 type: "article"
 date: 2020-10-06T08:49:15+00:00

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/_index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/_index.md
@@ -1,5 +1,5 @@
 ---
-title : "Chainguard Enforce for Kubernetes"
+title : "Enforce for Kubernetes"
 lead: ""
 description: "Chainguard Enforce for Kubernetes Documentation"
 type: "article"

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations.md
@@ -40,14 +40,18 @@ cloud provider’s IAM system.
 ## Setting up a Cloud Account Association for AWS
 
 To configure (or upgrade) a cloud account association with AWS, start by setting up the
-association in Chainguard Enforce using `chainctl`. First, associate the ID of
-the relevant Enforce group and the AWS account ID to variables for later use.
-You can find the IAM group ID by running `chainctl iam groups ls -o table`:
+association in Chainguard Enforce using `chainctl`. 
+
+First, associate the ID of the relevant Enforce group and the AWS account ID to variables for later use. You can find the IAM group ID by running `chainctl iam groups ls -o table`.
 
 ```sh
 export ENFORCE_GROUP_ID="<<uidp of target Enforce IAM group>>"
 export AWS_ACCOUNT_ID="12 digit AWS account ID to connect to"
+```
 
+Then, run the `chainctl` command to begin setting up the AWS account with the Enforce group. 
+
+```sh
 chainctl iam group set-aws $ENFORCE_GROUP_ID --account $AWS_ACCOUNT_ID
 ```
 
@@ -87,8 +91,6 @@ terraform plan
 terraform apply
 ```
 
-More documentation and examples are available in the [module source repository](https://github.com/chainguard-dev/terraform-aws-chainguard-account-association).
-
 Once your AWS account is configured, you can check that the account association
 is configured correctly:
 
@@ -99,22 +101,28 @@ chainctl iam groups check-aws $ENFORCE_GROUP_ID
 You’ll receive output that the configuration was successful.
 
 ```sh
-2022/09/01 11:26:47 AWS role impersonation was successful!
+2023/01/24 20:17:09 AWS role impersonation was successful!
 ```
+
+More documentation and examples are available in the [module source repository](https://github.com/chainguard-dev/terraform-aws-chainguard-account-association).
 
 ## Setting up a Cloud Account Association for GCP
 
-To configure (or upgrade) a cloud account association with GCP, start by setting up the
-association in Chainguard Enforce using `chainctl`. First, store the ID of the
+To configure (or upgrade) a cloud account association with GCP, first store the ID of the
 relevant Enforce group, the GCP account ID, and the GCP project number into
-variables for later use. You can find the IAM group ID by running `chainctl iam
-groups ls -o table`:
+variables for later use. 
+
+You can find the IAM group ID (UIDP) by running `chainctl iam groups ls -o table`. To find your GCP project ID and project number, open a web browser window and navigate to [https://console.cloud.google.com/welcome](https://console.cloud.google.com/welcome). Ensure you are in your preferred project from the dropdown in the nav bar, and note your **Project ID** (which should be a string of characters), and your **Project number** (which should be a string of numbers only).
 
 ```
 export ENFORCE_GROUP_ID="UIDP of target Enforce IAM group"
 export PROJECT_ID="GCP project ID"
 export PROJECT_NUMBER="GCP project number"
+```
 
+Next, set up the association in Chainguard Enforce using `chainctl`. 
+
+```sh
 chainctl iam group set-gcp $ENFORCE_GROUP_ID \
   --project-id $PROJECT_ID \
   --project-number $PROJECT_NUMBER
@@ -149,9 +157,16 @@ terraform plan
 terraform apply
 ```
 
-More documentation and examples are available in the [module source repository](https://github.com/chainguard-dev/terraform-google-chainguard-account-association).
+You will be asked for confirmation during this process. If you are satisfied with the description you receive in the output, type `yes` to confirm.
 
 It may take a few minutes for changes to propagate.
+
+If you experience an error message when running the Terraform commands above, you may need to authenticate from the terminal to GCP with the following `gcloud` command`.
+
+```sh
+gcloud auth application-default login
+```
+
 Once your GCP project is configured you can check that the account association
 is configured correctly:
 
@@ -162,5 +177,7 @@ chainctl iam groups check-gcp $ENFORCE_GROUP_ID
 You’ll receive output that the configuration was successful.
 
 ```sh
-2022/09/01 11:26:47 GCP role impersonation was successful!
+2023/01/24 20:17:09 GCP role impersonation was successful!
 ```
+
+More documentation and examples are available in the [module source repository](https://github.com/chainguard-dev/terraform-google-chainguard-account-association).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/_index.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/_index.md
@@ -1,0 +1,11 @@
+---
+title : "Enforce Signing"
+lead: ""
+description: "Chainguard Enforce Signing Documentation"
+type: "article"
+date: 2023-01-24T08:48:45+00:00
+lastmod: 2023-01-24T08:48:45+00:00
+draft: false
+images: []
+weight: 001
+---

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
@@ -1,0 +1,26 @@
+---
+title: "Overview and FAQs"
+type: "article"
+description: "Overview and FAQs of Chainguard Enforce Signing"
+date: 2023-01-27T15:56:52-07:00
+lastmod: 2022-01-27T15:56:52-07:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-enforce-signing"
+weight: 10
+toc: true
+---
+
+> _This documentation is related to Chainguard Enforce Signing. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+
+Chainguard Enforce Signing is powered by the open source security tool suite [Sigstore](https://www.sigstore.dev/). Enabling you to generate digital signatures for software artifacts, Enforce Signing will enforce signing and verification inside your organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality).
+
+Enforce Signing helps organizations ensure the integrity of container images, code commits, and other software artifacts with private signatures that can be validated at any point that verification is needed. Additionally, you can bring your own key and certificate to work with Enforce Signing, so key usage can be monitored and audited against your organization's compliance requirements. 
+
+Enforce Signing is built with privacy in mind. While Sigstore is built on [transparency](https://docs.sigstore.dev/rekor/overview) by design, Enforce Signing will not store any of your information in a public transparency log. This enables you to conform to your organization's privacy requirements while still being able to get the value of Sigstore.
+
+<!-- ## FAQs
+
+To add  -->

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
@@ -15,11 +15,11 @@ toc: true
 
 **Chainguard Enforce Signing is in _Beta Preview_. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs).**
 
-Chainguard Enforce Signing is powered by the open source security tool suite [Sigstore](https://www.sigstore.dev/). Enabling you to generate digital signatures for software artifacts, Enforce Signing will enforce signing and verification inside your organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality).
+Chainguard Enforce Signing is powered by [Sigstore](https://www.sigstore.dev/), a suite of open source security tools. Enabling you to generate digital signatures for software artifacts, Enforce Signing will enforce signing and verification inside your organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality).
 
-Enforce Signing helps organizations ensure the integrity of container images, code commits, and other software artifacts with private signatures that can be validated at any point that verification is needed. Additionally, you can bring your own key and certificate to work with Enforce Signing, so key usage can be monitored and audited against your organization's compliance requirements. 
+Enforce Signing helps organizations ensure the integrity of container images, code commits, and other software artifacts with private signatures that can be validated at any point that verification is needed. Additionally, you can bring your own key and certificate to work with Chainguard Enforce Signing, so key usage can be monitored and audited against your organization's compliance requirements. 
 
-Enforce Signing is built with privacy in mind. While Sigstore is built on [transparency](https://docs.sigstore.dev/rekor/overview) by design, Enforce Signing will not store any of your information in a public transparency log. This enables you to conform to your organization's privacy requirements while still being able to get the value of Sigstore.
+Chainguard Enforce Signing is built with privacy in mind. While Sigstore is built on [transparency](https://docs.sigstore.dev/rekor/overview) by design, Enforce Signing will not store any of your information in a public transparency log. This enables you to conform to your organization's privacy requirements while still being able to get the value of Sigstore.
 
 ## FAQs
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs.md
@@ -13,7 +13,7 @@ weight: 10
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce Signing. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+**Chainguard Enforce Signing is in _Beta Preview_. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs).**
 
 Chainguard Enforce Signing is powered by the open source security tool suite [Sigstore](https://www.sigstore.dev/). Enabling you to generate digital signatures for software artifacts, Enforce Signing will enforce signing and verification inside your organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality).
 
@@ -21,6 +21,22 @@ Enforce Signing helps organizations ensure the integrity of container images, co
 
 Enforce Signing is built with privacy in mind. While Sigstore is built on [transparency](https://docs.sigstore.dev/rekor/overview) by design, Enforce Signing will not store any of your information in a public transparency log. This enables you to conform to your organization's privacy requirements while still being able to get the value of Sigstore.
 
-<!-- ## FAQs
+## FAQs
 
-To add  -->
+Here are some of the frequently asked questions on Chainguard Enforce Signing. Please [contact us](https://www.chainguard.dev/contact?utm_source=docs) if you have additional questions.
+
+### Where are signing keys stored?
+
+Keys are stored as KMS resources in your own AWS or GCP project. When you set up an account association, you’ll give Chainguard access to sign with your KMS key. Since the key is in your project, you can set up audit logging to see when your key has been used.
+
+### Does Chainguard have access to my private key?
+
+Chainguard has permissions to sign with your KMS key, which is how certificates from Enforce Signing are issued. Chainguard can’t see the private key and we recommend setting up audit logging to track each time the key has been used.
+
+### Which cloud providers are supported?
+
+Currently, we support Enforce Signing on GCP and AWS. For GCP, you can use the GCP CA service directly for Enforce Signing. For both GCP and AWS, you can set up a KMS-based certificate authority by providing your own KSM key and a valid root certificate chain.
+
+### Does Enforce Signing support AWS Private CA?
+
+Neither the open source Sigstore project nor Enforce Signing currently supports AWS Private CA. If you’re interested in using Enforce Signing with AWS Private CA, please [let us know](https://www.chainguard.dev/contact?utm_source=docs).

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
@@ -13,7 +13,7 @@ weight: 10
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce Signing. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+**Chainguard Enforce Signing is in _Beta Preview_. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs).**
 
 Powered by the open source security tool suite [Sigstore](https://www.sigstore.dev/), Chainguard Enforce Signing enables you to generate digital signatures for software artifacts inside your own organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality). Enforce Signing can be monitoried and audited against your organization's compliance and privacy requirements so you have full control. Learn more about Enforce Signing in our [Overview and FAQs doc](/chainguard/chainguard-enforce/chainguard-enforce-signing/chainguard-enforce-signing-faqs/).
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
@@ -42,7 +42,7 @@ To set up a Google CA Service, you'll first need an instance of the GCP CA Servi
 gcloud services enable privateca.googleapis.com
 ```
 
-You'll need create a new CA Pool (alternately, you can use an existing one if you have one set up). For demonstration purposes, we'll use the `devops` tier. Replace `$POOL_NAME` with the name you would like to use for your CA Pool. 
+You'll need create a new CA Pool (alternately, you can use an existing one if you have one set up). For demonstration purposes, we'll use the `devops` tier. Replace `$POOL_NAME` with the name you would like to use for your CA Pool. Depending on your configuration, you may need to pass the location of where you want this CA Pool, with the `--location=` flag. 
 
 ```sh
 gcloud privateca pools create $POOL_NAME --tier=devops
@@ -204,7 +204,7 @@ The following checks were performed on each of these signatures:
 [{"critical":{"identity":{"docker-reference":"$IMAGE"},"image":{"docker-manifest-digest":"sha256:77...9"},"type":"cosign container image signature"},"optional":{"...":"https://auth.chainguard.dev/","Issuer":"https://auth.chainguard.dev/","..."},"Subject":"$EMAIL"}}]
 ```
 
-Congratulations! You have signed and verified a software artifact with Chainguard Enforce Signing!
+This output indicates that software artifact's signature was successfully verified.
 
 ## Learn More
 

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-signing/getting-started-chainguard-enforce-signing.md
@@ -1,0 +1,145 @@
+---
+title: "Getting Started"
+type: "article"
+description: "Getting Started with Chainguard Enforce Signing"
+date: 2023-01-26T15:56:52-07:00
+lastmod: 2022-01-26T15:56:52-07:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-enforce-signing"
+weight: 10
+toc: true
+---
+
+> _This documentation is related to Chainguard Enforce Signing. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+
+Powered by the open source security tool suite [Sigstore](https://www.sigstore.dev/), Chainguard Enforce Signing enables you to generate digital signatures for software artifacts inside your own organization using the individual identities of your team members and [ephemeral keys](https://www.chainguard.dev/unchained/the-principle-of-ephemerality).
+
+Enforce Signing helps organizations ensure the integrity of container images, code commits, and other software artifacts with private signatures that can be validated at any point that verification is needed. Additionally, you can bring your own key and certificate to work with Enforce Signing, so key usage can be monitored and audited against your organization's compliance requirements. 
+
+Enforce Signing is built with privacy in mind. While Sigstore is built on [transparency](https://docs.sigstore.dev/rekor/overview) by design, Enforce Signing will not store any of your information in a public transparency log. This enables you to conform to your organization's privacy requirements while still being able to get the value of Sigstore.
+
+This guide will onboard you to Chainguard Enforce Signing.
+
+## Prerequisites
+
+In addition to having access to Chainguard Enforce (which you can request via our [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)) and an [IAM group](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-manage-iam-groups-in-chainguard-enforce/) set up, you will need the following tools and versions noted in order to follow this guide.
+
+* [Go](https://go.dev/doc/install), version 1.19.3 or above
+* [Cosign, version 2.0.0-rc.1](/open-source/sigstore/cosign/how-to-install-cosign/#installing-a-cosign-pre-release-with-go) or above
+* [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli), version 1.2.8 or above
+* The [Chainguard command line tool `chainctl`](/chainguard/chainguard-enforce/how-to-install-chainctl/), version 0.1.
+
+You will also need access to a Google Cloud Platform (GCP) account, Google Kubernetes Engine (GKE), and the relevant [tools and configuration to orchestrate GKE](https://cloud.google.com/anthos/fleet-management/docs/before-you-begin/gke), including the [gcloud CLI tool](https://cloud.google.com/sdk/gcloud).  
+
+With these tools in place you are reading to begin.
+
+## Step 1 — Set Up a Certificate Authority
+
+If you don't have a certificate authority (CA) already, you'll first need to host your own for Enforce Signing to request certificates from it. We will walk through setting up a Google Certificate Authority Service. 
+
+To set up a Google CA Service, you'll first need an instance of the GCP CA Service in your GCP Project. You can enable the CA service by running the following command. This may take a few minutes.
+
+```sh
+gcloud services enable privateca.googleapis.com
+```
+
+You'll need create a new CA Pool (alternately, you can use an existing one if you have one set up). For demonstration purposes, we'll use the `devops` tier. Replace `$POOL_NAME` with the name you would like to use for your CA Pool. 
+
+```sh
+gcloud privateca pools create $POOL_NAME --tier=devops
+```
+
+Read the [full documentation about Google CA Pools](https://cloud.google.com/certificate-authority-service/docs/creating-ca-pool) for more details.
+
+Then you’ll create a new root certificate authority. The below is an example command to set this up. You can also set this up in the Console user interface. Please read the full [Creating certificate authorities doc](https://cloud.google.com/certificate-authority-service/docs/creating-certificate-authorities) from GCP to understand all your options.
+
+Pass a name you will remember to `$ROOT_CA_NAME`, and the name you gave to your CA Pool in place of `$POOL_NAME`.
+
+```sh
+gcloud privateca roots create $ROOT_CA_NAME --pool=$POOL_NAME \
+  --subject="CN=my-ca, O=Test LLC"
+```
+
+You can optionally use a `--key-algorithm` flag in the command above. Without it, the above command defaults to `rsa-pkcs1-4096-sha256`. Read more about the [crypto algorithm to use for creating a managed KMS key](https://cloud.google.com/sdk/gcloud/reference/beta/privateca/roots/create#--key-algorithm) for a CA and its options. 
+
+Once you’ve set up your CA, keep its resource name readily available. You may have to click **View CA certificate** in the Console user interface to find the resource name, under **Resource name**. It is expected to be in a format similar to the following, with the variables referring to your own project details.
+
+```
+projects/$PROJECT_ID/locations/$LOCATION/caPools/$POOL_NAME/certificateAuthorities/$CA_ID
+```
+
+With this set up, you're ready to set up your own instance of Chainguard Enforce Signing.
+
+## Step 2 — Create an Enforce Signing Instance
+
+to set up a Chainguard Enforce Signing instance, you'll be using `chainctl`, the Chainguard CLI tool. You can choose any name that is meaningful to you to reference this instance, replace the `$ENFORCE_SIGNING_NAME` variable with the name of your choosing. Also, replace the `$CA_RESOURCE_NAME` with the long resource name (discussed above) of your Google CA Service.
+
+```sh
+chainctl sigstore ca create --name=$ENFORCE_SIGNING_NAME --ca=googleca  --googleca-ref=$CA_RESOURCE_NAME 
+```
+
+Each Enforce Signing instance comes with a unique hostname for the certificate authority, which you can find by running:
+
+```sh
+chainctl sigstore ca ls 
+```
+
+You can use this command to pull up the ID and name of your CA at any time. 
+
+## Step 3 — Setting Up Account Association
+
+Now that you’ve provided Enforce with references to your CA service, you’ll need to give Chainguard authorization to use those resources.
+
+To set up your account association, you'll be using Terraform. Follow our guidance on [Cloud Account Association for GCP](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/cloud-account-associations/#setting-up-a-cloud-account-association-for-gcp) to complete this setup.
+
+To confirm resources were set up as expected, you can navigate to your [Workload Identity Pools](https://console.cloud.google.com/iam-admin/workload-identity-pools) within your GCP Project. On this page should be a resource called **Chainguard Pool**. If you click on the pool details and review the **connected service accounts**, you'll have a few service accounts that are now prefixed with `chainguard`. The service account `chainguard-enforce-signer` that the Enforce Signing service will be running under to request certificates. 
+
+To confirm that the account association setup was successful, run this `chainctl` command.
+
+```sh
+chainctl iam groups check-gcp
+```
+
+You may need to select the Group that you are currently working with.
+
+If everything is set up correctly, you'll receive output similar to the following.
+
+```
+GCP role impersonation was successful!
+```
+
+With everything set up, we are now ready to work with a software artifact.
+
+## Step 4 — Signing and Verifying an Image
+
+At this point, you’re ready to sign and verify an image with your brand new certificate authority! 
+
+First, [log into Chainguard](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/log-in-chainguard-enforce/#signing-in-through-chainctl):
+
+```sh
+chainctl auth login
+```
+
+This will ask you to go through an [OIDC flow](software-security/glossary/#oidc) to authenticate with Chainguard.
+
+Next, you’ll need to set up your environment to point cosign to your personal Enforce Signing instance. Here, replace `$ENFORCE_CA_NAME` with the name of your Enforce CA. You can pull this up again by running `chainctl sigstore ca ls `. 
+
+```sh
+eval $(chainctl sigstore env $ENFORCE_CA_NAME)
+```
+
+<!-- You will have to authenticate again, to get an authentication token unique to your instance of Enforce Signing. This command will set the required environment variables for cosign to sign your image with your private certificate authority. Now, you’re ready to sign with cosign! 
+
+You can sign your image by running:
+
+eval $(chainctl sigstore env <CA_NAME>)
+cosign sign <image>
+
+To verify your image, you’ll need to provide the expected certificate identity and issuer. The issuer is https://auth.chainguard.dev/, which is automatically set by the sigstore env command. The certificate identity will correspond to the email address you used to authenticate.
+
+
+eval $(chainctl sigstore env <CA_NAME>)
+cosign verify <image> --certificate-identity=<identity>  -->

--- a/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
@@ -12,7 +12,7 @@ menu:
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
 
 The Chainguard Enforce command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard Enforce provides, and enable you to make queries into the state of your clusters and policies registered with the platform.
 

--- a/content/open-source/sigstore/cosign/how-to-install-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-install-cosign.md
@@ -98,6 +98,18 @@ go install github.com/sigstore/cosign/cmd/cosign@latest
 
 The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`.
 
+### Installing a Cosign Pre-release with Go
+
+You can install a pre-release of Cosign with Go directly from the [Cosign GitHub releases page](https://github.com/sigstore/cosign/releases). 
+
+At the time of writing, the newest pre-release is [v2.0.0-rc.1](https://github.com/sigstore/cosign/releases/tag/v2.0.0-rc.1). You can download this version with the following command. 
+
+```sh
+go install github.com/sigstore/cosign/v2/cmd/cosign@v2.0.0-rc.1
+```
+
+The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`. Check the [release page]([Cosign GitHub releases page](https://github.com/sigstore/cosign/releases) for additional releases. 
+
 ## Installing Cosign with the Cosign Binary
 
 Installing Cosign via its binary offers you greater control over your installation, but this method also requires you to manage your installation yourself. In order to install via binary, check for the most updated version in the open source GitHub repository for Cosign under the [releases page](https://github.com/sigstore/cosign/releases). 


### PR DESCRIPTION
The main purpose of this PR is to add docs on Enforce Signing. Please test and edit the tutorial. Additionally, I edited the cloud account association doc based on going through that workflow to set up Enforce Signing.

I also did some left nav bar clean up and light edits elsewhere. 

Signed-off-by: ltagliaferri 