### PR TITLE
Updating to latest image autodocs

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -59,7 +59,7 @@ jobs:
           chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}/changelog.md"
 
       - name: Update the reference docs for Chainguard Images
-        uses: chainguard-dev/deved-autodocs@1.6.8
+        uses: chainguard-dev/deved-autodocs@1.7.0
         with:
           command: build images
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/deved-autodocs@1.6.8
+        uses: chainguard-dev/deved-autodocs@1.7.0
         with:
           command: notify pullrequest
         env:


### PR DESCRIPTION
This PR updates the Image autodocs workflow to the latest version. This is necessary to include the most recent retired images in the ignore list, so they don't keep being built at every run.