### PR TITLE
Add Enforce version to autodocs PR and commit messages

### DIFF
--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -50,6 +50,7 @@ jobs:
           head -n 1)
         if [ "$current" != "$latest" ]; then
           echo "status=outdated" >> $GITHUB_OUTPUT
+          echo "latest=$latest" >> $GITHUB_OUTPUT
         fi
 
   integrate-enforce-docs:
@@ -114,8 +115,12 @@ jobs:
           # Now open a PR if needed
           PR=$(gh pr list --json title,headRefName,url |jq '.[] | select(.headRefName=="autodocs")')
           if [ -z "${PR}" ]; then
-            gh pr create --assignee jamonation --base main --head autodocs --title "Enforce docs autocommit" \
-              --body "Enforce docs autocommit" --no-maintainer-edit --label automated,documentation,enforce
+            gh pr create \
+              --assignee jamonation \
+              --base main --head autodocs \
+              --title "Enforce docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
+              --body "Enforce docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
+              --no-maintainer-edit --label automated,documentation,enforce
           else
             echo "PR exists, see ${PR}"
           fi


### PR DESCRIPTION
## Type of change
enhancement

### What should this PR do?
This PR adds enforce version numbers to the PR and commit messages.

### Why are we making this change?
It is mostly cosmetic but just seems like the right thing to do while I'm thinking about it.

### What are the acceptance criteria? 
New enforce releases should have a PR title like `Enforce docs v0.x.x autocmmit`, and same for the body.

### How should this PR be tested?
Wait for an Enforce release and then run the workflow manually.