### PR TITLE
Detect theme and pass color-scheme query param to embedded terminal

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -22,7 +22,16 @@ function timer () {
   window.terminal.load = () => {
     const t = document.getElementById('terminal-init');
     const image = t.attributes.getNamedItem('data-image').nodeValue;
-    const iframe = `<div id="terminal-container"><iframe id="terminal" frameBorder="0" rel="opener" src="https://terminal.inky.wtf/?image=${image}"></iframe></div>`;
+    const color_scheme = localStorage.getItem("theme") || "dark";
+    const bg_light = "background: white;"
+    const bg_dark = "background: #0E0E0E;"
+    let bg = new String;
+    if (color_scheme == "dark") {
+      bg = bg_dark;
+    } else {
+      bg = bg_light;
+    }
+    const iframe = `<div id="terminal-container"><iframe id="terminal" frameBorder="0" rel="opener" src="https://terminal.inky.wtf/?image=${image}&color-scheme=${color_scheme}" style="${bg}"></iframe></div>`;
     t.insertAdjacentHTML('afterend', iframe);
     document.getElementById('close-button').addEventListener('click', window.terminal.exit);
     interval = window.setInterval(timer, 1000);


### PR DESCRIPTION
## Type of change
platform

### What should this PR do?
This passes through light/dark mode theme preferences to the embedded terminal as a query parameter `color-scheme=dark` or `color-scheme=light`.

### Why are we making this change?
Light terminal on dark background looks bad, this matches the user's preference.

### What are the acceptance criteria? 
Terminal should load with appropriate colour scheme. e.g.

<img width="1275" alt="Screenshot 2023-05-12 at 2 00 10 PM" src="https://github.com/chainguard-dev/edu/assets/328553/b6f40206-2c4d-4488-adbb-f40f16d7c402">
<img width="1275" alt="Screenshot 2023-05-12 at 2 00 17 PM" src="https://github.com/chainguard-dev/edu/assets/328553/bc12689a-bcbb-4711-9ee3-ce2b67f16bf0">


### How should this PR be tested?
Run academy locally and load a tutorial. It should match the selected colour scheme. Switch colour schemes, reload, and the new terminal should match again.