### PR TITLE
Fix copy around scanner used by rumble

### DIFF
--- a/content/chainguard/chainguard-images/images-compared.md
+++ b/content/chainguard/chainguard-images/images-compared.md
@@ -1,6 +1,6 @@
 ---
 title: "Comparison of Vulnerabilities in Container Images"
-lead: "Detected CVEs Over Time" 
+lead: "Detected CVEs Over Time"
 type: "article"
 description: "Comparing popular base images with Chainguard Images in number of CVEs detected over time"
 date: 2022-09-15T08:49:31+00:00
@@ -15,12 +15,12 @@ weight: 400
 toc: true
 ---
 
-On this page you can find comparison graphs showing the number of CVEs (common vulnerabilities and exposures) detected by [Trivy](https://github.com/aquasecurity/trivy) on popular official base images versus [Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs).
+On this page you can find comparison graphs showing the number of CVEs (common vulnerabilities and exposures) detected by [Grype](https://github.com/anchore/grype) on popular official base images versus [Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs).
 
 ## Comparing the latest official Nginx image with cgr.dev/chainguard/nginx
 
 {{< rumble title="Nginx" description="Comparing the latest official Nginx image with cgr.dev/chainguard/nginx" left="nginx:latest" right="cgr.dev/chainguard/nginx:latest" >}}
 
-## Comparing the latest official PHP image with cgr.dev/chainguard/nginx
+## Comparing the latest official PHP image with cgr.dev/chainguard/php
 
 {{< rumble title="PHP" description="Comparing the latest official PHP image with cgr.dev/chainguard/php" left="php:latest" right="cgr.dev/chainguard/php:latest" >}}

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -36,7 +36,7 @@ Chainguard Images are available from the [Chainguard Registry](/chainguard/chain
 
 ## Comparing the latest official Nginx image with cgr.dev/chainguard/nginx
 
-The following graph shows a comparison between the official Nginx image and Chainguard's Nginx image, based on the number of CVEs (common vulnerabilities and exposures) detected by Trivy:
+The following graph shows a comparison between the official Nginx image and Chainguard's Nginx image, based on the number of CVEs (common vulnerabilities and exposures) detected by [Grype](https://github.com/anchore/grype):
 
 {{< rumble title="Nginx" description="Comparing the latest official Nginx image with cgr.dev/chainguard/nginx" left="nginx:latest" right="cgr.dev/chainguard/nginx:latest" >}}
 


### PR DESCRIPTION
Quick fix to copy used around rumble, used to be Trivy but it changed recently to Grype.