### PR TITLE
Fix overly broad nginx rewrite for /vulnerabilities

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -59,7 +59,7 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
-        location ~ /vulnerabilities/ {
+        location ~ ^/vulnerabilities/ {
             rewrite ^ /vulnerabilities/index.html break;
         }
 


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Fixes nginx location that was capturing any URL with `/vulnerabilities` in it.