### PR TITLE
Fix yaml indenting in data/notices.yaml for nginx warning

### DIFF
--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -21,11 +21,9 @@
 - title: "Image Overview: nginx"
   type: WARNING
   note: |
-    On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may
-need to take action to update your application to prevent disruption. 
+    On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may need to take action to update your application to prevent disruption. 
 
-    Specifically, the config file is being changed to bring the default configuration closer to that of
-other images. If you override the config with a custom configuration, you should not be affected.
+    Specifically, the config file is being changed to bring the default configuration closer to that of other images. If you override the config with a custom configuration, you should not be affected.
 
     The changes include:
 

--- a/data/notices.yaml
+++ b/data/notices.yaml
@@ -24,13 +24,13 @@
     On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may
 need to take action to update your application to prevent disruption. 
 
-   Specifically, the config file is being changed to bring the default configuration closer to that of
+    Specifically, the config file is being changed to bring the default configuration closer to that of
 other images. If you override the config with a custom configuration, you should not be affected.
 
-   The changes include:
+    The changes include:
 
-    - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
-    - Allowing nginx to automatically determine the number of worker processes
-    - Moving the HTML directory to /usr/share/nginx/html
+      - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
+      - Allowing nginx to automatically determine the number of worker processes
+      - Moving the HTML directory to /usr/share/nginx/html
 
-   You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a temporary variant that will be removed shortly after we make the change.
+    You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a temporary variant that will be removed shortly after we make the change.


### PR DESCRIPTION
Fix the yaml indenting in `data/notes.yaml`