### PR TITLE
Revert "Fix missing quote in integrate Enforce action"

### DIFF
--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -54,7 +54,7 @@ runs:
       shell: bash
       run: |
         sed '/draft: false/a tags: ["chainctl", "Reference", "Product"]' \
-          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md"
+          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md
 
     - name: download domains.md from cloud storage
       shell: bash

--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -54,7 +54,7 @@ runs:
       shell: bash
       run: |
         sed '/draft: false/a tags: ["chainctl", "Reference", "Product"]' \
-          -i "content/chainguard/chainguard-enforce/chainctl-docs/*.md
+          -i content/chainguard/chainguard-enforce/chainctl-docs/*.md
 
     - name: download domains.md from cloud storage
       shell: bash


### PR DESCRIPTION
Reverts chainguard-dev/edu#531 and fixes integrate Enforce docs Github action sed step.