### PR TITLE
Add gitsign to enforce github actions

### DIFF
--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -23,6 +23,9 @@ jobs:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 
+    - name: 'Setup gitsign'
+      uses: chainguard-dev/actions/setup-gitsign@main
+
     - name: Authenticate to Google Cloud
       id: auth
       uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955 # v0
@@ -56,7 +59,6 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git config commit.gpgsign false
 
         # Check git status and push changes if needed
         GIT_STATUS=$(git status content --porcelain)


### PR DESCRIPTION
### What should this PR do?
This PR adds gitsign support to the Enforce autodocs workflow.

### Why are we making this change?
Commits ought to be signed when run via Github actions.

### What are the acceptance criteria? 
N/A

### How should this PR be tested?
Only way to test here easily is to merge this, run the action, and check for a signed commit.