### PR TITLE
Update nginx.conf with 404.html page; incorporate upstream image changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM cgr.dev/chainguard/nginx:latest
 
-COPY public/ /var/lib/nginx/html/
+COPY public/ /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,8 @@ events {
     worker_connections  1024;
 }
 
+pid /tmp/nginx.pid;
+
 http {
     include       mime.types;
     default_type  application/octet-stream;
@@ -29,7 +31,7 @@ http {
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/(index.html|index.xml)?$" /chainguard/chainguard-enforce/enforce-overview/;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-policy-examples(.+)?$" /chainguard/chainguard-enforce/policies/chainguard-enforce-policy-examples$1;
         "~^/open-source/melange/getting-started-with-melange(.+)?$" /open-source/melange/tutorials/getting-started-with-melange/;
-        
+
         # complete content directory redirects here
         "~^/chainguard/chainguard-enforce/events/(.+)$" /chainguard/chainguard-enforce/cloudevents/$1;
         "~^/chainguard/chainguard-enforce/reference/configure-enforcer-options-during-installation(.+)?$" /chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation$1;
@@ -45,10 +47,13 @@ http {
         }
 
         location / {
-            root   /var/lib/nginx/html/;
+            root   /usr/share/nginx/html/;
 	    index  index.html index.htm;
             try_files $uri $uri/index.html =404;
         }
+
+	# use hugo's built in 404 page for now
+	error_page 404 /404.html;
 
         # redirect server error pages to the static page /50x.html
         #


### PR DESCRIPTION
## Type of change
fixes #659 

### What should this PR do?
This change points nginx at Hugo's 404.html page instead of the unsightly default. It also Updates nginx.conf to take into account changes to cgr.dev/chainguard/nginx image.

### Why are we making this change?
It is much nicer for users to have a consistent experience with menus, layout etc. with a themed 404 page. There are some configuration changes to where nginx files live as well.

### What are the acceptance criteria? 
Not sure if netlify will pick up on the 404 page.

### How should this PR be tested?
After merging, the GitHub action to deploy the site should work. Visiting a non-existent URL should result in the themed 404 page.