### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,41 @@
+# 2023-11-10
+New images added:
+
+- timestamp-authority-cli
+- timestamp-authority-server
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- aws-for-fluent-bit/tags_history.md
+- aws-load-balancer-controller/tags_history.md
+- buck2/image_specs.md
+- buck2/tags_history.md
+- calico-node-driver-registrar/tags_history.md
+- dex/tags_history.md
+- external-dns/tags_history.md
+- fluent-bit/tags_history.md
+- fluentd/tags_history.md
+- gitlab-exporter/tags_history.md
+- grype/tags_history.md
+- haproxy/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kubernetes-csi-external-attacher/tags_history.md
+- kubernetes-csi-external-provisioner/tags_history.md
+- kubernetes-csi-external-resizer/tags_history.md
+- kubernetes-csi-external-snapshot-controller/tags_history.md
+- kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
+- kubernetes-csi-external-snapshotter/tags_history.md
+- kubernetes-csi-node-driver-registrar/tags_history.md
+- melange/tags_history.md
+- newrelic-fluent-bit-output/tags_history.md
+- postgres/tags_history.md
+- prometheus-pushgateway-bitnami/tags_history.md
+- pulumi/image_specs.md
+- pulumi/tags_history.md
+- slim-toolkit-debug/tags_history.md
+
 # 2023-11-09
 
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:3ee4c0b36a8ae03b2b5edd4255062c56480e6dca084494f6fd766bb8e76b0ac8` |
-|  `latest`     | November 9th | `sha256:626056abe1867737df96cc782821b859e54b1474cbcb3a8d22ea4a81588ddb7b` |
+|  `latest-dev` | November 9th | `sha256:aad4aa09c6a4a2e772ec8f934d17d0c4ba31d6b9ecca5d1770e03cdee23c2ac7` |
+|  `latest`     | November 9th | `sha256:4aec0d940828925ad895e6310b0e44696fec40e3e717460fc3cc2d170d8b3b0a` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:ebdd84dfc3c435cdce64b3c1470dfbbf419205985da4aef496325da6bdd6072c` |
-|  `latest-dev` | November 9th | `sha256:5d824902c508b5066c3a0d0d33001e2f8079c3c6a7dec6cf7f5dc1d988ad5160` |
+|  `latest`     | November 9th | `sha256:fca106d3d4896527926cb46f629f0fb2d0e9b564ae8afb8cb0a49dc0665fc3a2` |
+|  `latest-dev` | November 9th | `sha256:c5788f6bc05ce85b9947f13190081c5d3548519f1e035faad8f700023a04d37f` |
 

--- a/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 9th | `sha256:21ff8fd808ff503258c1687ee6d94668f8d8f61f85ad9603379f709af50e4f4a` |
+|  `latest` | November 9th | `sha256:d9385b80cda7d89e8c467c69e0cc97f4c13879b45d30a572b558ee0f30a7dfb2` |
 

--- a/content/chainguard/chainguard-images/reference/aws-load-balancer-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-load-balancer-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:a0f7d954cab42abfb0299aaf3e3d6a7b19d8d369d8a863946f1703db90bd3f57` |
-|  `latest`     | October 30th | `sha256:38e0ad2d4fb922e2ab12626d40683aa4c205fdff77cd426af37709f752a55214` |
+|  `latest`     | November 9th | `sha256:f87b9993a8a8afa97a59c138dddc68782e7b840e4cc50b0d9ee7e4550a08374f` |
+|  `latest-dev` | November 9th | `sha256:1e16d349493bc3862f1cb67234d380e1fcec60c4306de09c6d1d567add8bfe10` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/buck2/image_specs.md
@@ -81,7 +81,7 @@ The table shows package distribution across variants.
 | `libstdc++-dev`          | X          | X      |
 | `libxml2`                | X          | X      |
 | `linux-headers`          | X          | X      |
-| `llvm-lld-16`            | X          | X      |
+| `llvm-lld-17`            | X          | X      |
 | `make`                   | X          | X      |
 | `mpc`                    | X          | X      |
 | `mpfr`                   | X          | X      |

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:1d6d01978611bf6cda2b20937fe7d8011b31f6c2caa471716e236270c76e92a2` |
-|  `latest`     | November 7th | `sha256:ab1c619cd4105523f7fdd6ee587e5ed347e07e045ee0879446d8515c14acb7d8` |
+|  `latest-dev` | November 9th | `sha256:e2448998089b170e125b388a5100317af898a2b090f91efc4774f6ea57dd946c` |
+|  `latest`     | November 9th | `sha256:daa6accab817b2a82e3d85398cc64d8dbcf6491dda7f233adf56bac75e8f0c15` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 4th | `sha256:651a607bddd7f6e6a9084ed95c7b4103f7c525bcb8459be2ec71cc0d01bc0a0d` |
+|  `latest` | November 9th | `sha256:67e32f0347dabb9281a28f4b3db0555e60dd0d582d6885ec7f2847ee48f3ecba` |
 

--- a/content/chainguard/chainguard-images/reference/dex/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dex/tags_history.md
@@ -31,5 +31,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `2.37.0` `v2.37.0` `2` `v2` `v2.37` `2.37`                                                          | October 30th | `sha256:66c186956513b3fe3fa72ed717148c3c0a71eb346a34567e5329e33a3384b315` |
 |  `v2.37.0-r7-dev` `2.37.0-r7-dev`                                                                    | October 29th | `sha256:974083a8f09478d67ce41a64c46c6a68dbf6ac80de6372ce4f979bed6690e0a3` |
 |  `2.37.0-r6-dev` `v2.37.0-r6-dev`                                                                    | October 13th | `sha256:32574cbaced835ec3bde4302d440124f244821930f6f5f6dc74e71db3ba9c2bf` |
-|  `2.37.0-r5-dev` `v2.37.0-r5-dev`                                                                    | October 9th  | `sha256:774262d7dc979db2d9dc9898f8ab1727d306c8e91814569fbdca087395ae26b4` |
 

--- a/content/chainguard/chainguard-images/reference/external-dns/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/external-dns/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:12b46ef5c881a30c62c4af83a17d542f3dd0a40301144803d2a2deab9ff111ff` |
-|  `latest`     | November 3rd | `sha256:896cb87fae1c28970e1d2470ccfe89e7ff4edda88bc75165a8bfea6c93bd50e8` |
+|  `latest`     | November 9th | `sha256:acf10f011888af663507ce4e6a36414df9b86ef107a430752d3685e63db1c28d` |
+|  `latest-dev` | November 9th | `sha256:a59e801b80cf3073da5e4748f7d22e907ab3d5f9fffbdda8e2c5a366b97332ca` |
 

--- a/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:5a9791948ac73b603b75b39ee407a5a99a9e18d81f74c4b4e8adaf0f1e003e4c` |
-|  `latest-dev` | November 9th | `sha256:c9e2d6fa8c4f4201d9564ee1a6c5937341b24e5d9c6e3acef973af6f2b176590` |
+|  `latest-dev` | November 9th | `sha256:010efa790ca1bf12fac66b2e3b389ffaa0429271ace32910be2e260621239df8` |
+|  `latest`     | November 9th | `sha256:dedf0ae1a583d6e2464c688ba7507dca2eede55c762c71730dc3dfb5bf0737ac` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed | Digest                                                                    |
 |----------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-splunk-dev` | November 8th | `sha256:1767ade6b9ab48aee4bfd55179debe6c171270d9487b3665555e4d53255611fd` |
-|  `latest-splunk`     | November 8th | `sha256:eb02e4092b7dbb428f861936fa76f61bdb7dd8e816b1eb8648989c0eba3a95d8` |
-|  `latest`            | November 7th | `sha256:139e8a2cb19b155f4a8788ff27f27b26fdfeb8a3d86554d98b11dd75ccf62c3f` |
-|  `latest-dev`        | November 7th | `sha256:74e76cdb69f68052689e5c8f974effa28e45d6b5d0bc95fd174504716f64c91a` |
+|  `latest-dev`        | November 9th | `sha256:057def37228842b912bf7f2c8292b6f1b7423f3a0e6131a94bef16da6f6e06a1` |
+|  `latest`            | November 9th | `sha256:e23738519f25a91ca899ca6775d1671ee4ad4c410470b809d793ad52c3154cec` |
+|  `latest-splunk`     | November 9th | `sha256:b4f36befa0a61073819733ee5e8967fe1476547e7745141dc6f429202954d3ca` |
+|  `latest-splunk-dev` | November 9th | `sha256:74b8821854e29d0c0abc3af0081ec6348f739fdb03924f6f45b9d58f552ed270` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:3a79a74346b408cdee5a4d596698bb57ffae869eb0470eb68d8e7c8c0857dcfe` |
-|  `latest`     | November 7th | `sha256:cb4efc343045d65e16e825a8daf8f16419b992432e1ef0bc78b043f5902935f6` |
+|  `latest`     | November 9th | `sha256:0f2e054a8c5f24fb312a2ce068327ca84064cf98703a075aa613d5f927260018` |
+|  `latest-dev` | November 9th | `sha256:abf295ae67fe9e063e3f2741d29e5dbbee877dceccd6d9a3019c9ef5565a8998` |
 

--- a/content/chainguard/chainguard-images/reference/grype/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/grype/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:41245eee497e5665dcbe234d080d3a7584fa4b324c9b05dbf1a2bc6c038b4022` |
-|  `latest-dev` | November 9th | `sha256:1f01038db70ee46aa9a158821cb8e0ab9e1d5ecad0bcc25caa6084267cd6fe66` |
+|  `latest-dev` | November 9th | `sha256:8600e3ebd0479cdffcdcf341c13f3ac819ce5eddbf0da77121f8c087e715a876` |
+|  `latest`     | November 9th | `sha256:a484af0305c8d6310a5f3fef2209419f527b86b169a22418a710b0569aba52e6` |
 

--- a/content/chainguard/chainguard-images/reference/haproxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/haproxy/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:2b25e9e78dfa9c9cac5602281ab4e3d26409533d95683bfea7c7d8b9b3e872c5` |
+|  `latest` | November 9th | `sha256:3f3fcdb4b173518b366771d660121548b09c28552d91aebbad687d714d8c189f` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:32094c26731b6faa7eefb057e60474ad4eeecc8dc99d0220e8854a6e8879c9c6` |
-|  `latest`     | November 7th | `sha256:df7202a6a39ec87353359215be904bba83e7860585966bfda4e34c25e81fabdc` |
+|  `latest-dev` | November 9th | `sha256:1fe207e2bb2d7223ab252c2c70009d9f627fd02b530ca3348be961d412d8e948` |
+|  `latest`     | November 9th | `sha256:88d124b7f003f39f44311654c0cf47c944bad4fe92931b8f653e41acd358029d` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-attacher/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-attacher/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:a4fe4d642ed0adc9846535a46325689d44b08c183ee2b12cb2bf52a01860a419` |
-|  `latest`     | October 30th | `sha256:6f72b63812513f133cadfc5d4c89a07f9aa8cf5e1c9bb0f73c5e71d44608f7c0` |
+|  `latest`     | November 9th | `sha256:b6dcd27d47fae142be1577b8109e4aa5949f2af8dd52fc5198050abfdbc77d2b` |
+|  `latest-dev` | November 9th | `sha256:bc379f2d149fa8e4d0d9ab0616cb693747be235353939dfdafe37cf627166f0e` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:c95791201160e92c1a71e534a770138d57c0667ec35b5e4bc9590a0ad02ccd88` |
-|  `latest`     | October 30th | `sha256:95bc3009ae4424e070f4d6cf9c5f418c7754f7656978ccfb48932b02f4ae64c3` |
+|  `latest`     | November 9th | `sha256:74d1e0cfa97986af8bcec867a0ebb000623ee5e9c0f55e2b417c2d45865ce3b9` |
+|  `latest-dev` | November 9th | `sha256:0e6090b6b0cc23d126b5edd4eaf47222750d8ef1240078e3d13bd22d0a93acab` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-resizer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-resizer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:73a7a8a386516764ff96c17a02a11195206b8a11f7492e33d9e3a61eb3993330` |
-|  `latest`     | October 30th | `sha256:e0e80d5eb93a2d8fd68273b567d51ae369028e987b62edca245f565a49c9f739` |
+|  `latest-dev` | November 9th | `sha256:8a1c4424fbd6afa707a89d851084762cf47df09c34422462e2ff41caac8e568d` |
+|  `latest`     | November 9th | `sha256:155e575d398f7560beb6cdd96c7d4eb58b636ac9ae9bd878250e83c8ca1ae613` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:15fb293d5fdf2f4160cbbd834c7e55d88ea897c39b469c195ce7f378bb7153b9` |
+|  `latest` | November 9th | `sha256:94a37303f0ffa380cdb6f03ec5328bfaef9b2326cf9cd568bbd0d7e85b8380e8` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshotter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshotter/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:39081896ff13506d20d55d74973e1c5b0d7488d22ea4085b2fbaa779a11ec32c` |
+|  `latest` | November 9th | `sha256:0498632476e6479329132cdbd8c911ea2e9cfcb74e6fbe9c82b7af465b2ea618` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-node-driver-registrar/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-node-driver-registrar/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 4th | `sha256:ebed8a0458afd3f9bca2d1846ba2d0cfa981f345fae9a79235ad9e06d17afe74` |
+|  `latest` | November 9th | `sha256:bf0789a0186e67c5cf333946eedd19d7c4d0f9932187f28c3c61ab33490af50b` |
 

--- a/content/chainguard/chainguard-images/reference/melange/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/melange/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:8a631be177446eceff6774fe8523bc3e54b808014770cf9456b5178cea8d22df` |
+|  `latest` | November 9th | `sha256:6e801711ebb43220a55e1079500a464080669c90580186c1f69adf2060eaa26d` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:9e912c89e517900ecafd36de77db4f05f167c8685201aedbbf686cb73d0d41e3` |
-|  `latest`     | November 9th | `sha256:0375b8d3a58ac821b968b5a9fe4c72e5323597bd540b9a934220024f62e46877` |
+|  `latest-dev` | November 9th | `sha256:6078eac65898e0a0b655cbc4fb268c6c1b52781b928ca215852a93a38cd07eb0` |
+|  `latest`     | November 9th | `sha256:960cf65d381f052ef7e7cc99ab5830a71c243dc85692e3ee6ae6a087d910a583` |
 

--- a/content/chainguard/chainguard-images/reference/postgres/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/postgres/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:dcf1284cce2c9d0fe6279294334dd027b3fdbc2aee13b4dcd64dd4b0cbee1a27` |
-|  `latest`     | November 7th | `sha256:e923d936f12349c0ee48ab7e913ea44adfd6732643baab31d7f880f956eed0a8` |
+|  `latest`     | November 9th | `sha256:56bafd6fedcf9d95c761adcff88834d8f7ff9b8cc5a4601a47477227738fd31f` |
+|  `latest-dev` | November 9th | `sha256:ce5582db3fe6efdae9d7f7463b01e0564364931b93a7712e7d36b235bda87634` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-pushgateway-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-pushgateway-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:52ca203f3110fd9fce3272f0794350bb1a934113faecbc30845d172ddb0f18d8` |
-|  `latest`     | October 30th | `sha256:3469708f5cc42883865fbe439a543ddabb9af9aa6746b00f7bd9371ebf32b9bb` |
+|  `latest-dev` | November 9th | `sha256:e91970d208a7680b5ac8349d2f448c8839e8ef8841163c7c6d5ece38b1bc0032` |
+|  `latest`     | November 9th | `sha256:9ca86c4c313e46c41b822b0ca58522f9bf7c8a4db0481684256d306f5df8cd92` |
 

--- a/content/chainguard/chainguard-images/reference/pulumi/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/image_specs.md
@@ -52,6 +52,7 @@ The table shows package distribution across variants.
 | `build-base`              | X      |
 | `busybox`                 | X      |
 | `c-ares`                  | X      |
+| `ca-certificates`         | X      |
 | `ca-certificates-bundle`  | X      |
 | `dotnet-7`                | X      |
 | `dotnet-7-runtime`        | X      |
@@ -95,6 +96,7 @@ The table shows package distribution across variants.
 | `libssl3`                 | X      |
 | `libstdc++`               | X      |
 | `libstdc++-dev`           | X      |
+| `libtasn1`                | X      |
 | `libunwind`               | X      |
 | `linux-headers`           | X      |
 | `lttng-ust`               | X      |
@@ -122,6 +124,8 @@ The table shows package distribution across variants.
 | `openssh-server-config`   | X      |
 | `openssh-sftp-server`     | X      |
 | `openssl-config`          | X      |
+| `p11-kit`                 | X      |
+| `p11-kit-trust`           | X      |
 | `pkgconf`                 | X      |
 | `posix-cc-wrappers`       | X      |
 | `pulumi`                  | X      |

--- a/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 3rd | `sha256:ae3718f286412404dcf8127bbfd5f179672104bcf69298ca758bb35e7614c531` |
+|  `latest` | November 9th | `sha256:43fd6286ce6879a64dc12cd84d1342d98b9537a7f1549b0e109190f24ccc482a` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:097902c8a8090860a09ca22d617905fc035df637c233cdef4aa47e5f2a38ad77` |
+|  `latest` | November 9th | `sha256:a0dfc184d757d2b819c227338a986c00e91cf0361d87260c074a817faa180424` |
 

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-cli/_index.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-cli/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Image Overview: timestamp-authority-cli"
+linktitle: "timestamp-authority-cli"
+type: "article"
+layout: "single"
+description: "Overview: timestamp-authority-cli Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-cli/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+## Sigstore timestamp-authority
+
+timestamp-authority is one of the core components of the sigstore stack.  For more information
+on this see [`sigstore-scaffolding`](../sigstore-scaffolding/).
+

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs.md
@@ -1,0 +1,71 @@
+---
+title: "timestamp-authority-cli Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public timestamp-authority-cli Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **timestamp-authority-cli** Image.
+
+## Variants Compared
+The **timestamp-authority-cli** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev               | latest                   |
+|--------------|--------------------------|--------------------------|
+| Default User | `nonroot`                | `nonroot`                |
+| Entrypoint   | `/usr/bin/timestamp-cli` | `/usr/bin/timestamp-cli` |
+| CMD          | not specified            | not specified            |
+| Workdir      | not specified            | not specified            |
+| Has apk?     | yes                      | no                       |
+| Has a shell? | yes                      | no                       |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                           | latest-dev | latest |
+|---------------------------|------------|--------|
+| `apk-tools`               | X          |        |
+| `bash`                    | X          |        |
+| `busybox`                 | X          |        |
+| `ca-certificates-bundle`  | X          | X      |
+| `git`                     | X          |        |
+| `glibc`                   | X          |        |
+| `glibc-locale-posix`      | X          |        |
+| `ld-linux`                | X          |        |
+| `libbrotlicommon1`        | X          |        |
+| `libbrotlidec1`           | X          |        |
+| `libcrypt1`               | X          |        |
+| `libcrypto3`              | X          |        |
+| `libcurl-openssl4`        | X          |        |
+| `libexpat1`               | X          |        |
+| `libnghttp2-14`           | X          |        |
+| `libpcre2-8-0`            | X          |        |
+| `libssl3`                 | X          |        |
+| `ncurses`                 | X          |        |
+| `ncurses-terminfo-base`   | X          |        |
+| `openssl-config`          | X          |        |
+| `timestamp-authority-cli` | X          | X      |
+| `wolfi-baselayout`        | X          | X      |
+| `zlib`                    | X          |        |
+

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info.md
@@ -1,0 +1,85 @@
+---
+title: "Provenance Information for timestamp-authority-cli Images"
+type: "article"
+unlisted: true
+description: "Provenance information for timestamp-authority-cli Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying timestamp-authority-cli Image Signatures
+The **timestamp-authority-cli** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/timestamp-authority-cli | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading timestamp-authority-cli Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the timestamp-authority-cli image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the timestamp-authority-cli image on `unix/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/timestamp-authority-cli | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying timestamp-authority-cli Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the timestamp-authority-cli image attestations:
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard/timestamp-authority-cli
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/timestamp-authority-cli --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "kubernetes-csi-external-snapshot-controller Image Tags History"
+title: "timestamp-authority-cli Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the kubernetes-csi-external-snapshot-controller Chainguard Image"
+description: "Image Tags and History for the timestamp-authority-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-cli/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:5f9ca3c1d4041bea0fe4216e671e82e315fc953211a2cfa84d2e8b50acfb3acd` |
-|  `latest`     | November 9th | `sha256:5a085b3d1e74d8525f0c758bb666c6efa00bd05ac99ae8439dd3b67d94d7402d` |
+|  `latest`     | November 9th | `sha256:e026b9b1dd6b24d8db7ed2a1d622240e1d1e1164ddf27f7b826c04b670cefea7` |
+|  `latest-dev` | November 9th | `sha256:eb89381f7a855e8e9400109b26961ef01444f5cf533ec6aac4a937c02a0d8948` |
 

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-server/_index.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-server/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Image Overview: timestamp-authority-server"
+linktitle: "timestamp-authority-server"
+type: "article"
+layout: "single"
+description: "Overview: timestamp-authority-server Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-server/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+## Sigstore timestamp-authority
+
+timestamp-authority is one of the core components of the sigstore stack.  For more information
+on this see [`sigstore-scaffolding`](../sigstore-scaffolding/).
+

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs.md
@@ -1,0 +1,71 @@
+---
+title: "timestamp-authority-server Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public timestamp-authority-server Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **timestamp-authority-server** Image.
+
+## Variants Compared
+The **timestamp-authority-server** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                  | latest                      |
+|--------------|-----------------------------|-----------------------------|
+| Default User | `nonroot`                   | `nonroot`                   |
+| Entrypoint   | `/usr/bin/timestamp-server` | `/usr/bin/timestamp-server` |
+| CMD          | not specified               | not specified               |
+| Workdir      | not specified               | not specified               |
+| Has apk?     | yes                         | no                          |
+| Has a shell? | yes                         | no                          |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                              | latest-dev | latest |
+|------------------------------|------------|--------|
+| `apk-tools`                  | X          |        |
+| `bash`                       | X          |        |
+| `busybox`                    | X          |        |
+| `ca-certificates-bundle`     | X          | X      |
+| `git`                        | X          |        |
+| `glibc`                      | X          |        |
+| `glibc-locale-posix`         | X          |        |
+| `ld-linux`                   | X          |        |
+| `libbrotlicommon1`           | X          |        |
+| `libbrotlidec1`              | X          |        |
+| `libcrypt1`                  | X          |        |
+| `libcrypto3`                 | X          |        |
+| `libcurl-openssl4`           | X          |        |
+| `libexpat1`                  | X          |        |
+| `libnghttp2-14`              | X          |        |
+| `libpcre2-8-0`               | X          |        |
+| `libssl3`                    | X          |        |
+| `ncurses`                    | X          |        |
+| `ncurses-terminfo-base`      | X          |        |
+| `openssl-config`             | X          |        |
+| `timestamp-authority-server` | X          | X      |
+| `wolfi-baselayout`           | X          | X      |
+| `zlib`                       | X          |        |
+

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info.md
@@ -1,0 +1,85 @@
+---
+title: "Provenance Information for timestamp-authority-server Images"
+type: "article"
+unlisted: true
+description: "Provenance information for timestamp-authority-server Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying timestamp-authority-server Image Signatures
+The **timestamp-authority-server** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/timestamp-authority-server | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading timestamp-authority-server Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the timestamp-authority-server image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the timestamp-authority-server image on `unix/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/timestamp-authority-server | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying timestamp-authority-server Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the timestamp-authority-server image attestations:
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard/timestamp-authority-server
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/timestamp-authority-server --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "kubernetes-csi-external-snapshot-controller Image Tags History"
+title: "timestamp-authority-server Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the kubernetes-csi-external-snapshot-controller Chainguard Image"
+description: "Image Tags and History for the timestamp-authority-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/timestamp-authority-server/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:5f9ca3c1d4041bea0fe4216e671e82e315fc953211a2cfa84d2e8b50acfb3acd` |
-|  `latest`     | November 9th | `sha256:5a085b3d1e74d8525f0c758bb666c6efa00bd05ac99ae8439dd3b67d94d7402d` |
+|  `latest-dev` | November 9th | `sha256:aa4f8fad329c4b1549ecbff5d4c066bd813dcbcc9bcb3bd717b1fbd5502aa500` |
+|  `latest`     | November 9th | `sha256:d0e70b771b6f6ee72c215dec8aa6e1aa979643893e4f22264a1910e96d77c352` |
 


### PR DESCRIPTION
New images added:

- timestamp-authority-cli
- timestamp-authority-server

Updated Docs:

- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- aws-for-fluent-bit/tags_history.md
- aws-load-balancer-controller/tags_history.md
- buck2/image_specs.md
- buck2/tags_history.md
- calico-node-driver-registrar/tags_history.md
- dex/tags_history.md
- external-dns/tags_history.md
- fluent-bit/tags_history.md
- fluentd/tags_history.md
- gitlab-exporter/tags_history.md
- grype/tags_history.md
- haproxy/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kubernetes-csi-external-attacher/tags_history.md
- kubernetes-csi-external-provisioner/tags_history.md
- kubernetes-csi-external-resizer/tags_history.md
- kubernetes-csi-external-snapshot-controller/tags_history.md
- kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
- kubernetes-csi-external-snapshotter/tags_history.md
- kubernetes-csi-node-driver-registrar/tags_history.md
- melange/tags_history.md
- newrelic-fluent-bit-output/tags_history.md
- postgres/tags_history.md
- prometheus-pushgateway-bitnami/tags_history.md
- pulumi/image_specs.md
- pulumi/tags_history.md
- slim-toolkit-debug/tags_history.md