### PR TITLE
Fix missing quote in integrate Enforce action

### DIFF
--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -54,7 +54,7 @@ runs:
       shell: bash
       run: |
         sed '/draft: false/a tags: ["chainctl", "Reference", "Product"]' \
-          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md
+          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md"
 
     - name: download domains.md from cloud storage
       shell: bash


### PR DESCRIPTION
## Type of change
Bug

### What should this PR do?
Fixes a missing " character in the integrate Enforce docs github action.

### How should this PR be tested?
The GitHub action https://github.com/chainguard-dev/edu/actions/workflows/autodocs-enforce.yaml should work again once this is merged.