### PR TITLE
Fix #405: make nav elements clickable with embedded terminal

### DIFF
--- a/assets/scss/terminal.scss
+++ b/assets/scss/terminal.scss
@@ -6,11 +6,10 @@ $chainguard--light-blue: #48a8e8;
 #terminal-container {
   position: fixed;
   bottom: 1.5rem;
-  left: 0;
-  width: 100%;
+  width: 55rem;
   font-family: monospace;
   padding: 0;
-  margin: 0;
+  margin: 0 auto 0 -6rem;
   z-index: 1000 !important;
 
   iframe {
@@ -27,11 +26,10 @@ $chainguard--light-blue: #48a8e8;
 }
 
 #terminal-nav {
-  width: 100%;
-  margin: 0 auto;
+  width: 55rem;
+  margin: 0 auto 0 -6rem;
   position: fixed;
   bottom: 0;
-  left: 0;
   z-index: 1001 !important;
 
   nav {


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Fixes #405 

### Why are we making this change?
Navbar on the left is blocked when the terminal is on a page

### What are the acceptance criteria? 
The left nav works on all pages with a terminal.

### How should this PR be tested?
Test locally with `hugo serve` and visit a page like http://localhost:1313/chainguard/chainguard-images/how-to-use-chainguard-images/ - expand one of the menus on the left like Chainguard Images and ensure that links can be clicked.