### PR TITLE
Tag history code width

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -15,6 +15,11 @@
   margin-top: 0;
 }
 
+// tag history page image digests are long, wrap them
+.docs-content > table > tbody > tr > td:nth-child(3) > code {
+  max-width: 320px;
+}
+
 // Beat <a> reset
 .docs-content.docs-content a:not(.tag) {
   color: var(--article-link-color);


### PR DESCRIPTION
Add max-width 320px to image digests on tag history pages