### PR TITLE
Fix issue-420 for image provenance verification.

### DIFF
--- a/content/chainguard/chainguard-images/reference/apko/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/apko/provenance_info.md
@@ -21,7 +21,7 @@ The **apko** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/apko | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/apko | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/bazel/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/bazel/provenance_info.md
@@ -21,7 +21,7 @@ The **bazel** Chainguard Images are signed using Sigstore, and you can check the
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/bazel | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/bazel | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/busybox/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/busybox/provenance_info.md
@@ -21,7 +21,7 @@ The **busybox** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/busybox | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/busybox | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/cc-dynamic/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/cc-dynamic/provenance_info.md
@@ -21,7 +21,7 @@ The **cc-dynamic** Chainguard Images are signed using Sigstore, and you can chec
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/cc-dynamic | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/cc-dynamic | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/cosign/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/cosign/provenance_info.md
@@ -21,7 +21,7 @@ The **cosign** Chainguard Images are signed using Sigstore, and you can check th
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/cosign | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/cosign | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/curl/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/curl/provenance_info.md
@@ -21,7 +21,7 @@ The **curl** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/curl | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/curl | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/deno/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/deno/provenance_info.md
@@ -21,7 +21,7 @@ The **deno** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/deno | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/deno | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/envoy/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/envoy/provenance_info.md
@@ -21,7 +21,7 @@ The **envoy** Chainguard Images are signed using Sigstore, and you can check the
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/envoy | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/envoy | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/etcd/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/etcd/provenance_info.md
@@ -21,7 +21,7 @@ The **etcd** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/etcd | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/etcd | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/fluent-bit/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/fluent-bit/provenance_info.md
@@ -21,7 +21,7 @@ The **fluent-bit** Chainguard Images are signed using Sigstore, and you can chec
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/fluent-bit | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/fluent-bit | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/gcc-glibc/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/gcc-glibc/provenance_info.md
@@ -21,7 +21,7 @@ The **gcc-glibc** Chainguard Images are signed using Sigstore, and you can check
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/gcc-glibc | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/gcc-glibc | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/gcc-musl/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/gcc-musl/provenance_info.md
@@ -21,7 +21,7 @@ The **gcc-musl** Chainguard Images are signed using Sigstore, and you can check 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/gcc-musl | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/gcc-musl | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/git/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/git/provenance_info.md
@@ -21,7 +21,7 @@ The **git** Chainguard Images are signed using Sigstore, and you can check the i
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/git | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/git | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/glibc-dynamic/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/glibc-dynamic/provenance_info.md
@@ -21,7 +21,7 @@ The **glibc-dynamic** Chainguard Images are signed using Sigstore, and you can c
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/glibc-dynamic | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/glibc-dynamic | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/go/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/go/provenance_info.md
@@ -21,7 +21,7 @@ The **go** Chainguard Images are signed using Sigstore, and you can check the in
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/go | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/go | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/graalvm-native/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/graalvm-native/provenance_info.md
@@ -21,7 +21,7 @@ The **graalvm-native** Chainguard Images are signed using Sigstore, and you can 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/graalvm-native | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/graalvm-native | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/gradle/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/gradle/provenance_info.md
@@ -21,7 +21,7 @@ The **gradle** Chainguard Images are signed using Sigstore, and you can check th
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/gradle | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/gradle | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/haproxy/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/haproxy/provenance_info.md
@@ -21,7 +21,7 @@ The **haproxy** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/haproxy | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/haproxy | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/helm/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/helm/provenance_info.md
@@ -21,7 +21,7 @@ The **helm** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/helm | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/helm | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/jdk/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/jdk/provenance_info.md
@@ -21,7 +21,7 @@ The **jdk** Chainguard Images are signed using Sigstore, and you can check the i
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/jdk | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/jdk | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/jenkins/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/jenkins/provenance_info.md
@@ -21,7 +21,7 @@ The **jenkins** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/jenkins | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/jenkins | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/jre/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/jre/provenance_info.md
@@ -21,7 +21,7 @@ The **jre** Chainguard Images are signed using Sigstore, and you can check the i
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/jre | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/jre | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/ko/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/ko/provenance_info.md
@@ -21,7 +21,7 @@ The **ko** Chainguard Images are signed using Sigstore, and you can check the in
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/ko | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/ko | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/kubectl/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/kubectl/provenance_info.md
@@ -21,7 +21,7 @@ The **kubectl** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/kubectl | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/kubectl | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/mariadb/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/mariadb/provenance_info.md
@@ -21,7 +21,7 @@ The **mariadb** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/mariadb | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/mariadb | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/maven/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/maven/provenance_info.md
@@ -21,7 +21,7 @@ The **maven** Chainguard Images are signed using Sigstore, and you can check the
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/maven | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/maven | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/melange/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/melange/provenance_info.md
@@ -21,7 +21,7 @@ The **melange** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/melange | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/melange | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/memcached/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/memcached/provenance_info.md
@@ -21,7 +21,7 @@ The **memcached** Chainguard Images are signed using Sigstore, and you can check
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/memcached | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/memcached | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/musl-dynamic/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/musl-dynamic/provenance_info.md
@@ -21,7 +21,7 @@ The **musl-dynamic** Chainguard Images are signed using Sigstore, and you can ch
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/musl-dynamic | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/musl-dynamic | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/nginx/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/nginx/provenance_info.md
@@ -21,7 +21,7 @@ The **nginx** Chainguard Images are signed using Sigstore, and you can check the
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/nginx | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/nginx | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/node/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/node/provenance_info.md
@@ -21,7 +21,7 @@ The **node** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/node | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/node | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/php/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/php/provenance_info.md
@@ -21,7 +21,7 @@ The **php** Chainguard Images are signed using Sigstore, and you can check the i
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/php | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/php | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/postgres/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/postgres/provenance_info.md
@@ -21,7 +21,7 @@ The **postgres** Chainguard Images are signed using Sigstore, and you can check 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/postgres | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/postgres | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/prometheus/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/prometheus/provenance_info.md
@@ -21,7 +21,7 @@ The **prometheus** Chainguard Images are signed using Sigstore, and you can chec
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/prometheus | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/prometheus | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/python/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/python/provenance_info.md
@@ -21,7 +21,7 @@ The **python** Chainguard Images are signed using Sigstore, and you can check th
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/python | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/python | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/rabbitmq/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/rabbitmq/provenance_info.md
@@ -21,7 +21,7 @@ The **rabbitmq** Chainguard Images are signed using Sigstore, and you can check 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/rabbitmq | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/rabbitmq | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/redis/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/redis/provenance_info.md
@@ -21,7 +21,7 @@ The **redis** Chainguard Images are signed using Sigstore, and you can check the
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/redis | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/redis | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/ruby/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/ruby/provenance_info.md
@@ -21,7 +21,7 @@ The **ruby** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/ruby | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/ruby | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/rust/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/rust/provenance_info.md
@@ -21,7 +21,7 @@ The **rust** Chainguard Images are signed using Sigstore, and you can check the 
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/rust | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/rust | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/sdk/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/sdk/provenance_info.md
@@ -21,7 +21,7 @@ The **sdk** Chainguard Images are signed using Sigstore, and you can check the i
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/sdk | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/sdk | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/static/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/static/provenance_info.md
@@ -21,7 +21,7 @@ The **static** Chainguard Images are signed using Sigstore, and you can check th
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/static | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/static | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/traefik/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/traefik/provenance_info.md
@@ -21,7 +21,7 @@ The **traefik** Chainguard Images are signed using Sigstore, and you can check t
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/traefik | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/traefik | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/wait-for-it/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/wait-for-it/provenance_info.md
@@ -21,7 +21,7 @@ The **wait-for-it** Chainguard Images are signed using Sigstore, and you can che
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/wait-for-it | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/wait-for-it | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.

--- a/content/chainguard/chainguard-images/reference/wolfi-base/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/wolfi-base/provenance_info.md
@@ -21,7 +21,7 @@ The **wolfi-base** Chainguard Images are signed using Sigstore, and you can chec
 The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify cgr.dev/chainguard/wolfi-base | jq
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/wolfi-base | jq
 ```
 
 By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.


### PR DESCRIPTION
## Type of change
Update cosign provenance verification due to cosign 2.0 being released.

### What should this PR do?
Updates the commands to work with version 2.0 of cosign.

### Why are we making this change?
Instructions are wrong for version 2.0.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
Try verifying with a new version of cosign, they fail.

One thing to think about is if we should have both instructions, or one overarching place where we say that we should be using cosign v2.0