### PR TITLE
Update tutorials with terminals to use melange+apko signed images

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,20 @@ Use a liquid tag within markdown to embed a YouTube video. For example, if you w
 To include an interactive terminal in a given tutorial page, add the following line in the Hugo frontmatter:
 
 ```
-academy/apko:latest
-academy/chainguard-images:latest
-academy/cosign:latest
-academy/images-demos:latest
-academy/rekor:latest
-academy/vexctl:latest
-policy-controller/base:latest
-policy-controller/install:latest
+terminalImage: imageName:latest
+```
+
+Use one of the following images depending on the topic:
+
+```
+apko:latest
+chainguard-images:latest
+cosign:latest
+images-demos:latest
+rekor:latest
+vexctl:latest
+policy-controller-base:latest
+policy-controller-install:latest
 ```
 
 The interactive terminal is under active development and not every tool is currently available within the environment.

--- a/content/open-source/apko/getting-started-with-apko.md
+++ b/content/open-source/apko/getting-started-with-apko.md
@@ -13,7 +13,7 @@ menu:
   docs:
     parent: "apko"
 weight: 100
-terminalImage: academy/apko:latest
+terminalImage: apko:latest
 toc: true
 ---
 

--- a/content/open-source/melange/tutorials/getting-started-with-melange.md
+++ b/content/open-source/melange/tutorials/getting-started-with-melange.md
@@ -14,7 +14,7 @@ menu:
     parent: "melange-tutorials"
 weight: 100
 toc: true
-terminalImage: melange:latest
+# terminalImage: melange:latest
 ---
 
 [melange](https://github.com/chainguard-dev/melange) is an [apk](https://wiki.alpinelinux.org/wiki/Package_management) builder tool that uses declarative pipelines to create apk packages. From a single YAML file, users are able to generate multi-architecture apks that can be injected directly into [apko](https://github.com/chainguard-dev/apko) builds, which renders apko and melange a [powerful combination for any container image factory](https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/).

--- a/content/open-source/melange/tutorials/getting-started-with-melange.md
+++ b/content/open-source/melange/tutorials/getting-started-with-melange.md
@@ -14,7 +14,7 @@ menu:
     parent: "melange-tutorials"
 weight: 100
 toc: true
-# terminalImage: gcloud:latest
+terminalImage: melange:latest
 ---
 
 [melange](https://github.com/chainguard-dev/melange) is an [apk](https://wiki.alpinelinux.org/wiki/Package_management) builder tool that uses declarative pipelines to create apk packages. From a single YAML file, users are able to generate multi-architecture apks that can be injected directly into [apko](https://github.com/chainguard-dev/apko) builds, which renders apko and melange a [powerful combination for any container image factory](https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/).

--- a/content/open-source/sbom/getting-started-openvex-vexctl.md
+++ b/content/open-source/sbom/getting-started-openvex-vexctl.md
@@ -13,7 +13,7 @@ menu:
     parent: "sbom"
 weight: 10
 toc: true
-terminalImage: academy/vexctl:latest
+terminalImage: vexctl:latest
 ---
 
 The `vexctl` CLI is a tool to make VEX work. As part of the open source [OpenVex](https://edu.chainguard.dev/open-source/sbom/what-is-openvex/) project, `vexctl` enables you to create, apply, and attest VEX (Vulnerability Exploitability eXchange) data in order to filter out false positive security alerts. 

--- a/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
@@ -12,7 +12,7 @@ menu:
   docs:
     parent: "cosign"
 weight: 003
-terminalImage: academy/cosign:latest
+terminalImage: cosign:latest
 toc: true
 ---
 

--- a/content/open-source/sigstore/policy-controller/disallowing-non-default-capabilities-with-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/disallowing-non-default-capabilities-with-policy-controller.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to prevent running containers with extra capabilities. You will create a `ClusterImagePolicy` that uses the [CUE](https://cuelang.org/) language to examine a pod spec, and only allow admission into a cluster if the pod is running with one or many [Linux capabilities](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) from defined set of safe capabilities flags.

--- a/content/open-source/sigstore/policy-controller/disallowing-privileged-containers-with-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/disallowing-privileged-containers-with-policy-controller.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to prevent running containers with elevated privileges. You will create a `ClusterImagePolicy` that uses the [CUE](https://cuelang.org/) language to examine a pod spec, and only allow admission into a cluster if the pod is running without the `privileged: true` setting.

--- a/content/open-source/sigstore/policy-controller/disallowing-run-as-root-user-with-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/disallowing-run-as-root-user-with-policy-controller.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to prevent running containers as the `root` user in a Kubernetes cluster. You will create a `ClusterImagePolicy` that uses the [CUE](https://cuelang.org/) language to examine a pod spec, and only allow admission into a cluster if the pod is running as a non-root user.

--- a/content/open-source/sigstore/policy-controller/disallowing-unsafe-sysctls-with-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/disallowing-unsafe-sysctls-with-policy-controller.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to only allow pods that use `sysctls` to modify kernel behaviour to run with the [safe set](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#safe-and-unsafe-sysctls) of parameters. You will create a `ClusterImagePolicy` that uses the [CUE](https://cuelang.org/) language to examine a pod spec that uses sysctls, and only allow admission into a cluster if the pod is running a safe set parameters.

--- a/content/open-source/sigstore/policy-controller/enforce-sbom-attestation-with-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/enforce-sbom-attestation-with-policy-controller.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to verify image attestations before admitting an image into a Kubernetes cluster. In this guide, you will create a `ClusterImagePolicy` that checks the existence of a SBOM attestation attached to a container image, and then test the admission controller by running a `registry.enforce.dev/chainguard/node` image with SBOM attestations.

--- a/content/open-source/sigstore/policy-controller/how-to-install-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/how-to-install-policy-controller.md
@@ -13,7 +13,7 @@ menu:
     parent: "policy-controller"
 weight: 001
 toc: true
-terminalImage: policy-controller/install:latest
+terminalImage: policy-controller-install:latest
 ---
 
 The [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) is a Kubernetes [admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) that can verify image signatures and policies. You can define policies using the [CUE](https://cuelang.org/) or [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policy languages.

--- a/content/open-source/sigstore/policy-controller/maximum-image-age-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/maximum-image-age-policy-controller.md
@@ -13,7 +13,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to verify image signatures before admitting an image into a Kubernetes cluster. In this guide, you will create a `ClusterImagePolicy` that checks the maximum age of a container image verifying that isn’t older than 30 days. For that, we’ll attempt to create two distroless images one older than 30 days and a fresh one.

--- a/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
+++ b/content/open-source/sigstore/policy-controller/using-policy-controller-to-verify-signed-chainguard-images.md
@@ -13,7 +13,7 @@ menu:
     parent: "policy-controller"
 weight: 006
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 This guide demonstrates how to use the [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) to verify image signatures before admitting an image into a Kubernetes cluster. In this guide, you will create a `ClusterImagePolicy` that checks for a keyless Cosign image signature, and then test the admission controller by running a signed `nginx` image.

--- a/content/open-source/sigstore/policy-controller/warn-deprecated-k8s-registry.md
+++ b/content/open-source/sigstore/policy-controller/warn-deprecated-k8s-registry.md
@@ -12,7 +12,7 @@ menu:
     parent: "policy-controller"
 weight: 002
 toc: true
-terminalImage: policy-controller/base:latest
+terminalImage: policy-controller-base:latest
 ---
 
 As of March 20, 2023, the Kubernetes project will be changing registries, from it k8s.gcr.io registry to a community-owned registry at registry.k8s.io. Pull requests to the previous registry will be redirected to the new one, and, on April 3, 2023, the old registry will be deprecated and frozen. You can read more about this on the Kubernetes blogpost, "[k8s.gcr.io Image Registry Will Be Frozen From the 3rd of April 2023](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/)."

--- a/content/open-source/sigstore/rekor/how-to-query-rekor.md
+++ b/content/open-source/sigstore/rekor/how-to-query-rekor.md
@@ -10,7 +10,7 @@ images: []
 menu:
   docs:
     parent: "rekor"
-terminalImage: academy/rekor:latest
+terminalImage: rekor:latest
 weight: 003
 toc: true
 ---

--- a/content/open-source/sigstore/rekor/how-to-sign-and-upload-metadata-to-rekor.md
+++ b/content/open-source/sigstore/rekor/how-to-sign-and-upload-metadata-to-rekor.md
@@ -12,7 +12,7 @@ menu:
   docs:
     parent: "rekor"
 weight: 004
-terminalImage: academy/rekor:latest
+terminalImage: rekor:latest
 toc: true
 ---
 


### PR DESCRIPTION
## Type of change
terminal

### What should this PR do?
This PR updates any page on academy with an embedded terminal to use the melange+apko generated images.

### Why are we making this change?
The github action to build the images has been running for [a while now](https://github.com/chainguard-dev/edu/actions/runs/4613507805), but tutorials haven't been updated to use them yet.

### What are the acceptance criteria? 
Tutorials with a terminal should still work.

### How should this PR be tested?
Run hugo locally and try running commands in any tutorial with a terminal.