### PR TITLE
Add Makefile and apko config for a local dev-container environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ resources
 .netlify
 .hugo_build.lock
 .DS_Store
+.bash_history
 
 # Editor / IDE config
 .idea

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ arch := $(shell uname -m)
 .PHONY: apko-build dev-container
 apko-build:
 	docker run --rm -v $$PWD:/work -it cgr.dev/chainguard/apko:latest build \
-	--repository-append https://packages.wolfi.dev/os \
-	--keyring-append    https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-	--package-append    wolfi-baselayout \
 	--arch              $(arch) \
 	/work/$(cfg) academy.local /work/academy.tar
 	docker load < academy.tar

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ apko-build:
 	rm academy.tar
 
 dev-container:
+ifeq ("$(arch)","x86_64")
 	docker run --rm \
 	-v $$PWD/config/entrypoint.sh:/entrypoint.sh \
 	-v $$PWD/public:/usr/share/nginx/html \
@@ -17,4 +18,14 @@ dev-container:
 	-v $$PWD:/home/inky/ \
 	-p 8080:8080 -p 1313:1313 \
 	-it --user root \
-	academy.local:latest-$(arch)
+	academy.local:latest-amd64
+else
+	docker run --rm \
+	-v $$PWD/config/entrypoint.sh:/entrypoint.sh \
+	-v $$PWD/public:/usr/share/nginx/html \
+	-v $$PWD/nginx.conf:/etc/nginx/nginx.conf \
+	-v $$PWD:/home/inky/ \
+	-p 8080:8080 -p 1313:1313 \
+	-it --user root \
+	academy.local:latest-$arch
+endif

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,11 @@ apko-build:
 	rm academy.tar
 
 dev-container:
-	docker run --rm -v $$PWD/config/entrypoint.sh:/entrypoint.sh -v $$PWD/public:/usr/share/nginx/html -v $$PWD/nginx.conf:/etc/nginx/nginx.conf -v $$PWD:/home/inky/ -p 8080:8080 -p 1313:1313 -it --user root apko.local:latest-$(arch)
+	docker run --rm \
+	-v $$PWD/config/entrypoint.sh:/entrypoint.sh \
+	-v $$PWD/public:/usr/share/nginx/html \
+	-v $$PWD/nginx.conf:/etc/nginx/nginx.conf \
+	-v $$PWD:/home/inky/ \
+	-p 8080:8080 -p 1313:1313 \
+	-it --user root \
+	apko.local:latest-$(arch)

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ dev-container:
 	-v $$PWD:/home/inky/ \
 	-p 8080:8080 -p 1313:1313 \
 	-it --user root \
-	apko.local:latest-$(arch)
+	academy.local:latest-$(arch)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+cfg?=apko.yaml
+arch := $(shell uname -m)
+
+.PHONY: apko-build dev-container
+apko-build:
+	docker run --rm -v $$PWD:/work -it cgr.dev/chainguard/apko:latest build \
+	--repository-append https://packages.wolfi.dev/os \
+	--keyring-append    https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+	--package-append    wolfi-baselayout \
+	--arch              $(arch) \
+	/work/$(cfg) academy.local /work/academy.tar
+	docker load < academy.tar
+	rm academy.tar
+
+dev-container:
+	docker run --rm -v $$PWD/config/entrypoint.sh:/entrypoint.sh -v $$PWD/public:/usr/share/nginx/html -v $$PWD/nginx.conf:/etc/nginx/nginx.conf -v $$PWD:/home/inky/ -p 8080:8080 -p 1313:1313 -it --user root apko.local:latest-$(arch)

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,0 +1,51 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - apk-tools
+    - bash
+    - ca-certificates-bundle
+    - coreutils
+    - hugo-extended
+    - nano
+    - vim
+    - tmux
+    - nginx
+    - wolfi-base
+
+accounts:
+  groups:
+    - groupname: inky
+      gid: 2000
+  users:
+    - username: inky
+      uid: 2000
+  run-as: inky
+
+work-dir: /home/inky
+
+paths:
+  - path: /var/lib/nginx
+    type: directory
+    uid: 2000
+    gid: 2000
+    permissions: 0o755
+    recursive: true
+  - path: /var/lib/nginx/tmp
+    uid: 2000
+    gid: 2000
+    type: directory
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
+    recursive: true
+  - path: /var/run
+    uid: 2000
+    gid: 2000
+    type: directory
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
+    recursive: false
+
+entrypoint:
+  command: /bin/bash /entrypoint.sh
+

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,6 +1,8 @@
 contents:
   repositories:
     - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - bash
     - ca-certificates-bundle

--- a/apko.yaml
+++ b/apko.yaml
@@ -2,15 +2,16 @@ contents:
   repositories:
     - https://packages.wolfi.dev/os
   packages:
-    - apk-tools
     - bash
     - ca-certificates-bundle
     - coreutils
     - hugo-extended
     - nano
-    - vim
-    - tmux
     - nginx
+    - nodejs
+    - npm
+    - tmux
+    - vim
     - wolfi-base
 
 accounts:

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+su - inky -s /bin/bash -c '/usr/sbin/nginx -c /etc/nginx/nginx.conf -e /dev/stderr -g "daemon on;" > /dev/null 2>&1'
+printf "\nWelcome to the Academy development environment!\n\n"
+export PS1="[academy] ❯ "
+export GOPATH="/root/.cache/go"
+export CGO_ENABLED=0
+bash -i

--- a/config/local-dev/config.toml
+++ b/config/local-dev/config.toml
@@ -1,0 +1,2 @@
+canonifyURLs = false
+baseURL = "http://localhost:8080"


### PR DESCRIPTION
This is a bit of an experiment that I hope we can turn into a daily tool for Academy work with various supporting tools. To start it adds a Makefile with two targets, `apko-build` and `dev-container`.

1. `apko-build`: creates a local image for Academy development, using our `cgr.dev/chainguard/apko` image and the included `apko.yaml` file in this PR.
2. `dev-container`: runs the image with various volumes mounted into it, and ports forwarded with a copy of Hugo and nginx to start with.

Future versions can add things like autodocs, rumble code, chainlink and so on.

To test, run:
```
make apko-build
make dev-container
```

Once it builds and runs, use `hugo serve --bind 0.0.0.0` and then visit http://localhost:1313 when it is ready.

To build and preview HTML files with the included nginx, run `hugo -e local-dev`, then visit http://localhost:8080.

Docker and `make` are the only prerequisites to run this I think.