### PR TITLE
Updating Wollfi with Dockerfiles guide

### DIFF
--- a/content/open-source/wolfi/wolfi-with-dockerfiles.md
+++ b/content/open-source/wolfi/wolfi-with-dockerfiles.md
@@ -95,7 +95,7 @@ nano Dockerfile
 
 Copy the following content to it:
 
-```
+```Dockerfile
 FROM cgr.dev/chainguard/wolfi-base
 
 ARG version=3.11
@@ -152,7 +152,7 @@ nano DockerfileDistroless
 
 Copy the following code into your new file:
 
-```
+```Dockerfile
 FROM cgr.dev/chainguard/wolfi-base as builder
 
 ARG version=3.11
@@ -166,7 +166,7 @@ USER nonroot
 COPY requirements.txt /app/
 RUN  pip3 install -r requirements.txt --user
 
-FROM cgr.dev/chainguard/python:3.11
+FROM cgr.dev/chainguard/python:latest
 
 ARG version=3.11
 WORKDIR /app


### PR DESCRIPTION
### What should this PR do?
This PR updates the "Wolfi with Dockerfiles" guide to use only `latest` tags, ahead of the changes coming in next week with images.

### Why are we making this change?
The second example Dockerfile in this tutorial would break next week because it uses a tag, so we're changing it to use `latest` instead.

### What are the acceptance criteria? 
The Dockerfiles in the guide should use only `latest`

### How should this PR be tested?
I did test the demos locally to make sure they work the same way with `latest`, and they do.