### PR TITLE
Disable terminal while troubleshooting

### DIFF
--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -116,7 +116,7 @@
   </div>
 
   <div class="row terminal resizable">
-    {{ partial "terminal.html" . }}
+    <!--{{ partial "terminal.html" . }}-->
     {{ partial "replacer.html" . }}
   </div>
   </div>


### PR DESCRIPTION
Disable terminal while troubleshooting broken DNS resolution in the terminal's K8s cluster.