### PR TITLE
Add policy controller guide on verifying Chainguard images

### DIFF
--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -15,7 +15,7 @@ toc: true
 terminalImage: policy-controller/base:latest
 ---
 
-This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to verify image signatures before admitting an image into a Kubernetes cluster. In this guide you will create a `ClusterImagePolicy` that checks for a keyless Cosign image signature, and then test the admission controller by running a signed `nginx` image.
+This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to verify image signatures before admitting an image into a Kubernetes cluster. In this guide, you will create a `ClusterImagePolicy` that checks for a keyless Cosign image signature, and then test the admission controller by running a signed `nginx` image.
 
 ## Prerequisites
 

--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -1,0 +1,146 @@
+---
+title: "Using Policy Controller to Verify Signed Chainguard Images"
+type: "article"
+description: "Using Policy Controller to Verify Signed Chainguard Images"
+lead: "Verify Chainguard Images with Policy Controller"
+date: 2023-02-22T13:11:29+08:29
+lastmod: 2023-02-22T13:11:29+08:29
+draft: false
+images: []
+menu:
+  docs:
+    parent: "policy-controller"
+weight: 006
+toc: true
+terminalImage: policy-controller/base:latest
+---
+
+This guide demonstrates how to use the [Sigstore Policy Controller]([Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/)) to verify image signatures for any [Chainguard Image](https://www.chainguard.dev/chainguard-images). To learn how to use the Policy Controller to enforce image signatures, you will create a `ClusterImagePolicy` that checks for a keyless Cosign signature on an image, and then test running a signed `nginx` image.
+
+## Prerequisites
+
+To follow along with this guide outside of the terminal that is embedded on this page, you will need the following:
+
+* A Kubernetes cluster with administrative access. You can set up a local cluster using [**kind**](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) or use an existing cluster.
+* **kubectl** — to work with your cluster. Install `kubectl` for your operating system by following the official [Kubernetes kubectl documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
+* [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) installed in your cluster. Follow our [How To Install Sigstore Policy Controller](https://edu.chainguard.dev/open-source/sigstore/policy-controller/how-to-install-policy-controller/) guide if you do not have it installed, and be sure to label any namespace that you intend to use with the `policy.sigstore.dev/include=true` label.
+
+If you are using the terminal that is embedded on this page, then all the prerequsites are installed for you.
+
+Once you have everything in place you can continue to the next step and create a sample policy to check for signed Chainguard images.
+
+## Step 1 - Checking the Policy Controller is Denying Admission
+
+Before creating a `ClusterImagePolicy`, check that the Policy Controller is deployed and that your `default` namespace is labeled correctly. Run the following to check that the deployment is complete:
+
+```bash
+kubectl -n cosign-system wait --for=condition=Available deployment/policy-controller-webhook && \
+kubectl -n cosign-system wait --for=condition=Available deployment/policy-controller-policy-webhook
+```
+
+When both deployments are finished, verify the `default` namespace is using the Policy Controller:
+
+```
+k get ns -l policy.sigstore.dev/include=true
+```
+
+You should receive output like the following:
+
+```
+NAME      STATUS   AGE
+default   Active   24s
+```
+
+Once you are sure that the Policy Controller is deployed and your `default` namespace is configured to use it, run a pod to make sure admission requests are handled and denied by default:
+
+```bash
+kubectl run --image cgr.dev/chainguard/nginx:latest nginx
+```
+
+Since there is no `ClusterImagePolicy` defined yet, the Policy Controller will deny the admission request with a message like the following:
+
+```
+Error from server (BadRequest): admission webhook "policy.sigstore.dev" denied the request: validation failed: no matching policies: spec.containers[0].image
+cgr.dev/chainguard/nginx@sha256:628a01724b84d7db2dc3866f645708c25fab8cce30b98d3e5b76696291d65c4a
+```
+
+In the next step you will define a policy that verifies Chainguard images are signed and apply it to your cluster.
+
+## Step 2 — Creating a `ClusterImagePolicy`
+
+Now that you have the Policy Controller running in your cluster, and have the `default` namespace configured to use it, you can now define a `ClusterImagePolicy` to admit images.
+
+Open a new file with `nano` or your preferred editor:
+
+```shell
+nano /tmp/cip.yaml
+```
+
+Copy the following policy to the `/tmp/cip.yaml` file:
+
+```yaml
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: chainguard-images-are-signed
+  annotations:
+    catalog.chainguard.dev/title: Chainguard Images
+    catalog.chainguard.dev/description: Enforce Chainguard images are signed
+    catalog.chainguard.dev/labels: chainguard
+spec:
+  images:
+    - glob: cgr.dev/chainguard/**
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+      ctlog:
+        url: https://rekor.sigstore.dev
+```
+
+The `glob: cgr.dev/chainguard/**` line in combination with the `authorities` section will allow any image in the `cgr.dev/chainguard` image registry that has a [keyless signature](https://docs.sigstore.dev/cosign/keyless/) to be admitted into your cluster.
+
+Save the file and then apply the policy:
+
+```bash
+kubectl apply -f /tmp/cip.yaml
+```
+
+You will receive output showing the policy is created:
+
+```
+clusterimagepolicy.policy.sigstore.dev/chainguard-images-are-signed created
+```
+
+Now run the `cgr.dev/chainguard/nginx:latest` image again:
+
+```bash
+kubectl run --image cgr.dev/chainguard/nginx:latest nginx
+```
+
+Since the image matches the policy, you will receive a message that the pod was created successfully:
+
+```
+pod/nginx created
+```
+
+Delete the pod once you're done experimenting with it:
+
+```
+kubectl delete pod nginx
+```
+
+To learn more about how the Policy Controller uses Cosign to verify and admits images, review the [Cosign](https://docs.sigstore.dev/cosign/overview/) Sigstore documentation.
+
+## Options for Continuous Verification
+
+While it is useful to use the Policy Controller to manage admission into a cluster, once a workload is running any vulnerability or policy violations that occur after containers are running will not be detected.
+
+[Chainguard Enforce](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/understanding-continuous-verification/) is designed to address this issue by continuously verifying whether a container or cluster contains any vulnerabilities or policy violations over time. This includes what packages are deployed, SBOMs (software bills of materials), provenance, signature data, and more.
+
+If you're interested in learning more about Chainguard Enforce, you can request access to the product by selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs).

--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -103,7 +103,7 @@ spec:
         url: https://rekor.sigstore.dev
 ```
 
-The `glob: cgr.dev/chainguard/**` line works in combination with the `authorities` section will allow any image in the `cgr.dev/chainguard` image registry that has a [keyless signature](https://docs.sigstore.dev/cosign/keyless/) to be admitted into your cluster.
+The `glob: cgr.dev/chainguard/**` line, working in combination with the `authorities` section, will allow any image in the `cgr.dev/chainguard` image registry that has a [keyless signature](https://docs.sigstore.dev/cosign/keyless/) to be admitted into your cluster.
 
 The `- keyless` options instruct the Policy Controller what to check for when it examines the signature on any image from the `cgr.dev/chainguard` registry. The specific fields are:
 

--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -25,9 +25,9 @@ To follow along with this guide outside of the terminal that is embedded on this
 * **kubectl** — to work with your cluster. Install `kubectl` for your operating system by following the official [Kubernetes kubectl documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
 * [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) installed in your cluster. Follow our [How To Install Sigstore Policy Controller](https://edu.chainguard.dev/open-source/sigstore/policy-controller/how-to-install-policy-controller/) guide if you do not have it installed, and be sure to label any namespace that you intend to use with the `policy.sigstore.dev/include=true` label.
 
-If you are using the terminal that is embedded on this page, then all the prerequsites are installed for you.
+If you are using the terminal that is embedded on this page, then all the prerequsites are installed for you. Note that it make take a minute or two for the Kubernetes cluster to finish provisioning. If you receive any errors while running commands, retry them after waiting a few seconds.
 
-Once you have everything in place you can continue to the next step and create a sample policy to check for signed Chainguard images.
+Once you have everything in place you can continue to the first step and confim that the Policy Controller is working as expected.
 
 ## Step 1 - Checking the Policy Controller is Denying Admission
 
@@ -41,7 +41,7 @@ kubectl -n cosign-system wait --for=condition=Available deployment/policy-contro
 When both deployments are finished, verify the `default` namespace is using the Policy Controller:
 
 ```
-k get ns -l policy.sigstore.dev/include=true
+kubectl get ns -l policy.sigstore.dev/include=true
 ```
 
 You should receive output like the following:

--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -64,7 +64,7 @@ Error from server (BadRequest): admission webhook "policy.sigstore.dev" denied t
 cgr.dev/chainguard/nginx@sha256:628a01724b84d7db2dc3866f645708c25fab8cce30b98d3e5b76696291d65c4a
 ```
 
-In the next step you will define a policy that verifies Chainguard images are signed and apply it to your cluster.
+In the next step, you will define a policy that verifies Chainguard Images are signed and apply it to your cluster.
 
 ## Step 2 — Creating a `ClusterImagePolicy`
 

--- a/terminal-images/policy-controller/policy-controller-base/Dockerfile
+++ b/terminal-images/policy-controller/policy-controller-base/Dockerfile
@@ -1,0 +1,13 @@
+FROM academy-base:latest
+
+USER root
+RUN apk add supervisor && rm -rf /tmp/* /var/cache/apk/*
+
+COPY supervisord.conf /etc/supervisord.conf
+RUN printf 'alias kubectl="k3s kubectl"\nalias k="k3s kubectl"\nsource <(kubectl completion bash)\ncomplete -o default -F __start_kubectl k\n' >> /etc/bash/bashrc
+RUN mkdir -p /var/log/ /var/lib/rancher/k3s/server/manifests
+RUN wget https://github.com/k3s-io/k3s/releases/download/v1.26.1%2Bk3s1/k3s && mv k3s /usr/local/bin/ && chmod +x /usr/local/bin/k3s
+COPY policy-controller.yaml /var/lib/rancher/k3s/server/manifests
+
+USER inky
+ENTRYPOINT ["/usr/bin/sudo", "/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]

--- a/terminal-images/policy-controller/policy-controller-base/policy-controller.yaml
+++ b/terminal-images/policy-controller/policy-controller-base/policy-controller.yaml
@@ -1,0 +1,1573 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    policy.sigstore.dev/include: "true"
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"labels":{},"name":"default"}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cosign-system
+---
+# Source: policy-controller/templates/policy-webhook/sa_policy_webhook.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+---
+# Source: policy-controller/templates/webhook/sa_webhook.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: policy-controller-webhook
+  namespace: cosign-system
+---
+# Source: policy-controller/templates/policy-webhook/secret_certs_policy_webhook.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+  name: policy-webhook-certs
+  namespace: cosign-system
+# The data is populated at install time.
+---
+# Source: policy-controller/templates/webhook/secret_certs_webhook.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: webhook-certs
+  namespace: cosign-system
+# The data is populated at install time.
+---
+# Source: policy-controller/templates/policy-webhook/configmap-clusterimagepolicy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-image-policies
+  namespace: cosign-system
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    cluster-image-policy-json: '{"images":[{"glob":"ghcr.io/example/*","regex":""}],"authorities":[{"key":{"data":"-----BEGIN PUBLIC KEY-----\\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExB6+H6054/W1SJgs5JR6AJr6J35J\\nRCTfQ5s1kD+hGMSE1rH7s46hmXEeyhnlRnaGF8eMU/SBJE/2NKPnxE7WzQ==\\n-----END PUBLIC KEY-----"}}]}'
+---
+# Source: policy-controller/templates/policy-webhook/configmap-policy-controller.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-policy-controller
+  namespace: cosign-system
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    no-match-policy: warn
+---
+# Source: policy-controller/templates/policy-webhook/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+  name: policy-controller-policy-webhook-logging
+  namespace: cosign-system
+data:
+  zap-logger-config: |-
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  # Changes are be picked up immediately.
+  loglevel.controller: "info"
+  loglevel.webhook: "info"
+---
+# Source: policy-controller/templates/webhook/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: policy-controller-webhook-logging
+  namespace: cosign-system
+data:
+  zap-logger-config: |-
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  # Changes are be picked up immediately.
+  loglevel.controller: "info"
+  loglevel.webhook: "info"
+---
+# Source: policy-controller/templates/crds/clusterimagepolicy.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterimagepolicies.policy.sigstore.dev
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha1"]
+      clientConfig:
+        service:
+          name: policy-webhook
+          namespace: cosign-system
+  group: policy.sigstore.dev
+  names:
+    kind: ClusterImagePolicy
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+    categories:
+      - all
+      - sigstore
+    shortNames:
+      - cip
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              description: Spec holds the desired state of the ClusterImagePolicy (from the client).
+              type: object
+              properties:
+                authorities:
+                  description: Authorities defines the rules for discovering and validating signatures.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      attestations:
+                        description: Attestations is a list of individual attestations for this authority, once the signature for this authority has been verified.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: Name of the attestation. These can then be referenced at the CIP level policy.
+                              type: string
+                            policy:
+                              description: Policy defines all of the matching signatures, and all of the matching attestations (whose attestations are verified).
+                              type: object
+                              properties:
+                                configMapRef:
+                                  description: ConfigMapRef defines the reference to a configMap with the policy definition.
+                                  type: object
+                                  properties:
+                                    name:
+                                      description: Name is unique within a namespace to reference a configmap resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace defines the space within which the configmap name must be unique.
+                                      type: string
+                                data:
+                                  description: Data contains the policy definition.
+                                  type: string
+                                fetchConfigFile:
+                                  description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                                  type: boolean
+                                includeObjectMeta:
+                                  description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
+                                includeSpec:
+                                  description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
+                                  type: boolean
+                                includeTypeMeta:
+                                  description: IncludeTypeMeta controls whether the TypeMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
+                                type:
+                                  description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                                  type: string
+                                url:
+                                  description: URL to the policy data.
+                                  type: string
+                            predicateType:
+                              description: PredicateType defines which predicate type to verify. Matches cosign verify-attestation options.
+                              type: string
+                      ctlog:
+                        description: CTLog sets the configuration to verify the authority against a Rekor instance.
+                        type: object
+                        properties:
+                          url:
+                            description: URL sets the url to the rekor instance (by default the public rekor.sigstore.dev)
+                            type: string
+                      key:
+                        description: Key defines the type of key to validate the image.
+                        type: object
+                        properties:
+                          data:
+                            description: Data contains the inline public key.
+                            type: string
+                          hashAlgorithm:
+                            description: HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set
+                            type: string
+                          kms:
+                            description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
+                            type: string
+                          secretRef:
+                            description: SecretRef sets a reference to a secret with the key.
+                            type: object
+                            properties:
+                              name:
+                                description: name is unique within a namespace to reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which the secret name must be unique.
+                                type: string
+                      keyless:
+                        description: Keyless sets the configuration to verify the authority against a Fulcio instance.
+                        type: object
+                        properties:
+                          ca-cert:
+                            description: CACert sets a reference to CA certificate
+                            type: object
+                            properties:
+                              data:
+                                description: Data contains the inline public key.
+                                type: string
+                              hashAlgorithm:
+                                description: HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set
+                                type: string
+                              kms:
+                                description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
+                                type: string
+                              secretRef:
+                                description: SecretRef sets a reference to a secret with the key.
+                                type: object
+                                properties:
+                                  name:
+                                    description: name is unique within a namespace to reference a secret resource.
+                                    type: string
+                                  namespace:
+                                    description: namespace defines the space within which the secret name must be unique.
+                                    type: string
+                          identities:
+                            description: Identities sets a list of identities.
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                issuer:
+                                  description: Issuer defines the issuer for this identity.
+                                  type: string
+                                issuerRegExp:
+                                  description: IssuerRegExp specifies a regular expression to match the issuer for this identity.
+                                  type: string
+                                subject:
+                                  description: Subject defines the subject for this identity.
+                                  type: string
+                                subjectRegExp:
+                                  description: SubjectRegExp specifies a regular expression to match the subject for this identity.
+                                  type: string
+                          url:
+                            description: URL defines a url to the keyless instance.
+                            type: string
+                      name:
+                        description: Name is the name for this authority. Used by the CIP Policy validator to be able to reference matching signature or attestation verifications. If not specified, the name will be authority-<index in array>
+                        type: string
+                      source:
+                        description: Sources sets the configuration to specify the sources from where to consume the signatures.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            oci:
+                              description: OCI defines the registry from where to pull the signatures.
+                              type: string
+                            signaturePullSecrets:
+                              description: SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source.
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                      static:
+                        description: Static specifies that signatures / attestations are not validated but instead a static policy is applied against matching images.
+                        type: object
+                        properties:
+                          action:
+                            description: Action defines how to handle a matching policy.
+                            type: string
+                images:
+                  description: Images defines the patterns of image names that should be subject to this policy.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      glob:
+                        description: Glob defines a globbing pattern.
+                        type: string
+                match:
+                  description: Match allows selecting resources based on their properties.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      group:
+                        type: string
+                      resource:
+                        type: string
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                      version:
+                        type: string
+                mode:
+                  description: Mode controls whether a failing policy will be rejected (not admitted), or if errors are converted to Warnings. enforce - Reject (default) warn - allow but warn
+                  type: string
+                policy:
+                  description: Policy is an optional policy that can be applied against all the successfully validated Authorities. If no authorities pass, this does not even get evaluated, as the Policy is considered failed.
+                  type: object
+                  properties:
+                    configMapRef:
+                      description: ConfigMapRef defines the reference to a configMap with the policy definition.
+                      type: object
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a configmap resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the configmap name must be unique.
+                          type: string
+                    data:
+                      description: Data contains the policy definition.
+                      type: string
+                    fetchConfigFile:
+                      description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                      type: boolean
+                    includeObjectMeta:
+                      description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
+                    includeSpec:
+                      description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
+                      type: boolean
+                    includeTypeMeta:
+                      description: IncludeTypeMeta controls whether the TypeMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
+                    type:
+                      description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                      type: string
+                    url:
+                      description: URL to the policy data.
+                      type: string
+    - name: v1beta1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              description: Spec holds the desired state of the ClusterImagePolicy (from the client).
+              type: object
+              properties:
+                authorities:
+                  description: Authorities defines the rules for discovering and validating signatures.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      attestations:
+                        description: Attestations is a list of individual attestations for this authority, once the signature for this authority has been verified.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: Name of the attestation. These can then be referenced at the CIP level policy.
+                              type: string
+                            policy:
+                              description: Policy defines all of the matching signatures, and all of the matching attestations (whose attestations are verified).
+                              type: object
+                              properties:
+                                configMapRef:
+                                  description: ConfigMapRef defines the reference to a configMap with the policy definition.
+                                  type: object
+                                  properties:
+                                    name:
+                                      description: Name is unique within a namespace to reference a configmap resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace defines the space within which the configmap name must be unique.
+                                      type: string
+                                data:
+                                  description: Data contains the policy definition.
+                                  type: string
+                                fetchConfigFile:
+                                  description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                                  type: boolean
+                                includeObjectMeta:
+                                  description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
+                                includeSpec:
+                                  description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
+                                  type: boolean
+                                includeTypeMeta:
+                                  description: IncludeTypeMeta controls whether the TypeMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
+                                type:
+                                  description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                                  type: string
+                                url:
+                                  description: URL to the policy data.
+                                  type: string
+                            predicateType:
+                              description: PredicateType defines which predicate type to verify. Matches cosign verify-attestation options.
+                              type: string
+                      ctlog:
+                        description: CTLog sets the configuration to verify the authority against a Rekor instance.
+                        type: object
+                        properties:
+                          url:
+                            description: URL sets the url to the rekor instance (by default the public rekor.sigstore.dev)
+                            type: string
+                      key:
+                        description: Key defines the type of key to validate the image.
+                        type: object
+                        properties:
+                          data:
+                            description: Data contains the inline public key.
+                            type: string
+                          hashAlgorithm:
+                            description: HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set
+                            type: string
+                          kms:
+                            description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
+                            type: string
+                          secretRef:
+                            description: SecretRef sets a reference to a secret with the key.
+                            type: object
+                            properties:
+                              name:
+                                description: name is unique within a namespace to reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which the secret name must be unique.
+                                type: string
+                      keyless:
+                        description: Keyless sets the configuration to verify the authority against a Fulcio instance.
+                        type: object
+                        properties:
+                          ca-cert:
+                            description: CACert sets a reference to CA certificate
+                            type: object
+                            properties:
+                              data:
+                                description: Data contains the inline public key.
+                                type: string
+                              hashAlgorithm:
+                                description: HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set
+                                type: string
+                              kms:
+                                description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
+                                type: string
+                              secretRef:
+                                description: SecretRef sets a reference to a secret with the key.
+                                type: object
+                                properties:
+                                  name:
+                                    description: name is unique within a namespace to reference a secret resource.
+                                    type: string
+                                  namespace:
+                                    description: namespace defines the space within which the secret name must be unique.
+                                    type: string
+                          identities:
+                            description: Identities sets a list of identities.
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                issuer:
+                                  description: Issuer defines the issuer for this identity.
+                                  type: string
+                                issuerRegExp:
+                                  description: IssuerRegExp specifies a regular expression to match the issuer for this identity.
+                                  type: string
+                                subject:
+                                  description: Subject defines the subject for this identity.
+                                  type: string
+                                subjectRegExp:
+                                  description: SubjectRegExp specifies a regular expression to match the subject for this identity.
+                                  type: string
+                          url:
+                            description: URL defines a url to the keyless instance.
+                            type: string
+                      name:
+                        description: Name is the name for this authority. Used by the CIP Policy validator to be able to reference matching signature or attestation verifications. If not specified, the name will be authority-<index in array>
+                        type: string
+                      source:
+                        description: Sources sets the configuration to specify the sources from where to consume the signatures.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            oci:
+                              description: OCI defines the registry from where to pull the signatures.
+                              type: string
+                            signaturePullSecrets:
+                              description: SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source.
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                      static:
+                        description: Static specifies that signatures / attestations are not validated but instead a static policy is applied against matching images.
+                        type: object
+                        properties:
+                          action:
+                            description: Action defines how to handle a matching policy.
+                            type: string
+                images:
+                  description: Images defines the patterns of image names that should be subject to this policy.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      glob:
+                        description: Glob defines a globbing pattern.
+                        type: string
+                match:
+                  description: Match allows selecting resources based on their properties.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      group:
+                        type: string
+                      resource:
+                        type: string
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                      version:
+                        type: string
+                mode:
+                  description: Mode controls whether a failing policy will be rejected (not admitted), or if errors are converted to Warnings. enforce - Reject (default) warn - allow but warn
+                  type: string
+                policy:
+                  description: Policy is an optional policy that can be applied against all the successfully validated Authorities. If no authorities pass, this does not even get evaluated, as the Policy is considered failed.
+                  type: object
+                  properties:
+                    configMapRef:
+                      description: ConfigMapRef defines the reference to a configMap with the policy definition.
+                      type: object
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a configmap resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the configmap name must be unique.
+                          type: string
+                    data:
+                      description: Data contains the policy definition.
+                      type: string
+                    fetchConfigFile:
+                      description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                      type: boolean
+                    includeObjectMeta:
+                      description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
+                    includeSpec:
+                      description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
+                      type: boolean
+                    includeTypeMeta:
+                      description: IncludeTypeMeta controls whether the TypeMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
+                    type:
+                      description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                      type: string
+                    url:
+                      description: URL to the policy data.
+                      type: string
+---
+# Source: policy-controller/templates/policy-webhook/clusterrole_policy_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: policy-controller-policy-webhook
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # Allow the reconciliation of exactly our validating webhook.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["list", "watch"]
+
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "update", "delete"]
+    resourceNames:
+    - "policy.sigstore.dev"
+    - "defaulting.clusterimagepolicy.sigstore.dev"
+    - "validating.clusterimagepolicy.sigstore.dev"
+
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations/finalizers", "mutatingwebhookconfigurations/finalizers"]
+    verbs: ["update"]
+    resourceNames:
+    - "policy.sigstore.dev"
+    - "defaulting.clusterimagepolicy.sigstore.dev"
+    - "validating.clusterimagepolicy.sigstore.dev"
+
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can Get the system namespace.
+    resourceNames: [ "cosign-system" ]
+
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"]
+    verbs: ["update"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can Get the system namespace.
+    resourceNames: [ "cosign-system" ]
+
+  # This is needed by k8schain to support fetching pull secrets attached to pod specs
+  # or their service accounts.  If pull secrets aren't used, the "secrets" below can
+  # be safely dropped, but the logic will fetch the service account to check for pull
+  # secrets.
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "secrets"]
+    verbs: ["get"]
+
+  # Allow reconciliation of the ClusterImagePolic CRDs.
+  - apiGroups: ["policy.sigstore.dev"]
+    resources: ["clusterimagepolicies"]
+    verbs: ["get", "list", "update", "watch", "patch"]
+
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update"]
+---
+# Source: policy-controller/templates/webhook/clusterrole_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: policy-controller-webhook
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+  # Allow the reconciliation of exactly our validating webhook.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["list", "watch"]
+
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "update", "delete"]
+    resourceNames: ["policy.sigstore.dev"]
+
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can Get the system namespace.
+    resourceNames: [ "cosign-system" ]
+
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"]
+    verbs: ["update"]
+    resourceNames: [ "cosign-system" ]
+
+  # This is needed by k8schain to support fetching pull secrets attached to pod specs
+  # or their service accounts.  If pull secrets aren't used, the "secrets" below can
+  # be safely dropped, but the logic will fetch the service account to check for pull
+  # secrets.
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "secrets"]
+    verbs: ["get"]
+---
+# Source: policy-controller/templates/policy-webhook/clusterrolebindings_policy_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-controller-policy-webhook
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: policy-controller-policy-webhook
+subjects:
+- kind: ServiceAccount
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+---
+# Source: policy-controller/templates/webhook/clusterrolebindings_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-controller-webhook
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: policy-controller-webhook
+subjects:
+- kind: ServiceAccount
+  name: policy-controller-webhook
+  namespace: cosign-system
+---
+# Source: policy-controller/templates/policy-webhook/role_policy_webhook.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+rules:
+  # Needed to watch and load configuration and secret data.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "update", "watch"]
+
+  # Needed for leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+  # This is needed to create / patch ConfigMap that is created by the reconciler
+  # to consolidate various CIP configuration into a policy ConfigMap.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["config-image-policies"]
+    verbs: ["get", "list", "create", "update", "patch", "watch"]
+---
+# Source: policy-controller/templates/webhook/role_webhook.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: policy-controller-webhook
+  namespace: cosign-system
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+rules:
+  # Needed to watch and load configuration and secret data.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "update", "watch"]
+
+  # Needed for leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+# Source: policy-controller/templates/policy-webhook/rolebinding_policy_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+subjects:
+- kind: ServiceAccount
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+roleRef:
+  kind: Role
+  name: policy-controller-policy-webhook
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: policy-controller/templates/webhook/rolebinding_webhook.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-controller-webhook
+  namespace: cosign-system
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+subjects:
+- kind: ServiceAccount
+  name: policy-controller-webhook
+  namespace: cosign-system
+roleRef:
+  kind: Role
+  name: policy-controller-webhook
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: policy-controller/templates/policy-webhook/service_policy_webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+  name: policy-webhook
+  namespace: cosign-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    control-plane: policy-controller-policy-webhook
+---
+# Source: policy-controller/templates/policy-webhook/service_policy_webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+  name: policy-controller-policy-webhook-metrics
+  namespace: cosign-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    control-plane: policy-controller-policy-webhook
+---
+# Source: policy-controller/templates/webhook/service_webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: webhook
+  namespace: cosign-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    control-plane: policy-controller-webhook
+---
+# Source: policy-controller/templates/webhook/service_webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: policy-controller-webhook-metrics
+  namespace: cosign-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    control-plane: policy-controller-webhook
+---
+# Source: policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-controller-policy-webhook
+  namespace: cosign-system
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-policy-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-controller
+      app.kubernetes.io/instance: policy-controller
+      control-plane: policy-controller-policy-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-controller
+        app.kubernetes.io/instance: policy-controller
+        control-plane: policy-controller-policy-webhook
+    spec:
+      nodeSelector:
+        {}         
+      tolerations:
+        []
+      serviceAccountName: policy-controller-policy-webhook
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  control-plane: policy-controller-policy-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - name: policy-webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: "ghcr.io/sigstore/policy-controller/policy-webhook@sha256:ae3d5b549c269c8b2a9b208d812365b6fc610d7a21c9ced8dc7eaae0a1914c09"
+        imagePullPolicy: "IfNotPresent"
+        args:
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: policy-controller-policy-webhook-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: policy-controller-policy-webhook-observability
+        - name: METRICS_DOMAIN
+          value: sigstore.dev/policy
+        - name: WEBHOOK_NAME
+          value: policy-webhook
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+          # Failing to provide a writable $HOME can cause TUF client initialization to panic
+          - mountPath: /home/nonroot
+            name: writable-home-dir
+        readinessProbe:
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "policy-webhook"
+        livenessProbe:
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "policy-webhook"
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - emptyDir: {}
+        name: writable-home-dir
+---
+# Source: policy-controller/templates/webhook/deployment_webhook.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    helm.sh/chart: policy-controller-0.4.0
+    app.kubernetes.io/name: policy-controller
+    app.kubernetes.io/instance: policy-controller
+    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/managed-by: Helm
+    control-plane: policy-controller-webhook
+  name: policy-controller-webhook
+  namespace: cosign-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-controller
+      app.kubernetes.io/instance: policy-controller
+      control-plane: policy-controller-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-controller
+        app.kubernetes.io/instance: policy-controller
+        control-plane: policy-controller-webhook
+    spec:
+      nodeSelector:
+        {}
+      tolerations:
+        []
+      serviceAccountName: policy-controller-webhook
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  control-plane: policy-controller-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - name: policy-controller-webhook
+        image: "ghcr.io/sigstore/policy-controller/policy-controller@sha256:f23a23910f873d01864c01122120666adf78a1dbb43f674c4d423d5fe480a718"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: policy-controller-webhook-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: policy-controller-webhook-observability
+        - name: METRICS_DOMAIN
+          value: sigstore.dev/policy
+        - name: WEBHOOK_NAME
+          value: webhook
+        - name: HOME
+          value: /home/nonroot
+        args:
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        livenessProbe:
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          httpGet:
+            port: 8443
+            scheme: HTTPS
+            path: /healthz
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        readinessProbe:
+          failureThreshold: 6
+          initialDelaySeconds: 20
+          periodSeconds: 1
+          httpGet:
+            port: 8443
+            scheme: HTTPS
+            path: /readyz
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+        volumeMounts:
+          # Failing to provide a writable $HOME can cause TUF client initialization to panic
+          - mountPath: /home/nonroot
+            name: writable-home-dir
+      volumes:
+      - emptyDir: {}
+        name: writable-home-dir
+---
+# Source: policy-controller/templates/policy-webhook/clusterrole_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/clusterrolebindings_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/configmap-clusterimagepolicy.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/configmap.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/policy_webhook_configurations.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/role_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/rolebinding_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/sa_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/secret_certs_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/service_policy_webhook.yaml
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: policy-controller/templates/policy-webhook/policy_webhook_configurations.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.clusterimagepolicy.sigstore.dev
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: policy-webhook
+        namespace: cosign-system
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: defaulting.clusterimagepolicy.sigstore.dev
+    sideEffects: None
+---
+# Source: policy-controller/templates/webhook/webhook_mutating.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: policy.sigstore.dev
+webhooks:
+- name: policy.sigstore.dev
+  namespaceSelector:    
+    matchExpressions:
+    - key: policy.sigstore.dev/include
+      operator: In
+      values:
+      - "true"
+  admissionReviewVersions: [v1]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: cosign-system
+  failurePolicy: Fail
+  sideEffects: None
+  reinvocationPolicy: IfNeeded
+---
+# Source: policy-controller/templates/policy-webhook/policy_webhook_configurations.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating.clusterimagepolicy.sigstore.dev
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: policy-webhook
+        namespace: cosign-system
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: validating.clusterimagepolicy.sigstore.dev
+    sideEffects: None
+---
+# Source: policy-controller/templates/webhook/webhook_validating.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: policy.sigstore.dev
+webhooks:
+- name: policy.sigstore.dev
+  namespaceSelector:    
+    matchExpressions:
+    - key: policy.sigstore.dev/include
+      operator: In
+      values:
+      - "true"
+  admissionReviewVersions: [v1]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: cosign-system
+  failurePolicy: Fail
+  sideEffects: None

--- a/terminal-images/policy-controller/policy-controller-base/supervisord.conf
+++ b/terminal-images/policy-controller/policy-controller-base/supervisord.conf
@@ -1,0 +1,30 @@
+[unix_http_server]
+file=/run/supervisord.sock ;
+
+[supervisord]
+logfile=/var/log/supervisord.log ;
+pidfile=/run/supervisord.pid ;
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock ;
+
+[program:k3s]
+command=/usr/local/bin/k3s server --write-kubeconfig-mode 644
+priority=1
+autostart=true
+autorestart=true
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/var/log/k3s.log
+
+[program:cp]
+command=/bin/sh -c "sleep 10; mkdir /home/inky/.kube; umask 0077; cp /etc/rancher/k3s/k3s.yaml /home/inky/.kube/config; chown -R inky /home/inky/.kube"
+autostart=true
+autorestart=false
+priority=2
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/var/log/k3s.log


### PR DESCRIPTION
### What should this PR do?
Add a guide with embedded terminal showing how to use Policy Controller to only admit keyless signed Chainguard images into a cluster.

### Why are we making this change?
Part of the ongoing series about policy controller tutorials.

### What are the acceptance criteria? 
The tutorial should be live under `/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images/` on Netlify preview.

### How should this PR be tested?
Test the steps locally using http://localhost:1313/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images/