### PR TITLE
Add images network requirements page

### DIFF
--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -1,0 +1,42 @@
+---
+title: "Network Requirements for Chainguard Images"
+lead: "Using Chainguard Images with firewalls, access control lists, and proxies"
+type: "article"
+description: "Using Chainguard Images with firewalls, access control lists, and proxies"
+date: 2023-05-15T08:49:31+00:00
+lastmod: 2023-05-15T08:49:31+00:00
+draft: false
+tags: ["Chainguard Images", "Product", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 500
+toc: true
+---
+
+This document provides an overview of network requirements  for using [Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs). To use Chainguard Images in environments with firewalls, VPNs, and IDS/IPS systems, you will need to add some rules to allow traffic into and out of your networks.
+
+## Chainguard Hosts
+
+This table lists the DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Images:
+
+| Hostname |Port |Protocol | Notes |
+|----------|-----|---------|-------|
+| cgr.dev | 443 | HTTPS | Main image registry|
+| packages.wolfi.dev | 443 | HTTPS | Package repository|
+
+## Third-party Hosts
+
+This table lists the third-party DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Images:
+
+| Hostname |Port |Protocol |Notes |
+|----------|-----|---------|------|
+| ghcr.io | 443 | HTTPS | Used for wolfi development|
+| *.r2.cloudflarestorage.com | 443 | HTTPS | Blob storage for cgr.dev|
+
+## DNS Records and TTLs
+
+Many of the hosts listed on this page use multiple DNS A records or CNAME aliases. Additionally, many A records have a short time to live of 60 seconds, and the majority are less than an hour (3600s).
+
+If your network filters traffic based on IP addresses, ensure that any firewalls update their rules at an appropriate interval to match the TTL for each DNS record.

--- a/content/chainguard/chainguard-images/registry/overview.md
+++ b/content/chainguard/chainguard-images/registry/overview.md
@@ -23,3 +23,7 @@ If you would like to learn more about **Chainguard Images**, you can review our 
 ## Status
 
 You can check the status of the Chainguard Registry at [https://status.cgr.dev](https://status.cgr.dev/).
+
+## Network Requirements
+
+Refer to our [Chainguard Images Network Requirements](/chainguard/chainguard-images/network-requirements) reference page for details about how to ensure access to Chainguard Registry in environments using firewalls, access control lists, and proxies.


### PR DESCRIPTION
## Type of change
documentation

### What should this PR do?
fixes https://github.com/chainguard-dev/internal/issues/1822
fixes https://github.com/chainguard-dev/edu/issues/341

### Why are we making this change?
Images has some network requirements that aren't captured anywhere explicitly.

### What are the acceptance criteria? 
New page should show up and capture all required hosts to use images.

### How should this PR be tested?
Check netlify preview pages:
[Network Requirements](https://deploy-preview-696--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/network-requirements/)
[Registry Network Requirements note](https://deploy-preview-696--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/registry/overview/#network-requirements)