### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,75 @@
+# 2023-11-02
+
+
+Updated Docs:
+
+- aspnet-runtime/tags_history.md
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- bazel/tags_history.md
+- buck2/tags_history.md
+- calico-node/tags_history.md
+- cassandra/tags_history.md
+- cilium-agent/tags_history.md
+- clang/tags_history.md
+- conda/tags_history.md
+- dask-gateway/tags_history.md
+- dask-gateway-server/tags_history.md
+- dotnet-runtime/tags_history.md
+- dotnet-sdk/tags_history.md
+- dynamic-localpv-provisioner/tags_history.md
+- git/tags_history.md
+- google-cloud-sdk/tags_history.md
+- gradle/tags_history.md
+- haproxy/_index.md
+- ingress-nginx-controller/tags_history.md
+- jenkins/tags_history.md
+- k8s-sidecar/tags_history.md
+- kafka/tags_history.md
+- keycloak/tags_history.md
+- kube-downscaler/tags_history.md
+- kubeflow-jupyter-web-app/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- kubeflow-volumes-web-app/tags_history.md
+- mariadb/tags_history.md
+- maven/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- nfs-subdir-external-provisioner/tags_history.md
+- node/tags_history.md
+- node-lts/tags_history.md
+- openai/tags_history.md
+- opensearch/tags_history.md
+- php/tags_history.md
+- powershell/tags_history.md
+- prometheus-cloudwatch-exporter/tags_history.md
+- pulumi/tags_history.md
+- python/tags_history.md
+- r-base/tags_history.md
+- redis/tags_history.md
+- redis-cluster-bitnami/tags_history.md
+- redis-sentinel-bitnami/tags_history.md
+- redis-server-bitnami/tags_history.md
+- rust/tags_history.md
+- semgrep/tags_history.md
+- skaffold/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- tomcat/tags_history.md
+- trillian-logserver/tags_history.md
+- trillian-logsigner/tags_history.md
+- trino/tags_history.md
+- wavefront-proxy/tags_history.md
+- weaviate/tags_history.md
+- zig/tags_history.md
+- zookeeper/tags_history.md
+
 # 2023-11-01
 
 

--- a/content/chainguard/chainguard-images/reference/aspnet-runtime/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aspnet-runtime/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:8630f3e6a43bf935922777106599e3db5362eca4956cd671564d411aa59d8dc1` |
+|  `latest` | November 1st | `sha256:67d0c858089246214eae4c40db3ac6bbd28ca1a7e44dcfd7b3b266fd7349ad9c` |
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:e24bd4c5a94ba1753e5fd316223f7b9a8dc3ff47c8e4adbf8dc095bf257548b4` |
-|  `latest`     | November 1st | `sha256:f777ae4e46f886cf95149c7dd5efa5793f6b6bf7be1eaff25990f291d8c86901` |
+|  `latest-dev` | November 1st | `sha256:de36cd64d0fca215e56d8f7730db65c4e960d2d3a66d464bbd152c16d079eff8` |
+|  `latest`     | November 1st | `sha256:30b9195180525e757aa64bf72c6aacbe37e27895ce89796c06a7cefa21eaeb78` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:2cb64ae4c2e3231b9f46d17f950de521bd17deb7f71c58cd8ab9b01c1de16a00` |
-|  `latest-dev` | November 1st | `sha256:f00e6b3ced694bcdb8830b7182b530e9394cf8acd579a53b0a512bfe23f365f3` |
+|  `latest`     | November 1st | `sha256:e1529e51eb93b29111719208434b78751de488ab754081ce0accc077336b6062` |
+|  `latest-dev` | November 1st | `sha256:094d9acf91041e34e4b41f00a4ba29ec4062807ad520f15fdcd15885de927f08` |
 

--- a/content/chainguard/chainguard-images/reference/bazel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/bazel/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:0e540c90a7dcbe4b3dc72628cc3dc4b75d159a13deb2bd8f5797c81f1f613495` |
+|  `latest` | November 1st | `sha256:5a8a88b66d1e3622c824060c0b9ca43fa7f17414eaafdf33c0ebeda0dac4edf9` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:397a2602c0a3e5cc49aff4b864f17cc19670ee03f7ecc206233128110c36cf25` |
-|  `latest`     | October 30th | `sha256:34284573af27b282ab9542e2a8a391a36babcf9b1eba64e35184604efbd89c56` |
+|  `latest-dev` | November 1st | `sha256:7f9363f68ee45163142fc8b27842e193826fa1411de8bc5663d03e83dbc5ccdb` |
+|  `latest`     | November 1st | `sha256:dfe2f213caa03fc4e3c462d6eb24f574c93af06e7e31d75e25232fe20ae411dd` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:d6c92e061bd1b6d07f64c4bbde28faf3a64ed1c6d079003a685ba64660ede297` |
+|  `latest` | November 1st | `sha256:4c32b04a7a2ac473139a57ec6c665c099b375baf96e7bdeeb8851fc93b57bda7` |
 

--- a/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:58fc38ff427c251781f4612235566870bfbb20e90ace4fb0462ac354f19c11ac` |
-|  `latest-dev` | October 30th | `sha256:6baa6a5aac2579cb0dadc14e4a9c620fce89cb8d0247a7ecfc3e64a5e1ba37e5` |
+|  `latest-dev` | November 1st | `sha256:d78fa1bcd01bc34525932307a09bd2a5bf95eb5dcb6e52adfb44ade2baf69727` |
+|  `latest`     | November 1st | `sha256:009bcfb971439546324cda4a45c2db7374a23a15bd63a8a3991a227f323a72cb` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:e9d8dd3f39edf2bceb98ea0f1638837976b1f44c63b2c139a18f3089b858a04e` |
-|  `latest`     | October 30th | `sha256:bc8319add9c0d188ae38322885ffe72acd29afd6a865781f47ce39094b7e714e` |
+|  `latest-dev` | November 1st | `sha256:cfa95ab3dea15fded0036b3bcda933071845efc6d6652886e594b981cd36cd87` |
+|  `latest`     | November 1st | `sha256:a359af13c37de8e8a75aec73ebfca18ed77effd20666d99719c0c453294f4f64` |
 

--- a/content/chainguard/chainguard-images/reference/clang/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/clang/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:dd1da559af25f2f12c2d16a9d17642f39978023a795491ef87466ec035a2c6d9` |
-|  `latest`     | October 30th | `sha256:73902877892b86e30145427ee6da2e5ff0fa16412d9689d4b1e976d28bbe4c0a` |
+|  `latest`     | November 1st | `sha256:1e0d5681aae3ee6b4114af8f94b7201b9756588782c75ec7cbdf0730f58c7838` |
+|  `latest-dev` | November 1st | `sha256:1235cc366a081f26dd4fa54288dd3144317efb35588fcfc43015f2894e999868` |
 

--- a/content/chainguard/chainguard-images/reference/conda/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/conda/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:b9b981a6e58df6459e49b4f6934bcfb20b67c1b7a26c10b43be9319c917e02d9` |
-|  `latest`     | October 30th | `sha256:db9e8c90f21575b71e7b133a3b1c58d16caf7c34265a6ff40a528eea6390635e` |
+|  `latest`     | November 1st | `sha256:ab4cd2c9f2f4ed9edceb3c1ca4e66633dbaf1b7f923de1622a39ebc604e9a3a4` |
+|  `latest-dev` | November 1st | `sha256:931228df4a8054668758bf404978652df1b640f6bdcbd40a357d7a393c188e4e` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:cd3559d743103c8f077773722d21976756b4074d1c6065c822ae33f639915595` |
-|  `latest`     | October 30th | `sha256:99691798761df4906e9255a793c9312bf3e02518a5fbec5ab186c84a38ae4e00` |
+|  `latest-dev` | November 1st | `sha256:8ff1bcba81246037a0e6fc92fc1849694054e8a2b6d2cff2a793420dcd9ad2d8` |
+|  `latest`     | November 1st | `sha256:bbaf08236b827f39472b43ba3ea1539f606b85343260201eb6ede3a8bc9f30a7` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:fcd683a09e449f0c3cef077f7ca3ff2605d8604264b3d68eb08ee87ecca5c05a` |
-|  `latest-dev` | October 30th | `sha256:019be99c4a971dcfc304783d8300734bad7e1d69af3d293e5fbca782f06ba5b5` |
+|  `latest-dev` | November 1st | `sha256:a83a8960626f887a1d760db35143d6fa5edf989d346db091c93790a2b6810a16` |
+|  `latest`     | November 1st | `sha256:ffc2786a02ea2975976dc04fa7d83dd1a12d2a1781b3d30b2ae092e7eb74e534` |
 

--- a/content/chainguard/chainguard-images/reference/dotnet-runtime/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dotnet-runtime/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:fffe74f4d36366f4232b7bb4b674504a8af0ac393945105bccb83948b098fecd` |
-|  `latest-dev` | October 30th | `sha256:6f75aa8f22f3ab4d9982612a5c6d084b15d736e2468743beede3d80f41fe6cad` |
+|  `latest-dev` | November 1st | `sha256:d5cad8a495abcb9d47d716f37a636918d433f3d490765f45e24373eba802f7fb` |
+|  `latest`     | November 1st | `sha256:d40133a9257de4a97c61b65ecd25b4e879618186f042771763457df0e23f1389` |
 

--- a/content/chainguard/chainguard-images/reference/dotnet-sdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dotnet-sdk/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:2130127d5e7a8a6d837a10c9ecb6f3667e6c39f55e0eab0d88ce1bc60b2e0efa` |
-|  `latest`     | October 30th | `sha256:5502de9ab1cf313ab2b161b31d496e0abaab8d10cb302f60b6bf57fe108045f8` |
+|  `latest-dev` | November 1st | `sha256:851ddf20233e453c30ecc1179406083da56271f19dcb3d2df7ce3480dfc58033` |
+|  `latest`     | November 1st | `sha256:c57c7afc7f891cec68a443d67ebbad895c106a64b540768a063a24abbbde735b` |
 

--- a/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:cf2906ed5db761bf2977b87c7f0674dc2313ea8dcdf9cf9b5f54b847696c5893` |
-|  `latest`     | October 30th | `sha256:0333323ef506dfd59d99ecbb50e58b6c0c29ae978bc50a1a3fed4587350a8fa1` |
+|  `latest-dev` | November 1st | `sha256:09403af87816f6cc591fa20fe78f4574f7fe30e828f8bb5dc9e9f80b480d4712` |
+|  `latest`     | November 1st | `sha256:2ad5427c0cc9a82dfb807088bce6c42ef7b7a621c11faa1f6ccb6d40472ae942` |
 

--- a/content/chainguard/chainguard-images/reference/git/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/git/tags_history.md
@@ -25,10 +25,10 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                  | Last Changed | Digest                                                                    |
 |--------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-root-dev`       | October 30th | `sha256:34afc69292844054fb35d03634d0110f0a909b4c11baa610a7cb273e876392ba` |
-|  `latest-root`           | October 30th | `sha256:7df28e074b5390a511849285ccdbf3d679a6ec2a52f1d320adf4b96ff584c362` |
-|  `latest-dev`            | October 30th | `sha256:a2d2da14133632f5c26435bbd3987adc70abb47ab4cfa077d4cc3dc18c4659af` |
-|  `latest`                | October 30th | `sha256:145e198f2abd7b94614c219e45418a077fd4de655388b4d1ae2d1e8625147150` |
+|  `latest-root`           | November 1st | `sha256:715c901b87478bd19bfecaefce96a91b67ebb7384d9eb2e37a81364762c01a84` |
+|  `latest-dev`            | November 1st | `sha256:23383a271661da20a6a5d63589b1643acb803cd1858a1272de5582df4722c2e0` |
+|  `latest`                | November 1st | `sha256:7d9705dcca1e64716a498e0d6036b31f412e4bcc4b1c30e16b13b5368335b3ec` |
+|  `latest-root-dev`       | November 1st | `sha256:9e59364be96fd9b568611777fc8137ee66a58ccc7e389ae43864493f055b8bb2` |
 |  `latest-glibc-dev`      | October 30th | `sha256:0fc0257691a3e41a6a37724b74060ab518f1f12c12f48d11e11804c42b4c1d21` |
 |  `latest-glibc`          | October 30th | `sha256:f33bf05165db149346aa8ed32c16d49b1c9346dae12a4188f62c29901463e4ac` |
 |  `latest-glibc-root`     | October 30th | `sha256:4be8a6d19758a4f7e69eefc7313e0ff2c181b554a90ca64d103d8d2edeeccf5c` |

--- a/content/chainguard/chainguard-images/reference/google-cloud-sdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/google-cloud-sdk/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:d07162a0bb559dd9581708e27667692644632b1bb3f41096c2f5e261c4599629` |
+|  `latest` | November 1st | `sha256:26562ced9645ef9445b16f5f569b71b6449ebbb6ba865265fab4c298fd749854` |
 

--- a/content/chainguard/chainguard-images/reference/gradle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gradle/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:b2668af773e09954f1fc7a44f1cc4694de9be62a901d09387ccd88f9ca618a7d` |
+|  `latest` | November 1st | `sha256:6879fbb9a8eda2ddf89f5bae8dfc98db2f40dcaa5ad2b4ebac0405c307c5d2df` |
 

--- a/content/chainguard/chainguard-images/reference/haproxy/_index.md
+++ b/content/chainguard/chainguard-images/reference/haproxy/_index.md
@@ -59,3 +59,19 @@ In order for the container to work, you need to mount your custom `haproxy.cfg` 
 docker run -it --rm -v "$(pwd):/etc/haproxy" cgr.dev/chainguard/haproxy haproxy -f /etc/haproxy/haproxy.cfg
 ```
 
+### Helm install
+
+When installing in Kubernetes, `securityContexts` that drop `[ "ALL" ]` capabilities interfere with the `setcap` privileged `haproxy`. In order to support Kubernetes based installs which default to dropping `ALL` capabilities, the necessary modifications must be made to add back `NET_ADMIN` capabilities.
+
+For example, in the `ha-redis` chart used by `argocd`, the `values.yaml` becomes:
+
+```yaml
+# values.yaml
+haproxy:
+  enabled: true
+  containerSecurityContext:
+    capabilities:
+      add:
+        - NET_BIND_SERVICE
+```
+

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:bf4d2c33b922c9068413143d0b831a49d9aa03d44d281bd3ace7efcd909ce828` |
-|  `latest`     | October 30th | `sha256:b2fd1a836a16c2332e7663e41b6338cbe16d129c40ae83baf1f83eb26ad80114` |
+|  `latest`     | November 1st | `sha256:a51dab2512b9b7fe12084c88c15432273fdba0c244c75094de89a18fe53b3f6c` |
+|  `latest-dev` | November 1st | `sha256:fdb7b7452d61497c57dd4fc39a8e99c943107490e4e39e932969de61d687ab98` |
 

--- a/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:4a9bead07ec6aff14fb65306e73db4ed7f3d08f08722f04aa195149726fc84f8` |
+|  `latest` | November 1st | `sha256:fdc49d87928dba935e4a7db661ac2a1cc3972a3230646e505c2dc6f6c93a56fc` |
 

--- a/content/chainguard/chainguard-images/reference/k8s-sidecar/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k8s-sidecar/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:26e586c0ad2b31f88f1100b527cd022b6230df5d878964ec31c38e93497ead4e` |
-|  `latest-dev` | October 30th | `sha256:9a9f2d4dbaaa95a004a58009944520319504aa433b8b08702c91a3f6675dd7c2` |
+|  `latest`     | November 1st | `sha256:d3032f5aa645721b6ce17486c56c1b9e3bf37452db279de7f6790ea82413b50b` |
+|  `latest-dev` | November 1st | `sha256:4f904cbff87b2d603c1bb66fbd2d3317885e75d397beb3840668abe5c5304818` |
 

--- a/content/chainguard/chainguard-images/reference/kafka/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kafka/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:04240db5c1d9ed90c0ec84c125cfc5e4df23c4e7ed62608fc9640b7d9e4b5582` |
-|  `latest-dev` | October 30th | `sha256:4c303be17a79a5166172543a8a27337a169e36991f161c7332a58c7083d0d8f6` |
+|  `latest-dev` | November 1st | `sha256:3ee89567a1734d2a3b173b7c0c00d2be5f93ea181099f65167b0ffda127005f1` |
+|  `latest`     | November 1st | `sha256:d4005b510e42a472a76c5077ff5861422b435e1d826a3b51e6f4dc661973ee42` |
 

--- a/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:8523464ab6e92b24b328367dc52ed954dca23f1a497c9c742742ec862e1cb03d` |
-|  `latest`     | October 30th | `sha256:acb6819a561bf5c9f137801ed0ba7eeb2d5fac4a2cf8bfbe4a2bff2f5177cfc8` |
+|  `latest`     | November 1st | `sha256:1d63aa6fb11bbe731119551cdfb0e5e69955196fa3b1b319f5ea943548e02717` |
+|  `latest-dev` | November 1st | `sha256:1d0ecba672b20aaee38752dd22f914b26df74797baa017046d1c7e2d07fa7ed4` |
 

--- a/content/chainguard/chainguard-images/reference/kube-downscaler/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-downscaler/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:308365a6c94fa3174e60642e0d49e49535cb6a46b8791bd7c7fd5be7e82c31ea` |
-|  `latest`     | October 30th | `sha256:17ba9897faf9c8b89e793bce1868b35db3edc24b2dd86ac6d089a0619e5041bd` |
+|  `latest-dev` | November 1st | `sha256:6ad265bde13594cfd35e65eac514c096aefe2f163a176ef661452926ee6c37e5` |
+|  `latest`     | November 1st | `sha256:40555bbe30a732ad9fd185cbbda53108a0d3ebd884266af8a1880028328b67a2` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:fae7874d81fd1c16b3c612bb4cc7ab46b63722640d4ebff706d8f5976f2de77d` |
-|  `latest`     | October 30th | `sha256:4969668664ba3bbcfe55849dadb81a5ee697f31d866c1e87f05d47d789c5c27d` |
+|  `latest`     | November 1st | `sha256:fb1dff5b76aaa448e8565a52339cc0760850efe9bf3511cee993e159936a1976` |
+|  `latest-dev` | November 1st | `sha256:2a51fb72a4197f109e23bbf6db87e0118ea571ff60cfd6baf333b9146cdc2896` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:c8aa94de8029c311ec52b8141b9a78849c279c1cc678172a9f1b8ce3bf2661bf` |
-|  `latest-dev` | November 1st | `sha256:5644610542b396ac72bd753497cc3cf889901f823cf66368ca919b179f5c77cf` |
+|  `latest-dev` | November 1st | `sha256:7798a4a953215e64aa8eea7a9ca94d4ee6bff4152fd9f72615e8db8f40360a73` |
+|  `latest`     | November 1st | `sha256:d4790ed69ac655f750996fdf5f2b0dd4a3df35e650aeb5de99be4b77bdaa438a` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 31st | `sha256:b74e8165866a09f5836061d86fdfef599207c54153607750294f58047f6f5b37` |
-|  `latest-dev` | October 31st | `sha256:75c2447255b3066c425922dd146f625277a7ceae8615908b9877c7dc8f599901` |
+|  `latest`     | November 1st | `sha256:5839bd9071492637a4c39bd5daa191d2eacf73892678ffca51379477b356b838` |
+|  `latest-dev` | November 1st | `sha256:9f00be8b57e6635b0bf92254c5e9c95fe3f59a5a668a95a3cf144df4ecc509bf` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 31st | `sha256:61f71fc1dd9d01ef0c1f69cdd2fb70f80988ab2440f22efcc0c7c6642f64fbae` |
-|  `latest`     | October 31st | `sha256:e267c40719919e6ff6b65af61ebd440e699a5cd93687967e3da0a3023b7cfe8c` |
+|  `latest-dev` | November 1st | `sha256:dc0d175fecc5e9805416972de93c10513ff7613af4b55e3ef03fe9aed593b3d7` |
+|  `latest`     | November 1st | `sha256:eda1bebf454f4ff345d37894974afeb97d7ffc18c2e6a63c874a0008a846d692` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 31st | `sha256:c2e542b770e764c179bb03f4bc8e47c82cfce0513f5ae173c0b929f6299924e7` |
-|  `latest-dev` | October 31st | `sha256:e0aa92cbb2c8f9fc94ed1128857e43b633d04ede7badb246373aa380d7319c91` |
+|  `latest-dev` | November 1st | `sha256:1eae7f8a0637d778837cd4f4edb0c7585eae761d963790102b819894a2e93500` |
+|  `latest`     | November 1st | `sha256:2d2b05bc977940e50ab0f8e98e3c348e0410dc9f6dfa4cccd3ca25ed066474e6` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 31st | `sha256:559237ce6ed6b99b158087549d740dbe06134f7644479fbc630bc6f71d8943c0` |
-|  `latest-dev` | October 31st | `sha256:97151d5ab1cfe626da70ceb7a90f34703724c8f85b2790e05aa053c48fd2ad77` |
+|  `latest-dev` | November 1st | `sha256:6decfafb060c69718fbfb88114e2e52d33d598c73e6e4088a617c846847bd35f` |
+|  `latest`     | November 1st | `sha256:30f5c85900bb752849ffa177c2268ae4a6d9f8bff88ba5b4d88609242143b97f` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 31st | `sha256:c814e185a5d8b9c318e56e3b02d991a51bd8b4fc1442fb309d53f3800a42e66c` |
-|  `latest-dev` | October 31st | `sha256:a197c99728bf0de8e8f216c2a13caa5f854f253e08074f908644631017a5b058` |
+|  `latest`     | November 1st | `sha256:d2ef36209c50f9d90a4074d4d77876dada06059e63c45cf894e3df09f96a0a59` |
+|  `latest-dev` | November 1st | `sha256:ea95afceae386f858b67dfcdf811b1e675be99ea0b5a9e21a4c031e41b187d93` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 31st | `sha256:6680cf230d8d7ae66ef22a4cc3a78584dabd7862167265407069231d1b523b57` |
-|  `latest`     | October 31st | `sha256:e24c752f6369a72e67d2f93a0046ad774c822d60c9f7be7aeac8a4e4e4984fa9` |
+|  `latest`     | November 1st | `sha256:d9d6d876b1159cf0318514601967031554a5458a527cd37f6d9c5096bc46e3c2` |
+|  `latest-dev` | November 1st | `sha256:0a95eaf562a95e939f906a17a4ff00b39126f94aa00e81d53f71d031e10dac0c` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:4e2fabd8f25df93e9e6aca58ef6194effc2e14ea3c5bcbdf4e30ab5876fbc412` |
-|  `latest`     | November 1st | `sha256:df4b820f825212a674fca272196b9a0710ed20155c60ddf305372dc2c35e55c9` |
+|  `latest`     | November 1st | `sha256:4fb019b1d25d65ad005d9b280c2c1b114666ceebcbc0350ad2592042a8aebb2d` |
+|  `latest-dev` | November 1st | `sha256:cf0d258095b6c41a2bba5625fa43e5c500a04f111c2f96becaa8483af9c6488c` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:da13cfbdcaa15fa5b994cab5f0c5e0680966b8a555d8f8071c38ddb2315c3035` |
-|  `latest`     | October 30th | `sha256:e6ef92462615770e5d9ebdcd9c1530bbc72c4e63f2b1c8ca80ac61061ae9bb41` |
+|  `latest`     | November 1st | `sha256:aac85f43c9574bbdcad336ef9724cd68ffff75b7148dc91df54c5a319d911ceb` |
+|  `latest-dev` | November 1st | `sha256:2e7cf3fdb25207aa83605d28e7479f037f1e00e3dfd3947cb49853bafab9c5c0` |
 

--- a/content/chainguard/chainguard-images/reference/mariadb/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/mariadb/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:0c2a518a258a2697f28bc63ea782d3986ac7f83cda1edd00dd19d1dafa6c8a1c` |
+|  `latest` | November 1st | `sha256:13be60cfcc92a72a2ea9c78a8098e13853466768075d6fe9040060fe387cdb5b` |
 

--- a/content/chainguard/chainguard-images/reference/maven/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/maven/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                        | Last Changed | Digest                                                                    |
 |--------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` `openjdk-17-dev` | October 30th | `sha256:368837bd3b268a47f8c41f449acbc858593b5c683113c2fa00360e917b0c0b1f` |
-|  `latest` `openjdk-17`         | October 30th | `sha256:24cf9ded858792ececfbd8420e92819c77bf0e4c3458f0b677b94a70ab44e31d` |
-|  `openjdk-11`                  | October 30th | `sha256:0310bd456f7ab19dbf805f78d146d50c66acbefc8cd198abfe1a87ab3f996924` |
-|  `openjdk-11-dev`              | October 30th | `sha256:ba1e680bf6ebd01e179c2db98554a4348e335dac5322b131f46a3d8750b8a39e` |
+|  `latest-dev` `openjdk-17-dev` | November 1st | `sha256:1da67e320b9228f176128cb126440d4b1f60a843b5aad869c9f659e7638c898c` |
+|  `openjdk-17` `latest`         | November 1st | `sha256:d8409b567a0fd8a50db0b611e3dd4d17da8d286babf8c88701e65e22e89c6876` |
+|  `openjdk-11-dev`              | November 1st | `sha256:fe81bab1604db407a9e28658a62f51594f93d03aebe111afe1f0d284ab99878f` |
+|  `openjdk-11`                  | November 1st | `sha256:fbcbad6873d426e0ee3e89f27ce13a436565da96c49a6e7e2efb4af65a05a370` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:a518841cf8a9c75eb596897937d4fa5e3a21933cf54fd6b7f4a835cd15ba716a` |
-|  `latest-dev` | November 1st | `sha256:9ecc4c27a14c75c3aebf41e7351bfa2f7ad0be523a77aee0a441cdc50955a393` |
+|  `latest-dev` | November 1st | `sha256:8775334324fbebd12aec5e298fc86ecea25fee9bb10ae795e68615c40e1dc484` |
+|  `latest`     | November 1st | `sha256:b11945e6d881850ef7bc2fffd12fcf361dcf56b93746ef36358490490f812cfd` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:fbb163320b0e74479ca51b85e81eef2538f583c637023386ebb1ba729ddded0b` |
-|  `latest`     | October 30th | `sha256:93d98a733053fb6c64c4686916973202e7a8771009c70c0de2fe89f5a11a4719` |
+|  `latest`     | November 1st | `sha256:758509056a14725fb31ed954fc15825e526b0d6a8d03883052077e46e1175a7a` |
+|  `latest-dev` | November 1st | `sha256:6ca730f690b8cd73a70e0fb279377bbe59959d3429707a3e94c928d4ab629e7d` |
 

--- a/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:24a23b22240d7f21b3fa60b69e1edcb8e8d180334de409032d59e73c8b14b0a1` |
-|  `latest-dev` | October 30th | `sha256:5696a0da614686bf248980ae4aef382a36c98cf69354692e15603ea5c0924d3e` |
+|  `latest`     | November 1st | `sha256:6521467d21c7cc0a7d92b71ca5f54ba7c041781468d82bfd12d5afd1026af3c6` |
+|  `latest-dev` | November 1st | `sha256:4ec01456bda2315e63aa7de1721965c6d9283058e36f865e45e5f36176ee02a0` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:b688e183578f53060ff0fbe0ac278867e4ecdbc434d5352f55d2ff57dc30f734` |
+|  `latest-dev` | November 1st | `sha256:7995cd2549c2ca7f243cc1976f5f60914e12e3aa84c06bdce74934597a177d01` |
 |  `latest`     | November 1st | `sha256:ef00028d58695bc53ef6ad3ac56bb5097397279a192c5f7da6a7f92210bb8488` |
 

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:16bd4bf0774940cbd645f57bce067758e1ddb0df6aefd356be644baed6acef9a` |
+|  `latest-dev` | November 1st | `sha256:20bb7415a5397e5378ccb8a40af35b5ea802756af1d3dcda5552e8de91c9a8b8` |
 |  `latest`     | November 1st | `sha256:0e741c657ed520b25789ab8007cd3a278995c7ca19eee4acdac5ddda2f8147a9` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:81d50d929dc189a7d5d92076f59578d04a3ac0e3455b8c3a4e3ce838fcf420bb` |
-|  `latest-dev` | October 30th | `sha256:d04d658ced1e6b3e0e50a8f5b0cf25ba23df0d090c10f785c088d85d147c22f0` |
+|  `latest`     | November 1st | `sha256:2e08310f882c8ae981540b032b1f1338c5e9cf11e1782a7c7728147bf7c652fd` |
+|  `latest-dev` | November 1st | `sha256:26a2512745a637c895f54c21b6bc9d9c70cfbbac34d98b6de8869c5ae89f4d5d` |
 

--- a/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:fb645db269e024b6829af3eadc971a8cfbf23c1d955337ef62e49b77dc0a57d8` |
-|  `latest-dev` | October 30th | `sha256:a5b2c8ec1811e26c0c672275c7990512c5f7a9e419c4b7b3fbd9dab275d73aaa` |
+|  `latest-dev` | November 1st | `sha256:6b907d281f3f38dc5c08a0e60a4716e0c9728358eada71362f98e701f2904813` |
+|  `latest`     | November 1st | `sha256:a97a899175c67fa623e61fd34eb583890e4b1ba67bd8a29f04e996d16547e858` |
 

--- a/content/chainguard/chainguard-images/reference/php/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/php/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)           | Last Changed | Digest                                                                    |
 |-------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-fpm`     | October 30th | `sha256:aec4aea24f35bca7a4673e23c4db7e959623c282033c9b768dd9dcddc4d690e2` |
-|  `latest-fpm-dev` | October 30th | `sha256:cdf76a9e3675dc20e21a171364cb277f37cda0bd69acc80b2bbf927e49c928a6` |
-|  `latest`         | October 30th | `sha256:99c1484aa42cdfd5bcfee97d8e1b34fdb828ea105a83f13f5d07b5e79ff19830` |
-|  `latest-dev`     | October 30th | `sha256:a23345522822235641bbdd625b720bd46648a85a5c1e07a3ecb1201969ffd20c` |
+|  `latest-fpm`     | November 1st | `sha256:7f72a5304fb651b0c9213ab68a9b3155b4994c6e5cb61d23424bdb2dd65f1c37` |
+|  `latest-fpm-dev` | November 1st | `sha256:c6163a2a2d1042aab14ad89bcb87505f85d62bb47938d77a95e8d587e6206894` |
+|  `latest`         | November 1st | `sha256:1bd16b813b91e61eba5b932dd7dc13c84dd93f34366db0381b07c4e7b77d9e65` |
+|  `latest-dev`     | November 1st | `sha256:18617c81fbd47850a644ec0fa1b4bd8e60c92c947ae0db6805bbfdd693bbacd9` |
 

--- a/content/chainguard/chainguard-images/reference/powershell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/powershell/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                      | Last Changed | Digest                                                                    |
 |------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-root` `root-latest` | October 30th | `sha256:6e37372f744097891fed3cb3294252c2cb36e3ef4de4183062b6b6b6d0c2a93d` |
-|  `latest`                    | October 30th | `sha256:57818975951bc3bba02537fd30b129525fa17e54663fb31f29f7ba3ae927646c` |
+|  `root-latest` `latest-root` | November 1st | `sha256:0198af277896311b8048f662daab0f6d2730290b596c10781e33105ebb77ffde` |
+|  `latest`                    | November 1st | `sha256:c159594df40e99b499098dcf321a3e1378afd4f948822b576a3d68094e35e704` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-cloudwatch-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-cloudwatch-exporter/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:0f59358137e1982b85904c31a547c4a71971818aa505be2356ab03a3c1007a7f` |
-|  `latest`     | October 30th | `sha256:f8702975e18a4b7f50cc37b3b39aa8fda4441aed945536b31abb4eb20c96f14f` |
+|  `latest-dev` | November 1st | `sha256:5df64f05fc1f55ddd828c539f4adb9754be9141484594684bcb71939cb2ab5eb` |
+|  `latest`     | November 1st | `sha256:787cfd4e266d32d2877669947ff8ecc5ea54bb29e8486cf30beecae139845815` |
 

--- a/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 1st | `sha256:dac574df156a60ceb5efa2b0420b752f7822700f44eb6de946a7a28a8e0635f5` |
+|  `latest` | November 1st | `sha256:32dfec5c51d05669fa1377f3e88275622fffcfc39ac129b5318413dac58b856d` |
 

--- a/content/chainguard/chainguard-images/reference/python/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/python/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:bb89655cc842562f993ab988902d70435e72b66c79e759e0443e2ad2cc4af3ed` |
-|  `latest`     | October 30th | `sha256:b8ae05271a3ac82634033e938cac688a92952119197056865ffb76e8edf1c008` |
+|  `latest-dev` | November 1st | `sha256:0b19b019efef129472c45582ca33a564105f80daa5a66ea89134b2a50e1688e8` |
+|  `latest`     | November 1st | `sha256:47d0a74e92d3bd87438a4ad18a76f9a5e59dc2d040ffcfa544b780e1caa72561` |
 

--- a/content/chainguard/chainguard-images/reference/r-base/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/r-base/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:3ed517e8832775ce8dc794c247db686612a1c6aaf5e4728c530ffe83a855f03f` |
-|  `latest-dev` | October 30th | `sha256:e3d9961301d9b58c4f07173a37dd4149dc2d2cedbc0b6f0daea047636f80838b` |
+|  `latest-dev` | November 1st | `sha256:2d82888d81cb16fa39a0e0cc5dfc0d70124f5f5edd027f5b076dd397923dc554` |
+|  `latest`     | November 1st | `sha256:870fb8706ce3700d779d902a29c50594c552a0330d098a4132646008907ef5ab` |
 

--- a/content/chainguard/chainguard-images/reference/redis-cluster-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-cluster-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:cd25f33e3d557eaffaeab67372cf7244520d980b7c8b02a4713c42737d2d47fe` |
-|  `latest-dev` | October 30th | `sha256:09a6cf5490fdfdb805c072b4033c9798b860da259833e6466d7d7c9b35914303` |
+|  `latest-dev` | November 1st | `sha256:8ca1bc9339978394ce0fb6e49c04c2380ec5f7a4b2efa9014fff04c4f6c5df8d` |
+|  `latest`     | November 1st | `sha256:4f95a95a9defb96b90dbb8a1cd6969feeda67954db88ddcf3afe7d4d5c8a6b22` |
 

--- a/content/chainguard/chainguard-images/reference/redis-sentinel-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-sentinel-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:505260b5c719ee5d5e26554504389b58e24b754a6250490ead0274e83d6cefec` |
-|  `latest`     | October 30th | `sha256:c7781b128a85f3d3904d3d8aa5de6004627317dac048406ab63a7c2735d4943e` |
+|  `latest-dev` | November 1st | `sha256:2a096d16c02d16ed6a4163ccac4caf3f60af42533a08b0397554c8cbadc41561` |
+|  `latest`     | November 1st | `sha256:5fb280b7d1b90b384db7e23720e59a5c155af4f8580640ca6b88ffbcd41a50f3` |
 

--- a/content/chainguard/chainguard-images/reference/redis-server-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-server-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:d05aa0a5c97e15c3a309f4cbe64ed6bc3b1fb24c7ac87a3da79796993f0a2779` |
-|  `latest-dev` | October 30th | `sha256:84a3880c4d17d08675c8e32a14510f1d2f19e4eec2b987c128bb634e225edd3b` |
+|  `latest`     | November 1st | `sha256:49d2851f918736ff3e1a34601a8fabe85b20f56927aa9c10b3875fc566135511` |
+|  `latest-dev` | November 1st | `sha256:7f507a82554c36d61d04d4fa2c0fd801fe92157b5437361aeab9386bdffa7691` |
 

--- a/content/chainguard/chainguard-images/reference/redis/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:ffb2fee030e23755e80e90407aa833ae1c2f9c6c0ffccf98f4141760ec9eaf22` |
-|  `latest-dev` | October 30th | `sha256:d40f61ce92aa5a3b27b715f51605e8820c326d43bc85ccbc6258fa1207613c5e` |
+|  `latest`     | November 1st | `sha256:0101f37fde3ca4aa56e802058389752bd48c9a375dbe2a94ffa3089336fff518` |
+|  `latest-dev` | November 1st | `sha256:56de64a0880506532555ca1e8ee8f6b22cefd432ed50cf8f222ca9778ee176ba` |
 

--- a/content/chainguard/chainguard-images/reference/rust/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rust/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:a987c8bf5853bcdb407b1cab8b6cf9e74e168c3403209112a9dc01898dd22ead` |
-|  `latest-dev` | October 30th | `sha256:c2f9e60c98d372368c33e241f904c62484995a52199dfbc1981e180829d035cf` |
+|  `latest`     | November 1st | `sha256:911f4d8fe64cd914db3db7dde3d8038c40b3922aad5553bc58f2e9fc9512bc95` |
+|  `latest-dev` | November 1st | `sha256:6f23f36d46f2f6af2c5f7f4112b19bc8772a827b58963f25a2747714b4357a51` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:0571d6a1a7b01b833be400076a5142e9993aef867976a0ee6fd884f3d7b224ff` |
-|  `latest-dev` | October 30th | `sha256:33cf0d781da2c93b46bb4c70631360b7247c79be8084d2696f0278f070026435` |
+|  `latest`     | November 1st | `sha256:04a45776fed2b5a2cb59b8f53f1b2c78177691f8b8b7015a2f4891fdc2b5b158` |
+|  `latest-dev` | November 1st | `sha256:6cc98dd1ddd9bea47b7943089f0905793e324d9882e6210110ab4e6a44b0e200` |
 

--- a/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:5123cf4715299563e782c0be84e35a2b765c2e44555c96000cd32169e7caac24` |
-|  `latest-dev` | October 30th | `sha256:d4f8bc4f7b1904df877fb34e459481aab10ef21bb66adb5d54aa5e6c73832c5f` |
+|  `latest`     | November 1st | `sha256:e5827b947b216e9c318f883ce8573d8dfe3f21209a21f5effebe20f627448b6a` |
+|  `latest-dev` | November 1st | `sha256:4f693a5a827d33a926b39415fc1e6dab524ef4af38b398b1b1d71666224772a9` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 31st | `sha256:6c50e07db165300c3fdd0127be513d0f2d177c0bd5cf511e4c75bea63e6bb8b6` |
+|  `latest` | November 1st | `sha256:0dbd49c4d9453fcf7dec017ff8be5b662512372687568580f764ea46970df41d` |
 

--- a/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:a8e474164ff4fcb475fb92ba340456432ec23870fab0a60fd46b17b113141a3f` |
+|  `latest` | November 1st | `sha256:3e5d82258dfc3c5f0b74f3238a94f9b49dbb7d636e10db053d29b7a82a87136b` |
 

--- a/content/chainguard/chainguard-images/reference/trillian-logserver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trillian-logserver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:368ddd5d74c024301a0c947c0c49f83d70570ea6acd9f9adb3d15f97e1d920f8` |
-|  `latest-dev` | October 30th | `sha256:611f27770109f2c81b8289922b600ab05c3d5cdf6e4d6b93643ff3c96fe2dd08` |
+|  `latest`     | November 1st | `sha256:f9e760ebefb35c70348ab73efdc7bae387b547bcd544f99aa6fc587dd468b3eb` |
+|  `latest-dev` | November 1st | `sha256:76954826871c573143d777d3afa8a283cae0890d71f412001cd24f2037616cd0` |
 

--- a/content/chainguard/chainguard-images/reference/trillian-logsigner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trillian-logsigner/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:04ff58153cde145831d251db373957174d9b295f1dc8b991e20e46fee5a5a993` |
-|  `latest`     | October 30th | `sha256:cffc891a822b1df4e7c1d4977c6a2ccfdae2bffef26cda04d3b4bab7abacd269` |
+|  `latest`     | November 1st | `sha256:bca2765f57cf8f96304c7cde1947541f215c540c5915069182a7ce4e77a0e7a5` |
+|  `latest-dev` | November 1st | `sha256:aca7233939584e97abcc906daf7e76c4eaff3a1d039755dae1dfb068edecfc86` |
 

--- a/content/chainguard/chainguard-images/reference/trino/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trino/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:e8a6c1c93779d50c45eacd7a1403ecb8637a426d916f150f0ca4fe2fa7ab9ef0` |
-|  `latest`     | October 30th | `sha256:e7894147bf75e0e023623e9663d58cbbf1658764904771b9199d674f552174b5` |
+|  `latest-dev` | November 1st | `sha256:c0ec7b82399012732b45fe887168fa823ab7643a6ba92416fe6645902fdb0cc5` |
+|  `latest`     | November 1st | `sha256:967eb39fe00c5f759bb6747f49806552c8454a05ff647cbb807bc8dc5f27a1bd` |
 

--- a/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:62d0f84f5d0216f3f670ebb467af89408e47293a30953156d1693a2843453374` |
-|  `latest-dev` | October 30th | `sha256:31481fe515e571bff20eb2875037b554371cfbc45ac07de42cbd44c7addf1837` |
+|  `latest`     | November 1st | `sha256:f78b03f6e0b962b7ec6be2d83ef3152987389b72b7e0f738c5d1df4cf77fd627` |
+|  `latest-dev` | November 1st | `sha256:c0cf8ba29b712c00b123ae91ebda6ea26d3d051a6b705a56fffd6686a7e5c6d8` |
 

--- a/content/chainguard/chainguard-images/reference/weaviate/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/weaviate/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:15e541e723c24ead644b0fddda3cf3e6ade95610f80f76b1d89f36fac3260c77` |
-|  `latest-dev` | October 30th | `sha256:064f91bf59532a0e04285da6dcb2a6581f2c9a54f94ceb3bb819f952801164af` |
+|  `latest`     | November 1st | `sha256:0096b5660247954a7ee31332aaa873ee9e48d7c7536907bbff34e6fe0b6e9dec` |
+|  `latest-dev` | November 1st | `sha256:67ec572fffbfea63a9869c70fd2a6327939d6e224d20c92be8c781d9e1eb26d3` |
 

--- a/content/chainguard/chainguard-images/reference/zig/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zig/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:ed0e5d0005833c1acbc9330ad7a01b692162aecdf1c3def4830b24e22b2e79d1` |
-|  `latest`     | October 30th | `sha256:85a5230355da097944116b1e06df91b9d24c437f4792b401013d496fa0400508` |
+|  `latest`     | November 1st | `sha256:979ac07daaa8922a49e99017350981072c5141c17ab3e78faed50654405f081b` |
+|  `latest-dev` | November 1st | `sha256:d1378a455f0f7658ce6f15eedb172bccbbc800e6cb6c2562c53bcb88ba993093` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:d0a37b8626a0c4c3cbf92bfbf4bc91a498da52a8f82eca5b11f534be9c1b7b7a` |
-|  `latest-dev` | October 30th | `sha256:814c2a191055ba56ac5475a5e19029c938524f3bd924e82ab5b7c4db8d87e9ac` |
+|  `latest-dev` | November 1st | `sha256:8f0e6733476adc88ea8787dd60209d0317447c09cabda8b3d1ad809d611003a7` |
+|  `latest`     | November 1st | `sha256:d9c179cab83c50efcff1591cf732fbf614d029b362acc7b070ca553c859c80b8` |
 


### PR DESCRIPTION
Updated Docs:

- aspnet-runtime/tags_history.md
- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- bazel/tags_history.md
- buck2/tags_history.md
- calico-node/tags_history.md
- cassandra/tags_history.md
- cilium-agent/tags_history.md
- clang/tags_history.md
- conda/tags_history.md
- dask-gateway/tags_history.md
- dask-gateway-server/tags_history.md
- dotnet-runtime/tags_history.md
- dotnet-sdk/tags_history.md
- dynamic-localpv-provisioner/tags_history.md
- git/tags_history.md
- google-cloud-sdk/tags_history.md
- gradle/tags_history.md
- haproxy/_index.md
- ingress-nginx-controller/tags_history.md
- jenkins/tags_history.md
- k8s-sidecar/tags_history.md
- kafka/tags_history.md
- keycloak/tags_history.md
- kube-downscaler/tags_history.md
- kubeflow-jupyter-web-app/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- kubeflow-volumes-web-app/tags_history.md
- mariadb/tags_history.md
- maven/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- newrelic-kubernetes/tags_history.md
- nfs-subdir-external-provisioner/tags_history.md
- node/tags_history.md
- node-lts/tags_history.md
- openai/tags_history.md
- opensearch/tags_history.md
- php/tags_history.md
- powershell/tags_history.md
- prometheus-cloudwatch-exporter/tags_history.md
- pulumi/tags_history.md
- python/tags_history.md
- r-base/tags_history.md
- redis/tags_history.md
- redis-cluster-bitnami/tags_history.md
- redis-sentinel-bitnami/tags_history.md
- redis-server-bitnami/tags_history.md
- rust/tags_history.md
- semgrep/tags_history.md
- skaffold/tags_history.md
- slim-toolkit-debug/tags_history.md
- tomcat/tags_history.md
- trillian-logserver/tags_history.md
- trillian-logsigner/tags_history.md
- trino/tags_history.md
- wavefront-proxy/tags_history.md
- weaviate/tags_history.md
- zig/tags_history.md
- zookeeper/tags_history.md