### PR TITLE
Update autodocs-images.yaml

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -11,6 +11,10 @@ env:
 
 jobs:
   main:
+    permissions:
+      id-token: write # Enable OIDC
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: "Check out Destination Repo"


### PR DESCRIPTION
Add permissions for gitsign action based on https://github.com/chainguard-dev/actions/blob/main/setup-gitsign/examples/pr.yaml

## Type of change
platform

### What should this PR do?
This (should) fix the failing autodocs action (e.g. https://github.com/chainguard-dev/edu/actions/runs/4684114681/jobs/8299909134) by giving it permission to use gitsign.

### Why are we making this change?
Fix the failing action.

### What are the acceptance criteria? 
The images auto docs action should succeed.

### How should this PR be tested?
Once merged, run the action manually.