### PR TITLE
Adding redirect for gcc-musl

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,7 @@ http {
         "~^/chainguard/chainguard-images/reference/nri-kube-events/(.+)?$"  /chainguard/chainguard-images/reference/;
         "~^/chainguard/chainguard-images/reference/nri-kubernetes/(.+)?$"  /chainguard/chainguard-images/reference/;
         "~^/chainguard/chainguard-images/reference/nri-prometheus/(.+)?$"  /chainguard/chainguard-images/reference/;
+        "~^/chainguard/chainguard-images/reference/gcc-musl/(.+)?$"  /chainguard/chainguard-images/reference/;
         "~^/chainguard/chainguard-images/network-requirements/(.+)?$"  /chainguard/network-requirements/;
         "~^/chainguard/chainguard-images/registry/(.+)?$"  /chainguard/chainguard-registry/;
     }


### PR DESCRIPTION
### What should this PR do?
Adds an Ngnix redirect rule to the retired `gcc-musl` image.