### PR TITLE
Fix network requirements link

### DIFF
--- a/content/chainguard/chainguard-registry/overview.md
+++ b/content/chainguard/chainguard-registry/overview.md
@@ -26,4 +26,4 @@ You can check the status of the Chainguard Registry at [https://status.cgr.dev](
 
 ## Network Requirements
 
-Refer to our [Chainguard Images Network Requirements](/chainguard/network-requirements) reference page for details about how to ensure access to Chainguard Registry in environments using firewalls, access control lists, and proxies.
+Refer to our [Chainguard Images Network Requirements](/chainguard/administration/network-requirements) reference page for details about how to ensure access to Chainguard Registry in environments using firewalls, access control lists, and proxies.


### PR DESCRIPTION
## Type of change
Fix

### What should this PR do?
Updates `/chainguard/network-requirements` to `/chainguard/administration/network-requirements` on `/chainguard/chainguard-registry/overview/`