### PR TITLE
Re-enable terminal

### DIFF
--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -56,9 +56,7 @@
       {{ end -}}
       -->
 
-      <!-- disable terminal 2023-04-28 - k8s cluster misbehaving
       {{ partial "terminal.html" . }}
-      -->
     </main>
 </div>
 {{ end }}


### PR DESCRIPTION
This re-enables the terminal. I added monitoring for node replacement events and can fix the issue until https://github.com/nestybox/sysbox/issues/680 is resolved.