### PR TITLE
Add Enforce network requirements page

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/network-requirements.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/network-requirements.md
@@ -1,0 +1,60 @@
+---
+title: "Network Requirements for Chainguard Enforce"
+type: "article"
+description: "Ports and Protocols Required for Chainguard Enforce"
+date: 2023-01-26T15:22:20
+lastmod: 2022-11-29T15:22:20
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-enforce-kubernetes"
+weight: 100
+toc: true
+---
+
+> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
+
+To use Chainguard Enforce for Kubernetes in environments with firewalls, VPNs, and IDS/IPS systems, you will need to add some rules to allow traffic into and out of your networks. The following table lists the DNS hostnames, associated ports, and protocols that will need to be allowed to communicate with your Kubernetes cluster or clusters.
+
+
+## Chainguard Hosts
+
+| Hostname |Port |Protocol |
+|----------|-----|---------|
+| auth.chainguard.dev | 443 | HTTPS |
+| canary.enforce.dev | 443 | HTTPS |
+| console-api.enforce.dev | 443 | HTTPS |
+| console.enforce.dev | 443 | HTTPS |
+|cosigned-continuous-verification.enforce.dev | 443 | HTTPS |
+| dl.enforce.dev | 443 | HTTPS |
+| eots-omni.enforce.dev | 443 | HTTPS |
+| issuer.enforce.dev | 443 | HTTPS |
+| policy-compiler.enforce.dev | 443 | HTTPS |
+| policy-conversion.enforce.dev | 443 | HTTPS |
+|policy-distribution.enforce.dev | 443 | HTTPS |
+| policy-defaulting.enforce.dev | 443 | HTTPS |
+| policy-validation.enforce.dev | 443 | HTTPS |
+| tsa.enforce.dev | 443 | HTTPS |
+
+## Third-party Hosts
+| Hostname |Port |Protocol |
+|----------|-----|---------|
+| chainguard-cd-nvt30yluzzsmvk7t.edge.tenants.us.auth0.com | 443 | HTTPS |
+| googlecode.l.googleusercontent.com | 443 | HTTPS |
+| raw.githubusercontent.com | 443 | HTTPS |
+| storage.googleapis.com | 443 | HTTPS |
+
+## Additional Notes
+
+### Ingress and Egress 
+
+Connections to the hosts listed here  are initiated as new outbound connections. If you are using stateful firewall rules, then you will need to add symmetric rules to ensure that traffic flows correctly.
+
+You will need egress rules that allow new traffic to the hosts listed here. You will need corresponding ingress rules that allow related and established traffic.
+
+### DNS Records and TTLs
+
+Many of the hosts listed on this page use multiple DNS A records or CNAME aliases. Additionally, many A records have a short time to live of 60 seconds, and the majority are less than an hour (3600s).
+
+If your network filters traffic based on IP addresses, ensure that any firewalls update their rules at an appropriate interval to match the TTL for each DNS record.

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/network-requirements.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/network-requirements.md
@@ -17,7 +17,6 @@ toc: true
 
 To use Chainguard Enforce for Kubernetes in environments with firewalls, VPNs, and IDS/IPS systems, you will need to add some rules to allow traffic into and out of your networks. The following table lists the DNS hostnames, associated ports, and protocols that will need to be allowed to communicate with your Kubernetes cluster or clusters.
 
-
 ## Chainguard Hosts
 
 | Hostname |Port |Protocol |
@@ -47,7 +46,7 @@ To use Chainguard Enforce for Kubernetes in environments with firewalls, VPNs, a
 
 ## Additional Notes
 
-### Ingress and Egress 
+### Ingress and Egress
 
 Connections to the hosts listed here  are initiated as new outbound connections. If you are using stateful firewall rules, then you will need to add symmetric rules to ensure that traffic flows correctly.
 
@@ -58,3 +57,17 @@ You will need egress rules that allow new traffic to the hosts listed here. You 
 Many of the hosts listed on this page use multiple DNS A records or CNAME aliases. Additionally, many A records have a short time to live of 60 seconds, and the majority are less than an hour (3600s).
 
 If your network filters traffic based on IP addresses, ensure that any firewalls update their rules at an appropriate interval to match the TTL for each DNS record.
+
+### JA3 Fingerprints
+
+Client traffic for each of the *.enforce.dev domains can be identified by the following JA3 fingerprint data:
+
+#### Fullstring
+```
+771,49195-49199-49196-49200-52393-52392-49161-49171-49162-49172-156-157-47-53-49170-10-4865-4866-4867,0-5-10-11-13-65281-16-18-43-51,29-23-24-25,0
+```
+
+#### Fingerprint
+```
+3fed133de60c35724739b913924b6c24
+```


### PR DESCRIPTION
### What should this PR do?
This PR adds a page under Chainguard Enforce for Kubernetes that details the network requirements to run Enforce in a Kubernetes cluster.

### How should this PR be tested?
The page should be visible under `/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/network-requirements/` in the preview site.