### PR TITLE
Add partial to render data/notices.yaml for any page that needs a notice

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -67,3 +67,19 @@ h3 code {
 h4 code {
   font-size: 1rem;
 }
+
+#note {
+  padding: 0 0.5rem;
+}
+
+#note.note-deprecated {
+  background: lightyellow;
+}
+
+#note.note-notice {
+  background: lightblue;
+}
+
+#note.note-warning {
+  background: lightcoral;
+}

--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -12,8 +12,8 @@
 # The 'type' field will render the div with the selfsame class applied.
 
 - title: "Image Overview: jre"
-  note: |
-    This image will switch from including a full compliment of JDK binaries to a minimally required set in a forthcoming release. The work is being tracked in [this GitHub issue](https://github.com/chainguard-images/images/issues/297).
-
-    If you rely on any binaries in this image that are not a part of the following list, you should switch to using the [JDK Image](/chainguard/chainguard-images/reference/jdk/overview/).
   type: WARNING
+  note: |
+    This image will switch from including a full complement of JDK binaries to a minimally required set in a forthcoming release. The work is being tracked in [this GitHub issue](https://github.com/chainguard-images/images/issues/297).
+
+    If you rely on any binaries or libraries that are included in this image beyond the core JRE runtime, consider switching to the [JDK Image](/chainguard/chainguard-images/reference/jdk/overview/).

--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -1,0 +1,19 @@
+# This file is used to create temporary notices on pages on an as needed basis.
+# For example when something is going to be deprecated, but has not been yet.
+# To use it, add a YAML object matching the following structure:
+#
+# - title: "This must match the page title"
+#   note: |
+#     A line, or multi-line message with details.
+#
+#     The note can be plain text, or use Markdown.
+#   type: One of NOTICE, WARNING, or DEPRECATED
+#
+# The 'type' field will render the div with the selfsame class applied.
+
+- title: "Image Overview: jre"
+  note: |
+    This image will switch from including a full compliment of JDK binaries to a minimally required set in a forthcoming release. The work is being tracked in [this GitHub issue](https://github.com/chainguard-images/images/issues/297).
+
+    If you rely on any binaries in this image that are not a part of the following list, you should switch to using the [JDK Image](/chainguard/chainguard-images/reference/jdk/overview/).
+  type: WARNING

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -37,6 +37,7 @@
         {{ partial "sidebar/docs-toc.html" . }}
       </nav>
       {{ end -}}
+      {{ partial "notice.html" . }}
       {{ .Content }}
       <div class="page-footer-meta d-flex flex-column flex-md-row justify-content-between">
         {{ if .Site.Params.lastMod -}}

--- a/layouts/partials/notice.html
+++ b/layouts/partials/notice.html
@@ -1,0 +1,8 @@
+{{ range $i := $.Site.Data.notices }}
+{{ if eq $i.title $.Params.Title }}
+<div id="note" class="note-{{ $i.type | lower }}">
+  <h2>{{ $i.type }}</h2>
+  {{ $i.note | markdownify}}
+</div>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
## Type of change
platform

### What should this PR do?
This PR adds a partial that will pick up on any note in `data/notices.yaml` and render it at the top of a page. Notes can be written in Markdown and specify a type of `NOTICE, WARNING, DEPRECATION` to get a coloured background.

### Why are we making this change?
Sometimes pages need a banner notice at the top for ephemeral changes and the like. This PR is intended to be used for one-off notices, warnings, and deprecation notes on pages.

### What are the acceptance criteria? 
Pages with notes will have a block at the top, those with no notes will have none.

### How should this PR be tested?
Test locally using the included JRE note. Run `hugo serve` and visit http://localhost:1313/chainguard/chainguard-images/reference/jre/overview/

You should see the following: 

<img width="741" alt="Screenshot 2023-03-27 at 3 06 15 PM" src="https://user-images.githubusercontent.com/328553/228041701-80fa40b3-11ab-482c-a2f7-380c5add3b72.png">
