### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,44 @@
+# 2023-11-11
+
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- fluentd/tags_history.md
+- gitlab-exporter/tags_history.md
+- gitlab-shell/tags_history.md
+- google-cloud-sdk/tags_history.md
+- ingress-nginx-controller/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kube-state-metrics/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kyverno/tags_history.md
+- kyverno-background-controller/tags_history.md
+- kyverno-cleanup-controller/tags_history.md
+- kyverno-cli/tags_history.md
+- kyverno-reports-controller/tags_history.md
+- kyvernopre/tags_history.md
+- metrics-server/tags_history.md
+- nats/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- newrelic-k8s-events-forwarder/tags_history.md
+- postgres/tags_history.md
+- prometheus-config-reloader/tags_history.md
+- prometheus-operator/tags_history.md
+- ruby/tags_history.md
+- semgrep/tags_history.md
+- skaffold/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- spire-agent/tags_history.md
+- spire-oidc-discovery-provider/tags_history.md
+- spire-server/tags_history.md
+- tekton-cli/tags_history.md
+- timestamp-authority-cli/tags_history.md
+- timestamp-authority-server/tags_history.md
+
 # 2023-11-10
 New images added:
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:aad4aa09c6a4a2e772ec8f934d17d0c4ba31d6b9ecca5d1770e03cdee23c2ac7` |
-|  `latest`     | November 9th | `sha256:4aec0d940828925ad895e6310b0e44696fec40e3e717460fc3cc2d170d8b3b0a` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:2d7ec00ee706b99986b6eb9c24005bbd17bb76add1ec8a923e5dee8410f1552e` |
+|  `latest-dev` | November 10th | `sha256:6161b9417082da18c69068224d835a0196b6f3dd6636ad185a57c3422bd37410` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:fca106d3d4896527926cb46f629f0fb2d0e9b564ae8afb8cb0a49dc0665fc3a2` |
-|  `latest-dev` | November 9th | `sha256:c5788f6bc05ce85b9947f13190081c5d3548519f1e035faad8f700023a04d37f` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:66c4b4a154a6b960907157a594abd49947de73c66c5061c5cfc934412e2c6abc` |
+|  `latest`     | November 10th | `sha256:4f3ab805a09dd1263a0b7f657cf30e9b8a8cddac9236c9fe5ca262feb880ec12` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -23,10 +23,10 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)              | Last Changed | Digest                                                                    |
-|----------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev`        | November 9th | `sha256:057def37228842b912bf7f2c8292b6f1b7423f3a0e6131a94bef16da6f6e06a1` |
-|  `latest`            | November 9th | `sha256:e23738519f25a91ca899ca6775d1671ee4ad4c410470b809d793ad52c3154cec` |
-|  `latest-splunk`     | November 9th | `sha256:b4f36befa0a61073819733ee5e8967fe1476547e7745141dc6f429202954d3ca` |
-|  `latest-splunk-dev` | November 9th | `sha256:74b8821854e29d0c0abc3af0081ec6348f739fdb03924f6f45b9d58f552ed270` |
+| Tag (s)              | Last Changed  | Digest                                                                    |
+|----------------------|---------------|---------------------------------------------------------------------------|
+|  `latest-splunk-dev` | November 10th | `sha256:9d310a9948a20d51cd425683699001f1decf7eb43788dc69859046fc4c0892e0` |
+|  `latest`            | November 10th | `sha256:e78ccf33f6f09bb0f8d118c47f87e08f984bf174f301ebd673400af1a1b446d5` |
+|  `latest-dev`        | November 10th | `sha256:c00c23ee98294e14125bda6b3694cad50da4d6c9ff1cd924b89489c4a2fd370d` |
+|  `latest-splunk`     | November 10th | `sha256:042d834920b71617ae78acb8169e6f56ceaf565336249244add374691dea7631` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:0f2e054a8c5f24fb312a2ce068327ca84064cf98703a075aa613d5f927260018` |
-|  `latest-dev` | November 9th | `sha256:abf295ae67fe9e063e3f2741d29e5dbbee877dceccd6d9a3019c9ef5565a8998` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:9d0ecf55e4e6a64a12ad71b68adbdbe7b6eb8a438684fa5ac2264f85bb510ebf` |
+|  `latest-dev` | November 10th | `sha256:4c0e929e03dd7b9e6dee11144f4a146f865363e478c6501046538b32fd706874` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:08129784e36d3b09a0e757fbb352fe97055ee30c781759f2fa103935075722ed` |
-|  `latest`     | November 7th | `sha256:03acf42744765178d06643003560197032ee166774013e8a89c868e5b57b9d8c` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:0f80dda4a7db21c2a349ba6de385037253008a788555417eb617f4b85cf1e1d7` |
+|  `latest`     | November 10th | `sha256:021a8ecec9c679181c196084ee3eeb31a2ab240c80f7f255d24881bbb93b89b3` |
 

--- a/content/chainguard/chainguard-images/reference/google-cloud-sdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/google-cloud-sdk/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:e1c648fff2a8658b409c41b4aa3d990578e7a05f51e40c12ffac50b00d397f0f` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:d91ae17591b7bb5ae8ae4c49fd8588accc028b39471f6653ca702d337527dac1` |
 

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 8th | `sha256:c24d5a50c0bc504f1d4f03aa68c7c1018265f7fe79b27b1e5041421562c9dd93` |
-|  `latest-dev` | November 8th | `sha256:3ca5691a0b46b6ad88eee3bb5b7f70a8776407472e12f332a438477e15163590` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:a331c18d4b188ed9b143cfc0062ed7b5d6ef6a04ae91aee555fc0358ba717b31` |
+|  `latest`     | November 10th | `sha256:d6cb0733f36d9e58d54b225a60d159d05d5acaf69c4a290345dec1c06b21a6af` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:1fe207e2bb2d7223ab252c2c70009d9f627fd02b530ca3348be961d412d8e948` |
-|  `latest`     | November 9th | `sha256:88d124b7f003f39f44311654c0cf47c944bad4fe92931b8f653e41acd358029d` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:bfba5eea5fc262ec80c796bd08323f73bb75dab935d8f8180c7231a0c3218286` |
+|  `latest-dev` | November 10th | `sha256:316a45f58da97ecd048a786e3a05aab77d93a1203db736b9dc3e68baaa0aeac5` |
 

--- a/content/chainguard/chainguard-images/reference/kube-state-metrics/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-state-metrics/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:7577cb9f0259f7e23882058c4f303c9b831cdf796a5e147579eb765b9d27b053` |
-|  `latest`     | October 30th | `sha256:b90a220662f94b08a75e644640b374b253282c27ad1ff566c8c336051b88b0a3` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:10a00a3940e129d188276ccc94314267ef2628c4d368d7074205d9023d139efd` |
+|  `latest`     | November 10th | `sha256:3e29688126c13479b90d590f61de01378bd37eec83342aaf3066185e47819758` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:5b987381cfab3866a0e99eba27ff2297dddf796c0414b97ced5c86af4e3e4e04` |
-|  `latest`     | November 7th | `sha256:aa4e297df81497a2f989f865fc7d7923128c7015909530e886dfe9edd3ad34d7` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:b85541a8aa1f7421e8bf9b6e172fa217277dced2a889fc577fec505fbabf5081` |
+|  `latest-dev` | November 10th | `sha256:5f2ca6472e4b8c3220f5210b7452f92592053a66d0e947dd575132688cf35f86` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 7th | `sha256:dfbea1a400c25288f792b9e55532aca351567bd2df0fa9620202d9cb8688b3a3` |
-|  `latest-dev` | November 7th | `sha256:e7732973969138d82cf5e5d27b9647c8b3b8b176588fe581ec400f98bfae1b82` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:48ad89078e1c8a9680224f3643c9dfde1019e0dd4abfa6034d136f44bd565942` |
+|  `latest`     | November 10th | `sha256:3801226cfd39413d6fef4aacfe253339653fbc19e06039a7336d5cf35a3942a7` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 7th | `sha256:d09eea93c4073b05db0c16687a26c7b52a64d7968032ff8bde49643e0ae1622c` |
-|  `latest-dev` | November 7th | `sha256:c4a8a42ebb067248cfa11231f46b376a93a3f44d08a616372dfebdfd50927243` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:fdd306448c2341f3b02380ad885d8d1f3ee8286d9f2a1b5c138882c7da4a461b` |
+|  `latest`     | November 10th | `sha256:365c867729d3a9e6280690578de0edba81d0762cea6969fe152a461c80f213c1` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:c11f596ab8aa78f3b960766212488531c6726b170fbb1772c5c56a5729dedc5f` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:f081d807dd76907b92b119e78ad1e1ecde87f63223366076511fad519795c267` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:59c38da06bda8aa121385f54ca277d57fc79998beef7e86d437d2b3e3fcc2363` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:0b2f1645b5acf7f2f1d3ee11cf3f22905c4a2fa4237b4a3c16ce64d204cced22` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:31ddf6eb2b76520daffbae3f89b798eb31be82c1f372dfb0a1e40e7060364577` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:2fec072d1f2c59267c9ff15cfa5e5387237951773572051c282cc510c5f6c0ea` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:a30949fc5be614721cf0267f212739307402542da888c7efe2410203ce7de3b6` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:ee40b882eeb95a429e8c412ccb62277aa4bfbd53ba2d272c57734caf64408aae` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:699486317aa19b3680a082bffd5984857d42c140c7e1d7ea381cafd697ec177b` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:0fdcb5af6d757ec187b9ba45c2206f995988a3bb5bfd227b5ae8652aa3e35dc6` |
 

--- a/content/chainguard/chainguard-images/reference/kyvernopre/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyvernopre/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:bd7a925391b59066751d35a6cee0182d46981818675fd44aeb2fde0fa706550f` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:09b1552d6a96e75711428d8da31f54372fc2736e045d3aefbb2f2d2b9aaf3b29` |
 

--- a/content/chainguard/chainguard-images/reference/metrics-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/metrics-server/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:f6d6bb2bb6f7a4c6c9f215e7dbe95420bc9f8cd604f5b5a7eabf41c2822347f2` |
-|  `latest`     | October 30th | `sha256:e53f4dc89f6a9b303a69bfd2944f154bb6ba2360ace477b373df4999542cc16c` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:1bdfb9b95022ac950390673274199523fda69a51f8cffcd73f1ab0e4c8ed9914` |
+|  `latest`     | November 10th | `sha256:6700fd22b02968510d0bc78bd346e439fd1e9868b761089cb43b756e698d2b8c` |
 

--- a/content/chainguard/chainguard-images/reference/nats/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nats/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:6f18cd8197c1512f09f5e482202d35ff2bdc61ba71923771392a0966635027b0` |
-|  `latest`     | October 30th | `sha256:f41750d8183d509af29c9c46487eee3067ff2b7687f3170d30d14a610958599b` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:c27fe2275fdc6ec29c651fe61a9053cdd69d00559d09c5f03dbd54a6915c422a` |
+|  `latest`     | November 10th | `sha256:43cb4a5b782172a7ad9a012dfe8b6b0fd98d00001a51cc99e54f3b34155fc06f` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:2f5c0ca4f215f8ebe903817a1f86925f147f7e2f0839d699459db1c54f303cfb` |
-|  `latest-dev` | November 9th | `sha256:7a46493def220fb8d02a88756698c947ebcad30da58d38cbb29d844684fa6064` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:26f8d3a428b246297673c670b0858f89dd2d01c8cc970f0862a779dc753a99a5` |
+|  `latest-dev` | November 10th | `sha256:e28e9a342e3a5470b35a9f957d9b6b8b5213c2b9de34e0414c2521ec0a113294` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-k8s-events-forwarder/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-k8s-events-forwarder/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:d5f372c9c3a6c7aa9dcac26f165d32d45ccf66d30500d54b7805373a7183e19e` |
-|  `latest`     | November 7th | `sha256:9f0ff4b61405c35a4b76dca215b5c9504a68c649e28a3f0be6c92ae0465e2ff2` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:78a886e02056ae31253367144d92ba9b4fef90340f004116353a333adf05647b` |
+|  `latest`     | November 10th | `sha256:9a39a40b9c4307fa943a0765394e93173451f84b6303a714364bc651a7d687f5` |
 

--- a/content/chainguard/chainguard-images/reference/postgres/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/postgres/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:56bafd6fedcf9d95c761adcff88834d8f7ff9b8cc5a4601a47477227738fd31f` |
-|  `latest-dev` | November 9th | `sha256:ce5582db3fe6efdae9d7f7463b01e0564364931b93a7712e7d36b235bda87634` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:859e00b4628621babb29b1ffc54c0193a75cba8dba5169e7da1b88084eaa3f77` |
+|  `latest`     | November 10th | `sha256:343c1b4ce6ea5a0e84794c4230462e4b8c8699be2ac2c116d37691b27bc7e0b7` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-config-reloader/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-config-reloader/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 8th | `sha256:fae178252f880842b8f3aed4e1b71348d4e79b8d62cd959f077773d591912593` |
-|  `latest-dev` | November 8th | `sha256:d3aecb2206389745b31ea5bc2fb8b25e0931c49f0aa5d1f96a234fcaaced0bdb` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:9bc1180380b0e3ae631ca87a1540a595ecf7fe330d50c473ac270c320f02a61e` |
+|  `latest`     | November 10th | `sha256:c128598b3a0fd5b7c2b8de6079eb051ce9c290e0d05c1a7a6fc49007a180dc9f` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-operator/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 8th | `sha256:742ecab5bfc7b0b74e60b06f5438d06bd0f6a330538e85a2fd3f21967ee2c4a5` |
-|  `latest`     | November 8th | `sha256:358e5f9f8db491b9d936525ef60b3843da2b92d53ae3f7c5cb52a0d7cc65734b` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:2bbdce268f8146d50bf3d9e6bf44bd0cf9b154105d8b2df08227a962f41882fa` |
+|  `latest-dev` | November 10th | `sha256:32af4ef7b9ae2486fbd84d43e03a82bbcfa74277ffa0a55df73be0ca981098e7` |
 

--- a/content/chainguard/chainguard-images/reference/ruby/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ruby/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:25f9bcf130898944b217ed2dc2f4aa9d3778fe53cf19abfc4c8d6670c96f9a5c` |
-|  `latest`     | November 7th | `sha256:b8e032b6f59dc5ee52afebec8f016a9fe540604f195d5e6b3910841fff1105ce` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:13116e6ba994523d27787ba5aa513074f42cf7a2372bc05fd36f4ccff6c16dc0` |
+|  `latest`     | November 7th  | `sha256:b8e032b6f59dc5ee52afebec8f016a9fe540604f195d5e6b3910841fff1105ce` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:7adcbbbb77f42433339f29d7dd58029c0c61d8d5f0cd3e09bdba5fc4377a43a6` |
-|  `latest-dev` | November 9th | `sha256:549cbe1bb2924ab1bed319fa6eac7c4ec385054b9eea71c3ba73ffcc2a2bfcd5` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:7e27d4a7f7318c08e92f8aa4466ad88e3d6990412add571f3886ddf728020821` |
+|  `latest`     | November 10th | `sha256:ab9eb033600a3b5f0ab0af163306c6c8ee2d1eb98356cd64298fd6af16a3e1db` |
 

--- a/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:e95d0ce2fdaa453866d03129c1cd4f9184ef25ae28a51a2f151f6b2ac53af0c0` |
-|  `latest`     | November 9th | `sha256:4f26d3bd6a4c9a4ffdd4dcca557cf82e0e02e5e126cc2801aa19139ad0694c73` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:21177e5b72a64d4ff2c9fc588994979b1c35e8dc44d6e532d40b6beef682effb` |
+|  `latest-dev` | November 10th | `sha256:143e86d91dc187af20bce9b72b693b8a7a93489250dc5c9e291e15a8200ba6a8` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 9th | `sha256:a0dfc184d757d2b819c227338a986c00e91cf0361d87260c074a817faa180424` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 10th | `sha256:8385c83ca13b36e05df0b7c7d3d9635b9d61cb8963af972471a09e304152c3c8` |
 

--- a/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:add4a1c7936bdb57e331cf97f462f804d8ab417b6504e59d58158bf67680076e` |
-|  `latest-dev` | November 9th | `sha256:662d10fcdb5c18d6aff9cb146e682b9d516a50ce2f1bd64b65124c6504d01ea0` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:7db4ec4f6ec06f075633f755fe9fd0fe39e3b9fe66b88f5b9afe16bcdfdbbad2` |
+|  `latest`     | November 9th  | `sha256:add4a1c7936bdb57e331cf97f462f804d8ab417b6504e59d58158bf67680076e` |
 

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:7bebcdf989ff2883eb61a4ae06f69552cf9e02741fe560312aa806c23c9f03b5` |
-|  `latest`     | November 9th | `sha256:d82b65494e2ab13f586509543649b686477385a7d5d5619aa15dcb81f720b705` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:89e3a67fc2da9e2f6aa4e8b817cd11bc1e372b9c52c047621b6a9d9ecda63926` |
+|  `latest`     | November 9th  | `sha256:d82b65494e2ab13f586509543649b686477385a7d5d5619aa15dcb81f720b705` |
 

--- a/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:23ea3b6d8f36c077c478492844d08491f0e89332e9ae86e73a2bd897d1fef640` |
-|  `latest`     | November 9th | `sha256:b7a402da33ac5988f5e8892b3b3ab250fc407134f3b3628fd366d432a80548f4` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:1e140a2d3e6ebc49ea465efa73fad5395a3bc0055a0f7e72374ca44c361fd543` |
+|  `latest`     | November 9th  | `sha256:b7a402da33ac5988f5e8892b3b3ab250fc407134f3b3628fd366d432a80548f4` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-cli/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:a9e7b78b3f6410ce4b9db36ffabca168dcf1ef4a93fb914bec8bf3bf04dcc581` |
-|  `latest`     | October 30th | `sha256:1fdfd27767151feff4c267bdef6bfdaf98f0effc71bcfe3b52d8b8e0afc711d0` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:d98fa1c31d690827a8a8c93147a7cdac71691a8053c959d26ced03a5c4ca2f2f` |
+|  `latest-dev` | November 10th | `sha256:b8d480d8a2b1d818cce4bdb67b5d5c8e81d6a042029177bee88750df8a82e84b` |
 

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-cli/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 9th | `sha256:e026b9b1dd6b24d8db7ed2a1d622240e1d1e1164ddf27f7b826c04b670cefea7` |
-|  `latest-dev` | November 9th | `sha256:eb89381f7a855e8e9400109b26961ef01444f5cf533ec6aac4a937c02a0d8948` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 10th | `sha256:d3c7d15e14438d0cd15f82454ed16a92fbfbb7c8ac415330152b4dea1544a079` |
+|  `latest`     | November 10th | `sha256:6d20fb8ca0ee2c4c6d1c96df25046f0e6359d07b7c4633e1cc3e5f8c6bdb7cc8` |
 

--- a/content/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timestamp-authority-server/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:aa4f8fad329c4b1549ecbff5d4c066bd813dcbcc9bcb3bd717b1fbd5502aa500` |
-|  `latest`     | November 9th | `sha256:d0e70b771b6f6ee72c215dec8aa6e1aa979643893e4f22264a1910e96d77c352` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | November 10th | `sha256:fd523df5207a03e09d5acf2c9a509c858b65799bcbb7a3216ac5b83fc09e80e3` |
+|  `latest-dev` | November 10th | `sha256:f2f904dd17f7cfbb5262ee318a4e81e813a892f29594b6427e9425cad6069a16` |
 


### PR DESCRIPTION
Updated Docs:

- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- fluentd/tags_history.md
- gitlab-exporter/tags_history.md
- gitlab-shell/tags_history.md
- google-cloud-sdk/tags_history.md
- ingress-nginx-controller/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kube-state-metrics/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kyverno/tags_history.md
- kyverno-background-controller/tags_history.md
- kyverno-cleanup-controller/tags_history.md
- kyverno-cli/tags_history.md
- kyverno-reports-controller/tags_history.md
- kyvernopre/tags_history.md
- metrics-server/tags_history.md
- nats/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- newrelic-k8s-events-forwarder/tags_history.md
- postgres/tags_history.md
- prometheus-config-reloader/tags_history.md
- prometheus-operator/tags_history.md
- ruby/tags_history.md
- semgrep/tags_history.md
- skaffold/tags_history.md
- slim-toolkit-debug/tags_history.md
- spire-agent/tags_history.md
- spire-oidc-discovery-provider/tags_history.md
- spire-server/tags_history.md
- tekton-cli/tags_history.md
- timestamp-authority-cli/tags_history.md
- timestamp-authority-server/tags_history.md