### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,22 @@
+# 2023-11-13
+
+
+Updated Docs:
+
+- aws-ebs-csi-driver/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- bazel/tags_history.md
+- buck2/tags_history.md
+- busybox/tags_history.md
+- cadvisor/tags_history.md
+- ffmpeg/tags_history.md
+- git/tags_history.md
+- guacamole-server/tags_history.md
+- k3s-allinone/tags_history.md
+- kube-fluentd-operator/tags_history.md
+- kubeflow-jupyter-web-app/tags_history.md
+- kubeflow-pipelines-viewer-crd-controller/tags_history.md
+
 # 2023-11-12
 
 

--- a/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:beb60c284d94e5f9fb2bd329d31ef4dff5cbecf072f158ec7739d51796da9bc6` |
-|  `latest`     | October 30th  | `sha256:22379c74c143abaf58de3ccf084cf80d10e9f4073185567f3ab3948ad0af81d6` |
+|  `latest`     | November 12th | `sha256:00045d6f2cb056f5472f39b3257bfe2cd1c9ce3df0094262e85c43f62e7bb8e7` |
+|  `latest-dev` | November 12th | `sha256:3c23bec7b45aed6322e218a6a2f5d5c534876ded1c35b9f3e5da752a95cf3f5e` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 10th | `sha256:66c4b4a154a6b960907157a594abd49947de73c66c5061c5cfc934412e2c6abc` |
-|  `latest`     | November 10th | `sha256:4f3ab805a09dd1263a0b7f657cf30e9b8a8cddac9236c9fe5ca262feb880ec12` |
+|  `latest`     | November 12th | `sha256:9f6ceffcac7c31c874fafb867c6e4cefcfa9d4508a2e50bf6559a3b16c696178` |
+|  `latest-dev` | November 12th | `sha256:9ad8d6d57fb3f408b4d372a98499beca2d74aef717b7e5db8fc4d88b3cd4c802` |
 

--- a/content/chainguard/chainguard-images/reference/bazel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/bazel/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 9th | `sha256:fcb97f9cdccedccd168baa53f559e12c8e7e36bd7181772432702b5b6ad07451` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 12th | `sha256:e907a23f716a9826e642f0eb38c829bfd73aac055851eedb7cfe56e193a2e2c6` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 9th | `sha256:e2448998089b170e125b388a5100317af898a2b090f91efc4774f6ea57dd946c` |
-|  `latest`     | November 9th | `sha256:daa6accab817b2a82e3d85398cc64d8dbcf6491dda7f233adf56bac75e8f0c15` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 12th | `sha256:0e4ac99f4dba4430507e454936d4c53b3e7b3d9a0ac9cc38d14a37193ab2d816` |
+|  `latest`     | November 12th | `sha256:5defb3fcd163d4505ede4a589bc3817f705955a255711fd5890f95e89d78afc2` |
 

--- a/content/chainguard/chainguard-images/reference/busybox/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/busybox/tags_history.md
@@ -23,9 +23,9 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)                                               | Last Changed | Digest                                                                    |
-|-------------------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest`                                             | November 8th | `sha256:c8cfa476e08837f87fc53959debb6127878feebd4f6d5f93b70017520ad36954` |
-|  `1.36` `1` `1.36.1`                                  | November 3rd | `sha256:d6a7ed7843540fc638e70069e3b75f8422ac3d871162518abb5cbd0ee4bd1d38` |
-|  `glibc-1` `latest-glibc` `glibc-1.36.1` `glibc-1.36` | October 30th | `sha256:8e3662a12cc913bc5d2aec46333589f4823910ef9560d8763f1fb04b2923aff1` |
+| Tag (s)                                               | Last Changed  | Digest                                                                    |
+|-------------------------------------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest`                                             | November 12th | `sha256:0b4a9d13098b4546a52f3e173527ced1dbc85bff4bac73e526782649276beed7` |
+|  `1.36` `1` `1.36.1`                                  | November 3rd  | `sha256:d6a7ed7843540fc638e70069e3b75f8422ac3d871162518abb5cbd0ee4bd1d38` |
+|  `glibc-1` `latest-glibc` `glibc-1.36.1` `glibc-1.36` | October 30th  | `sha256:8e3662a12cc913bc5d2aec46333589f4823910ef9560d8763f1fb04b2923aff1` |
 

--- a/content/chainguard/chainguard-images/reference/cadvisor/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cadvisor/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 7th | `sha256:7a74326f6b284a2ffbf7747855d434c6315480f7f30e88c2f4777dd2569b3a91` |
-|  `latest`     | October 30th | `sha256:96fb7d46227006b52d2f153996f144c33850bf1319023285f6c749ac2a32d270` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 12th | `sha256:f4e2e27d058e4ac41ccddf0222a6843ab2f2f8a314d368b7e14600295139c90b` |
+|  `latest`     | October 30th  | `sha256:96fb7d46227006b52d2f153996f144c33850bf1319023285f6c749ac2a32d270` |
 

--- a/content/chainguard/chainguard-images/reference/ffmpeg/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ffmpeg/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:d11b9096d5ab8d91a55f4ab9145b177e50a902bd3de3b52fe86bca660a069069` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 12th | `sha256:34c09df9720197d069a276e9a3ba6e3b6c155c19a2d94e7794f828bb19c110e4` |
 

--- a/content/chainguard/chainguard-images/reference/git/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/git/tags_history.md
@@ -23,14 +23,14 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)                  | Last Changed | Digest                                                                    |
-|--------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-root-dev`       | November 8th | `sha256:b969be2fda23a14046a4606df538a4f3a8d8b71f0140ee5e45708b5e87c40e84` |
-|  `latest-root`           | November 8th | `sha256:000915c2b501398e6599f6d4b7dc86907f517d11046a43920cb59a8178bc6a69` |
-|  `latest`                | November 8th | `sha256:1bf68691ace95197ea13bbd9e42a03431ea6bda02b5918a2bf1b721bf130aac8` |
-|  `latest-dev`            | November 8th | `sha256:1d80374e81656083971cdd41672806407addfd60f5124f0b8b8c5824dddd21f1` |
-|  `latest-glibc-dev`      | November 7th | `sha256:b9f35cc9ba8d502ac2c41058b01f64a065eba4b479eb73dfda589b109d52bead` |
-|  `latest-glibc-root`     | November 7th | `sha256:7b8cc2438ec722123981e158905c5f51e071b969559a22539ee5550f24e64d8c` |
-|  `latest-glibc`          | November 7th | `sha256:1b8cab44e875a98241980fc93bb78c9083149582a88d7fb07225259be5f269b0` |
-|  `latest-glibc-root-dev` | November 7th | `sha256:eb1b26744e6df379e8b3d86e7c16fc1bcd3b62c327edd208a19cc65828073af1` |
+| Tag (s)                  | Last Changed  | Digest                                                                    |
+|--------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev`            | November 12th | `sha256:31281e045e8ee5ce38b7f45865508ab41cd34d36565be217ec1ae4904491b604` |
+|  `latest-root`           | November 12th | `sha256:5ce1c0cca3014e1a06cad83a506a457adb886f34fd5da59b05ce33f52ebfc36b` |
+|  `latest`                | November 12th | `sha256:c81fb057d751ae1e1baa95ea058ca66213a394215f9fec964c541de92d73f506` |
+|  `latest-root-dev`       | November 12th | `sha256:bddedefb53d5a0f3b927a3346b8fdd1fc816c2ce6b0a4a5c384ddc4b9183bbb4` |
+|  `latest-glibc-root-dev` | November 12th | `sha256:38950630d1097b5dd244c864451050510f0613f6113c66c538597267217bec1d` |
+|  `latest-glibc-dev`      | November 12th | `sha256:084a6ac75538f608d4ab8145a801ae1818b2b12016f5cbbbd0ef63f47dd9befa` |
+|  `latest-glibc-root`     | November 7th  | `sha256:7b8cc2438ec722123981e158905c5f51e071b969559a22539ee5550f24e64d8c` |
+|  `latest-glibc`          | November 7th  | `sha256:1b8cab44e875a98241980fc93bb78c9083149582a88d7fb07225259be5f269b0` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:67274401ca8e3a39c75c660dc2a458567eea8c4c1fb88f5b513df275c0673380` |
-|  `latest`     | November 9th  | `sha256:7a2fb930acd627c321c93231d01f0a49808910b60945bee8d9699f63c7cd36fc` |
+|  `latest`     | November 12th | `sha256:9ac79fc115aa6be2d020f4b1d9a910746aa5ed10dba6519b0598d6ae93d74b98` |
+|  `latest-dev` | November 12th | `sha256:113474cda078455eea219b05904191f2db87b802262874c0f7eca3a0e9fc577a` |
 

--- a/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | November 7th | `sha256:607b60f520a87282ed43abf9d1e9367bf77324db6f85b7ba67784b869904f2f6` |
-|  `latest-dev` | November 7th | `sha256:52d6bafa5f1875ba57e5d552c3809450c8460ee3ab38f0e5c403748ec18c2fa0` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 12th | `sha256:4b04a5728d8111b719dfdecaee458f5a7c9de4fcf780a1cc0a4b6a16213309d8` |
+|  `latest`     | November 7th  | `sha256:607b60f520a87282ed43abf9d1e9367bf77324db6f85b7ba67784b869904f2f6` |
 

--- a/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | November 7th | `sha256:afa3a8038c3e6bf08f3ffa10b28471c9715f8b48c13f28ab502279fbf5b5dffe` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 12th | `sha256:1d19b86b4587b2f3b50e3f35e066472f4339e88e5e06c30f8a3151dd3a11fb01` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:6bd84a867ca0b8b2579a5bf25f1a205950757db74dc92f3f4abb8ac25a01c3ad` |
-|  `latest-dev` | November 11th | `sha256:f40d9b5c8fc8e95a47f4ae86a2c4efa0d64a56a305561526e01c9f52cfe829e9` |
+|  `latest-dev` | November 12th | `sha256:4c3a9257f9ffdc6fa53e317c03d296fbc4371e48b8b11488ca938294db44e750` |
+|  `latest`     | November 12th | `sha256:1033415d3c44ac32583212d05729aaa08c1dbf5ced9415131e5ee87f3881ce06` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:12d00f7a34c599ac55c8e3da96b6f90c4fec8af194c9f3381153137cb8d029ba` |
-|  `latest`     | October 30th  | `sha256:6ef847c7f83ca9ac4d292aa4dc77dc8751e59797809863fb4f3fd4d1014b087b` |
+|  `latest`     | November 12th | `sha256:11a95f5ece36ed563cebc21c07da7d182d1c2f93fb03b46669352cfafc191a28` |
+|  `latest-dev` | November 12th | `sha256:0915527a5442d3bdf0023de88de79aa45484034601fea8f7971cb04f81dda8cd` |
 


### PR DESCRIPTION
Updated Docs:

- aws-ebs-csi-driver/tags_history.md
- aws-efs-csi-driver/tags_history.md
- bazel/tags_history.md
- buck2/tags_history.md
- busybox/tags_history.md
- cadvisor/tags_history.md
- ffmpeg/tags_history.md
- git/tags_history.md
- guacamole-server/tags_history.md
- k3s-allinone/tags_history.md
- kube-fluentd-operator/tags_history.md
- kubeflow-jupyter-web-app/tags_history.md
- kubeflow-pipelines-viewer-crd-controller/tags_history.md