### PR TITLE
Add note about r2 cloudflare hosts to images network requirements page

### DIFF
--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -34,6 +34,9 @@ This table lists the third-party DNS hostnames, associated ports, and protocols 
 |----------|-----|---------|------|
 | ghcr.io | 443 | HTTPS | Used for wolfi development|
 | *.r2.cloudflarestorage.com | 443 | HTTPS | Blob storage for cgr.dev|
+| 9236a389bd48b98df91adc1bc924620.r2.cloudflarestorage.com | 443 | HTTPS | Blob storage for cgr.dev|
+
+Note: you can use either the single `9236a389bd48b98df91adc1bc924620.r2.cloudflarestorage.com` host or the wildcard `*.rc.cloudflarestorage.com` hostname in your firewall and proxy configurations. However, the `9236a389bd48b98df91adc1bc924620.r2.cloudflarestorage.com` hostname may change at some point in the future.
 
 ## DNS Records and TTLs
 


### PR DESCRIPTION
## Type of change
Docs

### What should this PR do?
Add additional cloudflare r2 network requirements entry

### Why are we making this change?
Some users may not want to allowlist the entire *.r2.cloudflarestorage.com namespace.