### PR TITLE
Add rumble-cve-data.yaml workflow to parse CVE data into CSVs

### DIFF
--- a/.github/workflows/rumble-cve-data.yaml
+++ b/.github/workflows/rumble-cve-data.yaml
@@ -1,0 +1,90 @@
+name: Rumble CVE Files
+on:
+  schedule:
+    - cron: "1 5 * * *"
+  workflow_dispatch:
+  push:
+    branches: [auto-rumble]
+
+env:
+  PROJECT_ID: "${{ secrets.PROJECT_ID }}"
+  STORAGE_BUCKET: "${{ secrets.STORAGE_BUCKET }}"
+  WORKLOAD_IDENTITY_PROVIDER: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
+  SERVICE_ACCOUNT: "${{ secrets.GH_ACTION_SERVICE_ACCOUNT }}"
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  generate-cve-files:
+    runs-on: ubuntu-latest
+
+    strategy: 
+      matrix:
+        image: ["bash", "busybox", "deno", "git", "go", "kube-state-metrics", "mariadb", "maven", "minio", "minio-client", "nginx", "node", "php", "python", "rabbitmq", "ruby", "rust", "wait-for-it", "wolfi-base"]
+        format: ["csv"] # supports JSON as well, but CSVs are smaller
+
+    permissions:
+      contents: write
+      id-token: write
+      
+    steps:
+      - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+    
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955 # v0
+        with:
+          token_format: 'access_token'
+          project_id: "${{ env.PROJECT_ID }}"
+          workload_identity_provider: "${{ env.WORKLOAD_IDENTITY_PROVIDER }}"
+          service_account: "${{ env.SERVICE_ACCOUNT }}"
+
+      - name: set up bigqueryrc
+        shell: bash
+        run: |
+          gcloud config set auth/impersonate_service_account "${{ env.SERVICE_ACCOUNT }}"
+          # the following is just used to quiet the bigqueryrc init message, the query result is unused
+          bq query --use_legacy_sql=false --format=csv --max_rows=1 'SELECT COUNT(*) FROM base-image-rumble.rumble.scheduled;' 2>&1 > /dev/null
+
+      - name: get images to compare
+        run: |
+          theirs=$(cat data/rumble.json |jq -r '.[] | select(.image == "${{ matrix.image}}") .left')
+          ours=$(cat data/rumble.json |jq -r '.[] | select(.image == "${{ matrix.image}}") .right')
+          echo "THEIRS=$theirs" >> "$GITHUB_ENV"
+          echo "OURS=$ours" >> "$GITHUB_ENV"
+
+      - name: rumble query
+        shell: bash
+        run: >
+          bq query --use_legacy_sql=false --format=${{ matrix.format }} --max_rows=100000\
+            'WITH ruuuumble AS (
+              SELECT s1.image,
+                      s1.time as t,
+                      s2.name as package,
+                      s2.vulnerability,
+                      s2.installed as version,
+                      s2.type,
+                      s2.severity
+              FROM base-image-rumble.rumble.scheduled_vulns
+              AS s2
+              INNER JOIN base-image-rumble.rumble.scheduled
+              AS s1
+              ON s1.id = s2.scan_id
+              WHERE s1.image = "${{ env.THEIRS }}"
+              OR s1.image = "${{ env.OURS }}"
+            )
+            SELECT image, package, vulnerability, version, type, severity FROM ruuuumble
+            WHERE DATE(t) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()
+            GROUP BY vulnerability, image, package, version, type, severity;' > /tmp/${{ matrix.image }}.${{ matrix.format }}
+
+      - name: upload generated file
+        shell: bash
+        run: |
+          gcloud storage cp /tmp/${{ matrix.image }}.${{ matrix.format }} gs://chainguard-academy/cve-data/${{ matrix.image }}.${{ matrix.format }}
+
+      - name: update permissions on file
+        shell: bash
+        run: |
+          gcloud storage objects update gs://chainguard-academy/cve-data/${{ matrix.image }}.${{ matrix.format }} \
+            --add-acl-grant=entity=AllUsers,role=READER \
+            --content-type text/${{ matrix.format }}


### PR DESCRIPTION
## Type of change
platform development

### What should this PR do?
This adds a GitHub action that extracts CVE data from rumble and uploads it to GCS as CSV files.

### Why are we making this change?
This action is needed to get data flowing into GCS so that it can be displayed on image overview pages. These files can then be parsed and used on image overview pages to show tabular information about CVEs.

### What are the acceptance criteria? 
The action ought to work.

### How should this PR be tested?
Run it once this is merged with fingers 🤞