### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,26 @@
+# 2023-11-03
+New images added:
+
+- gitlab-exporter
+
+Updated Docs:
+
+- argocd/tags_history.md
+- argocd-repo-server/tags_history.md
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- cilium-agent/tags_history.md
+- conda/tags_history.md
+- ctlog-trillian-ctserver/tags_history.md
+- gatekeeper/tags_history.md
+- helm/_index.md
+- k3s/tags_history.md
+- k3s-allinone/tags_history.md
+- powershell/tags_history.md
+- semgrep/tags_history.md
+- wasmtime/tags_history.md
+- wavefront-proxy/tags_history.md
+
 # 2023-11-02
 
 

--- a/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:73eceb7bf56026d20967ce0b5a298a75911219cf573fbb6ca9387bbd46592b38` |
-|  `latest-dev` | October 30th | `sha256:2f9200d8ac9f2ffd4d815b5a9072fa4ade754491988fe9d94777eaf6ebb184c0` |
+|  `latest`     | November 2nd | `sha256:db7a6cf8d831e79ad9917743daff137dd78a90488d88f4007c9ae6da73c1c94c` |
+|  `latest-dev` | November 2nd | `sha256:aadcc5a73826ad679562fbcfa6f57c29f7144d71b6b7b78e00be91ce79cf4c19` |
 

--- a/content/chainguard/chainguard-images/reference/argocd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argocd/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:5bbd109db41e411ce4208ea3370539839882464ddc3a70b7bf007550290abdab` |
-|  `latest`     | October 30th | `sha256:19a94b9e863a9b940a648579c48391a782d8e30fa9815b2d6973aba11f71b45c` |
+|  `latest`     | November 2nd | `sha256:f64ed95a21f5506c1bec746908b0302aa5dae404123c313556a2924e87aa3a3f` |
+|  `latest-dev` | November 2nd | `sha256:61fb5e5a5115c85f004a231800b178060d601fa9f9174ab09098d8b72ece156e` |
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:de36cd64d0fca215e56d8f7730db65c4e960d2d3a66d464bbd152c16d079eff8` |
-|  `latest`     | November 1st | `sha256:30b9195180525e757aa64bf72c6aacbe37e27895ce89796c06a7cefa21eaeb78` |
+|  `latest`     | November 2nd | `sha256:b5056b85cb28a23b559bf85d20489685fbe936482316dbcf7255e6034fd9a5e7` |
+|  `latest-dev` | November 2nd | `sha256:62e57d0c0dddd794162572d54135c73c719ef7fc230107abc7e6cfaaf7523e18` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:e1529e51eb93b29111719208434b78751de488ab754081ce0accc077336b6062` |
-|  `latest-dev` | November 1st | `sha256:094d9acf91041e34e4b41f00a4ba29ec4062807ad520f15fdcd15885de927f08` |
+|  `latest-dev` | November 2nd | `sha256:90ff9168bf0b93198de4634d22692c0d91c77a35403d31103dfb2a340a384909` |
+|  `latest`     | November 2nd | `sha256:33185d5467897d3879dc8fc25915767ea09a1b5436edac456588276bd1738c01` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 1st | `sha256:cfa95ab3dea15fded0036b3bcda933071845efc6d6652886e594b981cd36cd87` |
-|  `latest`     | November 1st | `sha256:a359af13c37de8e8a75aec73ebfca18ed77effd20666d99719c0c453294f4f64` |
+|  `latest-dev` | November 2nd | `sha256:3b469f2baae743665213821b7a8a584f58eeee9858f00bfee05c904f7032fd8f` |
+|  `latest`     | November 2nd | `sha256:cebd31b97bb46b1ffcc3c4e71a423f100b488f0a1ac7ee35c3f03c3ebe2bd0fa` |
 

--- a/content/chainguard/chainguard-images/reference/conda/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/conda/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:ab4cd2c9f2f4ed9edceb3c1ca4e66633dbaf1b7f923de1622a39ebc604e9a3a4` |
-|  `latest-dev` | November 1st | `sha256:931228df4a8054668758bf404978652df1b640f6bdcbd40a357d7a393c188e4e` |
+|  `latest`     | November 2nd | `sha256:4467f8c3aef42365f3c16b2cf89cb78feb2d79ae3c42231d66b2acc1e624471b` |
+|  `latest-dev` | November 2nd | `sha256:3fc32d8f7987c227332630ebc5e736ea5ccb89daac8e28714e05fc39466a8b78` |
 

--- a/content/chainguard/chainguard-images/reference/ctlog-trillian-ctserver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ctlog-trillian-ctserver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:09907c54f8ddb5987ee8a9c51ba461943bfceaa2b511b7f02054834b34a33cfc` |
-|  `latest`     | October 30th | `sha256:9107749c91928d956e270e3475d2333c05a16415f9f6154a36965e209a37514c` |
+|  `latest-dev` | November 2nd | `sha256:fef40a5ce37dec61962471a135e2984b231082e2c7df35259a1d81aa24eda230` |
+|  `latest`     | November 2nd | `sha256:01a61995a92550ee7fcbe73b58790fce27c90170ef3fe3b9191e85d0f351b8be` |
 

--- a/content/chainguard/chainguard-images/reference/gatekeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gatekeeper/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | October 30th | `sha256:f1f23795365a6f607d0e2f7d6c17d682818004e212e6580875aedda0a3304dfc` |
-|  `latest-dev` | October 30th | `sha256:844080235c13f0ebae64a0feec9b0dd88645c8617470981893de7f7ac7c82293` |
+|  `latest`     | November 2nd | `sha256:4f960498c16e48257a2ca04edd73e2f55f8aa73385b3b638559058eebf6c09e3` |
+|  `latest-dev` | November 2nd | `sha256:17a5dacea3036f0b5fc44409ab6d901d74386dd94377b7c5ccd3634005990be7` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/_index.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/_index.md
@@ -1,0 +1,64 @@
+---
+title: "Image Overview: gitlab-exporter"
+linktitle: "gitlab-exporter"
+type: "article"
+layout: "single"
+description: "Overview: gitlab-exporter Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/gitlab-exporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+# GitLab Images
+
+## Get It!
+
+The images are available on `cgr.dev`, e.g. `gitlab-kas`:
+
+```
+docker pull cgr.dev/chainguard/gitlab-kas:latest
+```
+
+## Usage
+
+This replaces the GitLab images used in the deployment by our Chainguard images for GitLab.
+See the [full documentation](https://docs.gitlab.com/charts/) for installation and usage.
+
+We can use the different GitLab Chainguard images that we've built for GitLab with the Helm chart of the project using the following commands.
+
+First, you need to install the Helm repository:
+
+```shell
+helm repo add gitlab https://charts.gitlab.io/
+helm repo update
+```
+
+Once you did this, you can install Gitlab Kas to the target cluster:
+
+```shell
+    helm upgrade --install gitlab gitlab/gitlab \
+        --timeout 600s \
+        --set global.hosts.domain=example.com \
+        --set gitlab.kas.image.repository="cgr.dev/chainguard/gitlab-kas" \
+        --set gitlab.kas.image.tag="latest" \
+        --set global.hosts.externalIP=10.10.10.10 \
+        --set certmanager-issuer.email=me@example.com \
+        --set postgresql.image.tag=13.6.0
+```
+

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/image_specs.md
@@ -1,0 +1,109 @@
+---
+title: "gitlab-exporter Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public gitlab-exporter Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/gitlab-exporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **gitlab-exporter** Image.
+
+## Variants Compared
+The **gitlab-exporter** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                                        | latest                                            |
+|--------------|---------------------------------------------------|---------------------------------------------------|
+| Default User | `nonroot`                                         | `nonroot`                                         |
+| Entrypoint   | `/scripts/entrypoint.sh /scripts/process-wrapper` | `/scripts/entrypoint.sh /scripts/process-wrapper` |
+| CMD          | not specified                                     | not specified                                     |
+| Workdir      | not specified                                     | not specified                                     |
+| Has apk?     | yes                                               | no                                                |
+| Has a shell? | yes                                               | yes                                               |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/gitlab-exporter/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                               | latest-dev | latest |
+|-------------------------------|------------|--------|
+| `apk-tools`                   | X          |        |
+| `bash`                        | X          | X      |
+| `busybox`                     | X          | X      |
+| `ca-certificates-bundle`      | X          | X      |
+| `curl`                        | X          | X      |
+| `git`                         | X          |        |
+| `gitlab-cng-base`             | X          | X      |
+| `gitlab-cng-exporter-scripts` | X          | X      |
+| `gitlab-exporter`             | X          | X      |
+| `gitlab-logger`               | X          | X      |
+| `glibc`                       | X          | X      |
+| `glibc-locale-posix`          | X          | X      |
+| `gomplate`                    | X          | X      |
+| `jemalloc`                    | X          | X      |
+| `ld-linux`                    | X          | X      |
+| `libbrotlicommon1`            | X          | X      |
+| `libbrotlidec1`               | X          | X      |
+| `libcrypt1`                   | X          | X      |
+| `libcrypto3`                  | X          | X      |
+| `libcurl-openssl4`            | X          | X      |
+| `libexpat1`                   | X          |        |
+| `libffi`                      | X          | X      |
+| `libgcc`                      | X          | X      |
+| `libnghttp2-14`               | X          | X      |
+| `libpcre2-8-0`                | X          |        |
+| `libpq-15`                    | X          | X      |
+| `libproc-2-0`                 | X          | X      |
+| `libssl3`                     | X          | X      |
+| `libstdc++`                   | X          | X      |
+| `ncurses`                     | X          | X      |
+| `ncurses-terminfo-base`       | X          | X      |
+| `openssl-config`              | X          | X      |
+| `procps`                      | X          | X      |
+| `readline`                    | X          | X      |
+| `ruby-3.2`                    | X          | X      |
+| `ruby3.2-bundler`             | X          | X      |
+| `ruby3.2-concurrent-ruby`     | X          | X      |
+| `ruby3.2-connection_pool`     | X          | X      |
+| `ruby3.2-excon`               | X          | X      |
+| `ruby3.2-faraday`             | X          | X      |
+| `ruby3.2-faraday-excon`       | X          | X      |
+| `ruby3.2-faraday-net_http`    | X          | X      |
+| `ruby3.2-mustermann`          | X          | X      |
+| `ruby3.2-nio4r`               | X          | X      |
+| `ruby3.2-pg`                  | X          | X      |
+| `ruby3.2-puma`                | X          | X      |
+| `ruby3.2-quantile`            | X          | X      |
+| `ruby3.2-rack-2.2`            | X          | X      |
+| `ruby3.2-rack-protection`     | X          | X      |
+| `ruby3.2-redis`               | X          | X      |
+| `ruby3.2-redis-client`        | X          | X      |
+| `ruby3.2-redis-namespace`     | X          | X      |
+| `ruby3.2-ruby2_keywords`      | X          | X      |
+| `ruby3.2-sidekiq`             | X          | X      |
+| `ruby3.2-sinatra`             | X          | X      |
+| `ruby3.2-tilt`                | X          | X      |
+| `ruby3.2-webrick`             | X          | X      |
+| `wolfi-baselayout`            | X          | X      |
+| `xtail`                       | X          | X      |
+| `yaml`                        | X          | X      |
+| `zlib`                        | X          | X      |
+

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info.md
@@ -1,0 +1,73 @@
+---
+title: "Provenance Information for gitlab-exporter Images"
+type: "article"
+unlisted: true
+description: "Provenance information for gitlab-exporter Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying Image Signatures
+The **gitlab-exporter** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/gitlab-exporter | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading and Verifying SBOMs
+
+All Chainguard Images come with a high-quality Software Bill Of Materials (SBOM) attested at build-time. The SBOM can be downloaded using the cosign tool:
+
+```shell
+cosign download attestation \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/gitlab-exporter | jq -r .payload | base64 -d | jq
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the SBOM from.
+
+With cosign 2.0+, you can use the `cosign verify-attestation` command to check the signature of an SBOM:
+
+```shell
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  --platform=linux/amd64 \
+  cgr.dev/chainguard/gitlab-exporter
+```
+
+And you should get output that verifies the SBOM signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/gitlab-exporter --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "wasmtime Image Tags History"
+title: "gitlab-exporter Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the wasmtime Chainguard Image"
+description: "Image Tags and History for the gitlab-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/wasmtime/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/wasmtime/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/wasmtime/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/wasmtime/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/gitlab-exporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/gitlab-exporter/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 2nd | `sha256:77732ff6c60d4efa3b8ad3989051b48399091de68d8fe5874430ba2117cb4467` |
-|  `latest-dev` | November 2nd | `sha256:843cd23c6a7b02f94e5b3ef22c335478df2bf2dd59b9e32413515db37446f836` |
+|  `latest`     | November 2nd | `sha256:95152c2a749eafb2e5eed96699fe23213375611cf7f66d0c5c3fbbaa1c4761d5` |
+|  `latest-dev` | November 2nd | `sha256:cdc4c0dd14747e4811acbf55ad20174f6e04fcd1fa9b86ce68ec497fd9bc4d15` |
 

--- a/content/chainguard/chainguard-images/reference/helm/_index.md
+++ b/content/chainguard/chainguard-images/reference/helm/_index.md
@@ -25,13 +25,28 @@ toc: true
 
 
 
-Minimal image with helm binary. **EXPERIMENTAL**
+Minimalist Wolfi-based helm images for deploying helm applications to a kubernetes cluster. Includes `dev` variant. **EXPERIMENTAL**
 
-## Get It!
+- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/helm)
+- [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/helm/provenance_info/)
 
-The image is available on `cgr.dev`:
+## Image Variants
+
+Our `latest` tags use the most recent build of the [Wolfi helm](https://github.com/wolfi-dev/os/blob/main/helm.yaml) package. The following tagged variants are available without authentication:
+
+- `latest`: This is a distroless image for running helm to install packages to a kubernetes cluster. It does not include `apk-tools` or `bash`, so no shell will be available.
+- `latest-dev`: This is a development / builder image that includes `bash`, `apk-tools`, and `busybox`. This variant allows you to customize your final image with additional Wolfi packages.
+
+### Helm Version
+This will automatically pull the image to your local system and execute the command `helm version`:
+
+```shell
+docker run --rm  cgr.dev/chainguard/helm version
+```
+
+You should see output similar to this:
 
 ```
-docker pull cgr.dev/chainguard/helm:latest
+version.BuildInfo{Version:"v3.13.1", GitCommit:"3547a4b5bf5edb5478ce352e18858d8a552a4110", GitTreeState:"dirty", GoVersion:"go1.21.3"}
 ```
 

--- a/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:497e4631e130f43b0dab95c6af409ca3f0f6f59a4c9a5bd79192a705dfad6f3c` |
-|  `latest`     | October 30th | `sha256:27ad3c239c822509a584e1f64cb1ef6f169f6bd7afd4fb8a0bdd677fd22c30c0` |
+|  `latest-dev` | November 2nd | `sha256:411665dc980348f431470329d06778ff7314973639f548f7e9789a62df356616` |
+|  `latest`     | November 2nd | `sha256:caf6bb51ea9212b00567630e0e98072e8bab4e2611de7416752c4e234a12fa3f` |
 

--- a/content/chainguard/chainguard-images/reference/k3s/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k3s/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | October 30th | `sha256:6ffa374880538eb525eb4a098825afd265cf3331d48604bbbcd86f9a91df35d3` |
-|  `latest`     | October 30th | `sha256:f295acc6a40b83c845ad0faf1bec2f236f9a0ab71a9304f9f72ae09bde1d5bad` |
+|  `latest-dev` | November 2nd | `sha256:70f2720f585f149ed1d203b8f50b532bedc00002f935186d17c76f611f3b4343` |
+|  `latest`     | November 2nd | `sha256:114dbe6786cf129e8c50dfba4640e0159f6acbefaf275f42f3c7e3dc95ec002a` |
 

--- a/content/chainguard/chainguard-images/reference/powershell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/powershell/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                      | Last Changed | Digest                                                                    |
 |------------------------------|--------------|---------------------------------------------------------------------------|
-|  `root-latest` `latest-root` | November 1st | `sha256:0198af277896311b8048f662daab0f6d2730290b596c10781e33105ebb77ffde` |
-|  `latest`                    | November 1st | `sha256:c159594df40e99b499098dcf321a3e1378afd4f948822b576a3d68094e35e704` |
+|  `latest-root` `root-latest` | November 2nd | `sha256:20184652ab7e6361ebfbace4a79b838803a4e9d4a6845a5688ea5c78e0f177c0` |
+|  `latest`                    | November 2nd | `sha256:107dc1064c07317b906c6e3c583b3284a544442c3c44f91b179b1399d4cc86b8` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:04a45776fed2b5a2cb59b8f53f1b2c78177691f8b8b7015a2f4891fdc2b5b158` |
-|  `latest-dev` | November 1st | `sha256:6cc98dd1ddd9bea47b7943089f0905793e324d9882e6210110ab4e6a44b0e200` |
+|  `latest`     | November 2nd | `sha256:1ffc722a16edd5a63020e0751ae1ae55b11acc0b47bd102004edd8fc58df0db6` |
+|  `latest-dev` | November 2nd | `sha256:7e187ca974ad59e76752db6b7161669780b9398db550e59b9d4f993ec1bd63ad` |
 

--- a/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 1st | `sha256:f78b03f6e0b962b7ec6be2d83ef3152987389b72b7e0f738c5d1df4cf77fd627` |
-|  `latest-dev` | November 1st | `sha256:c0cf8ba29b712c00b123ae91ebda6ea26d3d051a6b705a56fffd6686a7e5c6d8` |
+|  `latest`     | November 2nd | `sha256:cfe187afb95240074229aa1dec545aa0794048fcbf236a38c9a55cfefd5f4100` |
+|  `latest-dev` | November 2nd | `sha256:4f586031efa6c44ab81e78969bd4bcd5a13bf70da29a84a42aa6bd3c60f88876` |
 


### PR DESCRIPTION
New images added:

- gitlab-exporter

Updated Docs:

- argocd/tags_history.md
- argocd-repo-server/tags_history.md
- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- cilium-agent/tags_history.md
- conda/tags_history.md
- ctlog-trillian-ctserver/tags_history.md
- gatekeeper/tags_history.md
- helm/_index.md
- k3s/tags_history.md
- k3s-allinone/tags_history.md
- powershell/tags_history.md
- semgrep/tags_history.md
- wasmtime/tags_history.md
- wavefront-proxy/tags_history.md