### PR TITLE
Add navbar title

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -392,7 +392,7 @@ h2[id^="chainctl"] {
 .navbar-title-padding {
   padding-top: 10px;
   padding-right: 10px;
-  padding-bottom: 50px;
+  padding-bottom: 32px;
   padding-left: 1px;
 }
 

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -381,6 +381,21 @@ h2[id^="chainctl"] {
   color: var(--navbar-contact-color) !important;
 }
 
+.navbar-title {
+  font-weight: 600;
+  font-size: 16px;
+  height: 20px;
+  padding-top: 10px;
+  padding-left: 5px;
+}
+
+.navbar-title-padding {
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-bottom: 50px;
+  padding-left: 1px;
+}
+
 .a--original {
   color: var(--a-original-color);
 }

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -11,6 +11,17 @@
 
   {{ if $showFlexSearch -}}
   <div class="search-container">
+    <div class="navbar-title-padding">
+      <svg class="index-logo" width="20" height="20" viewBox="0 0 72 72" fill="none"
+      xmlns="http://www.w3.org/2000/svg">
+      <path d="M36 0V33C36 34.6569 37.3431 36 39 36H72L36 0Z" fill="#F99AFB" />
+      <path d="M36 0L72 36V3C72 1.34315 70.6569 0 69 0H36Z" fill="currentColor" />
+      <path
+        d="M39 36H72V69C72 70.6569 70.6569 72 69 72H36C16.1177 72 -8.69081e-07 55.8822 0 36C8.69081e-07 16.1177 16.1178 -8.69081e-07 36 0L36 33C36 34.6569 37.3431 36 39 36Z"
+        fill="#3443F4" />
+      </svg>
+      <a class="navbar-title" href="/">Chainguard Academy</a>
+    </div>
     <form class="doks-search position-relative flex-grow-1">
       <input class="search form-control is-search" type="search" placeholder="Search" aria-label="Search" autocomplete="off">
     </form>


### PR DESCRIPTION
Adding navbar title based on the Figma mockups from Travers: https://www.figma.com/file/hlminFMUGXds23binoDsTg/Chainguard-Academy-2.0?type=design&node-id=3268-1849&mode=design&t=sa9poDx85qlflKyU-0

Deploy preview: https://deploy-preview-927--ornate-narwhal-088216.netlify.app/

<img width="331" alt="Screenshot 2023-08-17 at 5 27 44 PM" src="https://github.com/chainguard-dev/edu/assets/5977693/fe1726b0-ded9-47e8-807d-55d72ca21c23">

Ensure link works. I did not enable on mobile.
