### PR TITLE
Adding missing JS for rumble graphs in images compared page

### DIFF
--- a/assets/js/rumble.js
+++ b/assets/js/rumble.js
@@ -6,6 +6,8 @@ function moveRumble() {
     let getIt = document.querySelector('#get-it');
     let rumble = document.querySelector('#rumble');
     let newRumble = rumble.cloneNode(true);
-    rumble.remove();
-    getIt.insertAdjacentElement('beforebegin', newRumble);
+    if (getIt !== null) {
+      rumble.remove();
+      getIt.insertAdjacentElement('beforebegin', newRumble);
+    }
 };

--- a/layouts/shortcodes/rumble.html
+++ b/layouts/shortcodes/rumble.html
@@ -1,7 +1,12 @@
 {{ if isset .Params "title"}}<h3>{{ .Get "title"}}</h3>{{ end }}
 {{ if isset .Params "description"}}<p>{{ .Get "description"}}</p>{{ end }}
-<iframe scrolling="no"
-        style="width:100%; min-height:400px; border: none; overflow: hidden"
-        src="/rumble/{{ if isset .Params "type" }}{{ .Get "type" }}{{ else }}bar{{ end }}?left={{ .Get "left" }}&right={{ .Get "right"}}">
 
-</iframe>
+<div id="rumble">
+    <iframe scrolling="no"
+            style="width:100%; min-height:400px; border: none; overflow: hidden"
+            src="/rumble/{{ if isset .Params "type" }}{{ .Get "type" }}{{ else }}bar{{ end }}?left={{ .Get "left" }}&right={{ .Get "right"}}">
+    </iframe>
+</div>
+
+{{- $rumble := resources.Get "js/rumble.js" -}}
+<script src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
This PR should fix the Rumble graphs not showing up on the "Images compared" page. It adds missing JS files that are now included within local app resources.

### Why are we making this change?
To fix an error reported on Slack, the rumble graphs is currently not loading on the "Comparison of Vulnerabilities in Container Images" page.

### What are the acceptance criteria? 
The two rumble graphs should load completely.

### How should this PR be tested?
The preview page will not pick up the fix because of Netlify CSP rules, but it should work locally.