### PR TITLE
update cosign instructions to verify chainctl

### DIFF
--- a/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
@@ -95,16 +95,17 @@ If you received output that you did not expect, check your bash profile to make 
 You can verify the integrity of your `chainctl` binary using Cosign. Ensure that you have the latest version of Cosign installed by following our [How to Install Cosign guide](/open-source/sigstore/cosign/how-to-install-cosign/). Verify your `chainctl` binary with the following command:
 
 ```sh
-COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+cosign verify-blob \
    --signature "https://dl.enforce.dev/chainctl/$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).sig" \
    --certificate "https://dl.enforce.dev/chainctl/$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).cert.pem" \
+   --certificate-identity "https://github.com/chainguard-dev/mono/.github/workflows/.release-drop.yaml@refs/tags/v$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')" \
+   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    $(which chainctl)
 ```
 
-You should receive output like the following:
+You should receive the following output:
 
 ```
-tlog entry verified with uuid: <uuid here> index: <log index here>
 Verified OK
 ```
 


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Fixes #423 with instructions on how to use cosign verify-blob to check signature on chainctl binary.

### Why are we making this change?
The docs are out of date.

### What are the acceptance criteria? 
Running the verify command should work.

### How should this PR be tested?
Test the command!