### PR TITLE
Add nginx rewrite for root /vulnerabilities/ url

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -59,6 +59,13 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
+        # serve the vuln-comparison page for /vulnerabilities page without a vuln id
+        # captures /vulnerabilities /vulnerabilities/ and /vulnerabilities/index.html
+        location ~ ^/vulnerabilities(\/|\/index.html)?$ {
+            rewrite ^ /chainguard/chainguard-images/vuln-comparison/index.html;
+        }
+
+        # all vulnerabilities with an ID get rendered by this page using javascript
         location ~ ^/vulnerabilities/ {
             rewrite ^ /vulnerabilities/index.html break;
         }


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Rewrites /vulnerabilities/ and /vulnerabilities/index.html with contents of /vuln-comparison/ landing page.

### Why are we making this change?
A /vulnerabilities/ page without an ID results in an empty page. Until we have a landing page for vulnerabilities, this redirects to the /vuln-comparison/ landing page.

### How should this PR be tested?
Staging URL should show /chainguard/chainguard-images/vuln-comparison/ page when hitting /vulnerabilities/ - netlify won't work since it doesn't use nginx.