### PR TITLE
Updating workflow to build persistent changelog

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -37,14 +37,12 @@ jobs:
           YAMLDOCS_SOURCE: "${{ github.workspace }}/images/images"
           YAMLDOCS_OUTPUT: "${{ github.workspace }}/${{ env.WORKDIR }}"
           YAMLDOCS_TEMPLATES: "${{ github.workspace }}/edu/autodocs/templates"
-          YAMLDOCS_CHANGELOG: "${{ github.workspace }}/${{ env.WORKDIR }}/changelog.md"
           YAMLDOCS_LAST_UPDATE: "${{ github.workspace }}/${{ env.WORKDIR }}/last-update.md"
           YAMLDOCS_DIFF_SOURCE: "${{ github.workspace }}/edu/content/chainguard/chainguard-images/${{ env.WORKDIR }}"
 
-      - name: "Copy changelog to autodocs folder"
+      - name: "Copy latest update log to autodocs folder"
         run: |
-          mv "${{ github.workspace }}/${{ env.WORKDIR }}/changelog.md" \
-          "${{ github.workspace }}/${{ env.WORKDIR }}/last-update.md" \
+          mv "${{ github.workspace }}/${{ env.WORKDIR }}/last-update.md" \
           "${{ github.workspace }}/edu/autodocs"
 
       - name: "Copy updates to main repo"
@@ -53,13 +51,18 @@ jobs:
           cp -R "${{ github.workspace }}/${{ env.WORKDIR }}" "${{ github.workspace }}/edu/content/chainguard/chainguard-images" && \
           echo "Finished copy"
 
-      - name: "Get Changelog"
+      - name: "Get Latest Update Log"
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "CHANGELOG<<$EOF" >> $GITHUB_ENV
           echo "`cat ${{ github.workspace }}/edu/autodocs/last-update.md`" >> $GITHUB_ENV
           echo "$EOF" >> $GITHUB_ENV
         id: images-build-output
+
+      - name: "Append Update to Changelog"
+        run: |
+          [ ! -f "${{ github.workspace }}/edu/autodocs/changelog.md" ] && touch ${{ github.workspace }}/edu/autodocs/changelog.md
+          sed -i '1s/^/${{ env.CHANGELOG }}\n\n/' ${{ github.workspace }}/edu/autodocs/changelog.md
 
       - name: Create a PR
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3


### PR DESCRIPTION
Another try at fixing the changelog persistence for autodocs images. The problem is that the application don't have access to the current changelog while building the new batch of automated docs, so now I'm using a step in the workflow to append the last update into the changelog file. Hoping this works now :)