### PR TITLE
Add new and labeled issues to Platform project

### DIFF
--- a/.github/workflows/add-issues-to-project-platform.yaml
+++ b/.github/workflows/add-issues-to-project-platform.yaml
@@ -1,0 +1,18 @@
+name: Add new and labeled issues to Platform project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/chainguard-dev/projects/44
+          github-token: ${{ secrets.PROJECT_WRITER }}
+          labeled: platform


### PR DESCRIPTION
Based on https://github.com/chainguard-dev/edu/blob/main/.github/workflows/add-issues-to-project-images.yaml

## Type of change
GitHub action.

### What should this PR do?
GitHub action to add new and labeled issues to Platform project

### Why are we making this change?
As part of reorg, we are tracking platform items separately from the Enforce board.
