### PR TITLE
Update Getting Started for Python image for clarity

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-python.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-python.md
@@ -160,7 +160,7 @@ To begin, create a directory for your app. You can use any meaningful name and p
 mkdir ~/inky/ && cd $_
 ```
 
-We'll first write out the requirements for our app in the `requirements.txt` file. We'll download the most recent version of Python [setuptools](https://pypi.org/project/setuptools/) at the time of writing, and also install [climage](https://pypi.org/project/climage/).
+We'll first write out the requirements for our app in a new file, for example we named our file `requirements.txt`. We'll download the most recent version of Python [setuptools](https://pypi.org/project/setuptools/) at the time of writing, and also install [climage](https://pypi.org/project/climage/).
 
 ```
 setuptools==67.4.0
@@ -173,7 +173,7 @@ With requirements declared, create a new file to serve as the application entry 
 nano inky.py
 ```
 
-The following Python script defines a  CLI app that takes in an image file, `chainguard.png`, and prints a representation of that file on the command line.
+The following Python script defines a  CLI app that takes in an image file, `inky.png`, and prints a representation of that file on the command line.
 
 ```python
 '''import climage module to display images on terminal'''
@@ -182,12 +182,18 @@ import climage
 
 def main():
     '''Take in PNG and output as ANSI to terminal'''
-    output = climage.convert('chainguard.png', is_unicode=True)
+    output = climage.convert('inky.png', is_unicode=True)
     print(output)
 
 if __name__ == "__main__":
     main()
 
+```
+
+Next, pull down the `inky.png` image file with `curl`. [Inspect the URL](https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/main/python/inky/inky.png) before downloading it to ensure it is safe to do so. Make sure you are still in the same directory where your `inky.py` script is.
+
+```shell
+curl -O https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/main/python/inky/inky.png
 ```
 
 You can now install the dependencies with `pip` and run the above program. It is recommended that you use a Python programming environment, ensure whether you are using the `pip` or `pip3` command.

--- a/content/chainguard/chainguard-images/getting-started/getting-started-python.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-python.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Python"
 description: "Tutorial on the distroless Python Chainguard Image"
 date: 2023-02-28T11:07:52+02:00
-lastmod: 2023-10-31T20:27:21+00:00
+lastmod: 2023-11-02T13:46:53+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -160,9 +160,15 @@ To begin, create a directory for your app. You can use any meaningful name and p
 mkdir ~/inky/ && cd $_
 ```
 
-We'll first write out the requirements for our app in a new file, for example we named our file `requirements.txt`. We'll download the most recent version of Python [setuptools](https://pypi.org/project/setuptools/) at the time of writing, and also install [climage](https://pypi.org/project/climage/).
+We'll first write out the requirements for our app in a new file, for example we named our file `requirements.txt`. You can edit this file in your preferred code editor, in our case we will use Nano.
 
+```shell
+nano requirements.txt
 ```
+
+We'll download the most recent version of Python [setuptools](https://pypi.org/project/setuptools/) at the time of writing, and also install [climage](https://pypi.org/project/climage/).
+
+```shell
 setuptools==67.4.0
 climage==0.1.3
 ```

--- a/content/chainguard/chainguard-images/getting-started/getting-started-python.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-python.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Python"
 description: "Tutorial on the distroless Python Chainguard Image"
 date: 2023-02-28T11:07:52+02:00
-lastmod: 2023-09-22T11:07:52+02:00
+lastmod: 2023-10-31T20:27:21+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []


### PR DESCRIPTION
## Type of change
Updating the [Getting Started with the Python Chainguard Image](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-python) guide for clarity

### What should this PR do? // Why are we making this change?
The guide did not have instructions for pulling down the `inky.png` file needed to complete example 2. I found it in the chainguard/edu-images-demos repo folder for the guide, so I tried to add instructions on how to pull it down using curl.

### What are the acceptance criteria?  // How should this PR be tested?
Run through the guide (particularly part 2, and the changes made to include pulling down `inky.png`) to make sure that the example is clear and works. 

I was having some issues with the Dockerfile portion of part 2 but I think that's on me, I didn't change anything there (I was getting an error saying the python 3.11 file did not exist in the path, but I am running python 3.11... I cannot wrap my brain around the macos file explorer so I have no idea how to even hunt it down, so I assume I'm just missing something. If that is the case, I would appreciate if someone could help me there for my own sake)