### PR TITLE
calculate rumble total cve counts in bigquery

### DIFF
--- a/.github/workflows/rumble.yaml
+++ b/.github/workflows/rumble.yaml
@@ -55,7 +55,7 @@ jobs:
                 high_cve_count as high_cve_cnt,
                 crit_cve_count as crit_cve_cnt,
                 unknown_cve_count as unknown_cve_cnt,
-                tot_cve_count as tot_cve_cnt,
+                low_cve_count+ med_cve_count+ high_cve_count + crit_cve_count+ unknown_cve_count AS tot_cve_count as tot_cve_cnt,
                 digest
             FROM ${{ env.BIGQUERY_TABLE }}
             WHERE DATE(time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
This change calculates total cve counts in the rumble bigquery 

### Why are we making this change?
The rumble graphs show incorrect data, this fixes them to show the correct totals.

### What are the acceptance criteria? 
Totals should be correct

### How should this PR be tested?
Test locally if netlify doesn't show the graphs.