### PR TITLE
Update rumble-cve-data.yaml

### DIFF
--- a/.github/workflows/rumble-cve-data.yaml
+++ b/.github/workflows/rumble-cve-data.yaml
@@ -75,7 +75,17 @@ jobs:
             )
             SELECT image, package, vulnerability, version, type, severity FROM ruuuumble
             WHERE DATE(t) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()
-            GROUP BY vulnerability, image, package, version, type, severity;' > /tmp/${{ matrix.image }}.${{ matrix.format }}
+            GROUP BY vulnerability, image, package, version, type, s
+            ORDER BY (
+              CASE WHEN s="Critical" THEN 1
+                  WHEN s="High" THEN 2
+                  WHEN s="Medium" THEN 3
+                  WHEN s="Low" THEN 4
+                  WHEN s="Negligible" THEN 5
+                  WHEN s="Unknown" THEN 6
+                  ELSE 7
+              END
+            )'; > /tmp/${{ matrix.image }}.${{ matrix.format }}
 
       - name: upload generated file
         shell: bash


### PR DESCRIPTION
## Type of change
platform

### What should this PR do?
Fixes a commit I somehow reverted, which ordered vulnerability data by severity.

### Why are we making this change?
Vulnerabilities should be sorted from critical -> negligible

### What are the acceptance criteria? 
Github action should run without issues.

### How should this PR be tested?
A file like https://storage.googleapis.com/chainguard-academy/cve-data/nginx.csv should show vulnerabilities in the correct order.