### PR TITLE
Add policy ui/cli management tabs back

### DIFF
--- a/content/chainguard/chainguard-enforce/policies/chainguard-policies-cli.md
+++ b/content/chainguard/chainguard-enforce/policies/chainguard-policies-cli.md
@@ -17,6 +17,11 @@ weight: 005
 toc: true
 ---
 
+{{< tabs >}}
+  {{< tab title="CLI" active=true url="/chainguard/chainguard-enforce/policies/chainguard-policies-cli/" >}}
+  {{< tab title="Console" active=false url="/chainguard/chainguard-enforce/policies/chainguard-policies-ui/" >}}
+{{</ tabs >}}
+
 Chainguard Enforce allows you to define and apply policies to your Kubernetes clusters, ensuring that only those deployments that satisfy a given policy are successful. This guide outlines how to create and manage policies using `chainctl`, the Chainguard Enforce command line interface. You must already have an account with Chainguard to follow this guide. You can request access for **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs).
 
 To review sample policies that you may want to leverage, please check out our page on [Chainguard Enforce Policy Examples](/chainguard/chainguard-enforce/policies/chainguard-enforce-policy-examples/). If you would like to use the [Chainguard Enforce UI](https://console.enforce.dev) to work with policies, check out our guide on [How to create policies in the Chainguard Enforce Console](/chainguard/chainguard-enforce/policies/chainguard-policies-ui/).

--- a/content/chainguard/chainguard-enforce/policies/chainguard-policies-ui/index.md
+++ b/content/chainguard/chainguard-enforce/policies/chainguard-policies-ui/index.md
@@ -17,6 +17,11 @@ weight: 001
 toc: true
 ---
 
+{{< tabs >}}
+  {{< tab title="CLI" active=false url="/chainguard/chainguard-enforce/policies/chainguard-policies-cli/" >}}
+  {{< tab title="Console" active=true url="/chainguard/chainguard-enforce/policies/chainguard-policies-ui/" >}}
+{{</ tabs >}}
+
 Security policies in Chainguard Enforce ensure that our development teams are deploying containers within set policies.
 
 We can associate a policy YAML file with a given group in order to achieve our security goals. This guide will go through how to set up policies on the Chainguard Enforce user interface available to you via [console.enforce.dev](https://console.enforce.dev). You must already have an account with Chainguard to follow this guide. You can request access for **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs).


### PR DESCRIPTION
## Type of change
documentation

### What should this PR do?
This adds tabs back to the policy ui/cli management pages

### Why are we making this change?
They got missed somehow in the v2 pull request

### What are the acceptance criteria? 
Tabs should work on the policy ui/cli pages

### How should this PR be tested?
Check on netlify