### PR TITLE
add warn mode and update cosign

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-disable-policy-enforcement.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-disable-policy-enforcement.md
@@ -1,10 +1,10 @@
 ---
-title: "How to disable policy enforcement"
+title: "How to Disable Policy Enforcement"
 type: "article"
 description: "Quickly handle incident responses in Chainguard Enforce"
 date: 2022-11-29T08:49:31+00:00
-lastmod: 2023-01-12T08:49:31+00:00
-draft: true
+lastmod: 2023-03-22T08:49:31+00:00
+draft: false
 images: []
 menu:
   docs:
@@ -15,17 +15,93 @@ toc: true
 
 > _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce for Kubernetes** on the [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs)._
 
+In the event of an incident response or another situation where you may need to modify Chainguard Enforce to _warn_ about instead of _fail_ a given policy, you can modify the policy configuration.
 
-Change the behavior of the policies by letting the controller warn instead of failing
+In an Enforce policy, images that fail to meet requirements will cause the image not to be admitted by default. To instead allow these through and warn the user that this operation did not meet the criteria, you can use the `mode` configuration option under `ClusterImagePolicy`. When set to `warn`, the policy will not block the admission, but instead will allow it through and emit a warning.
 
-Configure it via a configMap for all the images not matching any defined policy https://docs.sigstore.dev/policy-controller/overview/#admission-of-images (explained in the last paragraph of this subsection)
+## Example Warning Policies 
 
-An example of no policy matched:
+The following sets the `mode` configuration to `warn`.
 
-    If the image does not match against any policy
-    Fallback to deprecated policy-controller validation behavior
-    Validation will be attempted against the secret defined under cosign.secretKeyRef.name during helm installation.
-    If a valid signature or attestation is obtained, image is admitted
-    If no valid signature or attestation is obtained, image is denied
+```yaml
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-keyless-warn
+spec:
+  mode: warn
+  images:
+  - glob: registry.local:5000/policy-controller/demo*
+  authorities:
+  - keyless:
+      url: http://fulcio.fulcio-system.svc
+    ctlog:
+      url: http://rekor.rekor-system.svc
+```
 
-Configuring policy-controller ClusterImagePolicy
+By specifying the `spec.mode` as `warn`, even if an image is found to be non-compliant it will be allowed through. At the same time, a warning is issued to the caller informing them that this is not a compliant image.
+
+In the Chainguard Enforce Policy Catalog, review also the CUE "Disallow privilege escalation" policy, which prevents privilege escalation (such as via `set-user-ID` or `set-group-ID` file mode). This is Linux only policy in v1.25+.
+
+```yaml
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: disallow-privilege-escalation-cue
+  annotations:
+    catalog.chainguard.dev/title: Disallow privilege escalation
+    catalog.chainguard.dev/labels: cue,workloads
+    catalog.chainguard.dev/description: |
+      Privilege escalation (such as via set-user-ID or set-group-ID file mode) should
+      not be allowed. This is Linux only policy in v1.25+ (spec.os.name != windows)
+
+    catalog.chainguard.dev/learnMoreLink: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
+spec:
+  match:
+  - version: "v1"
+    resource: "pods"
+  images: [glob: '**']
+  authorities: [static: {action: pass}]
+  mode: warn
+  policy:
+    includeSpec: true
+    type: "cue"
+    data: |
+      // Create a schema for SecurityContext where allowPrivilegeEscalation
+      // is a bool that defaults to true
+      #SecurityContext: {
+        allowPrivilegeEscalation: bool | *true
+        ...
+      }
+      spec: {
+        initContainers: [...{
+          // Apply the schema to the security context in each container.
+          securityContext: #SecurityContext
+          // When allowPrivilegeEscalation is true (either specified, or by default)
+          // then surface our error by "validating" name against our error string.
+          if securityContext.allowPrivilegeEscalation {
+            name: "securityContext.allowPrivilegeEscalation must be false"
+          }
+        }]
+        containers: [...{
+          // Apply the schema to the security context in each container.
+          securityContext: #SecurityContext
+          // When allowPrivilegeEscalation is true (either specified, or by default)
+          // then surface our error by "validating" name against our error string.
+          if securityContext.allowPrivilegeEscalation {
+            name: "securityContext.allowPrivilegeEscalation must be false"
+          }
+        }]
+        ephemeralContainers: [...{
+          // Apply the schema to the security context in each container.
+          securityContext: #SecurityContext
+          // When allowPrivilegeEscalation is true (either specified, or by default)
+          // then surface our error by "validating" name against our error string.
+          if securityContext.allowPrivilegeEscalation {
+            name: "securityContext.allowPrivilegeEscalation must be false"
+          }
+        }]
+      }
+```
+
+Again, the `mode` configuration is set to `warn`. If you are logged into the Enforce Console, you can access the [Disallow privilege escalation policy](https://console.enforce.dev/policies/catalog/create/disallow-privilege-escalation-cue) from the Policy Catalog from the **Create policy** button.

--- a/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
+++ b/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
@@ -95,7 +95,7 @@ The following checks were performed on each of these signatures:
 [{"critical":{"identity":{"docker-reference":"index.docker.io/docker-username/demo-container"},"image":{"docker-manifest-digest":"sha256:e..."},"type":"cosign container image signature"},"optional":{"1.3.6.1.4.1.57264.1.1":"https://accounts.google.com","Bundle":{"SignedEntryTimestamp":"...","Payload":{"body":"eyJhcGlWZX...X19","integratedTime":...,"logIndex":...,"logID":"..."}},"Issuer":"https://accounts.google.com","Subject":"username@gmail.com"}}]
 ```
 
-As part of the JSON output, you should get feedback on the issuer that you used and the email address associated with it. For example, if you used Google as the authenticator, you will have `"Issuer":"https://accounts.google.com","Subject":"username@gmail.com"}}]` as the last part of your output. 
+As part of the JSON output, you should get feedback on the issuer that you used and the email address associated with it. For example, if you used Google as your OIDC provider, you will have `"Issuer":"https://accounts.google.com","Subject":"username@gmail.com"}}]` as the last part of your output. 
 
 ## Cosign with Keys
 

--- a/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
+++ b/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
@@ -38,7 +38,7 @@ In keyless signing, short-lived certificates are generated and linked into the c
 
 Through offering short-lived credentials, keyless signing can support the recommended practice of operating your build environment like a production environment. This prevents the opportunity for long-lived keys to be stolen and used to sign malicious artifacts. Even if these short-lived keys used in keyless signing were stolen, they’d be useless!
 
-While keyless signing can be used by individuals in the same manner as long-lived key pairs, it is also well suited for continuous integration and continuous deployment workloads. Keyless signing works by sending an OpenID Connect (OIDC) token to a certificate authority like Fulcio to be signed by a workload’s authenticated OIDC identity. This allows the developer to cryptographically demonstrate that the software artifact was built by the continuous integration pipeline of a given repository, for example. 
+While keyless signing can be used by individuals in the same manner as long-lived key pairs, it is also well suited for continuous integration and continuous deployment workloads. Keyless signing works by sending an OpenID Connect (OIDC) token to a certificate authority like [Fulcio](/open-source/sigstore/fulcio) to be signed by a workload’s authenticated OIDC identity. This allows the developer to cryptographically demonstrate that the software artifact was built by the continuous integration pipeline of a given repository, for example. 
 
 Cosign uses ephemeral keys and certificates, gets them signed automatically by the Fulcio root certificate authority, and stores these signatures in the Rekor transparency log, which automatically provides an attestation at the time of creation. 
 

--- a/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
+++ b/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
@@ -42,7 +42,7 @@ While keyless signing can be used by individuals in the same manner as long-live
 
 Cosign uses ephemeral keys and certificates, gets them signed automatically by the Fulcio root certificate authority, and stores these signatures in the Rekor transparency log, which automatically provides an attestation at the time of creation. 
 
-You can manually create a keyless signature with the following command in cosign. In our example, we’ll use [Docker Hub](https://hub.docker.com/). If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`. 
+You can manually create a keyless signature with the following `cosign` command. In our example, we’ll use [Docker Hub](https://hub.docker.com/) to store the signature. If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`. 
 
 ```sh
 cosign sign docker-username/demo-container

--- a/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
+++ b/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
@@ -4,7 +4,7 @@ type: "article"
 lead: "A primer to signing software artifacts with Cosign"
 description: "Understanding Cosign, a project under Sigstore"
 date: 2022-19-07T08:49:31+00:00
-lastmod: 2022-19-07T08:49:31+00:00
+lastmod: 2023-03-11T08:49:31+00:00
 draft: false
 images: []
 menu:
@@ -28,15 +28,78 @@ While code signing is not new technology, the growing prevalence of software in 
 
 Code signing involves a developer, software publisher, or entity (like an automated workload) digitally signing a software artifact to confirm their identity and ensure that the artifact was not tampered with since having been signed. Code signing has several implementations, and Cosign is one such implementation, but all code signing technology follows a similar process as Cosign. 
 
-<!-- ![Architectural overview of Sigstore](sigstore-overview/svg) -->
+The recommended practice for a developer (or organization) looking to sign their code with Cosign is to use keyless signing. This process will first generate an ephemeral key pair which will then be used to create a digital signature for a given software artifact. A **key pair** is a combination of a signing key to sign data, and a verification key that is used to verify data signed with the corresponding signing key. With the `cosign sign` command, the developer will sign their software artifact, and that signature will be stored in the registry (if applicable). This signature can later be verified by others through searching for an artifact, finding its signature, and then verifying it. 
 
-A developer (or organization) looking to sign their code with Cosign will first generate a key pair with public and private keys, and will then use the private key to create a digital signature for a given software artifact. A **key pair** is a combination of a signing key to sign data, and a verification key that is used to verify data signed with the corresponding signing key. Public keys can be known to others (and can be openly distributed), and private keys must only be known by the owner for signatures to be secure. With the key pair, the developer will sign their software artifact and store that signature in the registry (if applicable). This signature can later be verified by others through searching for an artifact, finding its signature, and then verifying it against the public key. 
+## Keyless Signing
 
-## Cosign in practice
+Code signing is a solution for many use cases related to attestation and verification with the goal of a more secure software supply chain. While key pairs are a technology standard that have a long history in technology (SSH keys, for instance), they create their own challenges for developers and engineering teams. The contents of a public key are very opaque; humans cannot readily discern who the owner of a given key is. Traditional public key infrastructure, or PKI, has done the work to create, manage, and distribute public-key encryption and digital certificates. A new form of PKI is keyless signing, which prevents the challenges of long-lived and opaque signing keys. 
 
-We will go through installation and using Cosign in the Lab section. To give you an understanding of Cosign commands, we’ll go over the basics here.
+In keyless signing, short-lived certificates are generated and linked into the chain of trust through completing an identity challenge that confirms the identity of the signer. Because these keys persist only long enough for signing to take place, signature verification ensures that the certificate was valid at the time of signing. Policy enforcement is supported through an encoding of the identity information onto the certificate, allowing others to verify the identity of the developer who signed.
 
-We’ll review Cosign commands here so you can understand how Cosign works in practice and we are using imagined demo containers. If you would like to follow along, please first [install Cosign](../how-to-install-cosign).
+Through offering short-lived credentials, keyless signing can support the recommended practice of operating your build environment like a production environment. This prevents the opportunity for long-lived keys to be stolen and used to sign malicious artifacts. Even if these short-lived keys used in keyless signing were stolen, they’d be useless!
+
+While keyless signing can be used by individuals in the same manner as long-lived key pairs, it is also well suited for continuous integration and continuous deployment workloads. Keyless signing works by sending an OpenID Connect (OIDC) token to a certificate authority like Fulcio to be signed by a workload’s authenticated OIDC identity. This allows the developer to cryptographically demonstrate that the software artifact was built by the continuous integration pipeline of a given repository, for example. 
+
+Cosign uses ephemeral keys and certificates, gets them signed automatically by the Fulcio root certificate authority, and stores these signatures in the Rekor transparency log, which automatically provides an attestation at the time of creation. 
+
+You can manually create a keyless signature with the following command in cosign. In our example, we’ll use [Docker Hub](https://hub.docker.com/). If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`. 
+
+```sh
+cosign sign docker-username/demo-container
+```
+
+You'll be taken through a workflow that requests you to grant permission to have your information stored permanently in transparency logs, and moves to a workflow with an OIDC provider.
+
+```
+Generating ephemeral keys...
+Retrieving signed certificate...
+
+	Note that there may be personally identifiable information associated with this signed artifact.
+	This may include the email address associated with the account with which you authenticate.
+	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
+
+By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
+Are you sure you would like to continue? [y/N] 
+Your browser will now be opened to:
+...
+```
+
+At this point, a browser window will open and you will be directed to a page that asks you to log in with Sigstore. You can authenticate with GitHub, Google, or Microsoft. Note that the email address that is tied to these credentials will be permanently visible in the Rekor transparency log. This makes it publicly visible that you are the one who signed the given artifact, and helps others trust the given artifact. That said, it is worth keeping this in mind when choosing your authentication method. Once you log in and are authenticated, you’ll receive feedback of “`Sigstore Auth Successful`”, and you may now safely close the window. 
+
+On the terminal, you’ll receive output that you were successfully verified, and you’ll get confirmation that the signature was pushed. 
+
+```
+Successfully verified SCT...
+tlog entry created with index: 
+Pushing signature to: index.docker.io/docker-username/demo-container
+```
+
+If you followed along with Docker Hub, you can check the user interface of your repository and verify that you pushed a signature. 
+
+You can then further verify that the keyless signature was successful by using `cosign verify` to check. You will need to know some information in order to verify the entry. You'll need to use the identity flags `--certificate-identity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command.
+
+```sh
+cosign verify \
+    --certificate-identity username@gmail.com \
+    --certificate-oidc-issuer https://accounts.google.com \
+    docker-username/demo-container 
+```
+
+```
+Verification for index.docker.io/docker-username/demo-container:latest --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+
+[{"critical":{"identity":{"docker-reference":"index.docker.io/docker-username/demo-container"},"image":{"docker-manifest-digest":"sha256:e..."},"type":"cosign container image signature"},"optional":{"1.3.6.1.4.1.57264.1.1":"https://accounts.google.com","Bundle":{"SignedEntryTimestamp":"...","Payload":{"body":"eyJhcGlWZX...X19","integratedTime":...,"logIndex":...,"logID":"..."}},"Issuer":"https://accounts.google.com","Subject":"username@gmail.com"}}]
+```
+
+As part of the JSON output, you should get feedback on the issuer that you used and the email address associated with it. For example, if you used Google as the authenticator, you will have `"Issuer":"https://accounts.google.com","Subject":"username@gmail.com"}}]` as the last part of your output. 
+
+## Cosign with Keys
+
+You can also use Cosign with long-lived key pairs. If you would like to follow along, please first [install Cosign](../how-to-install-cosign).
 
 ```sh
 cosign generate-key-pair 
@@ -77,58 +140,3 @@ You should now have some familiarity with the process of signing and verifying c
 
 Code signing provides developers and others who release code a way to attest to their identity, and in turn, those who are consumers (whether end users or developers who incorporate existing code) can verify those signatures to ensure that the code is originating from where it is said to have originated, and check that that particular developer (or vendor) is trusted. 
 
-## Keyless Signing
-
-Code signing is a solution for many use cases related to attestation and verification with the goal of a more secure software supply chain. While key pairs are a technology standard that have a long history in technology (SSH keys, for instance), they create their own challenges for developers and engineering teams. The contents of a public key are very opaque; humans cannot readily discern who the owner of a given key is. Traditional public key infrastructure, or PKI, has done the work to create, manage, and distribute public-key encryption and digital certificates. A new form of PKI is keyless signing, which prevents the challenges of long-lived and opaque signing keys. 
-
-In keyless signing, short-lived certificates are generated and linked into the chain of trust through completing an identity challenge that confirms the identity of the signer. Because these keys persist only long enough for signing to take place, signature verification ensures that the certificate was valid at the time of signing. Policy enforcement is supported through an encoding of the identity information onto the certificate, allowing others to verify the identity of the developer who signed.
-
-Through offering short-lived credentials, keyless signing can support the recommended practice of operating your build environment like a production environment. This prevents the opportunity for long-lived keys to be stolen and used to sign malicious artifacts. Even if these short-lived keys used in keyless signing were stolen, they’d be useless!
-
-While keyless signing can be used by individuals in the same manner as long-lived key pairs, it is also well suited for continuous integration and continuous deployment workloads. Keyless signing works by sending an OpenID Connect (OIDC) token to a certificate authority like Fulcio to be signed by a workload’s authenticated OIDC identity. This allows the developer to cryptographically demonstrate that the software artifact was built by the continuous integration pipeline of a given repository, for example. 
-
-Cosign uses ephemeral keys and certificates, gets them signed automatically by the Fulcio root certificate authority, and stores these signatures in the Rekor transparency log, which automatically provides an attestation at the time of creation. 
-
-You can manually create a keyless signature with the following command in cosign. In our example, we’ll use [Docker Hub](https://hub.docker.com/). If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`. 
-
-```sh
-COSIGN_EXPERIMENTAL=1 cosign sign docker-username/demo-container
-```
-
-```
-Generating ephemeral keys...
-Retrieving signed certificate...
-Your browser will now be opened to:
-```
-
-At this point, a browser window will open and you will be directed to a page that asks you to log in with Sigstore. You can authenticate with GitHub, Google, or Microsoft. Note that the email address that is tied to these credentials will be permanently visible in the Rekor transparency log. This makes it publicly visible that you are the one who signed the given artifact, and helps others trust the given artifact. That said, it is worth keeping this in mind when choosing your authentication method. Once you log in and are authenticated, you’ll receive feedback of “`Sigstore Auth Successful`”, and you may now safely close the window. 
-
-On the terminal, you’ll receive output that you were successfully verified, and you’ll get confirmation that the signature was pushed. 
-
-```
-Successfully verified SCT...
-tlog entry created with index: 
-Pushing signature to: index.docker.io/docker-username/demo-container
-…
-```
-
-If you followed along with Docker Hub, you can check the user interface of your repository and verify that you pushed a signature. 
-
-You can then further verify that the keyless signature was successful by using cosign verify to check.
-
-```sh
-COSIGN_EXPERIMENTAL=1 cosign verify docker-username/demo-container 
-```
-
-```
-The following checks were performed on all of these signatures:
-  - The cosign claims were validated
-  - The claims were present in the transparency log
-  - The signatures were integrated into the transparency log when the certificate was valid
-  - Any certificates were verified against the Fulcio roots.
-…
-{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36"},"Type":"cosign container image signature"},"Optional":null}
-…
-```
-
-As part of the JSON output, you should get feedback on the issuer that you used and the email address associated with it. For example, if you used Google as the authenticator, you will have `"Issuer":"https://accounts.google.com","Subject":"your-email@gmail.com"}}]` as the last part of your output. 

--- a/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
@@ -25,7 +25,7 @@ Let’s step through signing a container with Cosign. We are using a container t
 
 Before beginning this section, ensure that you have Docker installed and that you are running Docker Desktop if that is relevant for your operating system. For guidance on installing and using Docker, refer to the [official Docker documentation](https://docs.docker.com/get-docker/). In order to push to the Docker container registry, you will need a [Docker Hub account](https://hub.docker.com/signup). If you are familiar with using a different container registry, feel free to use that. 
 
-Additionally, you will need Cosign installed, which you can achieve by following our [How to Install Cosign guide](../how-to-install-cosign/).
+Additionally, you will need Cosign installed, which you can achieve by following our [How to Install Cosign guide](/open-source/sigstore/cosign/how-to-install-cosign/).
 
 ## Creating a Container
 
@@ -121,7 +121,7 @@ You should be able to now access your published container via your Docker Hub ac
 
 Now that the container is in a registry (in our example, it is in Docker Hub), you are ready to sign the container and push that signature to the registry.
 
-You will call your registry user name and container name with the following Cosign command. Note that we are signing the image in Docker Hub keylessly with Cosign.
+You will call your registry user name and container name with the following `cosign` command. Note that we are signing the image in Docker Hub keylessly with Cosign.
 
 ```sh
 cosign sign docker-username/hello-container
@@ -166,7 +166,7 @@ cosign verify \
     docker-username/hello-container 
 ```
 
-Here, we are passing the public key contained in the cosign.pub file to the cosign verify command. 
+Here, we are passing the public key contained in the cosign.pub file to the `cosign verify` command. 
 
 You should receive output indicating that the Cosign claims were validated. 
 


### PR DESCRIPTION
publishing doc on warn vs fail mode for policies and cosign sign keyless updates from cosign 2.0