### PR TITLE
Enhancement: Position menu with active navigation item

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -103,6 +103,20 @@ Array.from(searchForms).forEach(container => {
   }
 });
 
+const menuPositioner = () => {
+  const nav = document.querySelectorAll("#sidebar-default")[1]
+  const itemActive = document.querySelectorAll(".sidebar-item-active")
+  const itemActiveMobile = document.querySelectorAll(".offcanvas-body .sidebar-item-active")
+  const navMobile = document.querySelector(".offcanvas-body")
+
+  if (itemActive.length) {
+    nav.scrollTop = itemActive[itemActive.length - 1].offsetTop - 300
+    navMobile.scrollTop = itemActiveMobile[itemActiveMobile.length - 1].offsetTop - 200
+  }
+}
+
+menuPositioner()
+
 window.addEventListener('load', function() {
   index = new FlexSearch.Document({
     tokenize: "forward",

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -57,9 +57,6 @@
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
-{{ $scrollLock := resources.Get "js/scroll-lock.js" | js.Build -}}
-{{ $slice = $slice | append $scrollLock -}}
-
 {{ $js := $slice | resources.Concat "main.js" -}}
 
 {{ if eq (hugo.Environment) "development" -}}


### PR DESCRIPTION
### What should this PR do?
This adds a function to updated the scroll position of the menu to keep the active item in view (desktop and mobile)

### Why are we making this change?
This is an enhancement for #820. Given how long the navigation list is, keeping the active menu item visible should help with clicking around less disorientating.

As far as I can tell the Doks doesn't have a in-place page loading feature. I didn't look closely, so I could be wrong.

### What are the acceptance criteria? 
Click on menu items that are nested in nodes and extends past the viewport height.

### How should this PR be tested?
`npm run start`