### PR TITLE
Update building-a-wolfi-package.md

### DIFF
--- a/content/open-source/wolfi/building-a-wolfi-package.md
+++ b/content/open-source/wolfi/building-a-wolfi-package.md
@@ -63,10 +63,8 @@ When building locally, you'll also need to include information about where to fi
 environment:
   contents:
     repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
       - https://packages.wolfi.dev/os
     keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 ```
 
@@ -320,11 +318,9 @@ When working with local dependencies, use the following notation in your `packag
 environment:
   contents:
     repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
       - https://packages.wolfi.dev/os
       - '@local /work/packages'
     keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox


### PR DESCRIPTION
Remove references to bootstrap/stage3

Re: Slack thread: https://kubernetes.slack.com/archives/C03MASRQP4M/p1694192937925909?thread_ts=1694192577.163769&cid=C03MASRQP4M

## Type of change

Docs simplification

### What should this PR do?

Remove misleading reference to bootstrap/stage3

### Why are we making this change?

Folks building packages don't need to depend on bootstrap/stage3, that's only needed when we're building wolfi from scratch.

### What are the acceptance criteria? 

### How should this PR be tested?