### PR TITLE
Adding tags to chainctl content

### DIFF
--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -50,6 +50,12 @@ runs:
         rsync -av --delete --exclude="_index.md" \
           "/tmp/chainctl-docs/" "content/chainguard/chainguard-enforce/chainctl-docs/"
 
+    - name: add tags to chainctl docs by inserting line with sed
+      shell: bash
+      run: |
+        sed '/draft: false/a tags: ["chainctl", "Reference", "Product"]' \
+          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md
+
     - name: download domains.md from cloud storage
       shell: bash
       run: |


### PR DESCRIPTION
## Type of change
Added tags to chainctl articles. Will add tags to product tutorials in separate PR. 

### What should this PR do?
Tags should appear in chainctl articles. 

### Why are we making this change?
Implementing tags is part of the Academy V2 design plans. 

### What are the acceptance criteria? 
Tags should appear on relevant content at the top of the article. Nothing should break. 

### How should this PR be tested?
The reviewer should preview a few chainctl tutorials to make sure tags are appearing correctly. 