### PR TITLE
Add css font-size rules for code elements in headers

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -51,3 +51,19 @@ blockquote > p {
 h2#chainctl, h2[id^="chainctl"] {
   display: none;
 }
+
+h1 code {
+  font-size: 2.0rem;
+}
+
+h2 code {
+  font-size: 1.5rem;
+}
+
+h3 code {
+  font-size: 1.25rem;
+}
+
+h4 code {
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Type of change
platform development

### What should this PR do?
This PR adds CSS rules to set the font-size of `<code>` elements contained in h1,h2,h3,h4 headers to larger sizes than the default. 

### Why are we making this change?
Here's a screenshot of a header without this change:
<img width="627" alt="Screenshot 2023-03-22 at 5 00 34 PM" src="https://user-images.githubusercontent.com/328553/227036979-f256c67e-530f-43f8-8ee8-39aeb204d279.png">

And here's one with it:
<img width="693" alt="Screenshot 2023-03-22 at 5 00 03 PM" src="https://user-images.githubusercontent.com/328553/227036876-28dee0a5-5555-45f0-be84-d9832b44a076.png">

And a preview of a set of test headers of various sizes:
![image](https://user-images.githubusercontent.com/328553/227037103-a764ac85-c83c-410e-85a1-5472a214b14d.png)


### What are the acceptance criteria? 
Headers with inline code elements should look visually consistent.

### How should this PR be tested?
Check any pages with inline code elements in headings levels 1 through 4.