### PR TITLE
Fix: Sub-navigation for image references

### DIFF
--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -70,41 +70,12 @@
                                </div>
                                <div class="collapse{{ if $active }} show{{ end }}" id="section-{{ md5 .LinkTitle }}">
                                  <ul class="btn-toggle-nav list-unstyled fw-normal small">
-                                   {{ range where .Pages ".Params.unlisted" "!=" "true" }}
-                                     {{ if .IsNode }}
-                                       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                       {{ $selected := eq $currentPage.RelPermalink .RelPermalink }}
-                                         <li class="sidebar-item-list-item {{if $selected }} sidebar-item-list-item-selected {{ end }}">
-                                           <div class="d-flex gap-1 justify-content-between align-items-center sidebar-item {{if $active }} sidebar-item-active {{ end }}">
-                                              <button class="border-0 bg-transparent d-flex align-items-center justify-content-between rounded sidebar-subcategory w-100 sidebar-item {{if not $active }} collapsed {{end}}" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .LinkTitle }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">
-                                                <a href="{{if $selected }}#{{ else }}{{ .Permalink }}{{ end }}" class="sidebar-item mx-0 p-0">
-                                                  <span>{{ .LinkTitle }}</span>
-                                                </a>
-                                                  {{ if len (where .Pages ".Params.unlisted" "!=" "true") }}
-                                                    <div class="chevron-rotator">
-                                                      <i class="bi bi-chevron-right {{if $active }} sidebar-icon-active {{ end }}"></i>
-                                                    <div class="chevron-rotator">
-                                                    {{ end }}
-                                              </button>
-                                           </div>
-                                           <div class="collapse{{ if $active }} show{{ end }}" id="section-{{ md5 .LinkTitle }}">
-                                             <ul class="btn-toggle-nav list-unstyled fw-normal small">
-                                               {{ range where .Pages ".Params.unlisted" "!=" "true" }}
-                                                 {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                                 <li class="sidebar-item-list-item {{if $active }} sidebar-item-list-item-selected {{ end }}">
-                                                  <a class="sidebar-subcategory docs-link rounded {{ if $active }} sidebar-item-active active {{ end }} sidebar-item" href="{{ .Permalink }}">{{ .LinkTitle }}</a>
-                                                 </li>
-                                               {{ end }}
-                                             </ul>
-                                           </div>
-                                         </li>
-                                     {{ else }}
-                                       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                         <li class="sidebar-item-list-item {{if $active }} sidebar-item-list-item-selected {{ end }}">
-                                          <a class="sidebar-subcategory docs-link rounded {{ if $active }} sidebar-item-active active {{ end }} sidebar-item" href="{{ .Permalink }}">{{ .LinkTitle }}</a>
-                                         </li>
-                                     {{ end }}
-                                   {{ end }}
+                                  {{ range where .Pages ".Params.unlisted" "!=" "true" }}
+                                    {{ $active := in $currentPage.RelPermalink .RelPermalink }}
+                                    <li class="sidebar-item-list-item {{if $active }} sidebar-item-list-item-selected {{ end }}">
+                                      <a class="sidebar-subcategory docs-link rounded {{ if $active }} sidebar-item-active active {{ end }} sidebar-item" href="{{ .Permalink }}">{{ .LinkTitle }}</a>
+                                    </li>
+                                  {{ end }}
                                  </ul>
                                </div>
                              </li>


### PR DESCRIPTION
### What should this PR do?
Update the menu partial so that image reference links are treated as page links instead of nodes.

### Why are we making this change?
Fixes: #1032

### What are the acceptance criteria? 
- Expand Chainguard Images
- Expand Reference
- Click anywhere in the image menu item to navigate to the corresponding page

### How should this PR be tested?
I'm assuming we don't have a case for this type of sub-navigation elsewhere (node with all hidden pages). Please check other expanding nodes if pages are no longer visible in the menu.