### PR TITLE
adding flag and removing alias command from curl section of chainctl …

### DIFF
--- a/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
@@ -3,7 +3,7 @@ title: "How to Install chainctl"
 type: "article"
 description: "Install the chainctl command line tool to work with Chainguard Enforce and Images"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2022-12-06T15:56:52-07:00
+lastmod: 2023-03-22T15:56:52-07:00
 draft: false
 images: []
 menu:
@@ -55,13 +55,7 @@ curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | t
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.
 
 ```sh
-sudo install -o $UID -g $GID 0755 chainctl /usr/local/bin/chainctl
-```
-
-Finally, alias its path so that you can use `chainctl` on the command line.
-
-```sh
-alias chainctl=/usr/local/bin/chainctl
+sudo install -o $UID -g $GID -m 0755 chainctl /usr/local/bin/chainctl
 ```
 
 At this point, you'll be able to use the `chainctl` command.


### PR DESCRIPTION
…install guide

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This is a minor change as far as copy goes, but it may have broader implications for users down the line.Per [this slack convo]() (and through testing on my own Mac) it turns out we need an `-m` flag on the `install` command in the `curl` section of the chainctl install guide. Additionally, the `alias` command isn't necessary.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Resolves:

* https://github.com/chainguard-dev/mono/issues/8618
* https://github.com/chainguard-dev/edu/issues/424

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->

Please double check that this works as expected and that I didn't miss anything else that needs to change with these updates.