### PR TITLE
Update enforce events page with registry cloudevents

### DIFF
--- a/content/chainguard/chainguard-enforce/reference/events.md
+++ b/content/chainguard/chainguard-enforce/reference/events.md
@@ -4,7 +4,7 @@ lead: ""
 description: "Chainguard Enforce Events"
 type: "article"
 date: 2022-11-15T12:05:04
-lastmod: 2023-05-08T20:57:24
+lastmod: 2023-05-09T09:39:56
 draft: false
 tags: ["Enforce", "Reference", "Product"]
 images: []
@@ -83,7 +83,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: k8s://namespace-UID
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the namespace
-Ce-Time: 2023-05-08T20:57:24.802421691Z
+Ce-Time: 2023-05-09T13:39:56.314414Z
 Ce-Type: dev.chainguard.admission.namespace.v1
 Content-Length: 282
 Content-Type: application/json
@@ -121,7 +121,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: k8s://namespace-UID
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the namespace
-Ce-Time: 2023-05-08T20:57:24.802602389Z
+Ce-Time: 2023-05-09T13:39:56.314535Z
 Ce-Type: dev.chainguard.admission.namespace.v1
 Content-Length: 282
 Content-Type: application/json
@@ -160,7 +160,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: k8s://cluster-id
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of cluster
-Ce-Time: 2023-05-08T20:57:24.802236593Z
+Ce-Time: 2023-05-09T13:39:56.314249Z
 Ce-Type: dev.chainguard.admission.v1
 Content-Length: 220
 Content-Type: application/json
@@ -197,9 +197,9 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: k8s://cluster-id
 Ce-Specversion: 1.0
 Ce-Subject: image ID e.g. us.gcr.io/prod-enforce-fabc/chainctl@sha256:123abc...
-Ce-Time: 2023-05-08T20:57:24.801442901Z
+Ce-Time: 2023-05-09T13:39:56.3133Z
 Ce-Type: dev.chainguard.policy.validation.changed.v1
-Content-Length: 476
+Content-Length: 470
 Content-Type: application/json
 User-Agent: Chainguard Enforce
 
@@ -215,15 +215,112 @@ User-Agent: Chainguard Enforce
   "body": {
     "cluster_id": "cluster identifier",
     "image_id": "image ID e.g. us.gcr.io/prod-enforce-fabc/chainctl@sha256:123abc...",
-    "last_seen": "2023-05-08T20:57:24.801277202Z",
+    "last_seen": "2023-05-09T13:39:56.312984Z",
     "policies": {
       "name of the evaluated policy": {
         "change": "Can be [Empty, \"new\", \"degraded\", \"improved\"]",
         "diagnostic": "holds any diagnostic messages surfaced during policy evaluation",
-        "last_checked": "2023-05-08T20:57:24.801433101Z",
+        "last_checked": "2023-05-09T13:39:56.313264Z",
         "valid": false
       }
     }
+  }
+}
+```
+## Service: Registry - Pull
+### Method: Pulled
+
+#### Example HTTP Headers
+
+```
+POST / HTTP/1.1
+Host: console-api.enforce.dev
+Accept-Encoding: gzip
+Authorization: Bearer oidctoken
+Ce-Audience: customer
+Ce-Group: UID of parent group
+Ce-Id: cloudevent generated UUID
+Ce-Source: cgr.dev
+Ce-Specversion: 1.0
+Ce-Subject: The identifier of the repository being pulled from
+Ce-Time: 2023-05-09T13:39:56.314774Z
+Ce-Type: dev.chainguard.registry.pull.v1
+Content-Length: 757
+Content-Type: application/json
+User-Agent: Chainguard Enforce
+
+```
+
+#### Example HTTP Body
+
+```json
+{
+  "actor": {
+    "subject": "identity that triggered the event"
+  },
+  "body": {
+    "digest": "The digest of the image being pulled",
+    "error": {
+      "code": "The OCI distribution-spec error code",
+      "message": "The error message",
+      "status": 0
+    },
+    "location": "Location holds the detected approximate location of the client who pulled. For example, \"ColumbusOHUS\" or \"Minato City13JP",
+    "method": "The method used to pull the image. One of: HEAD or GET",
+    "repo_id": "The identifier of the repository being pulled from",
+    "repository": "The identifier of the repository being pulled from",
+    "tag": "The tag of the image being pulled",
+    "type": "Type determines whether the object being pulled is a manifest or blob",
+    "user_agent": "The user-agent of the client who pulled",
+    "when": "2023-05-09T09:39:56.313043"
+  }
+}
+```
+## Service: Registry - Push
+### Method: Pushed
+
+#### Example HTTP Headers
+
+```
+POST / HTTP/1.1
+Host: console-api.enforce.dev
+Accept-Encoding: gzip
+Authorization: Bearer oidctoken
+Ce-Audience: customer
+Ce-Group: UID of parent group
+Ce-Id: cloudevent generated UUID
+Ce-Source: cgr.dev
+Ce-Specversion: 1.0
+Ce-Subject: The identifier of the repository being pushed to
+Ce-Time: 2023-05-09T13:39:56.314628Z
+Ce-Type: dev.chainguard.registry.push.v1
+Content-Length: 687
+Content-Type: application/json
+User-Agent: Chainguard Enforce
+
+```
+
+#### Example HTTP Body
+
+```json
+{
+  "actor": {
+    "subject": "identity that triggered the event"
+  },
+  "body": {
+    "digest": "The digest of the image being pushed",
+    "error": {
+      "code": "The OCI distribution-spec error code",
+      "message": "The error message",
+      "status": 0
+    },
+    "location": "Location holds the detected approximate location of the client who pushed. For example, \"ColumbusOHUS\" or \"Minato City13JP",
+    "repo_id": "The identifier of the repository being pushed to",
+    "repository": "The identifier of the repository being pushed to",
+    "tag": "The tag of the image being pushed",
+    "type": "Type determines whether the object being pushed is a manifest or blob",
+    "user_agent": "The user-agent of the client who pushed",
+    "when": "2023-05-09T09:39:56.312984"
   }
 }
 ```
@@ -243,7 +340,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/auth/v1/register
 Ce-Specversion: 1.0
 Ce-Subject: Chainguard UIDP
-Ce-Time: 2023-05-08T20:57:24.803859277Z
+Ce-Time: 2023-05-09T13:39:56.316752Z
 Ce-Type: dev.chainguard.api.auth.registered.v1
 Content-Length: 154
 Content-Type: application/json
@@ -280,7 +377,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/events/v1/subscriptions
 Ce-Specversion: 1.0
 Ce-Subject: UIDP identifier of the subscription
-Ce-Time: 2023-05-08T20:57:24.803341882Z
+Ce-Time: 2023-05-09T13:39:56.316869Z
 Ce-Type: dev.chainguard.api.events.subscription.created.v1
 Content-Length: 152
 Content-Type: application/json
@@ -316,7 +413,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/events/v1/subscriptions
 Ce-Specversion: 1.0
 Ce-Subject: UIDP identifier of the subscription to delete
-Ce-Time: 2023-05-08T20:57:24.80356128Z
+Ce-Time: 2023-05-09T13:39:56.316981Z
 Ce-Type: dev.chainguard.api.events.subscription.deleted.v1
 Content-Length: 119
 Content-Type: application/json
@@ -352,7 +449,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP with which this account information is associated
-Ce-Time: 2023-05-08T20:57:24.804346273Z
+Ce-Time: 2023-05-09T13:39:56.318455Z
 Ce-Type: dev.chainguard.api.iam.account_associations.created.v1
 Content-Length: 385
 Content-Type: application/json
@@ -396,7 +493,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP with which this account information is associated
-Ce-Time: 2023-05-08T20:57:24.80458537Z
+Ce-Time: 2023-05-09T13:39:56.318609Z
 Ce-Type: dev.chainguard.api.iam.account_associations.updated.v1
 Content-Length: 336
 Content-Type: application/json
@@ -440,7 +537,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the group whose associations will be deleted
-Ce-Time: 2023-05-08T20:57:24.804742869Z
+Ce-Time: 2023-05-09T13:39:56.318728Z
 Ce-Type: dev.chainguard.api.iam.account_associations.deleted.v1
 Content-Length: 129
 Content-Type: application/json
@@ -476,7 +573,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/group_invites
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this invite resides
-Ce-Time: 2023-05-08T20:57:24.804922767Z
+Ce-Time: 2023-05-09T13:39:56.315186Z
 Ce-Type: dev.chainguard.api.iam.group_invite.created.v1
 Content-Length: 145
 Content-Type: application/json
@@ -514,7 +611,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/group_invites
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2023-05-08T20:57:24.805112765Z
+Ce-Time: 2023-05-09T13:39:56.315334Z
 Ce-Type: dev.chainguard.api.iam.group_invite.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -550,7 +647,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this group resides
-Ce-Time: 2023-05-08T20:57:24.805305464Z
+Ce-Time: 2023-05-09T13:39:56.318074Z
 Ce-Type: dev.chainguard.api.iam.group.created.v1
 Content-Length: 169
 Content-Type: application/json
@@ -587,7 +684,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this group resides
-Ce-Time: 2023-05-08T20:57:24.805469462Z
+Ce-Time: 2023-05-09T13:39:56.318181Z
 Ce-Type: dev.chainguard.api.iam.group.updated.v1
 Content-Length: 169
 Content-Type: application/json
@@ -624,7 +721,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2023-05-08T20:57:24.805594661Z
+Ce-Time: 2023-05-09T13:39:56.318319Z
 Ce-Type: dev.chainguard.api.iam.group.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -660,7 +757,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of identity
-Ce-Time: 2023-05-08T20:57:24.807660841Z
+Ce-Time: 2023-05-09T13:39:56.317749Z
 Ce-Type: dev.chainguard.api.iam.identity.created.v1
 Content-Length: 329
 Content-Type: application/json
@@ -701,7 +798,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: The unique identifier of this specific identity
-Ce-Time: 2023-05-08T20:57:24.807879839Z
+Ce-Time: 2023-05-09T13:39:56.317857Z
 Ce-Type: dev.chainguard.api.iam.identity.updated.v1
 Content-Length: 245
 Content-Type: application/json
@@ -739,7 +836,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2023-05-08T20:57:24.808039637Z
+Ce-Time: 2023-05-09T13:39:56.317941Z
 Ce-Type: dev.chainguard.api.iam.identity.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -775,7 +872,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of identity provider
-Ce-Time: 2023-05-08T20:57:24.805757059Z
+Ce-Time: 2023-05-09T13:39:56.315512Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.created.v1
 Content-Length: 378
 Content-Type: application/json
@@ -816,7 +913,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: The UIDP of the IAM group to nest this identity provider under
-Ce-Time: 2023-05-08T20:57:24.805946257Z
+Ce-Time: 2023-05-09T13:39:56.315663Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.updated.v1
 Content-Length: 279
 Content-Type: application/json
@@ -854,7 +951,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the IdP
-Ce-Time: 2023-05-08T20:57:24.806086656Z
+Ce-Time: 2023-05-09T13:39:56.315766Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.deleted.v1
 Content-Length: 89
 Content-Type: application/json
@@ -890,7 +987,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/policies
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of policy
-Ce-Time: 2023-05-08T20:57:24.806390653Z
+Ce-Time: 2023-05-09T13:39:56.315857Z
 Ce-Type: dev.chainguard.api.iam.policy.created.v1
 Content-Length: 286
 Content-Type: application/json
@@ -931,7 +1028,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/policies
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the policy
-Ce-Time: 2023-05-08T20:57:24.806596151Z
+Ce-Time: 2023-05-09T13:39:56.315979Z
 Ce-Type: dev.chainguard.api.iam.policy.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -966,7 +1063,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/policies
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the policy
-Ce-Time: 2023-05-08T20:57:24.80674515Z
+Ce-Time: 2023-05-09T13:39:56.316077Z
 Ce-Type: dev.chainguard.api.iam.policy.updated.v1
 Content-Length: 204
 Content-Type: application/json
@@ -1004,7 +1101,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/policyVersions
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the policy version
-Ce-Time: 2023-05-08T20:57:24.806887248Z
+Ce-Time: 2023-05-09T13:39:56.316165Z
 Ce-Type: dev.chainguard.api.iam.policy.version.activated.v1
 Content-Length: 108
 Content-Type: application/json
@@ -1040,7 +1137,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the Role to bind
-Ce-Time: 2023-05-08T20:57:24.807053547Z
+Ce-Time: 2023-05-09T13:39:56.316283Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.created.v1
 Content-Length: 261
 Content-Type: application/json
@@ -1080,7 +1177,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UID of this role binding
-Ce-Time: 2023-05-08T20:57:24.807214645Z
+Ce-Time: 2023-05-09T13:39:56.316379Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.updated.v1
 Content-Length: 173
 Content-Type: application/json
@@ -1117,7 +1214,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UID of the record
-Ce-Time: 2023-05-08T20:57:24.807379244Z
+Ce-Time: 2023-05-09T13:39:56.316536Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.deleted.v1
 Content-Length: 91
 Content-Type: application/json
@@ -1153,7 +1250,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/repos
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific repository
-Ce-Time: 2023-05-08T20:57:24.804063575Z
+Ce-Time: 2023-05-09T13:39:56.31665Z
 Ce-Type: dev.chainguard.api.platform.registry.repo.updated.v1
 Content-Length: 179
 Content-Type: application/json
@@ -1190,7 +1287,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/tenant/v1/clusters
 Ce-Specversion: 1.0
 Ce-Subject: Cluster UIDP under which this cluster resides
-Ce-Time: 2023-05-08T20:57:24.812500295Z
+Ce-Time: 2023-05-09T13:39:56.318882Z
 Ce-Type: dev.chainguard.api.tenant.cluster.created.v1
 Content-Length: 1735
 Content-Type: application/json
@@ -1211,8 +1308,8 @@ User-Agent: Chainguard Enforce
         "example activity": {
           "controller_name": "the name of the Controller CRD which was the source of this activity on the tenant cluster",
           "last_seen": {
-            "nanos": 801275802,
-            "seconds": 1683579444
+            "nanos": 312983000,
+            "seconds": 1683639596
           },
           "namespace": "the namespace in which the source of this cluster activity lives",
           "spec_hash": "the hash of the Controller or Webhook CRD's spec",
@@ -1237,14 +1334,14 @@ User-Agent: Chainguard Enforce
       },
       "issuer": "the identity issuer tied to this cluster",
       "last_seen": {
-        "nanos": 801267102,
-        "seconds": 1683579444
+        "nanos": 312983000,
+        "seconds": 1683639596
       },
       "managed_name": "unique name assigned to this cluster's managed agent",
       "name": "name of the cluster",
       "registered": {
-        "nanos": 801266802,
-        "seconds": 1683579444
+        "nanos": 312983000,
+        "seconds": 1683639596
       },
       "remote_id": "the remote ID of this cluster",
       "status": {
@@ -1272,7 +1369,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/tenant/v1/clusters
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2023-05-08T20:57:24.81296119Z
+Ce-Time: 2023-05-09T13:39:56.319209Z
 Ce-Type: dev.chainguard.api.tenant.cluster.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -1307,7 +1404,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/tenant/v1/clusters
 Ce-Specversion: 1.0
 Ce-Subject: Cluster UIDP under which this cluster resides
-Ce-Time: 2023-05-08T20:57:24.813115689Z
+Ce-Time: 2023-05-09T13:39:56.319317Z
 Ce-Type: dev.chainguard.api.tenant.cluster.updated.v1
 Content-Length: 1663
 Content-Type: application/json
@@ -1327,8 +1424,8 @@ User-Agent: Chainguard Enforce
       "example activity": {
         "controller_name": "the name of the Controller CRD which was the source of this activity on the tenant cluster",
         "last_seen": {
-          "nanos": 801276802,
-          "seconds": 1683579444
+          "nanos": 312984000,
+          "seconds": 1683639596
         },
         "namespace": "the namespace in which the source of this cluster activity lives",
         "spec_hash": "the hash of the Controller or Webhook CRD's spec",
@@ -1353,14 +1450,14 @@ User-Agent: Chainguard Enforce
     },
     "issuer": "the identity issuer tied to this cluster",
     "last_seen": {
-      "nanos": 801276602,
-      "seconds": 1683579444
+      "nanos": 312984000,
+      "seconds": 1683639596
     },
     "managed_name": "unique name assigned to this cluster's managed agent",
     "name": "name of the cluster",
     "registered": {
-      "nanos": 801276502,
-      "seconds": 1683579444
+      "nanos": 312984000,
+      "seconds": 1683639596
     },
     "remote_id": "the remote ID of this cluster",
     "status": {


### PR DESCRIPTION
## Type of change
documentation

### What should this PR do?
This is a manual update to the Enforce cloudevents page with details about registry events. 

### Why are we making this change?
This PR is a manual one in advance of an Enforce release that will also capture these changes.

### What are the acceptance criteria? 
Registry push/pull events should show up.

### How should this PR be tested?
Check the [Enforce Events page](https://deploy-preview-676--ornate-narwhal-088216.netlify.app/chainguard/chainguard-enforce/reference/events/#service-registry---pull) on netlify preview.