### PR TITLE
Updated ReadMe with tagging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,63 @@ policy-controller/install:latest
 ```
 
 The interactive terminal is under active development and not every tool is currently available within the environment.
+
+### Adding Tags
+
+To include tags to a piece of content, add the following line to the file's front matter: 
+
+`tags: ["TAG1", TAG2", etc]`
+
+This line should appear between the `draft` line and the `images` line in the front matter. Make sure your tags are in all uppercase.
+
+For example: 
+
+```
+...
+draft: false
+tags: ["IMAGES", "OVERVIEW", "PRODUCT"]
+images: []
+menu:
+...
+```
+
+When applying tags, please make sure they conform to the working tag list below so that the tagging logic is consistent. If you'd like to add a new tag or suggest a tag revision, please submit a PR with a justification for the change. 
+
+
+Tags are based on:
+* _Content topics_ covered in the content, such as tools (Enforce, apko, etc), orgs/standards (OCI, SLSA, etc), and other relevant topics (SBOMs, etc).
+* _Content types_ represented by the content, such procedural, conceptual, interactive, troubleshooting, etc. 
+
+**Tags Working List**
+
+**Topic tags**
+* APKO
+* CHAINCTL 
+* COSIGN
+* ENFORCE
+* FULCIO
+* IMAGES
+* MELANGE
+* OCI
+* POLICY
+* POLICY CONTROLLER
+* PRODUCT 
+* REKOR
+* SBOM
+* SIGSTORE
+* SLSA
+* VEX
+* WOLFI
+
+**Type tags** 
+
+* CHEAT SHEET
+* CONCEPTUAL
+* FAQ
+* INTERACTIVE
+* OVERVIEW 
+* PROCEDURAL 
+* REFERENCE
+* TROUBLESHOOTING
+* VIDEO
+* WORKSHOP KIT


### PR DESCRIPTION
## Type of change
Added tagging instructions to the Academy Repo's ReadMe. 

### What should this PR do?
Display tagging instructions in the Readme. 

### Why are we making this change?
To provide instructions for  authors. 

### What are the acceptance criteria? 
Reviewers are encouraged to submit feedback on the instructions, logic, and working tag lists. 

### How should this PR be tested?
Review the tagging instructions in the ReadMe. 