### PR TITLE
Enforce GitHub signing

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,12 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+spec:
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+      ctlog:
+        url: https://rekor.sigstore.dev
+    - key:
+        # Allow commits signed by GitHub.
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
## Type of change
enhancement

### What should this PR do?
This PR adds the `.chainguard/source.yaml` file for Enforce commit verification. I think I have it set up to allow any commit signed with a Sigstore identity, as well as (this is the important one) the Github UI GPG key.

### Why are we making this change?
Many PRs just need small one line/character edits. Doing it via the Github review and editor UI is easier. With this those edits (along with any other Sigstore signature) should get a passing ✅ 

### What are the acceptance criteria? 
We'll know pretty quickly after this is merged if it works by going through our usual CLI workflows and editing via the UI.

### How should this PR be tested?
I'm not sure how to test this, I copied/modified it shamelessly from https://github.com/chainguard-dev/helm-charts/blob/main/.chainguard/source.yaml