### PR TITLE
Update building-a-wolfi-package.md to fix broken link to php

### DIFF
--- a/content/open-source/wolfi/building-a-wolfi-package.md
+++ b/content/open-source/wolfi/building-a-wolfi-package.md
@@ -20,7 +20,7 @@ Thanks to a fine-tuned maintenance process combining top-notch automation and es
 
 That being said, it's important to note that Wolfi is rather new; it just recently crossed the mark of 1,000 packages in the Wolfi OS repository. That means some packages that you would find in a more established distro won't be available yet in Wolfi. In this article, we'll cover the whole process involved in building a new Wolfi package, or how a Wolfi package comes to be.
 
-> Note: Many of the examples shown in this article are based on the [Wolfi PHP package](https://github.com/wolfi-dev/os/blob/main/php.yaml), which is a slightly complex build that generates several subpackages from a single melange YAML file. You can keep that link open in a separate tab to use as reference as you go through this guide.
+> Note: Many of the examples shown in this article are based on the [Wolfi PHP package](https://github.com/wolfi-dev/os/blob/main/php-8.2.yaml), which is a slightly complex build that generates several subpackages from a single melange YAML file. You can keep that link open in a separate tab to use as reference as you go through this guide.
 ## How Does it Compile?
 The first step in building a new Wolfi package is finding official documentation with guidance on how to build the package from source. All Wolfi packages need to be built from source in order to assure provenance and authenticity of package contents.
 


### PR DESCRIPTION
The link to the php YAML was broken because of an update that changed the php.yaml to php-8.2.yaml This PR is to help fix this so that it leads to a correct link and not a broken one.

## Type of change
Changing a link to fix a typo/broken link. 

### What should this PR do?
No known issue reported.

### Why are we making this change?
Fixing a link. 

### What are the acceptance criteria? 
When user clicks on the Wolfi PHP yaml linked in the documentation, it should navigate to the php-8.2.yaml file.

### How should this PR be tested?
Regular testing steps.