### PR TITLE
Remove TOC from openapi reference page

### DIFF
--- a/content/chainguard/chainguard-enforce/reference/api/index.md
+++ b/content/chainguard/chainguard-enforce/reference/api/index.md
@@ -12,7 +12,6 @@ menu:
   docs:
     parent: "chainguard"
 weight: 100
-toc: true
 ---
 
 {{< openapi spec-url="/api.json" >}}


### PR DESCRIPTION
## Type of change
docs

### What should this PR do?
Removes TOC on Openapi reference page for more horizontal space

### Why are we making this change?
The invisible TOC takes up too might horizontal space

### What are the acceptance criteria? 

### How should this PR be tested?

Screenshot showing how it will look:

![image](https://github.com/chainguard-dev/edu/assets/328553/bc7e2da4-eaf0-47be-ae87-fce6585fc5e4)


