### PR TITLE
Update COSIGN_EXPERIMENTAL everywhere to v2

### DIFF
--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -36,20 +36,21 @@ There are three URLs from the list of assets on that page that you will need to 
 With these URLs, construct (or copy) the following command to verify the tar archive:
 
 ```sh
-COSIGN_EXPERIMENTAL=1 cosign verify-blob \
-   --signature https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.sig \
-   --certificate https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt \
-   https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz
+cosign verify-blob \
+  --signature https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.sig \
+  --certificate https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz.crt \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity "https://github.com/chainguard-dev/apko/.github/workflows/release.yaml@refs/tags/v0.6.0" \
+  https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz
 ```
 
 Running the command may take a moment, but when it completes you will receive the following output:
 
 ```
-tlog entry verified with uuid: 9ec23abb6326ebbaa6932f720847080e8f5e0b2925a1643b63962691917c8137 index: 8538988
 Verified OK
 ```
 
-If any of the URLs are incorrect, of if there was a problem with the apko release file, a mismatching signature or certificate, or if the release file was not signed, you will receive an error like the following:
+If any of the URLs are incorrect, of if there was a problem with the apko release file, a mismatching signature or certificate identity, or if the release file was not signed, you will receive an error like the following:
 
 ```
 Error: verifying blob https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz: invalid signature when validating ASN.1 encoded signature
@@ -70,6 +71,8 @@ Then you can verify the files that you downloaded using Cosign:
 COSIGN_EXPERIMENTAL=1 cosign verify-blob \
    --signature apko_0.6.0_linux_amd64.tar.gz.sig \
    --certificate apko_0.6.0_linux_amd64.tar.gz.crt \
+   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+   --certificate-identity "https://github.com/chainguard-dev/apko/.github/workflows/release.yaml@refs/tags/v0.6.0" \
    apko_0.6.0_linux_amd64.tar.gz
 ```
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -68,7 +68,7 @@ curl -L -O https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_
 Then you can verify the files that you downloaded using Cosign:
 
 ```sh
-COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+cosign verify-blob \
    --signature apko_0.6.0_linux_amd64.tar.gz.sig \
    --certificate apko_0.6.0_linux_amd64.tar.gz.crt \
    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \

--- a/content/open-source/sigstore/fulcio/how-to-generate-a-fulcio-certificate.md
+++ b/content/open-source/sigstore/fulcio/how-to-generate-a-fulcio-certificate.md
@@ -20,13 +20,7 @@ In this tutorial, we are going to create and examine a Fulcio certificate to dem
 
 Pease note that using Cosign requires Go v1.16 or higher. The Go Project provides [official download instructions](https://go.dev/doc/install).
 
-To get started, set the `COSIGN_EXPERIMENTAL` variable to `1`. This is required in order to enable the keyless signing flow functionality, which is currently in beta.
-
-```sh
-export COSIGN_EXPERIMENTAL=1
-```
-
-Next, place some text in a text file. For instance:
+To get started, place some text in a text file. For instance:
 
 ```sh
 echo "test file contents" > test-file.txt
@@ -52,6 +46,17 @@ After authentication, you can close the browser tab. In your terminal, you will 
 Using payload from: test-file.txt
 Generating ephemeral keys...
 Retrieving signed certificate...
+
+	Note that there may be personally identifiable information associated with this signed artifact.
+	This may include the email address associated with the account with which you authenticate.
+	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
+
+By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
+Are you sure you would like to continue? [y/N] y
+```
+
+If you agree, enter `y` and continue. You will receive output like this:
+
 Your browser will now be opened to:
 https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=...
 Successfully verified SCT...
@@ -62,6 +67,10 @@ using ephemeral certificate:
 
 tlog entry created with index: 2494952
 Signature wrote in the file fulcio.sig
+using ephemeral certificate:
+-----BEGIN CERTIFICATE-----
+(...)
+-----END CERTIFICATE-----
 Certificate wrote in the file fulcio.crt.base64
 ```
 

--- a/content/open-source/sigstore/fulcio/how-to-inspect-and-verify-fulcio-certificates.md
+++ b/content/open-source/sigstore/fulcio/how-to-inspect-and-verify-fulcio-certificates.md
@@ -91,17 +91,18 @@ We will then verify the certificate against the Fulcio certificate authority roo
 step certificate verify fulcio.crt --roots ~/.sigstore/root/targets/fulcio_intermediate_v1.crt.pem
 ```
 
-The final command checks the signature in the `fulcio.sig` file, tracing the certificate up to the Fulcio root certificate.
+The final command checks the signature in the `fulcio.sig` file, tracing the certificate up to the Fulcio root certificate. You'll need to use the identity flags `--certificate-ide
+ntity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command:
 
 ```sh
-cosign verify-blob test-file.txt --signature fulcio.sig --cert fulcio.crt.base64
+cosign verify-blob test-file.txt \
+  --signature fulcio.sig \
+  --cert fulcio.crt.base64 \
+  --certificate-identity username@gmail.com \
+  --certificate-oidc-issuer https://accounts.google.com
 ```
 
 You will receive output following this command. 
 
-```
-tlog entry verified with uuid: 727e2834d2af9389bbc49ebd798050a72698fec4fabff1433cd83071b4a6914d index: 2494952
-Verified OK
-```
 
-You should receive a `Verified OK` message along with the UUID and index number of the certificate within Fulcio.
+You should receive a `Verified OK` message if the signature, certificate, and identities match.

--- a/content/open-source/sigstore/how-to-keyless-sign-a-container-with-sigstore/index.md
+++ b/content/open-source/sigstore/how-to-keyless-sign-a-container-with-sigstore/index.md
@@ -205,12 +205,10 @@ After this step, there will be some actions to setup the Docker build, log into 
 
 ```js
       - name: Sign the container image
-          env:
-              COSIGN_EXPERIMENTAL: "true"
           run: cosign sign ghcr.io/${{ github.repository }}@${{ steps.push-step.outputs.digest }}
 ```
 
-Here you’ll use `COSIGN_EXPERIMENTAL` to enact keyless signing. Next, you’ll run the `cosign sign` command on the container we are pushing to GitHub Container Registry with the relevant variable calling our repository and digest. 
+Here you’ll run the `cosign sign` command on the container we are pushing to GitHub Container Registry with the relevant variable calling our repository and digest. 
 
 Because we are doing a public repository, this will automatically be pushed to the public instance of the Rekor transparency log
 
@@ -284,8 +282,6 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest
 
       - name: Sign the container image
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         run: cosign sign ghcr.io/${{ github.repository }}@${{ steps.push-step.outputs.digest }}
 ```
 
@@ -452,7 +448,9 @@ With your container signed by Cosign keyless signing in GitHub Actions, you next
 You can do that by using the `cosign verify` command against the published container image. 
 
 ```sh
-COSIGN_EXPERIMENTAL=true cosign verify ghcr.io/github-username/django-keyless-signing | jq
+cosign verify ghcr.io/github-username/django-keyless-signing \
+  --certificate-identity https://github.com/github-username/django-keyless-signing/.github/workflows/docker-publish.yml@refs/heads/main \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com | jq
 ```
 
 Your output should be similar to the following, though note that the strings are abbreviated.


### PR DESCRIPTION
## Type of change
Fixes #520 

### What should this PR do?
This PR updates the remaining guides that use cosign v1 `COSIGN_EXPERIMENTAL=1` flag to specify certificate issuer and oidc issuer flags.

### Why are we making this change?
Cosign v2 is out!

### What are the acceptance criteria? 
Any referenced guide should work with the v2 flags.

### How should this PR be tested?
Tech test each cosign verify/verify-blob/verify-attestation command in 5 tutorials that are referenced in the linked issue.