### PR TITLE
reenable terminal, and make it easy to toggle with a json file

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -48,9 +48,17 @@ function timer() {
   };
 })();
 
-window.terminal.load();
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
+  const response = await fetch("https://storage.googleapis.com/chainguard-academy/terminal/status.json");
+  const status = await response.json();
+  if (status.enabled == false) {
+    return;
+  }
+
+  document.querySelector(".terminal-top-container").style.display = "flex";
+
+  window.terminal.load();
   // For resizing
   const resizable = document.querySelector(".resizable");
   window

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -116,7 +116,7 @@
   </div>
 
   <div class="row terminal resizable">
-    <!--{{ partial "terminal.html" . }}-->
+    {{ partial "terminal.html" . }}
     {{ partial "replacer.html" . }}
   </div>
   </div>

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -6,7 +6,7 @@
        form-action 'self';
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net;
        script-src 'self' edu.chainguard.dev *.googleapis.com cdn.jsdelivr.net *.googletagmanager.com 'sha256-vOgyKS2vkH4n5TxBJpeh9SgzrE6LVGsAeOAvEST6oCc=' 'sha256-R2OmoLN/NlJovrWBYuTwjPfAD+YHvBVdudGDjY2VLmI=' https://unpkg.com;
-       connect-src 'self' *.google-analytics.com;
+       connect-src 'self' *.google-analytics.com https://storage.googleapis.com;
        img-src 'self' edu.chainguard.dev data:;
        base-uri 'self';
      ">

--- a/layouts/partials/terminal.html
+++ b/layouts/partials/terminal.html
@@ -1,6 +1,6 @@
 {{ if .Params.terminalImage }}
 <div class="resizable-handler"></div>
-<div class="terminal-top-container">
+<div class="terminal-top-container" style="display: none;">
   <div id="terminal-nav">
       <div class="terminal-title">Terminal</div>
       <div class="d-flex align-items-center grab-container">


### PR DESCRIPTION
This PR makes it easier to toggle the terminal on/off using a status file at https://storage.googleapis.com/chainguard-academy/terminal/status.json

If that file reads `{"enabled": false}` then the terminal won't load, otherwise proceed with business as usual. Should help with troubleshooting if/when there's an issue with the K8s cluster.