### PR TITLE
Fix title in left nav

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -382,9 +382,9 @@ h2[id^="chainctl"] {
 }
 
 .navbar-title {
-  font-weight: 600;
-  font-size: 16px;
-  height: 20px;
+  font-weight: 500;
+  font-size: 0.96em;
+  height: 50px;
   padding-top: 10px;
   padding-left: 5px;
 }


### PR DESCRIPTION
I'm not sure what happened, but something must have touched the CSS on the left nav, so I modified this in order to prevent the line from breaking. 

Current site: 

<img width="600" alt="Screenshot 2023-08-29 at 3 30 41 PM" src="https://github.com/chainguard-dev/edu/assets/5977693/656a1ff2-38cf-4ce4-8350-461854b840ea">

My local update: 

<img width="637" alt="Screenshot 2023-08-29 at 3 31 38 PM" src="https://github.com/chainguard-dev/edu/assets/5977693/f9094307-fe9a-4d34-8ed5-d301f43b60c4">

**To test**: 

Please verify the Netlify deploy preview shows `Chainguard Academy` all on one line.
