### PR TITLE
Make Doc TOC optional

### DIFF
--- a/content/software-security/secure-software-development/minimum-attestation-references.md
+++ b/content/software-security/secure-software-development/minimum-attestation-references.md
@@ -1,6 +1,6 @@
 ---
 title: "Minimum Attestation References"
-type: "article"
+type: "wide"
 date: 2023-05-10T15:21:01+02:00
 lastmod: 2023-05-10T15:21:01+02:00
 draft: false

--- a/content/software-security/secure-software-development/ssdf.md
+++ b/content/software-security/secure-software-development/ssdf.md
@@ -1,7 +1,7 @@
 ---
 title: "Secure Software Development Framework (SSDF) Table, NIST SP 800-218"
 linktitle: "Table of NIST SSDF"
-type: "article"
+type: "wide"
 date: 2023-05-10T15:21:01+02:00
 lastmod: 2023-05-10T15:21:01+02:00
 draft: false

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="row flex-xl-nowrap">
-  <div class="col-lg-5 col-xl-5 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
+  <div class="col-lg-5 col-xl-4 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
     <nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">
       {{ partial "sidebar/docs-menu.html" . }}
     </nav>

--- a/layouts/wide/single.html
+++ b/layouts/wide/single.html
@@ -6,12 +6,9 @@
     </nav>
   </div>
   {{ if ne .Params.toc false -}}
-  <nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }} d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
-    {{ partial "sidebar/docs-toc.html" . }}
-  </nav>
   {{ end -}}
   {{ if .Params.toc -}}
-  <main class="docs-content col-lg-11 col-xl{{ if eq .Site.Params.options.fullWidth false }}-9{{ end }}">
+  <main class="docs-content col-lg-11 col-xl{{ if eq .Site.Params.options.fullWidth false }}-12{{ end }}">
     {{ else -}}
     <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
       {{ end -}}


### PR DESCRIPTION
This resolves #468 and also improves the aesthetics of the tables for https://github.com/chainguard-dev/internal/issues/1792

@erikaheidi you can now use "wide" instead of the "article" `type` in the top matter in the Image specification autodocs (and any other than you think would make sense)