### PR TITLE
Updating autodocs workflow to fix image docs changelog

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -30,7 +30,7 @@ jobs:
           chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: "Update the reference docs for Chainguard Images"
-        uses: chainguard-dev/deved-autodocs@1.3.5
+        uses: chainguard-dev/deved-autodocs@1.3.6
         with:
           command: build images
         env:
@@ -39,6 +39,7 @@ jobs:
           YAMLDOCS_TEMPLATES: "${{ github.workspace }}/edu/autodocs/templates"
           YAMLDOCS_CHANGELOG: "${{ github.workspace }}/${{ env.WORKDIR }}/changelog.md"
           YAMLDOCS_LAST_UPDATE: "${{ github.workspace }}/${{ env.WORKDIR }}/last-update.md"
+          YAMLDOCS_DIFF_SOURCE: "${{ github.workspace }}/edu/content/chainguard/chainguard-images/{{ env.WORKDIR }}"
 
       - name: "Copy changelog to autodocs folder"
         run: |
@@ -56,7 +57,7 @@ jobs:
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "CHANGELOG<<$EOF" >> $GITHUB_ENV
-          echo "`cat ${{ github.workspace }}/autodocs/last-update.md`" >> $GITHUB_ENV
+          echo "`cat ${{ github.workspace }}/edu/autodocs/last-update.md`" >> $GITHUB_ENV
           echo "$EOF" >> $GITHUB_ENV
         id: images-build-output
 
@@ -76,7 +77,7 @@ jobs:
 
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/deved-autodocs@1.3.5
+        uses: chainguard-dev/deved-autodocs@1.3.6
         with:
           command: notify pullrequest
         env:


### PR DESCRIPTION
This PR updates the image autodocs workflow to fix an issue with the changelog generation. Now we can set the source dir for the "diff" so it works correctly when comparing the generated folders with existing content.