### PR TITLE
Fixing description in debugging distroless article

### DIFF
--- a/content/chainguard/chainguard-images/debugging-distroless-images.md
+++ b/content/chainguard/chainguard-images/debugging-distroless-images.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging Distroless Images"
 type: "article"
-description: "Comparing popular base images with Chainguard Images in number of CVEs detected over time"
+description: "In this article, we'll discuss a few different strategies to debug distroless images, considering these images typically don't include a shell or package managers."
 date: 2022-09-15T08:49:31+00:00
 lastmod: 2022-09-15T08:49:31+00:00
 draft: false


### PR DESCRIPTION
Small fix to the Debugging Distroless article, just now realized the description was not correct.