### PR TITLE
Fix notice partial and css rules with working class names

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -29,9 +29,11 @@ blockquote {
   margin: 1.5em 10px;
   padding: 0.5em 10px;
 }
+
 blockquote > p {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
+
 .featured-icon {
   font-size: 4rem;
 }
@@ -48,12 +50,13 @@ blockquote > p {
   color: #8087fc;
 }
 
-h2#chainctl, h2[id^="chainctl"] {
+h2#chainctl,
+h2[id^="chainctl"] {
   display: none;
 }
 
 h1 code {
-  font-size: 2.0rem;
+  font-size: 2rem;
 }
 
 h2 code {
@@ -72,14 +75,14 @@ h4 code {
   padding: 0 0.5rem;
 }
 
-#note.note-deprecated {
+#note.deprecated {
   background: lightyellow;
 }
 
-#note.note-notice {
+#note.notice {
   background: lightblue;
 }
 
-#note.note-warning {
+#note.warning {
   background: lightcoral;
 }

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -86,3 +86,15 @@ h4 code {
 #note.warning {
   background: lightcoral;
 }
+
+[data-dark-mode] #note.deprecated {
+  background: yellowgreen;
+}
+
+[data-dark-mode] #note.notice {
+  background: darkcyan;
+}
+
+[data-dark-mode] #note.warning {
+  background: darkred;
+}

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -84,7 +84,7 @@ h4 code {
 }
 
 #note.warning {
-  background: lightcoral;
+  background: darkorange;
 }
 
 [data-dark-mode] #note.deprecated {
@@ -96,5 +96,5 @@ h4 code {
 }
 
 [data-dark-mode] #note.warning {
-  background: darkred;
+  background: darkgoldenrod;
 }

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -96,5 +96,5 @@ h4 code {
 }
 
 [data-dark-mode] #note.warning {
-  background: darkgoldenrod;
+  background: darkorchid;
 }

--- a/layouts/partials/notice.html
+++ b/layouts/partials/notice.html
@@ -1,6 +1,6 @@
 {{ range $i := $.Site.Data.notices }}
 {{ if eq $i.title $.Params.Title }}
-<div id="note" class="note-{{ $i.type | lower }}">
+<div id="note" class="{{ $i.type | lower }}">
   <h2>{{ $i.type }}</h2>
   {{ $i.note | markdownify}}
 </div>


### PR DESCRIPTION
## Type of change
Bug

### What should this PR do?
Fixes missing CSS styles on notice partial blocks.

### Why are we making this change?
CSS classes weren't being rendered to the final main.css file

### What are the acceptance criteria? 
A warning block should be coloured coral red.

### How should this PR be tested?
Check the netlify preview for the [JRE images overview page](https://deploy-preview-530--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/reference/jre/overview/)