### PR TITLE
normalize nginx redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,7 @@ http {
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events(.+)?$" /chainguard/chainguard-enforce/reference/events$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-events(.+)?$" /chainguard/chainguard-enforce/reference/events$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog(.+)?$" /chainguard/chainguard-enforce/changelog$1;
+        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-disable-policy-enforcement(.+)?$" /chainguard/chainguard-enforce/policies/how-to-disable-policy-enforcement$1;
         "~^/open-source/apko/apk-package-manager(.+)?$" /open-source/wolfi/apk-package-manager$1;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,13 +14,13 @@ http {
     # add URLs after the `default` line that are moved and aren't redirecting via Hugo aliases
     map $request_uri $redirect_url {
         default "";
-        "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl/;
-        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-discovery-onboarding/(.+)?$" /chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-discovery-onboarding/;
-        "~^/chainguard/chainguard-enforce/chainctl-docs/(.*)$" /chainguard/chainctl/chainctl-docs/$1;
-        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events/(.+)$" /chainguard/chainguard-enforce/reference/events/$1;
-        "~^/chainguard/chainguard-enforce/chainguard-enforce-events/(.+)$" /chainguard/chainguard-enforce/reference/events/$1;
-        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog/(.+)$" /chainguard/chainguard-enforce/changelog/$1;
-        "~^/open-source/apko/apk-package-manager/(.*)$" /open-source/wolfi/apk-package-manager/;
+        "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl$1;
+        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-discovery-onboarding(.+)?$" /chainguard/chainguard-enforce/chainguard-enforce-discovery-onboarding$1;
+        "~^/chainguard/chainguard-enforce/chainctl-docs(.+)?$" /chainguard/chainctl/chainctl-docs$1;
+        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events(.+)?$" /chainguard/chainguard-enforce/reference/events$1;
+        "~^/chainguard/chainguard-enforce/chainguard-enforce-events(.+)?$" /chainguard/chainguard-enforce/reference/events$1;
+        "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog(.+)?$" /chainguard/chainguard-enforce/changelog$1;
+        "~^/open-source/apko/apk-package-manager(.+)?$" /open-source/wolfi/apk-package-manager$1;
     }
 
     server {


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Normalize nginx redirects to catch out of date, incorrect, or inconsistent URLs

### Why are we making this change?
Makes everything use a consistent, reusable format for redirects

### What are the acceptance criteria? 
Redirects work

### How should this PR be tested?
Can test locally using:
```
npm run build
docker build . -t academy:nginx
docker run --rm -t -p 8080:8080 academy:nginx
```

curl some incorrect urls like this and look for the Location header and 301 response code:
```
curl -sIL http://127.0.0.1:8080/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-discovery-onboarding
```