### PR TITLE
Add images-demos terminal image and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To include an interactive terminal in a given tutorial page, add the following l
 academy/apko:latest
 academy/chainguard-images:latest
 academy/cosign:latest
+academy/images-demos:latest
 academy/rekor:latest
 academy/vexctl:latest
 policy-controller/base:latest

--- a/terminal-images/academy-base/Dockerfile
+++ b/terminal-images/academy-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk add curl bash tmux sudo tini nano jq && rm -rf /tmp/* /var/cache/apk/*
+RUN apk add curl bash bash-completion tmux sudo tini nano jq && rm -rf /tmp/* /var/cache/apk/*
 
 RUN addgroup inky \
       --gid 1000 && \
@@ -17,6 +17,5 @@ RUN echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel
 WORKDIR /home/inky
 USER inky
 
-ENV COSIGN_EXPERIMENTAL=1
 ENTRYPOINT ["/usr/bin/sudo", "/sbin/tini", "--"]
 CMD ["/bin/sleep", "3600"]

--- a/terminal-images/images-demos/Dockerfile
+++ b/terminal-images/images-demos/Dockerfile
@@ -1,0 +1,9 @@
+FROM academy-base:latest
+
+RUN sudo apk add git docker && sudo rm -rf /tmp/* /var/cache/apk/*
+RUN sudo adduser inky docker
+RUN git clone https://github.com/chainguard-dev/edu-images-demos.git
+
+WORKDIR /home/inky/edu-images-demos
+ 
+CMD ["/usr/bin/dockerd"]


### PR DESCRIPTION
### What should this PR do?
This PR adds the `academy/images-demo:latest` terminal image to academy.

### Why are we making this change?
This image enables running language-specific tutorials from the https://github.com/chainguard-dev/edu-images-demos repo

### What are the acceptance criteria? 
The readme should be updated

### How should this PR be tested?
Embedding the terminal with `terminalImage: academy/images-demo:latest` on a page should work when testing locally.