### PR TITLE
Update chainlink ignores and action to run nightly

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,5 +1,7 @@
 name: Check links on Academy
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
   push:
     branches:
@@ -46,13 +48,13 @@ jobs:
 
       - name: Find unchecked links
         run: |
-          jq -r '.unchecked []| {"url":.rawurl, "files":.files}' results.json |\
+          jq -r '.unchecked []?| {"url":.rawurl, "files":(.files |keys)}' results.json |\
             jq -s |\
             yq -P > unchecked.json
 
       - name: Find 404 links
         run: |
-          jq -r '.checked []| select(.status == 404) | {"url":.rawurl, "files":.files}' results.json |\
+          jq '.checked []?| select(.status == 404) | {"url":.rawurl, "files":(.files |keys)}' results.json |\
             jq -s |\
             yq -P > checked.json
 

--- a/tools/chainlink/ignore.json
+++ b/tools/chainlink/ignore.json
@@ -5,6 +5,7 @@
     "^/$",
     "^mailto:",
     "ntia\\.gov",
-    "ntia\\.doc\\.gov"
+    "ntia\\.doc\\.gov",
+    "twitter\\.com"
   ]
 }


### PR DESCRIPTION
## Type of change
enhancement

### What should this PR do?
This PR makes chainlink run nightly, and ignore twitter URLs since they seem to not appreciate being crawled

### Why are we making this change?
Catch any invalid links nightly

### What are the acceptance criteria? 
Action should run when this PR is opened.

### How should this PR be tested?
Check for updates to the GitHub issue #674 