### PR TITLE
Update broken reference to keyless signatures using cosign

### DIFF
--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -21,7 +21,7 @@ We’ll verify a binary artifact, in this case, a copy of [`apko`](/open-source/
 
 ### Verifying a binary with Cosign keyless signatures
 
-All apko releases are released with [keyless signatures using Cosign](open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an apko release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
+All apko releases are released with [keyless signatures using Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing). You can verify the signature for an apko release using the `cosign` tool directly, or by calculating the SHA256 hash of the release and finding the corresponding Rekor transparency log entry.
 
 If you would like to learn how to verify a binary using Rekor or curl, follow the steps in our guide [How to Verify File Signatures with Rekor or curl](/open-source/sigstore/rekor/how-to-verify-file-signatures-with-rekor-or-curl/).
 


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Resolves pointing to an invalid file path which results in 404. 

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Link referencing to a page was resulting in a 404 error due to an invalid path to the file. 

![Screen Recording 2023-06-12 at 2 07 19 PM](https://github.com/chainguard-dev/edu/assets/13623913/51bcd142-1e0f-452a-bd47-bc601305cf0d)


### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
- Start the server locally: 
- go to [Verifying a binary with Cosign keyless signatures](http://localhost:1313/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/#verifying-a-binary-with-cosign-keyless-signatures) section and try to click the highlighted link on the image below. 

<img width="755" alt="image" src="https://github.com/chainguard-dev/edu/assets/13623913/cf8e2e13-7a50-41be-aed7-d85ab716b2a9">
