### PR TITLE
Disable terminal while backend is being repaired

### DIFF
--- a/layouts/partials/terminal.html
+++ b/layouts/partials/terminal.html
@@ -1,4 +1,4 @@
-{{ if .Params.terminalImage }}
+<!--{{ if .Params.terminalImage }}
 <div id="terminal-init" data-image="{{ .Params.terminalImage }}">
 </div>
 
@@ -24,4 +24,4 @@
 {{/*  Display terminal.js script   */}}
 <script src="{{ $terminal.Permalink }}" integrity="{{ $terminal.Data.Integrity }}"></script>
 
-{{ end }}
+{{ end }}-->


### PR DESCRIPTION
The cluster that hosts the terminal is unhealthy, so this PR turns off the terminal on all pages by disabling the Hugo partial template.