### PR TITLE
Style updates + link

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -306,7 +306,6 @@ h2[id^="chainctl"] {
 }
 
 .sidebar-subcategory {
-  text-transform: capitalize;
   font-family: $TextFont;
   font-size: 14px !important;
   font-weight: 500 !important;

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -27,6 +27,7 @@ Main features include:
 - High quality build-time SBOMs (software bill of materials) attesting the provenance of all artifacts within the image
 - Verifiable signatures provided by [Sigstore](/open-source/sigstore/cosign/an-introduction-to-cosign/)
 - Automated nightly builds to ensure images are completely up-to-date and contain all available security patches
+- Reproducible builds with Cosign and apko ([read more about reproducibility](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds))
 
 Chainguard Images are available from the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/) and can be pulled from `cgr.dev`. You can review images files [on GitHub](https://github.com/chainguard-images).
 

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -12,7 +12,7 @@
   <div class="content-and-terminal">
   <div class="center-content single-html">
     <main class="docs-content {{ if ne .Params.toc false -}} has-toc {{ end }}">
-      <!-- <div class="back-button">
+       <div class="back-button">
         {{ $parentTitle := .Parent.Title }}
         {{ $parentLink := .Parent.Permalink }}
         {{ if or (eq $parentTitle "Product Docs") (eq $parentTitle "Open Source") (eq $parentTitle "Education") }}
@@ -30,7 +30,7 @@
           </div>
           <span class="pills-text">{{ $parentTitle }}</span>
         </a>
-      </div> -->
+      </div> 
 
       {{ if not .Params.hide_title -}}
         <h1>{{ .Title }}</h1>


### PR DESCRIPTION
Resolves #267 (lower casing images titles)

Band aid for #820 (adding back button breadcrumbs on top)

Adding link based on [this thread](https://chainguard-dev.slack.com/archives/C02Q5KWBQ7J/p1688578809170829)