### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,59 @@
+# 2023-11-14
+New images added:
+
+- kubeflow-pipelines-frontend
+- kyverno-policy-reporter
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-ebs-csi-driver/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- aws-for-fluent-bit/tags_history.md
+- conda/tags_history.md
+- crane/tags_history.md
+- dask-gateway-server/tags_history.md
+- dex/tags_history.md
+- external-secrets/tags_history.md
+- ffmpeg/tags_history.md
+- fluent-bit/tags_history.md
+- fluentd/tags_history.md
+- gitlab-exporter/tags_history.md
+- guacamole-server/tags_history.md
+- k8sgpt/tags_history.md
+- k8sgpt-operator/tags_history.md
+- kube-downscaler/tags_history.md
+- kube-fluentd-operator/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kubeflow-jupyter-web-app/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-api-server/tags_history.md
+- kubeflow-pipelines-cache-deployer/tags_history.md
+- kubeflow-pipelines-cache-server/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- kubeflow-pipelines-persistenceagent/tags_history.md
+- kubeflow-pipelines-scheduledworkflow/tags_history.md
+- kubeflow-pipelines-viewer-crd-controller/tags_history.md
+- nats/tags_history.md
+- newrelic-fluent-bit-output/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- newrelic-prometheus-configurator/tags_history.md
+- openai/tags_history.md
+- postgres/tags_history.md
+- prometheus-node-exporter/tags_history.md
+- semgrep/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- spire-agent/tags_history.md
+- spire-oidc-discovery-provider/tags_history.md
+- spire-server/tags_history.md
+- timoni/tags_history.md
+
 # 2023-11-13
 
 

--- a/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 12th | `sha256:00045d6f2cb056f5472f39b3257bfe2cd1c9ce3df0094262e85c43f62e7bb8e7` |
-|  `latest-dev` | November 12th | `sha256:3c23bec7b45aed6322e218a6a2f5d5c534876ded1c35b9f3e5da752a95cf3f5e` |
+|  `latest`     | November 13th | `sha256:60360b7a8f6d676e8ee7d255b65e620bb32ee35f3eb815bccb81d4910ce0a6b0` |
+|  `latest-dev` | November 13th | `sha256:436efd5efb4dcdece29383fd45f7581d5f6ff67409d8567ddbd88ffb8168c549` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 12th | `sha256:9f6ceffcac7c31c874fafb867c6e4cefcfa9d4508a2e50bf6559a3b16c696178` |
-|  `latest-dev` | November 12th | `sha256:9ad8d6d57fb3f408b4d372a98499beca2d74aef717b7e5db8fc4d88b3cd4c802` |
+|  `latest-dev` | November 13th | `sha256:a62e172f95293c273d657f7c7137b460a3f388a6b8b4197a9da7ad5375292d8b` |
+|  `latest`     | November 13th | `sha256:cb75df78f0e86de592f26dc1aa58ee2078fa4c1f11636ac89e9d26f1f51cb8a5` |
 

--- a/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 11th | `sha256:ba0d4fad03ec85cd85b4225bd077dd9985207076638d857941306d9c9a644130` |
+|  `latest` | November 13th | `sha256:f093540246ddd58933a97cee87e23b813c2c4f9c6cfb1bac8a5a0cd5bf49c321` |
 

--- a/content/chainguard/chainguard-images/reference/conda/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/conda/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:959a171a5689a97b8a7a485ee8f240404adfa49a634dbe7bc1d50d6622449934` |
-|  `latest`     | November 7th  | `sha256:b4db5f276ee476a75ec6744615cfdaccbdea1a62948e10b6fc177e46037c8662` |
+|  `latest-dev` | November 13th | `sha256:164402e4a6ef9ed0627c6ee205bedfbe6bcd6cbceff254add801f8e196cfa88b` |
+|  `latest`     | November 13th | `sha256:a00dc0a13722763bfc00f44e5ca2cc2d79f8e5ff4a84a6be37d388b56aaa38f3` |
 

--- a/content/chainguard/chainguard-images/reference/crane/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/crane/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:41021416360dee83a34340605b81859e901a15cf34ad8d925191b61c77de4a18` |
-|  `latest`     | October 30th  | `sha256:af4d1f62e9db79ec2515c3a2f0282e2ea2a2ddfcf113ea385db297eb03658b9b` |
+|  `latest-dev` | November 13th | `sha256:290ee330546639d6cece26a4676c3692b82bb3be9826ef2cfe8fc10b151c454b` |
+|  `latest`     | November 13th | `sha256:f7e869cec68c1b03a91a1e3a9f43fd1e958e6ed11b1ab09006ac65eee7b596e5` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:e8b0198713213537e88aa9120b4122f26245334fbbc5bd0bb1d75a7e7b6ef8f0` |
-|  `latest`     | November 9th  | `sha256:faf0cb3fe2016d9a34e4d2046afcdffbe0e61d204668ffb61eb50285acb4b3ba` |
+|  `latest`     | November 13th | `sha256:9dd46e35a2612e866d2cd6f1eeaea1f61d166bdd357af1c232a752f1999e126f` |
+|  `latest-dev` | November 13th | `sha256:68da4890398307d266cfefd62e85f917df70094f6e0ee86070f71766c5d6f909` |
 

--- a/content/chainguard/chainguard-images/reference/dex/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dex/tags_history.md
@@ -30,5 +30,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `v2.37.0-dev` `2.37.0-r8-dev` `2-dev` `2.37-dev` `2.37.0-dev` `v2.37-dev` `v2-dev` `v2.37.0-r8-dev` | November 3rd  | `sha256:a26d010dbcba8d421b8d87336c9d9cafc9d35a8e60ff9097f1b065aba8e761fd` |
 |  `2.37.0` `v2.37.0` `2` `v2` `v2.37` `2.37`                                                          | October 30th  | `sha256:66c186956513b3fe3fa72ed717148c3c0a71eb346a34567e5329e33a3384b315` |
 |  `v2.37.0-r7-dev` `2.37.0-r7-dev`                                                                    | October 29th  | `sha256:974083a8f09478d67ce41a64c46c6a68dbf6ac80de6372ce4f979bed6690e0a3` |
-|  `2.37.0-r6-dev` `v2.37.0-r6-dev`                                                                    | October 13th  | `sha256:32574cbaced835ec3bde4302d440124f244821930f6f5f6dc74e71db3ba9c2bf` |
 

--- a/content/chainguard/chainguard-images/reference/external-secrets/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/external-secrets/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:f68d230bb19218c97139bcbb7b8f44810aa51bc7068ecd8a4de540426444a991` |
-|  `latest`     | October 31st  | `sha256:7fe06b86e6849f46d1d8d47e183c87f6c89446b1b6ba45b6edad1a25d2735c83` |
+|  `latest`     | November 13th | `sha256:b68a6ae2619c35dfe755341d59edf3a43032292551c7de0557e26ecb7a14148d` |
+|  `latest-dev` | November 13th | `sha256:2b16c9e7391265cee3d455cdc96b66db369d291163ba321bf6ba9700b0220942` |
 

--- a/content/chainguard/chainguard-images/reference/ffmpeg/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ffmpeg/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 12th | `sha256:34c09df9720197d069a276e9a3ba6e3b6c155c19a2d94e7794f828bb19c110e4` |
+|  `latest` | November 13th | `sha256:b77343dcd57328f17da9e019208394f933b0d70644d31025dd81d6e8131a994f` |
 

--- a/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:005f5235727fbb09656764b479d230a91456c36523060f43635234ac84e385de` |
-|  `latest`     | November 11th | `sha256:0777f43c41dc56f72e00984eba2d6ba4054951000d65c02b7883fda7e2135755` |
+|  `latest-dev` | November 13th | `sha256:6a279f96594637fd8d604aaab4d50eb2e1f2fcb21a9826c29b1386761b40198d` |
+|  `latest`     | November 13th | `sha256:1113c97f9f9b2f75016631d79b9e281e2a22c2731c3539e85b804f1fd8bf210c` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed  | Digest                                                                    |
 |----------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev`        | November 11th | `sha256:a0ff23615ec9927b175590ea6bbe2b3ce919121272db2b8128278e20bc85ef56` |
-|  `latest`            | November 11th | `sha256:42770c0fc3e67368a3189758f1d9e8ec6d3487dd9748d34c73ba0ffc26584da7` |
-|  `latest-splunk-dev` | November 11th | `sha256:7d591b6ab7cb4e02384fc0fcee66f4ac1dd0296a027a2527c8c8ddfa4147d1dd` |
-|  `latest-splunk`     | November 11th | `sha256:36f56ad43028315af41825aad7dbe8e69e93a519230051e47ed9966373ee7717` |
+|  `latest-splunk-dev` | November 13th | `sha256:e4a994f28e61bb3e11571285ca49b06ad533b2e8cf56009d618abb28d031ebf8` |
+|  `latest-splunk`     | November 13th | `sha256:64ec8a44dd38bee80b57ed7b2a86492fdd2d865bd2c93141e3d98a8f8c9d164c` |
+|  `latest`            | November 13th | `sha256:f8f60ad3fef2815d0f830a0c98d869875800f0a334d14222f00480bbe3cdaaf4` |
+|  `latest-dev`        | November 13th | `sha256:b8090aeb64b65d783785f4d092d694e4312f2d50deb9ea283d7f56f9b51d98ed` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:8d8ef9386055ce54a2cd00fcea4db3acfafecd33dfc7f0beb530f41832261e92` |
-|  `latest`     | November 11th | `sha256:6b4900e02ab84adb85c97aada1e38b548de7a272c7e38ee9ba4330c028586992` |
+|  `latest-dev` | November 13th | `sha256:2d381900d8b3996e2d6c0ff055bde21fca8c3c67fd45b0d608cbacf4021400d5` |
+|  `latest`     | November 13th | `sha256:4862f47f69f77cb0c2640efec4028e35a08d5180bf4bd3854605b504090fecc3` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 12th | `sha256:9ac79fc115aa6be2d020f4b1d9a910746aa5ed10dba6519b0598d6ae93d74b98` |
-|  `latest-dev` | November 12th | `sha256:113474cda078455eea219b05904191f2db87b802262874c0f7eca3a0e9fc577a` |
+|  `latest`     | November 13th | `sha256:8cb0ae3263b8b1dea0521f18616e09c2d19d19c63937feb9b96d0d2f699556e3` |
+|  `latest-dev` | November 13th | `sha256:20f7374599be48874ba9d985ec1d015231bdb9d0ace2f0137c3309fe2aba4036` |
 

--- a/content/chainguard/chainguard-images/reference/k8sgpt-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k8sgpt-operator/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:27a050600cfe53b7442716a338a47ec4237896d7d7f4d26d692c8c5268c1592f` |
-|  `latest`     | October 30th  | `sha256:54314715b9bc649a51327d15283ab0dfe5a28006e534446aa6cf7b77874b1cf5` |
+|  `latest`     | November 13th | `sha256:63d01928a3e3af2a8d55fc001129e5043d84126de6e890b4cf1db74ee3e0199f` |
+|  `latest-dev` | November 13th | `sha256:74b83c85f3b1d5aaf0ae27a1673666c88bb33c524e54075c504a604becfc7098` |
 

--- a/content/chainguard/chainguard-images/reference/k8sgpt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k8sgpt/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:dacc22fbdc9b2ccb0d458b47c100191888c08995e47386cc09966f6d401c0285` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 13th | `sha256:3d2621faa6441fba29b3dbc38521d9c053e0611854452585278bbf3613115c6b` |
 

--- a/content/chainguard/chainguard-images/reference/kube-downscaler/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-downscaler/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:8e6b6dbff5e8f0909e5268ed735bed62a20b94f87ca803757668c608608b1702` |
-|  `latest`     | November 7th  | `sha256:57b0fefc3e19be2899137a9847970e7b18d0d61df24dbc878062c550d9ea42f5` |
+|  `latest`     | November 13th | `sha256:a131a4910462396426197fb06896e33aff85e59bd318cea069db456d184141a8` |
+|  `latest-dev` | November 13th | `sha256:3704da57479dd84e1ea4d04e4fa36a152841a4f587f33ded55ec7bbb7ad7a2d4` |
 

--- a/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 12th | `sha256:1d19b86b4587b2f3b50e3f35e066472f4339e88e5e06c30f8a3151dd3a11fb01` |
+|  `latest` | November 13th | `sha256:10a9fa37fdf814af6e3f545930f4c08ac65432d39f1912eafaf7a27e74360273` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:b8c55d90839aa0736c20585c862764f468a81080727b0c4a1fc0f3456461bfaa` |
-|  `latest`     | November 11th | `sha256:2ac9ff9b2767ef38a433bf9c9744ef5ca6dd10bee75183be8059e04b745bbd11` |
+|  `latest-dev` | November 13th | `sha256:7f8fa3a0d347e444c51210101b41edd64f05d68a3a4f251961158e975ea8da3b` |
+|  `latest`     | November 13th | `sha256:fd21bcc1b89cbfebcc8e6945c0629b577b7ec64802c01c7c81001920c747fee1` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 12th | `sha256:4c3a9257f9ffdc6fa53e317c03d296fbc4371e48b8b11488ca938294db44e750` |
-|  `latest`     | November 12th | `sha256:1033415d3c44ac32583212d05729aaa08c1dbf5ced9415131e5ee87f3881ce06` |
+|  `latest`     | November 13th | `sha256:fc69387299a1e6306ff34cf1e1e6da2b0711adb68358c4c26d0e81fc6e51b278` |
+|  `latest-dev` | November 13th | `sha256:5aac6bdc672bb5e79b011c00b9f64f21962063dc30c132a4f06d79ac491b1a9b` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:951d3aae68d7dd576f28afa2d06216d08e260f52f2b33fcda0d3b7a69d161e2b` |
-|  `latest`     | November 7th  | `sha256:0e3c306290d319ef9b0307b289a42aed65cac5a901b57c7828995c3a73e1ebf8` |
+|  `latest`     | November 13th | `sha256:7b57caae4fcf4feee4bcd15ea900f72f76bceaeb5e7abc261aae11725cba9f23` |
+|  `latest-dev` | November 13th | `sha256:201bfe788540f4843969564a12286f5491d17999a804d7b8f326970b316e1f42` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:9fa53cbb72c589fe3d8a78832a1de2afe8a37b68bdb6642b2c0eb1ceb846e657` |
-|  `latest`     | November 11th | `sha256:01e2a58c745c50be038dc64b45873ba8f7b75e98bc590523b1f4c983349bd3c6` |
+|  `latest`     | November 13th | `sha256:6be0769e7cf19752a10982937d3d53ff7c38ffa53511077cb6e2e8e3df147900` |
+|  `latest-dev` | November 13th | `sha256:88a5cde67dbd1a9d6dadd9fa33b12b3f10ee66be7837631d300768ec8f904691` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:fcae6353188cc888b00428d35d8e59849b676f5b5d955f9a79123b6c3d520d64` |
-|  `latest-dev` | November 11th | `sha256:06888a6764b7e5630af548c3d52d95cdc9aae7259b0510f45f31840ca0857527` |
+|  `latest`     | November 13th | `sha256:886cd8b8756e239a74a6f9c64945de6e16adf71bbf47c93e59f5935e81f05afa` |
+|  `latest-dev` | November 13th | `sha256:91632ab06b6aaee012459a7b59e288fb4dee2ef32b6a64ff29248a52ea656a9c` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:96e5c64704ece1216e233ae795d963896326fd9a32cc4dcbdf30b51f5d009390` |
-|  `latest`     | November 9th  | `sha256:0923aadbf4138c19c58175f0c202a7d52a4c156211fd7e30a67668c75eb8ccad` |
+|  `latest`     | November 13th | `sha256:e4a7582cd43e7b5c4dd09342e428eb6a8393e9c8316b0aae23cf606a4eb91bb2` |
+|  `latest-dev` | November 13th | `sha256:c4efd1df145c4e0ee83c98ba6ab389f10f61f57559a4e2f78ac0e197e248050f` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:aa9b138c4db4cb334410636df01397e3f68352a36ccd6d64a49cf11cbc399654` |
-|  `latest`     | November 7th  | `sha256:fc17d7ad8bc176405eb8490d085f649bc9bc8bfe957720c2a873ec2cd428f8bb` |
+|  `latest`     | November 13th | `sha256:9bbcef3a4366e889044b88aafad0990f7aae10d418b2f091c02c5078f1f378e0` |
+|  `latest-dev` | November 13th | `sha256:47e43fd9c11ff1072585d3cd91783d4fee6c5b24be4f7ff3e665ee40e375fed9` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:c8cf26533f38b89e8e4d0700e5bc57cf5363ee782f7bc4918dd0076cb814beea` |
-|  `latest`     | November 11th | `sha256:a720af34266ee6626e0f0242675938a2f621564164bfabdba75cfa490436383c` |
+|  `latest-dev` | November 13th | `sha256:dd21412442d6c58460c7fe09e292729105635f0f9ddb7b9b0eab9d874575f1cd` |
+|  `latest`     | November 13th | `sha256:e2aee28361b24a0887e8914a997a285c7177f70541f045878e416f6bc2440819` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-api-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-api-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:384a821dcdebaa418fe03c4f90d8aa4db1cf67d9bfc03953519bfb50c6288bc8` |
-|  `latest`     | November 8th  | `sha256:7ca7152d5d7bb8f57edba9e690e52c0a166be0e9ee66e375a9b656afaafd5ffe` |
+|  `latest`     | November 13th | `sha256:dc1a98101e6b9a720371400c19fedd8fd3c0a3b4af3dc00ba0b677a6b214bf35` |
+|  `latest-dev` | November 13th | `sha256:bc3b55ce58795c2efc507a0b90f047c33fafe53d4589b4a45bc35a5037ec04d0` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:a961b04a612fb67b318aa5f8e519cc4538662bb2689697b8fdf521b58f7d99fa` |
-|  `latest`     | November 11th | `sha256:1664d1021f0b52e4555a03109b20954670783ac19d3b15a51c103d9a8803fa65` |
+|  `latest`     | November 13th | `sha256:f4dfe3671d8cf8704984262fd3b164b977e783f58bf35e39642c16d43f18f5d7` |
+|  `latest-dev` | November 13th | `sha256:286ff1dec2c143d7f756990800e8705af41ad27f0a733ec3f2d0fbdb68df235a` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:9fbbea81e9de516062ebb5db7a6bcdcd12c419d164c861624e211d6cdae6df2f` |
-|  `latest`     | November 8th  | `sha256:d8caa17c2458748bd0e0c8e4f6b36cbea1dc9e40fd2be691b23c02594b7e2d74` |
+|  `latest-dev` | November 13th | `sha256:18e4fe5bf838efac0baf84627b4561ec59d58fbf3023c90d20a90b6096340739` |
+|  `latest`     | November 13th | `sha256:f40162194285d952f9fc2d3ae5fd038b9014faedce620f1515c0ae00f92e57f9` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/_index.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Image Overview: kubeflow-pipelines-frontend"
+linktitle: "kubeflow-pipelines-frontend"
+type: "article"
+layout: "single"
+description: "Overview: kubeflow-pipelines-frontend Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+Minimalist Kubeflow Pipelines Images
+

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs.md
@@ -1,0 +1,79 @@
+---
+title: "kubeflow-pipelines-frontend Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public kubeflow-pipelines-frontend Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **kubeflow-pipelines-frontend** Image.
+
+## Variants Compared
+The **kubeflow-pipelines-frontend** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                                   | latest                                       |
+|--------------|----------------------------------------------|----------------------------------------------|
+| Default User | `nonroot`                                    | `nonroot`                                    |
+| Entrypoint   | not specified                                | not specified                                |
+| CMD          | `node ./server/dist/server.js ./client 3000` | `node ./server/dist/server.js ./client 3000` |
+| Workdir      | not specified                                | not specified                                |
+| Has apk?     | yes                                          | no                                           |
+| Has a shell? | yes                                          | no                                           |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                               | latest-dev | latest |
+|-------------------------------|------------|--------|
+| `apk-tools`                   | X          |        |
+| `bash`                        | X          |        |
+| `busybox`                     | X          |        |
+| `c-ares`                      | X          | X      |
+| `ca-certificates-bundle`      | X          | X      |
+| `git`                         | X          |        |
+| `glibc`                       | X          | X      |
+| `glibc-locale-posix`          | X          | X      |
+| `icu`                         | X          | X      |
+| `kubeflow-pipelines-frontend` | X          | X      |
+| `ld-linux`                    | X          | X      |
+| `libbrotlicommon1`            | X          | X      |
+| `libbrotlidec1`               | X          | X      |
+| `libbrotlienc1`               | X          | X      |
+| `libcrypt1`                   | X          |        |
+| `libcrypto3`                  | X          | X      |
+| `libcurl-openssl4`            | X          |        |
+| `libexpat1`                   | X          |        |
+| `libgcc`                      | X          | X      |
+| `libnghttp2-14`               | X          | X      |
+| `libpcre2-8-0`                | X          |        |
+| `libssl3`                     | X          | X      |
+| `libstdc++`                   | X          | X      |
+| `ncurses`                     | X          |        |
+| `ncurses-terminfo-base`       | X          |        |
+| `nodejs-20`                   | X          | X      |
+| `npm`                         | X          | X      |
+| `openssl-config`              | X          | X      |
+| `wget`                        | X          | X      |
+| `wolfi-baselayout`            | X          | X      |
+| `zlib`                        | X          | X      |
+

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info.md
@@ -1,0 +1,85 @@
+---
+title: "Provenance Information for kubeflow-pipelines-frontend Images"
+type: "article"
+unlisted: true
+description: "Provenance information for kubeflow-pipelines-frontend Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying kubeflow-pipelines-frontend Image Signatures
+The **kubeflow-pipelines-frontend** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/kubeflow-pipelines-frontend | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading kubeflow-pipelines-frontend Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the kubeflow-pipelines-frontend image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the kubeflow-pipelines-frontend image on `unix/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/kubeflow-pipelines-frontend | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying kubeflow-pipelines-frontend Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the kubeflow-pipelines-frontend image attestations:
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard/kubeflow-pipelines-frontend
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/kubeflow-pipelines-frontend --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "aws-cli Image Tags History"
+title: "kubeflow-pipelines-frontend Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the aws-cli Chainguard Image"
+description: "Image Tags and History for the kubeflow-pipelines-frontend Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/aws-cli/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/aws-cli/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/aws-cli/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/aws-cli/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:ac13193c54a01984f31b817705fb2ac82131003010eead26fc775de0fd199fbf` |
-|  `latest-dev` | November 13th | `sha256:bb9e7c6b1bbb51bd6ee5de1e4926ae6383072ed9eebe5888e697ef7e0a9e6c9f` |
+|  `latest`     | November 13th | `sha256:d791beb3ca26b298c02a37e0ab3c617140759ec603fb2e99b1d47385589b8251` |
+|  `latest-dev` | November 13th | `sha256:c76053523639b4f2e7700015e9adeb09846122206d9c2a53d10c6d72e765135d` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:0b35c03ae4d2abc29376caa72a53e5c9f4abe96b8550bcb1581efd3c5dfab787` |
-|  `latest`     | November 11th | `sha256:7e39dc2025c5b88503c82cf0f11d3d2ebc8085c1b159facaccb0605ff8bd7839` |
+|  `latest`     | November 13th | `sha256:2fe4857411f3f913679a56a4ec2e116c47a16f3b2cf407425e6357b64b6e6623` |
+|  `latest-dev` | November 13th | `sha256:32826dd766546843734c2623a821ee712a313cb39c75cea7ac1bbd9cb3630c46` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:dbcbc83a3b03a6e8914adcd7697f0fa811f6cb1248e8d1e72fdc2bd657bd3508` |
-|  `latest`     | November 8th  | `sha256:03c14acc8b69b432ce174aa68921f0385a0b529aea7dafc4d1844bdda90840da` |
+|  `latest-dev` | November 13th | `sha256:f6d28b2a9700e72911e313eb614e99b55a9fed2ee038fffe6f72a824df814bd7` |
+|  `latest`     | November 13th | `sha256:da5a7ad8b91b97525d7fa2be3861b59ed044de9bd8845e3076dc0a97ee8336b2` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:000dbc31201668bb6f20a87f3e1068ee680cbeef106b4d605c06cf3c86781e3e` |
-|  `latest`     | November 8th  | `sha256:8beba085f3ea5fbe15d1411a57043113a6bb8ccc5671b272517996befd839a17` |
+|  `latest`     | November 13th | `sha256:c8c11c75c028673842e3fbdfca3d674616630ac57f01d2a9272b86e7b8f852cb` |
+|  `latest-dev` | November 13th | `sha256:d2e4a967aabf028c2e053b6c3ee18e2506c7267cfa8a7094dd7095e0c785a183` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 12th | `sha256:11a95f5ece36ed563cebc21c07da7d182d1c2f93fb03b46669352cfafc191a28` |
-|  `latest-dev` | November 12th | `sha256:0915527a5442d3bdf0023de88de79aa45484034601fea8f7971cb04f81dda8cd` |
+|  `latest`     | November 13th | `sha256:1236b1b517379a2caf1e50755b3892e8c9e021f691b36c622b0d7d777a1e1b13` |
+|  `latest-dev` | November 13th | `sha256:2a29e107ed5353899edbd27d022e3d9edc80be23b23539eba83819c297aec766` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/_index.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Image Overview: kyverno-policy-reporter"
+linktitle: "kyverno-policy-reporter"
+type: "article"
+layout: "single"
+description: "Overview: kyverno-policy-reporter Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info/" >}}
+{{</ tabs >}}
+
+
+

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs.md
@@ -1,0 +1,72 @@
+---
+title: "kyverno-policy-reporter Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public kyverno-policy-reporter Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **kyverno-policy-reporter** Image.
+
+## Variants Compared
+The **kyverno-policy-reporter** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                    | latest                        |
+|--------------|-------------------------------|-------------------------------|
+| Default User | `nonroot`                     | `nonroot`                     |
+| Entrypoint   | `/usr/bin/policyreporter run` | `/usr/bin/policyreporter run` |
+| CMD          | not specified                 | not specified                 |
+| Workdir      | `/app`                        | `/app`                        |
+| Has apk?     | yes                           | no                            |
+| Has a shell? | yes                           | no                            |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                                  | latest-dev | latest |
+|----------------------------------|------------|--------|
+| `apk-tools`                      | X          |        |
+| `bash`                           | X          |        |
+| `busybox`                        | X          |        |
+| `ca-certificates-bundle`         | X          | X      |
+| `git`                            | X          |        |
+| `glibc`                          | X          |        |
+| `glibc-locale-posix`             | X          |        |
+| `kyverno-policy-reporter`        | X          | X      |
+| `kyverno-policy-reporter-compat` | X          | X      |
+| `ld-linux`                       | X          |        |
+| `libbrotlicommon1`               | X          |        |
+| `libbrotlidec1`                  | X          |        |
+| `libcrypt1`                      | X          |        |
+| `libcrypto3`                     | X          |        |
+| `libcurl-openssl4`               | X          |        |
+| `libexpat1`                      | X          |        |
+| `libnghttp2-14`                  | X          |        |
+| `libpcre2-8-0`                   | X          |        |
+| `libssl3`                        | X          |        |
+| `ncurses`                        | X          |        |
+| `ncurses-terminfo-base`          | X          |        |
+| `openssl-config`                 | X          |        |
+| `wolfi-baselayout`               | X          | X      |
+| `zlib`                           | X          |        |
+

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info.md
@@ -1,0 +1,85 @@
+---
+title: "Provenance Information for kyverno-policy-reporter Images"
+type: "article"
+unlisted: true
+description: "Provenance information for kyverno-policy-reporter Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying kyverno-policy-reporter Image Signatures
+The **kyverno-policy-reporter** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/kyverno-policy-reporter | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading kyverno-policy-reporter Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the kyverno-policy-reporter image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the kyverno-policy-reporter image on `unix/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/kyverno-policy-reporter | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying kyverno-policy-reporter Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the kyverno-policy-reporter image attestations:
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard/kyverno-policy-reporter
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/kyverno-policy-reporter --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "aws-cli Image Tags History"
+title: "kyverno-policy-reporter Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the aws-cli Chainguard Image"
+description: "Image Tags and History for the kyverno-policy-reporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/aws-cli/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/aws-cli/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/aws-cli/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/aws-cli/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/kyverno-policy-reporter/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:ac13193c54a01984f31b817705fb2ac82131003010eead26fc775de0fd199fbf` |
-|  `latest-dev` | November 13th | `sha256:bb9e7c6b1bbb51bd6ee5de1e4926ae6383072ed9eebe5888e697ef7e0a9e6c9f` |
+|  `latest-dev` | November 13th | `sha256:42838dde4828a313a29f08220eecb5a3472c3993d3c045228a1d0379c3be7027` |
+|  `latest`     | November 13th | `sha256:fcc338a61d26ec53bb017797985d68846752b23f483b8f9637d89922f9310be7` |
 

--- a/content/chainguard/chainguard-images/reference/nats/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nats/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:3beea6b579f306ed6e993cf57093bdea7815459cef795d9157b34d05094a552e` |
+|  `latest-dev` | November 13th | `sha256:22f6348f0ec26f27a8526c786d4ad7c911772f4b703d650b9c09a9a7c67c58bc` |
 |  `latest`     | November 10th | `sha256:43cb4a5b782172a7ad9a012dfe8b6b0fd98d00001a51cc99e54f3b34155fc06f` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:403b3770a1b8c4b6738edb17e65b896d4ebbd5085c3af314cbf8da0ecbb4a572` |
-|  `latest`     | November 11th | `sha256:5a7fb0c20149408968c02b317feb357234af2c361587013b10f9596e563eae4f` |
+|  `latest`     | November 13th | `sha256:cc963553a054b57d4ff99df4724de6bd3bb1f408d95c23857c2b0ccbe6d96007` |
+|  `latest-dev` | November 13th | `sha256:3b7b8c75d073478e8b1e0aae12c51ea100400ae908afaa03b602cb1828dc18e8` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:a7be4b53ce6352efb0528031cd78fbaeaa8ad8ade857b3810fab6703c5ac1167` |
-|  `latest`     | November 10th | `sha256:26f8d3a428b246297673c670b0858f89dd2d01c8cc970f0862a779dc753a99a5` |
+|  `latest`     | November 13th | `sha256:e23d6c9043ec9975158575b26455e1415b2376dfabf03510299fcf24dbd566ca` |
+|  `latest-dev` | November 13th | `sha256:ae972959f337fa06cb121d61568d4a46d552cfc22d2c91adb11455a284eb5aba` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:3b69572ae85b252e247b0b670d14b31e0cc8006dd5080f095dba47beb173eaf2` |
-|  `latest`     | November 7th  | `sha256:95a1500c5128cd912454b85b824ae18f2f1313587c721c1bfb71191cbf2b3f58` |
+|  `latest-dev` | November 13th | `sha256:b326e84f5b4103a6f943529ff0eb3b179860b334d5c82414fb441837e2de67cb` |
+|  `latest`     | November 13th | `sha256:08a67b305ec1e99197422db5638c052794eacc3ef084e43cf93dc21b4c3275c8` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-prometheus-configurator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-prometheus-configurator/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:6229da95f74393efbf488e01408bc2863f7373b8a1f4ef3c89926ba9470d4ed8` |
-|  `latest`     | October 30th  | `sha256:ecfff3f0db66fcf956fe70834af28bb692e3e883228bba6c5d535d45fdf54a08` |
+|  `latest`     | November 13th | `sha256:7d7accac484f900d7866d39410eeac8e9a222780b0cb0982f364116c52f5d054` |
+|  `latest-dev` | November 13th | `sha256:9eb76dd9ad4d8a7b6d62e612fa3379e4160d4dd237e2718323120f91becb90d3` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:a543d3b87b229bea40a8b95d224ccd0a55884f7d5a0ad8a1d5356a64b399be14` |
-|  `latest-dev` | November 11th | `sha256:ee5b0eb60bc51ccd83efafa67853f1065b28718530a8a9af316d8fb685a07e49` |
+|  `latest`     | November 13th | `sha256:6f057aef09ffbd76d0a9a9473e0a33011d896d103072896e8146db646cfb24d3` |
+|  `latest-dev` | November 13th | `sha256:f526af1766bd24791507c3cf1302beb39e538728d17b5fcfe0105d00e1c0c290` |
 

--- a/content/chainguard/chainguard-images/reference/postgres/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/postgres/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:a6ee3910db1a2fe8a1beca69c52269c94672c2095fa8dcb14786f6e0c5ca5c95` |
-|  `latest`     | November 11th | `sha256:2d6d3afcf269632e02f7c6f9c5359c05d054199612d22285d1ba60942f81ad9d` |
+|  `latest`     | November 13th | `sha256:ef20e81e7bad7016f5efffeb227bc1dfdc412197f03eb217b710b468a94fc065` |
+|  `latest-dev` | November 13th | `sha256:e1cc161a4fc813d2bc540d65a1eb8be48b837c2e9c3ffb03966ddaa181cab3ab` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-node-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-node-exporter/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:1b8801d478babb61ea52c67e6ab5f423a21f0c043758cab9aae358d65d301550` |
-|  `latest`     | October 30th  | `sha256:09f68e470dd249b87600023adac65e9b466543b1bb9e32ecdfb6ecded378b4d9` |
+|  `latest`     | November 13th | `sha256:72150195352e7d059dc4fa09b3f76be0fbc0984ac83ea1d120abc7a6c46a3db1` |
+|  `latest-dev` | November 13th | `sha256:dcfb679fa27fe3692f34d9d67b8e7495f7b2929dc145ef2f6f9a7ac19abb943a` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:98dfa4f24740bf5733ddb092f1a213185b4c49b995e1bd2090eabcccede99e03` |
-|  `latest`     | November 10th | `sha256:ab9eb033600a3b5f0ab0af163306c6c8ee2d1eb98356cd64298fd6af16a3e1db` |
+|  `latest`     | November 13th | `sha256:2d5096db4b8368d5b5a0a26da1fa8b24b11643231940598d411eb53dcbd37c00` |
+|  `latest-dev` | November 13th | `sha256:30b99db7e09f69a3cadd0ebad961b2e21d0c2bb465bd7c306efaf4e6a63a2458` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 11th | `sha256:27a40bc75844ce659efa64196976839ffa184a5c87cc3d2e0cef4d024431e1a3` |
+|  `latest` | November 13th | `sha256:4a924b13ecb3ad270ed47687d8ea36d39a9a4fe660bac0db31bd0fee00fbc803` |
 

--- a/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 10th | `sha256:7db4ec4f6ec06f075633f755fe9fd0fe39e3b9fe66b88f5b9afe16bcdfdbbad2` |
-|  `latest`     | November 9th  | `sha256:add4a1c7936bdb57e331cf97f462f804d8ab417b6504e59d58158bf67680076e` |
+|  `latest`     | November 13th | `sha256:7b343c4206219c997cc1de105bcdc42ad4c903ac3b8adc2e8ae1f4fb1bb60b42` |
+|  `latest-dev` | November 13th | `sha256:da6167275f5ca3c4dfe636f2571f41c6c1b7e2bbbb0cfe9d5f6880e0bb02bbd6` |
 

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 10th | `sha256:89e3a67fc2da9e2f6aa4e8b817cd11bc1e372b9c52c047621b6a9d9ecda63926` |
-|  `latest`     | November 9th  | `sha256:d82b65494e2ab13f586509543649b686477385a7d5d5619aa15dcb81f720b705` |
+|  `latest`     | November 13th | `sha256:60624f3bf3afee39e0c88252d628cec66c439d358153083ea5f337722c560123` |
+|  `latest-dev` | November 13th | `sha256:1e8fc6deefee0fc13335ae0754f5e9a5c2e69650546075bf4cc311255955bda0` |
 

--- a/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 10th | `sha256:1e140a2d3e6ebc49ea465efa73fad5395a3bc0055a0f7e72374ca44c361fd543` |
-|  `latest`     | November 9th  | `sha256:b7a402da33ac5988f5e8892b3b3ab250fc407134f3b3628fd366d432a80548f4` |
+|  `latest-dev` | November 13th | `sha256:65a725a5ea3b676e34803ef04eed2b107d8e2bd41e282ed4b21e2a1fb01aa6d2` |
+|  `latest`     | November 13th | `sha256:cb19c6c6359616b3d7a58c9fe4315c6b44d7dda7da4840fa2380fc250c808b1d` |
 

--- a/content/chainguard/chainguard-images/reference/timoni/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timoni/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:48d1f6afa2dd00d34981d90e783358f8d0519d6929f9866aaca0e88fe4ef7a0a` |
-|  `latest`     | November 7th  | `sha256:4c58765aa4c76f35775cd06332802abf17275afcbb692e615b1c799cbb8cffa4` |
+|  `latest`     | November 13th | `sha256:6edeb5adb4172878b3b1dccfb3e285ae7e04351d1e8e74c3be55c51781584cda` |
+|  `latest-dev` | November 13th | `sha256:2335981cbd8357f421fa5f646b9f46351c9811c4db81c30e6a1d076df3ccd7aa` |
 


### PR DESCRIPTION
New images added:

- kubeflow-pipelines-frontend
- kyverno-policy-reporter

Updated Docs:

- aws-cli/tags_history.md
- aws-ebs-csi-driver/tags_history.md
- aws-efs-csi-driver/tags_history.md
- aws-for-fluent-bit/tags_history.md
- conda/tags_history.md
- crane/tags_history.md
- dask-gateway-server/tags_history.md
- dex/tags_history.md
- external-secrets/tags_history.md
- ffmpeg/tags_history.md
- fluent-bit/tags_history.md
- fluentd/tags_history.md
- gitlab-exporter/tags_history.md
- guacamole-server/tags_history.md
- k8sgpt/tags_history.md
- k8sgpt-operator/tags_history.md
- kube-downscaler/tags_history.md
- kube-fluentd-operator/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kubeflow-jupyter-web-app/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-api-server/tags_history.md
- kubeflow-pipelines-cache-deployer/tags_history.md
- kubeflow-pipelines-cache-server/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- kubeflow-pipelines-persistenceagent/tags_history.md
- kubeflow-pipelines-scheduledworkflow/tags_history.md
- kubeflow-pipelines-viewer-crd-controller/tags_history.md
- nats/tags_history.md
- newrelic-fluent-bit-output/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- newrelic-kubernetes/tags_history.md
- newrelic-prometheus-configurator/tags_history.md
- openai/tags_history.md
- postgres/tags_history.md
- prometheus-node-exporter/tags_history.md
- semgrep/tags_history.md
- slim-toolkit-debug/tags_history.md
- spire-agent/tags_history.md
- spire-oidc-discovery-provider/tags_history.md
- spire-server/tags_history.md
- timoni/tags_history.md