### PR TITLE
Add enforce.dev to images network requirements, fix table wrapping

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -18,13 +18,15 @@
 // tag history page image digests are long, wrap them
 .docs-content > table > tbody > tr > td:nth-child(3) > code {
   max-width: 320px;
+  word-wrap: anywhere;
 }
 
 .docs-content > table {
   table-layout: fixed;
+  word-wrap: anywhere;
 }
 
-.docs-content > table > code{
+.docs-content > table > code {
   word-wrap: anywhere;
 }
 

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -25,14 +25,15 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | Hostname |Port |Protocol | Notes |
 |----------|-----|---------|-------|
 | cgr.dev | 443 | HTTPS | Main image registry|
+| enforce.dev | 443 | HTTPS | Registry authentication |
 | packages.wolfi.dev | 443 | HTTPS | Package repository|
 
 ## Third-party Hosts
 
 This table lists the third-party DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Images:
 
-| Hostname |Port |Protocol |Notes |
-|----------|-----|---------|------|
+|Hostname |Port |Protocol |Notes |
+|---------|-----|---------|------|
 | ghcr.io | 443 | HTTPS | Used for wolfi development|
 | *.r2.cloudflarestorage.com | 443 | HTTPS | Blob storage for cgr.dev|
 | 9236a389bd48b98df91adc1bc924620.r2.cloudflarestorage.com | 443 | HTTPS | Blob storage for cgr.dev|

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -28,6 +28,10 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | enforce.dev | 443 | HTTPS | Registry authentication |
 | packages.wolfi.dev | 443 | HTTPS | Package repository|
 
+Note that to be able to authenticate with the `enforce.dev` domain, you will need to ensure access to and from the following CIDR ranges:
+
+{{< blurb/enforce-ips >}}
+
 ## Third-party Hosts
 
 This table lists the third-party DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Images:


### PR DESCRIPTION
## Type of change
docs

### What should this PR do?
Add enforce.dev to images network requirements page. Also fix table cells overflowing.

### Why are we making this change?
Need access to/from `enforce.dev` for auth to registry.

### How should this PR be tested?
Check netlify for Enforce and Images network requirements pages, make sure the tables don't overflow.