### PR TITLE
Moving 'Enforcer Options' doc to 'Installation' bucket

### DIFF
--- a/content/chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation.md
+++ b/content/chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation.md
@@ -3,6 +3,7 @@ title: "Configuring Enforcer Options"
 linktitle: "Enforcer Options"
 aliases:
 - /chainguard/chainguard-enforce/chainguard-enforce-kubernetes/configure-enforcer-options-during-installation/
+- /chainguard/chainguard-enforce/reference/configure-enforcer-options-during-installation/
 type: "article"
 lead: ""
 description: "Installing Chainguard with chainctl configuring your Enforcer Options"
@@ -11,8 +12,8 @@ tags: ["Enforce", "Product", "Procedural"]
 images: []
 menu:
   docs:
-    parent: "reference"
-weight: 70
+    parent: "installation"
+weight: 20
 toc: true
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -32,7 +32,7 @@ http {
         
         # complete content directory redirects here
         "~^/chainguard/chainguard-enforce/events/(.+)$" /chainguard/chainguard-enforce/cloudevents/$1;
-
+        "~^/chainguard/chainguard-enforce/reference/configure-enforcer-options-during-installation(.+)?$" /chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation$1;
     }
 
     server {


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Narayan suggested moving the Configure Enforce Options guide from the Reference bucket to the Installation bucket.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

I think i had originally moved it under Reference in error.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Make sure everything looks okay. I added an alias to the front matter but do we need to worry any more about redirects?