### PR TITLE
Add registry overview

### DIFF
--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -29,7 +29,7 @@ distributions. We believe our approach is more maintainable and extensible.
 We call Wolfi an undistro because unlike a typical Linux distribution, Wolfi is a stripped-down distribution designed for the cloud-native era. Most notably, we don’t include a Linux kernel, instead relying on the environment (such as the container runtime) to provide this.
 
 ### Which images are available?
-You can check which images are already available at our [Images Reference](https://edu.chainguard.dev/chainguard/chainguard-images/reference/) or directly in our [GitHub Repository](https://github.com/chainguard-images).
+You can check which images are already available at our [Images Catalog](https://edu.chainguard.dev/chainguard/chainguard-images/reference/), through the [Chainguardy Registry](/chainguard/chainguard-images/registry/overview/), or in our [GitHub Repository](https://github.com/chainguard-images).
 
 ### What is an SBOM and why is it important?
 An SBOM is a Software Bill of Materials, which is a list containing detailed information about all software that is included within a software artifact, whether it's an application, a container image, or a physical appliance.

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -27,11 +27,11 @@ Main features include:
 - Verifiable signatures provided by [Sigstore](/open-source/sigstore/cosign/an-introduction-to-cosign/)
 - Automated nightly builds to ensure images are completely up-to-date and contain all available security patches
 
-Chainguard Images are available from the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/) and [on GitHub](https://github.com/chainguard-images).
+Chainguard Images are available from the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/) and can be pulled from `cgr.dev`. You can review images files [on GitHub](https://github.com/chainguard-images).
 
 ## Why Distroless
 
-[Distroless images](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) are the result of pushing minimalism in containers to the next level. When compared to traditional base images such as [alpine](https://hub.docker.com/_/alpine) or [debian](https://hub.docker.com/_/debian), they are more stripped back, lacking even a shell or package managers. However, compared to the empty “scratch” image, they do contain structure essential for the majority of Linux applications such as root certificates for TLS and core files like `/etc/passwd`.
+[Distroless images](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) are the result of pushing minimalism in containers to the next level. When compared to traditional base images such as [Alpine](https://hub.docker.com/_/alpine) or [Debian](https://hub.docker.com/_/debian), they are more stripped back, lacking even a shell or package managers. However, compared to the empty “scratch” image, they do contain structure essential for the majority of Linux applications such as root certificates for TLS and core files like `/etc/passwd`.
 
 The following graph shows a comparison between the official Nginx image and Chainguard's Nginx image, based on the number of CVEs (common vulnerabilities and exposures) detected by Trivy:
 

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -27,7 +27,7 @@ Main features include:
 - Verifiable signatures provided by [Sigstore](/open-source/sigstore/cosign/an-introduction-to-cosign/)
 - Automated nightly builds to ensure images are completely up-to-date and contain all available security patches
 
-Chainguard Images are available [on Github](https://github.com/chainguard-images) and the `cgr.dev` registry.
+Chainguard Images are available from the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/) and [on GitHub](https://github.com/chainguard-images).
 
 ## Why Distroless
 

--- a/content/chainguard/chainguard-images/registry/_index.md
+++ b/content/chainguard/chainguard-images/registry/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Chainguard Registry"
+lead: ""
+description: "Chainguard Registry Documentation"
+type: "article"
+date: 2023-03-21T08:48:45+00:00
+lastmod: 2023-03-22T08:48:45+00:00
+draft: false
+images: []
+---

--- a/content/chainguard/chainguard-images/registry/overview.md
+++ b/content/chainguard/chainguard-images/registry/overview.md
@@ -14,7 +14,7 @@ weight: 50
 toc: true
 ---
 
-The Chainguard Registry provides public access to all public Chainguard Images, and provides customer access for image variants through login and authentication. These variants may include older software releases and other custom images. The Chainguard Registry works with [chainctl](/chainguard/chainguard-enforce/how-to-install-chainctl/) and offers a place for you and your team to access and manage your organization's Chainguard Images. Through Chainguard's [IAM model](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/overview-of-enforce-iam-model/), you can decide who has access to images across your organization. 
+The Chainguard Registry provides public access to all public Chainguard Images, and provides customer access for image variants through login and authentication. 
 
 While all public Chainguard Images are freely available, logging in with a Chainguard account and authenticating when pulling from the registry provides a mechanism for Chainguard to contact you if there are any current or known upcoming issues with images you are pulling.
 

--- a/content/chainguard/chainguard-images/registry/overview.md
+++ b/content/chainguard/chainguard-images/registry/overview.md
@@ -1,0 +1,21 @@
+---
+title: "Overview"
+type: "article"
+description: "An Overview of the Chainguard Registry"
+date: 2023-03-21T16:36:47+00:00
+lastmod: 2023-03-21T16:36:47+00:00
+draft: false
+images: []
+tags: ["Chainguard Images"]
+menu:
+  docs:
+    parent: "registry"
+weight: 50
+toc: true
+---
+
+The Chainguard Registry provides public access to all public Chainguard Images, and provides customer access for image variants through login and authentication. These variants may include older software releases and other custom images. The Chainguard Registry works with [chainctl](/chainguard/chainguard-enforce/how-to-install-chainctl/) and offers a place for you and your team to access and manage your organization's Chainguard Images. Through Chainguard's [IAM model](/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/overview-of-enforce-iam-model/), you can decide who has access to images across your organization. 
+
+While all public Chainguard Images are freely available, logging in with a Chainguard account and authenticating when pulling from the registry provides a mechanism for Chainguard to contact you if there are any current or known upcoming issues with images you are pulling.
+
+If you would like to learn more about **Chainguard Images**, you can review our [Images documentation](/chainguard/chainguard-images/overview/), and you can request further information through our [inquiry form](https://www.chainguard.dev/get-demo?utm_source=docs).


### PR DESCRIPTION
Adding a `/registry` directory under Chainguard Images to collect registry related docs and adding a short overview for starters. Also updated some other Images links to point to the registry docs