### PR TITLE
Add data/notices.yaml warning about nginx image breaking changes

### DIFF
--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -21,4 +21,4 @@
 - title: "Image Overview: nginx"
   type: WARNING
   note: |
-    Multiple breaking changes to this image were made on 19 April 2023. If you have used prior versions of this image, refer to the [Breaking Changes Warning](#breaking-changes-warning) section of this page for more details on the changes.
+    Multiple breaking changes to this image were made on 25 April 2023. If you have used prior versions of this image, refer to the [Breaking Changes Warning](#breaking-changes-warning) section of this page for more details on the changes.

--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -17,3 +17,8 @@
     This image will switch from including a full complement of JDK binaries to a minimally required set in a forthcoming release. The work is being tracked in [this GitHub issue](https://github.com/chainguard-images/images/issues/297).
 
     If you rely on any binaries or libraries that are included in this image beyond the core JRE runtime, consider switching to the [JDK Image](/chainguard/chainguard-images/reference/jdk/overview/).
+
+- title: "Image Overview: nginx"
+  type: WARNING
+  note: |
+    Multiple breaking changes to this image were made on 19 April 2023. If you have used prior versions of this image, refer to the [Breaking Changes Warning](#breaking-changes-warning) section of this page for more details on the changes.

--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -21,4 +21,16 @@
 - title: "Image Overview: nginx"
   type: WARNING
   note: |
-    Multiple breaking changes to this image were made on 25 April 2023. If you have used prior versions of this image, refer to the [Breaking Changes Warning](#breaking-changes-warning) section of this page for more details on the changes.
+    On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may
+need to take action to update your application to prevent disruption. 
+
+   Specifically, the config file is being changed to bring the default configuration closer to that of
+other images. If you override the config with a custom configuration, you should not be affected.
+
+   The changes include:
+
+    - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
+    - Allowing nginx to automatically determine the number of worker processes
+    - Moving the HTML directory to /usr/share/nginx/html
+
+   You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a temporary variant that will be removed shortly after we make the change.


### PR DESCRIPTION
## Type of change
documentation

### What should this PR do?
Adds a warning to `data/notices.yaml` about the nginx image breaking changes in https://github.com/chainguard-images/images/pull/478

### Why are we making this change?
The nginx image configuration is changing and anyone using an image from before April 19 should know about it.

### What are the acceptance criteria? 
Warning block should show up on the image page.

### How should this PR be tested?
Check `/chainguard/chainguard-images/reference/nginx/overview/` on the netlify preview.