### PR TITLE
Enable hugo aliases - doks turns them off by default

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://edu.chainguard.dev/"
 canonifyURLs = false
-disableAliases = true
+disableAliases = false
 disableHugoGeneratorInject = true
 enableEmoji = true
 enableGitInfo = false


### PR DESCRIPTION
## Type of change
hugo fix, refs #653 

### What should this PR do?
This PR turns on URL aliases to handle redirects for pages that have been moved.

### Why are we making this change?
The DOKS theme has redirects disabled for some reason in the default configuration.

### What are the acceptance criteria? 
Netlify _redirects should still be populated, and redirects for pages with an `aliases:` list in the frontmatter should also work.

### How should this PR be tested?
Check netlify _redirects, and also pick a few URLs from there and visit them on netlify. Be sure the redirect works. Use `curl` to examine a page too. The HTML should look like this:

```
curl -si localhost:1313/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/critical-cve-policy/
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 526
Content-Type: text/html; charset=utf-8
Last-Modified: Mon, 01 May 2023 17:41:37 GMT
Date: Mon, 01 May 2023 17:42:06 GMT

<!DOCTYPE html>
<html lang="en-US">
  <head>
    <title>http://localhost:1313/chainguard/chainguard-enforce/policies/other-policies/critical-cve-policy/</title>
    <link rel="canonical" href="http://localhost:1313/chainguard/chainguard-enforce/policies/other-policies/critical-cve-policy/">
    <meta name="robots" content="noindex">
    <meta charset="utf-8">
    <meta http-equiv="refresh" content="0; url=http://localhost:1313/chainguard/chainguard-enforce/policies/other-policies/critical-cve-policy/">
  </head>
</html>
```