### PR TITLE
Copy layouts/index.redirects from doks theme

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,0 +1,5 @@
+{{- range $p := .Site.Pages -}}
+{{- range .Aliases }}
+{{ . }} {{ $p.RelPermalink -}}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
This hopefully fixes the red ❌ in every PR for broken redirects on netlify.

### Why are we making this change?
The doks theme has a `layouts/index.redirects` Go template that [strips empty space](https://pkg.go.dev/text/template#hdr-Text_and_spaces). Since the template has some commented out lines after the logic, they get mashed into the list of redirects and cause the error.

### What are the acceptance criteria? 
PRs should have all ✅ for the various checks.

### How should this PR be tested?
See if this PR passes!