### PR TITLE
Update getting started with melange to use arch specific instructions

### DIFF
--- a/assets/js/replacer.js
+++ b/assets/js/replacer.js
@@ -20,7 +20,7 @@ function makeVarsEditable() {
         }
 
         // add a span around variables
-        let newElem = `<span data-title="test" class="inline-variable">${m[0]}</span>`;
+        let newElem = `<span data-title="test" title="Click to edit" class="inline-variable">${m[0]}</span>`;
         element.innerHTML = element.innerHTML.replace(m[0], newElem);
 
         // make it editable

--- a/content/open-source/melange/tutorials/getting-started-with-melange.md
+++ b/content/open-source/melange/tutorials/getting-started-with-melange.md
@@ -361,15 +361,16 @@ The following command will set up a volume sharing your current folder with the 
 ```shell
 docker run --rm -v ${PWD}:/work cgr.dev/chainguard/apko \
   build apko.yaml hello-minicli:test hello-minicli.tar \
+  --arch host
   -k melange.rsa.pub
 ```
-This will build an OCI image based on your host system's architecture. If you receive warnings at this point, those are likely related to the types of SBOMs being uploaded and can be safely ignored.
+This will build an OCI image based on your host system's architecture (specified by the `--arch host` flag). If you receive warnings at this point, those are likely related to the types of SBOMs being uploaded and can be safely ignored.
 
 The command will generate a few new files in the app's directory:
 
 - `hello-minicli.tar` — the packaged OCI image that can be imported with a `docker load` command
-- `sbom-x86_64.cdx` — an SBOM file for `x86_64` architecture in `cdx` format
-- `sbom-x86_64.spdx.json` — an SBOM file for `x86_64` architecture in `spdx-json` format
+- `sbom-%host-architecture%.cdx` — an SBOM file for your host architecture in `cdx` format
+- `sbom-%host-architecture%.spdx.json` — an SBOM file for your host architecture in `spdx-json` format
 
 Next, load your image within Docker:
 
@@ -378,12 +379,12 @@ docker load < hello-minicli.tar
 ```
 ```
 10f951ac3cd2: Loading layer [==================================================>]  7.764MB/7.764MB
-Loaded image: hello-minicli:test
+Loaded image: hello-minicli:test-%host-architecture%
 ```
 Now you can run your Minicli program with:
 
 ```shell
-docker run --rm hello-minicli:test
+docker run --rm hello-minicli:test-%host-architecture%
 ```
 The demo should output an advice slip such as:
 

--- a/content/open-source/melange/tutorials/getting-started-with-melange.md
+++ b/content/open-source/melange/tutorials/getting-started-with-melange.md
@@ -361,7 +361,7 @@ The following command will set up a volume sharing your current folder with the 
 ```shell
 docker run --rm -v ${PWD}:/work cgr.dev/chainguard/apko \
   build apko.yaml hello-minicli:test hello-minicli.tar \
-  --arch host
+  --arch host \
   -k melange.rsa.pub
 ```
 This will build an OCI image based on your host system's architecture (specified by the `--arch host` flag). If you receive warnings at this point, those are likely related to the types of SBOMs being uploaded and can be safely ignored.
@@ -381,6 +381,9 @@ docker load < hello-minicli.tar
 10f951ac3cd2: Loading layer [==================================================>]  7.764MB/7.764MB
 Loaded image: hello-minicli:test-%host-architecture%
 ```
+
+Note that the `%host-architecture%` will vary, and there may be multiple images loaded into your Docker daemon. Be sure to edit the variable in the following `docker run` command to match your target architecture. You can also click to edit it inline on this page.
+
 Now you can run your Minicli program with:
 
 ```shell


### PR DESCRIPTION
## Type of change
docs

### What should this PR do?
Updates the Getting Started With Melange guide to use specific `--arch` flags for apko.

### Why are we making this change?
Making sure the tutorial will work for anyone who tries it out for the first time.

### What are the acceptance criteria? 
Tutorial should work

### How should this PR be tested?
Run through the steps, ensuring the `apko build ...`, and `docker run ...` steps work.