### PR TITLE
Fix search input and suggestions blur

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -16,7 +16,7 @@ Array.from(searchForms).forEach(container => {
     }
     if (e.key === 'Escape' ) {
       search.blur();
-      search.classList.add('d-none');
+      suggestions.classList.add('d-none');
     }
   }
 


### PR DESCRIPTION
### What should this PR do?
Resolves a front-end bug with search visibility and fixes an annoyance with `esc` behaviour when suggestions are visible.

### Why are we making this change?
Fixes #825

### What are the acceptance criteria? 
- Fill search input
- Press `esc` when suggestion box shows
- Press `esc` with no results (Search input should still be visible)

### How should this PR be tested?
- Test on desktop and mobile browsers