### PR TITLE
Run Enforce docs on a schedule, only when there is a release

### DIFF
--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -2,6 +2,9 @@ name: Build Enforce Docs
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "update-enforce-workflow"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -11,6 +14,45 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
+  check-new-docs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    outputs:
+      status: ${{ steps.find-release.outputs.status }}
+    steps:
+    - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955 # v0
+      with:
+        token_format: 'access_token'
+        project_id: "${{ env.PROJECT_ID }}"
+        workload_identity_provider: "${{ env.WORKLOAD_IDENTITY_PROVIDER }}"
+        service_account: "${{ env.SERVICE_ACCOUNT }}"
+
+    - id: find-release
+      name: 'Find latest Enforce release'
+      run: |
+        latest=$(gcloud storage cat \
+          "gs://chainguard-academy/enforce-changelog/changelog.md" | \
+          awk '/###/ {print $NF}' | \
+          head -n 1)
+        echo "latest=$latest" >> $GITHUB_OUTPUT
+
+    - id: compare-releases
+      name: 'Check for a newer release'
+      run: |
+        exists=$(gcloud storage ls gs://chainguard-academy/enforce-changelog/release-files/ |grep "${{ steps.find-release.outputs.latest}}")
+        if [ -z $exists ]; then
+          echo "status=outdated" >> $GITHUB_OUTPUT
+        fi
+
   enforce-autodocs:
     runs-on: ubuntu-latest
 
@@ -18,6 +60,9 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
+ 
+    needs: compare-releases
+    if: needs.compare-releases.outputs.status == 'outdated'
 
     steps:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'

--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -36,20 +36,17 @@ jobs:
         workload_identity_provider: "${{ env.WORKLOAD_IDENTITY_PROVIDER }}"
         service_account: "${{ env.SERVICE_ACCOUNT }}"
 
-    - id: find-release
-      name: 'Find latest Enforce release'
+    - id: compare-releases
+      name: 'Compare published docs to upstream releases'
       run: |
         latest=$(gcloud storage cat \
           "gs://chainguard-academy/enforce-changelog/changelog.md" | \
           awk '/###/ {print $NF}' | \
           head -n 1)
-        echo "latest=$latest" >> $GITHUB_OUTPUT
-
-    - id: compare-releases
-      name: 'Check for a newer release'
-      run: |
-        exists=$(gcloud storage ls gs://chainguard-academy/enforce-changelog/release-files/ |grep "${{ steps.find-release.outputs.latest}}")
-        if [ -z $exists ]; then
+        current=$(awk '/###/ {print $NF}' \
+	  content/chainguard/chainguard-enforce/changelog.md | \
+          head -n 1)
+        if [ "$current" != "$latest" ]; then
           echo "status=outdated" >> $GITHUB_OUTPUT
         fi
 

--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -1,6 +1,8 @@
 name: Build Enforce Docs
 
 on:
+  schedule:
+    - cron: "0 * * * *"
   workflow_dispatch:
   push:
     branches:
@@ -50,7 +52,7 @@ jobs:
           echo "status=outdated" >> $GITHUB_OUTPUT
         fi
 
-  enforce-autodocs:
+  integrate-enforce-docs:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
 
     outputs:
-      status: ${{ steps.find-release.outputs.status }}
+      status: ${{ steps.compare-releases.outputs.status }}
     steps:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
@@ -61,8 +61,8 @@ jobs:
       id-token: write
       pull-requests: write
  
-    needs: compare-releases
-    if: needs.compare-releases.outputs.status == 'outdated'
+    needs: check-new-docs
+    if: needs.check-new-docs.outputs.status == 'outdated'
 
     steps:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'

--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -43,7 +43,7 @@ jobs:
           "gs://chainguard-academy/enforce-changelog/changelog.md" | \
           awk '/###/ {print $NF}' | \
           head -n 1)
-        current=$(awk '/###/ {print $NF}' | \
+        current=$(awk '/###/ {print $NF}' \
           content/chainguard/chainguard-enforce/changelog.md | \
           head -n 1)
         if [ "$current" != "$latest" ]; then

--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -43,8 +43,8 @@ jobs:
           "gs://chainguard-academy/enforce-changelog/changelog.md" | \
           awk '/###/ {print $NF}' | \
           head -n 1)
-        current=$(awk '/###/ {print $NF}' \
-	  content/chainguard/chainguard-enforce/changelog.md | \
+        current=$(awk '/###/ {print $NF}' | \
+          content/chainguard/chainguard-enforce/changelog.md | \
           head -n 1)
         if [ "$current" != "$latest" ]; then
           echo "status=outdated" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Type of change
automated enhancement

### What should this PR do?
This PR runs the Enforce docs workflow on an hourly schedule. It also only runs if there is a detected difference between upstream releases and published releases in the changelog. 

### Why are we making this change?
It isn't much, but this cuts down the toil of monitoring when Enforce releases are published and running the GitHub action here manually.

### What are the acceptance criteria? 
The schedule should run hourly, and only open a PR if there's a delta between current and latest docs in the changelog.

### How should this PR be tested?
Here is an actions run showing a no-op when both released and published docs match: https://github.com/chainguard-dev/edu/actions/runs/4738648929

And here is one when the versions are different:
https://github.com/chainguard-dev/edu/actions/runs/4738609362