### PR TITLE
Add tags for enforce changelog, events, and fix chainctl tags *again*

### DIFF
--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -54,7 +54,19 @@ runs:
       shell: bash
       run: |
         sed '/draft: false/a tags: ["chainctl", "Reference", "Product"]' \
-          -i content/chainguard/chainguard-enforce/chainctl-docs/*.md
+          -i content/chainguard/chainguard-enforce/chainctl-docs/**/*.md
+
+    - name: add tags to changelog by inserting line with sed
+      shell: bash
+      run: |
+        sed '/draft: false/a tags: ["Enforce", "Reference", "Product"]' \
+          -i content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog.md
+
+    - name: add tags to cloudevents by inserting line with sed
+      shell: bash
+      run: |
+        sed '/draft: false/a tags: ["Enforce", "Reference", "Product"]' \
+          -i content/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events/index.md
 
     - name: download domains.md from cloud storage
       shell: bash


### PR DESCRIPTION
## Type of change
Tagging

### What should this PR do?
This PR adds tags to a few remaining Enforce pages - cloudevents, and changelog, and fixes chainctl tags.

### Why are we making this change?
I missed updating tags using Github workflows for these pages. chainctl pages weren't covered with the original sed expression as well, only _index.md was getting tagged 🤦 

### What are the acceptance criteria? 
Cloud events, changelog, and chainctl pages ought to all have tags.

### How should this PR be tested?
This will only run after merging to main.