### PR TITLE
change location of why apk

### DIFF
--- a/content/open-source/wolfi/apk-package-manager.md
+++ b/content/open-source/wolfi/apk-package-manager.md
@@ -12,7 +12,7 @@ images: []
 menu:
   docs:
     parent: "apko"
-weight: 600
+weight: 400
 toc: true
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,7 @@ http {
         "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl/;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-discovery-onboarding/(.+)?$" /chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-discovery-onboarding/;
         "~^/chainguard/chainguard-enforce/chainctl-docs/(.*)$" /chainguard/chainctl/chainctl-docs/$1;
+        "~^/open-source/apko/apk-package-manager/(.*)$" /open-source/wolfi/apk-package-manager/;
     }
 
     server {


### PR DESCRIPTION
Changing location (and menu weight) of "why apk" based on discussion here: https://github.com/chainguard-dev/internal/issues/1665#issuecomment-1508948376

Also updated the nginx config