### PR TITLE
Adding versions policy for chainguard images

### DIFF
--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -13,22 +13,19 @@ weight: 500
 toc: true
 ---
 
-### Are Chainguard Images based on Alpine?
-Some of our images are still based on Alpine, but going forward the majority will be based on  [Wolfi](/open-source/wolfi/), a Linux _undistro_ we built specifically to address software supply chain security issues.
-
-### How do Chainguard Images relate to the Google Distroless Images? 
+### How do Chainguard Images relate to the Google Distroless Images?
 The [Google distroless](https://github.com/GoogleContainerTools/distroless) images follow a similar
 philosophy to many of our images: they are minimal images that don't include package managers or
 shells. The main difference is in the implementation. The Google distroless images are built with
 [Bazel](https://bazel.build) and based on the Debian distribution, whereas Chainguard Images are
-built with [apko](/open-source/apko) based on the [Wolfi](/open-source/wolfi) or Alpine
-distributions. We believe our approach is more maintainable and extensible.
+built with [apko](/open-source/apko) and based on the [Wolfi](/open-source/wolfi)
+undistro. We believe our approach is more maintainable and extensible.
 
 ### What is an "undistro"?
 We call Wolfi an undistro because unlike a typical Linux distribution, Wolfi is a stripped-down distribution designed for the cloud-native era. Most notably, we don’t include a Linux kernel, instead relying on the environment (such as the container runtime) to provide this.
 
 ### Which images are available?
-You can check which images are already available at our [GitHub Repository](https://github.com/chainguard-images).
+You can check which images are already available at the [Chainguard Images Reference](https://edu.chainguard.dev/chainguard/chainguard-images/reference/) page or directly at our [GitHub Repository](https://github.com/chainguard-images).
 
 ### What is an SBOM and why is it important?
 An SBOM is a Software Bill of Materials, which is a list containing detailed information about all software that is included within a software artifact, whether it's an application, a container image, or a physical appliance.
@@ -38,6 +35,12 @@ SBOMs provide visibility into the software you depend on. They can allow automat
 ### Who maintains Chainguard Images?
 [Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs) are officially maintained by [Chainguard](https://chainguard.dev) employees, but they are also open source, which means any community member is welcome to suggest improvements.
 
+### How often are Chainguard Images updated?
+All images are rebuilt and updated every night to incorporate any available new patches and package updates.
+
 ### Can I simply replace my current base image with a Chainguard Image and it will work out of the box?
 Chainguard Images are distroless, which means they are minimalist and most of them don't come with a package manager. Depending on your stack, you may need to include additional software by copying artifacts from multi-stage builds.
+
+### Which image versions are publicly available?
+The `latest` tags of all images are publicly available and do not require authentication. Starting in April, only authenticated users will have access to older tags.
 

--- a/content/chainguard/chainguard-images/versions-policy.md
+++ b/content/chainguard/chainguard-images/versions-policy.md
@@ -1,0 +1,53 @@
+---
+title: "Chainguard Images Version Policy"
+type: "article"
+description: "Maintenance policy for Chainguard Images Versions"
+date: 2023-02-03T08:49:31+00:00
+lastmod: 2023-02-03T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 420
+toc: true
+---
+
+Our mission with Chainguard Images is to improve the security of the industry through a set of freely available container images that set the standard for provenance, minimalism, and low CVE counts.
+
+As part of this mission we need to limit the maintenance cost of providing these images. For that reason, we limit the images available to anonymous and free-plan users. By requiring user registration, we can notify users of changes to images e.g. if a new version has been released which fixes a critical security vulnerability or when pulling an old version of an image that is leaving support imminently.  This allows us to safely concentrate our efforts on the latest versions of all our freely available images, and keep users from unknowingly depending on out of date, vulnerable dependencies.
+Image versions available to anonymous users
+
+Users who do not register will only be able to pull the `latest` tag and by digest.
+
+## Image versions available to registered users
+
+Users who register will have access to a greater range of tags. This will typically cover the last two minor versions of an image e.g. if the last two minor versions are `1.2.3` and `1.1.9`, the tags available would be:
+
+- `latest`, `1.2.3`, `1.2`, `1` (all pointing to the same image)
+- `1.1.9`, `1.1` (both pointing to the same image)
+
+Often images will also provide an “edge” tag, representing release candidates or similar.
+
+The exact tags available for an image should be made clear in the documentation for that image.
+
+## What happens when an image tag leaves registered user availability?
+
+When a new image version is released, old patch and minor versions will be deprecated. This will start a 30 day grace period, after which the image tag will be deleted. The image will remain pullable by SHA digest.
+
+By registering, you can choose to receive notifications prior to deletion.
+
+## Images available to subscribed users
+Users can pay for a subscription providing access to older versions of images amongst other benefits. These images will be continuously rebuilt, so any software dependencies that aren’t part of the core package (such as OS components) will be kept up-to-date and vulnerability free. Please contact us regarding exact versions that are supported.
+
+## When will this be enforced?
+We will start requiring authentication to pull image tags on 24th April 2023.
+
+## What about non-semver projects?
+
+These will be documented on a case-by-case basis but should try to follow the same spirit i.e. supporting at least 2 versions.
+
+## Why 2 minor versions?
+
+For most packages we expect 2 minor versions to provide users with a reasonable window of time to upgrade to the latest supported version. This is not a hard rule. For example, in some instances we might support two major versions over a prolonged period to support a community through a long migration cycle. We will make these support decisions on an image by image basis.
+


### PR DESCRIPTION
This PR brings in a new page to clarify our policy for Chainguard Images Versions / Tags.

It also updates the FAQ with a couple more questions related to updates and public tags.

The PR is a draft for now until the blog post is also published.