### PR TITLE
Fix typo in How to Use Chainguard Images

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
@@ -47,7 +47,7 @@ You can also add a relevant tag that you have access to. In the case of the Git 
 docker pull cgr.dev/chainguard/git:latest-glibc
 ```
 
-You may use tags to pull a specific version of a software like Git, or programming language version in a catalog you have access to. Chainguard Academy has tag history pages for each image, which you can find in our reference docs. For example, the [Git Image Tags History](/chainguard/chainguard-images/reference/git/tags_history/), [PHP Image Tags History](/chainguard/chainguard-images/reference/php/tags_history/), and [JDK Image Tags Hisory](/chainguard/chainguard-images/reference/jdk/tags_history/).
+You may use tags to pull a specific version of a software like Git, or programming language version in a catalog you have access to. Chainguard Academy has tag history pages for each image, which you can find in our reference docs. For example, the [Git Image Tags History](/chainguard/chainguard-images/reference/git/tags_history/), [PHP Image Tags History](/chainguard/chainguard-images/reference/php/tags_history/), and [JDK Image Tags History](/chainguard/chainguard-images/reference/jdk/tags_history/).
 
 You can learn about the Chainguard Images tags history in our guide about [Using the Tag History API](chainguard/chainguard-images/using-the-tag-history-api/). 
 


### PR DESCRIPTION
### What should this PR do?
Fixes a typo on https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use-chainguard-images/

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->