### PR TITLE
Adding missing pipelines to melange docs

### DIFF
--- a/content/open-source/melange/melange-pipelines/go/build.md
+++ b/content/open-source/melange/melange-pipelines/go/build.md
@@ -1,9 +1,9 @@
 ---
 title: "go/build"
 type: "article"
-description: "Reference docs for the build melange pipeline"
-date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+description: "Reference docs for the go/build melange pipeline"
+date: 2023-04-06T11:07:52+02:0
+lastmod: 2023-04-06T11:07:52+02:0
 draft: false
 tags: ["melange", "Reference"]
 images: []

--- a/content/open-source/melange/melange-pipelines/go/build.md
+++ b/content/open-source/melange/melange-pipelines/go/build.md
@@ -1,0 +1,39 @@
+---
+title: "go/build"
+type: "article"
+description: "Reference docs for the build melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["melange", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Run a build using the go compiler
+
+### Dependencies
+- go
+- busybox
+- ca-certificates-bundle
+
+
+### Reference
+| Input         | Description                                                                                                                                                        |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `packages`*   | List of space-separated packages to compile. Files con also be specified.This value is passed as an argument to go build. All paths are relativeto inputs.modroot. |
+| `tags`        | A comma-separated list of build tags to pass to the go compiler                                                                                                    |
+| `output`*     | Filename to use when writing the binary. The final install location inside the apk will be in prefix / install-dir / output                                        |
+| `modroot`     | Top directory of the go module, this is where go.mod lives. Before buidingthe go pipeline wil cd into this directory. Default is set to `.`                        |
+| `prefix`      | Prefix to relocate binaries Default is set to `usr`                                                                                                                |
+| `ldflags`     | List of [pattern=]arg to pass to the go compiler with -ldflags                                                                                                     |
+| `install-dir` | Directory where binaries will be installed Default is set to `bin`                                                                                                 |
+
+
+### Example
+There are no examples available.

--- a/content/open-source/melange/melange-pipelines/go/install.md
+++ b/content/open-source/melange/melange-pipelines/go/install.md
@@ -1,0 +1,39 @@
+---
+title: "go/install"
+type: "article"
+description: "Reference docs for the install melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["melange", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Run a build using the go compiler
+
+### Dependencies
+- go
+- busybox
+- ca-certificates-bundle
+- git
+
+
+### Reference
+| Input         | Description                                                                                                       |
+|---------------|-------------------------------------------------------------------------------------------------------------------|
+| `package`*    | Import path to the package                                                                                        |
+| `version`     | Package version to install. This can be a version tag (v1.0.0), a commit hash or another ref (eg latest or HEAD). |
+| `prefix`      | Prefix to relocate binaries Default is set to `usr`                                                               |
+| `install-dir` | Directory where binaries will be installed Default is set to `bin`                                                |
+| `ldflags`     | List of [pattern=]arg to pass to the go compiler with -ldflags                                                    |
+| `tags`        | A comma-separated list of build tags to pass to the go compiler                                                   |
+
+
+### Example
+There are no examples available.

--- a/content/open-source/melange/melange-pipelines/go/install.md
+++ b/content/open-source/melange/melange-pipelines/go/install.md
@@ -1,9 +1,9 @@
 ---
 title: "go/install"
 type: "article"
-description: "Reference docs for the install melange pipeline"
-date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+description: "Reference docs for the go/install melange pipeline"
+date: 2023-04-06T11:07:52+02:00
+lastmod: 2023-04-06T11:07:52+02:0
 draft: false
 tags: ["melange", "Reference"]
 images: []

--- a/content/open-source/melange/melange-pipelines/ruby/build.md
+++ b/content/open-source/melange/melange-pipelines/ruby/build.md
@@ -1,9 +1,9 @@
 ---
 title: "ruby/build"
 type: "article"
-description: "Reference docs for the build melange pipeline"
-date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+description: "Reference docs for the ruby/build melange pipeline"
+date: 2023-04-06T11:07:52+02:0
+lastmod: 2023-04-06T11:07:52+02:0
 draft: false
 tags: ["melange", "Reference"]
 images: []

--- a/content/open-source/melange/melange-pipelines/ruby/build.md
+++ b/content/open-source/melange/melange-pipelines/ruby/build.md
@@ -1,0 +1,34 @@
+---
+title: "ruby/build"
+type: "article"
+description: "Reference docs for the build melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["melange", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Build a ruby gem
+
+### Dependencies
+- busybox
+- ca-certificates-bundle
+
+
+### Reference
+| Input    | Description                  |
+|----------|------------------------------|
+| `gem`*   | Gem name                     |
+| `output` | Gem output filename          |
+| `opts`   | Options to pass to gem build |
+
+
+### Example
+There are no examples available.

--- a/content/open-source/melange/melange-pipelines/ruby/clean.md
+++ b/content/open-source/melange/melange-pipelines/ruby/clean.md
@@ -1,0 +1,29 @@
+---
+title: "ruby/clean"
+type: "article"
+description: "Reference docs for the clean melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["melange", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Clean a ruby gem
+
+### Dependencies
+- busybox
+- ca-certificates-bundle
+
+
+### Reference
+This pipeline doesn't expect any input arguments.
+
+### Example
+There are no examples available.

--- a/content/open-source/melange/melange-pipelines/ruby/clean.md
+++ b/content/open-source/melange/melange-pipelines/ruby/clean.md
@@ -1,9 +1,9 @@
 ---
 title: "ruby/clean"
 type: "article"
-description: "Reference docs for the clean melange pipeline"
-date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+description: "Reference docs for the ruby/clean melange pipeline"
+date: 2023-04-06T11:07:52+02:0
+lastmod: 2023-04-06T11:07:52+02:0
 draft: false
 tags: ["melange", "Reference"]
 images: []

--- a/content/open-source/melange/melange-pipelines/ruby/install.md
+++ b/content/open-source/melange/melange-pipelines/ruby/install.md
@@ -1,0 +1,35 @@
+---
+title: "ruby/install"
+type: "article"
+description: "Reference docs for the install melange pipeline"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["melange", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "melange"
+weight: 600
+toc: true
+---
+
+
+Install a ruby gem
+
+### Dependencies
+- busybox
+- ca-certificates-bundle
+
+
+### Reference
+| Input      | Description                                                     |
+|------------|-----------------------------------------------------------------|
+| `gem`      | Gem name                                                        |
+| `gem-file` | The full filename of the gem to build                           |
+| `version`* | Gem version to install. This can be a version tag (1.0.0)       |
+| `opts`     | Options to pass to the gem install command Default is set to `` |
+
+
+### Example
+There are no examples available.

--- a/content/open-source/melange/melange-pipelines/ruby/install.md
+++ b/content/open-source/melange/melange-pipelines/ruby/install.md
@@ -1,9 +1,9 @@
 ---
 title: "ruby/install"
 type: "article"
-description: "Reference docs for the install melange pipeline"
-date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+description: "Reference docs for the ruby/install melange pipeline"
+date: 2023-04-06T11:07:52+02:0
+lastmod: 2023-04-06T11:07:52+02:0
 draft: false
 tags: ["melange", "Reference"]
 images: []


### PR DESCRIPTION
Adds missing `ruby` and `go` pipelines to melange reference docs as per #569 .

This is not yet automated, since it will require a few adjustments to build the page (the metadata alone won't be enough since we want to include usage examples).

Preview: https://deploy-preview-574--ornate-narwhal-088216.netlify.app/open-source/melange/melange-pipelines/go/build/