### PR TITLE
Disable terminal until k8s cluster is fixed

### DIFF
--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -56,7 +56,9 @@
       {{ end -}}
       -->
 
+      <!-- disable terminal 2023-04-28 - k8s cluster misbehaving
       {{ partial "terminal.html" . }}
+      -->
     </main>
 </div>
 {{ end }}


### PR DESCRIPTION
GKE network endpoint is broken, so requests can't reach the terminal environment. Disabling until the terminal environment is reachable again.