### PR TITLE
Switch academy/apko image to use melange and apko

### DIFF
--- a/content/open-source/apko/getting-started-with-apko.md
+++ b/content/open-source/apko/getting-started-with-apko.md
@@ -120,16 +120,10 @@ docker run --rm -v ${PWD}:/work -w /work cgr.dev/chainguard/apko build wolfi-bas
 You should get output similar to this:
 
 ```
-Mar 15 20:17:02.023 [INFO] loading config file: wolfi-base.yaml
+. . .
 Mar 15 20:17:02.023 [INFO] [arch:x86_64] Building images for 1 architectures: [amd64]
 Mar 15 20:17:02.023 [INFO] [arch:x86_64] building tags [wolfi-base:test]
 . . .
-Mar 15 20:17:03.873 [INFO] [arch:x86_64] finished building filesystem in /tmp/apko-436761415/x86_64
-Mar 15 20:17:04.098 [INFO] [arch:x86_64] built image layer tarball as /tmp/apko-temp-55692145/apko-x86_64.tar.gz
-Mar 15 20:17:04.098 [INFO] [arch:x86_64] building OCI image from layer '/tmp/apko-temp-55692145/apko-x86_64.tar.gz'
-Mar 15 20:17:04.260 [INFO] [arch:x86_64] OCI layer digest: sha256:75da6a428ac82e4abb12719ff8dcba796c9b767093cfbb561d516f702bf64f13
-Mar 15 20:17:04.260 [INFO] [arch:x86_64] OCI layer diffID: sha256:471733c3aded4cd397ea5d2ac6651a2c7455169823e59570748eebd2be8e886d
-time="2023-03-15T20:17:04Z" level=info msg="Generating arch image SBOMs"
 Mar 15 20:17:04.261 [INFO] loading config file: wolfi-base.yaml
 Mar 15 20:17:04.416 [INFO] [arch:x86_64] adding amd64 to index
 Mar 15 20:17:04.419 [INFO] [arch:x86_64] Generating index SBOM

--- a/content/open-source/apko/getting-started-with-apko.md
+++ b/content/open-source/apko/getting-started-with-apko.md
@@ -4,7 +4,7 @@ type: "article"
 lead: "Minimalist OCI image builder based on APK"
 description: "Quickstart to get apko up and running"
 date: 2022-07-06T08:49:31+00:00
-lastmod: 2022-07-06T08:49:31+00:00
+lastmod: 2023-03-15T16:49:31+00:00
 contributors: ["Erika Heidi"]
 draft: false
 images: []
@@ -111,7 +111,7 @@ Save and close the file after you're done including these contents. With `nano`,
 The only thing left to do now is run apko to build this image. The following build command will:
 
 - set up a volume share in the current directory, synchronizing its contents with apko's image workdir; this way, the generated artifacts will be available on your host system.
-- execute the `cgr.dev/chainguard/apko` image with the `build` command, tagging the image as `wolfi-base:test` and saving the build as `wolfi-test.rar`.
+- execute the `cgr.dev/chainguard/apko` image with the `build` command, tagging the image as `wolfi-base:test-amd64` and saving the build as `wolfi-test.tar`.
 
 ```shell
 docker run --rm -v ${PWD}:/work -w /work cgr.dev/chainguard/apko build wolfi-base.yaml wolfi-base:test wolfi-test.tar
@@ -120,17 +120,20 @@ docker run --rm -v ${PWD}:/work -w /work cgr.dev/chainguard/apko build wolfi-bas
 You should get output similar to this:
 
 ```
-Feb  8 17:21:33.665 [INFO] loading config file: wolfi-base.yaml
-Feb  8 17:21:33.666 [INFO] [arch:x86_64] WARNING: ignoring archs in config, only building for current arch (amd64)
-Feb  8 17:21:33.666 [INFO] [arch:x86_64] building image 'wolfi-base:test'
-...
-Feb  8 17:21:41.772 [INFO] [arch:x86_64] finished building filesystem in /tmp/apko-2993726922
-Feb  8 17:21:41.845 [INFO] [arch:x86_64] built image layer tarball as /tmp/apko-temp-3502723090/apko-x86_64.tar.gz
-&{ID:wolfi IDLike: Name:Wolfi PrettyName:Wolfi Version: VersionID:20230201 VersionCodename:}Feb  8 17:21:41.955 [INFO] [arch:x86_64] building OCI image from layer '/tmp/apko-temp-3502723090/apko-x86_64.tar.gz'
-Feb  8 17:21:42.064 [INFO] [arch:x86_64] OCI layer digest: sha256:8f62e40cd09e48c90e93a0119a45e49fd50e9cd4cf0561a618b708623ed106e1
-Feb  8 17:21:42.064 [INFO] [arch:x86_64] OCI layer diffID: sha256:bf6e72d71c134bb210fac46f8abd9218821412d8bf9219f48d1b5e9e243e8233
-Feb  8 17:21:42.064 [WARNING] [arch:x86_64] multiple SBOM formats requested, uploading SBOM with media type: spdx+json
-Feb  8 17:21:42.068 [INFO] [arch:x86_64] output OCI image file to wolfi-test.tar
+Mar 15 20:17:02.023 [INFO] loading config file: wolfi-base.yaml
+Mar 15 20:17:02.023 [INFO] [arch:x86_64] Building images for 1 architectures: [amd64]
+Mar 15 20:17:02.023 [INFO] [arch:x86_64] building tags [wolfi-base:test]
+. . .
+Mar 15 20:17:03.873 [INFO] [arch:x86_64] finished building filesystem in /tmp/apko-436761415/x86_64
+Mar 15 20:17:04.098 [INFO] [arch:x86_64] built image layer tarball as /tmp/apko-temp-55692145/apko-x86_64.tar.gz
+Mar 15 20:17:04.098 [INFO] [arch:x86_64] building OCI image from layer '/tmp/apko-temp-55692145/apko-x86_64.tar.gz'
+Mar 15 20:17:04.260 [INFO] [arch:x86_64] OCI layer digest: sha256:75da6a428ac82e4abb12719ff8dcba796c9b767093cfbb561d516f702bf64f13
+Mar 15 20:17:04.260 [INFO] [arch:x86_64] OCI layer diffID: sha256:471733c3aded4cd397ea5d2ac6651a2c7455169823e59570748eebd2be8e886d
+time="2023-03-15T20:17:04Z" level=info msg="Generating arch image SBOMs"
+Mar 15 20:17:04.261 [INFO] loading config file: wolfi-base.yaml
+Mar 15 20:17:04.416 [INFO] [arch:x86_64] adding amd64 to index
+Mar 15 20:17:04.419 [INFO] [arch:x86_64] Generating index SBOM
+Mar 15 20:17:04.420 [INFO] [arch:x86_64] Final index tgz at: wolfi-test.tar
 ```
 
 From the output, you can notice that the image was successfully built as `wolfi-test.tar` in the container, which is shared with your local folder on the host thanks to the volume you created when running the `docker run` command.
@@ -145,7 +148,7 @@ docker load <  wolfi-test.tar
 You'll get output like this:
 ```
 bf6e72d71c13: Loading layer [==================================================>]  5.491MB/5.491MB
-Loaded image: wolfi-base:test
+Loaded image: wolfi-base:test-amd64
 ```
 
 You can check that the image is available at the host system with:
@@ -154,15 +157,15 @@ You can check that the image is available at the host system with:
 docker image list
 ```
 
-You should be able to find the `wolfi-base` image with the `test` tag among the results.
+You should be able to find the `wolfi-base` image with the `test-amd64` tag among the results.
 
 Now you can run the image with:
 
 ```shell
-docker run -it wolfi-base:test
+docker run -it wolfi-base:test-amd64
 ```
 
-This will get you into a container running the apko-built image `wolfi-base:test`. It's a regular shell that you can explore to see what's included - just keep in mind that this is a minimalist image with only the base Wolfi system. To include additional software packages, check the [Wolfi repository](https://github.com/wolfi-dev/os) to find the packages you'll need for your specific use case, or check out [melange](/open-source/melange/), apko's companion project that allows users to build their own APK packages from source.
+This will get you into a container running the apko-built image `wolfi-base:test-amd64`. It's a regular shell that you can explore to see what's included - just keep in mind that this is a minimalist image with only the base Wolfi system. To include additional software packages, check the [Wolfi repository](https://github.com/wolfi-dev/os) to find the packages you'll need for your specific use case, or check out [melange](/open-source/melange/), apko's companion project that allows users to build their own APK packages from source.
 
 ## Conclusion
 

--- a/terminal-images/apko/Dockerfile
+++ b/terminal-images/apko/Dockerfile
@@ -1,6 +1,0 @@
-FROM academy-base:latest
-
-RUN sudo apk add docker && rm -rf /tmp/* /var/cache/apk/*
-RUN sudo adduser inky docker
-
-CMD ["/usr/bin/dockerd"]

--- a/terminal-images/apko/apko.yaml
+++ b/terminal-images/apko/apko.yaml
@@ -1,0 +1,36 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    - "/work/packages"
+  packages:
+    - alpine-baselayout-data
+    - apk-tools
+    - bash
+    - ca-certificates-bundle
+    - docker
+    - nano
+    - sudo
+    - tmux
+    - academy-apko
+
+accounts:
+  groups:
+    - groupname: inky
+      gid: 2000
+  users:
+    - username: inky
+      uid: 2000
+  run-as: inky
+
+environment:
+  DOCKER_HOST: "tcp://127.0.0.1:2375"
+
+entrypoint:
+  entrypoint:
+  type: service-bundle
+  services:
+    docker: /usr/bin/sudo /usr/bin/dockerd -H tcp://127.0.0.1:2375
+
+archs:
+  - x86_64

--- a/terminal-images/apko/melange.yaml
+++ b/terminal-images/apko/melange.yaml
@@ -1,0 +1,32 @@
+package:
+  name: academy-apko
+  version: 0.1.0
+  description: Chainguard Academy apko image
+  target-architecture:
+    - aarch64
+    - x86_64
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+      - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    packages:
+      - alpine-baselayout-data
+      - ca-certificates-bundle
+      - busybox
+
+pipeline:
+  - name: Setup stuff
+    runs: |
+      mkdir -p \
+        "${{targets.destdir}}/usr/bin" \
+        "${{targets.destdir}}/usr/local/bin" \
+        "${{targets.destdir}}/etc/profile.d" \
+        "${{targets.destdir}}/etc/sudoers.d"
+      echo "inky ALL=(ALL:ALL) NOPASSWD: ALL" > "${{targets.destdir}}/etc/sudoers.d/wheel"
+      cp ./profile.sh "${{targets.destdir}}/etc/profile.d/inky-profile.sh"

--- a/terminal-images/apko/profile.sh
+++ b/terminal-images/apko/profile.sh
@@ -1,0 +1,4 @@
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+alias k='k3s kubectl'
+alias kubectl='k3s kubectl'
+cd $HOME


### PR DESCRIPTION
### What should this PR do?
This PR migrates the embedded terminal on Academy for the [Getting Started with apko](https://edu.chainguard.dev/open-source/apko/getting-started-with-apko) tutorial to an image that is built with melange and apko.

It also updates the tutorial since `apko` now adds the CPU architecture as part of an image tag name.

Finally, this build configuration will now integrate with the Github action to build images nightly to ensure images are always patched and up to date.

### Why are we making this change?
Images on the Academy site aren't automated, and every one of them ships with CVEs. e.g. the existing apko image has 26. Using melange and apko results in 0 🎉 

### What are the acceptance criteria? 
The tutorial should work.

### How should this PR be tested?
Test by changing the `terminalImage` line in `content/open-source/apko/getting-started-with-apko.md`. Make it use the test version of the apko image:
```
terminalImage: academy/test:latest
```

Then run hugo locally and try the tutorial: http://127.0.0.1:1313/open-source/apko/getting-started-with-apko