### PR TITLE
Bump autodocs to fix specs page

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -28,7 +28,7 @@ jobs:
         run: mkdir -p "${{ github.workspace }}/${{ env.WORKDIR }}" && chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: "Update the reference docs for Chainguard Images"
-        uses: chainguard-dev/deved-autodocs@1.2.1
+        uses: chainguard-dev/deved-autodocs@1.3.0
         with:
           command: build images
         env:


### PR DESCRIPTION
This PR updates the autodocs github action version to the latest, bringing a fix to the image variants / specs page.