### PR TITLE
updating curl commands for chainctl install

### DIFF
--- a/content/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding.md
@@ -61,7 +61,7 @@ brew install chainctl
 A platform agnostic approach to installing `chainctl` is through using `curl`, which you can achieve with the following command.
 
 ```bash
-curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.

--- a/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
+++ b/content/chainguard/chainguard-enforce/how-to-install-chainctl.md
@@ -60,7 +60,7 @@ You are now ready to use the `chainctl` command. You can verify that it works co
 A platform agnostic approach to installing `chainctl` is through using `curl`, which you can achieve with the following command.
 
 ```bash
-curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.

--- a/content/ui/install.md
+++ b/content/ui/install.md
@@ -9,7 +9,7 @@ mkdir ~/enforce-demo && cd $_
 To install `chainctl`, we’ll use the `curl` command to pull the application down.
 
 ```sh
-curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
+curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')"
 ```
 
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->


### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Resolves #865 

### Why are we making this change?
<!-- What larger problem does this PR address? -->
This changes a few `curl` commands that appear throughout the Enforce docs used to install `chainctl`. This was causing issues for some Mac users, and the new command does some `sed` magic to make sure the command works for all users.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
This follows @eddiezane's suggestions 

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
I tested the new command on my Mac + Linux machines, works fine on both. Of course I wasn't having problems with the original command, but if anyone else wants to give the new command a whirl go for it.