### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,60 @@
+# 2023-11-16
+
+
+Updated Docs:
+
+- argocd/image_specs.md
+- argocd-repo-server/tags_history.md
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- buck2/tags_history.md
+- cert-manager-acmesolver/tags_history.md
+- cert-manager-cainjector/tags_history.md
+- cert-manager-controller/tags_history.md
+- cert-manager-webhook/tags_history.md
+- cilium-agent/tags_history.md
+- cilium-hubble-relay/tags_history.md
+- cilium-operator-generic/tags_history.md
+- fluentd/tags_history.md
+- flux-kustomize-controller/tags_history.md
+- gitlab-shell/tags_history.md
+- guacamole-server/tags_history.md
+- hugo/_index.md
+- hugo/tags_history.md
+- ingress-nginx-controller/tags_history.md
+- istio-install-cni/tags_history.md
+- istio-operator/tags_history.md
+- istio-pilot/tags_history.md
+- istio-proxy/tags_history.md
+- jenkins/tags_history.md
+- kube-logging-operator/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kubeflow-pipelines-frontend/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- memcached-exporter/tags_history.md
+- newrelic-kube-events/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- node/tags_history.md
+- node-lts/tags_history.md
+- openai/tags_history.md
+- pgbouncer/tags_history.md
+- php/tags_history.md
+- pulumi/tags_history.md
+- redis-cluster-bitnami/tags_history.md
+- redis-sentinel/tags_history.md
+- redis-sentinel-bitnami/tags_history.md
+- redis-server-bitnami/tags_history.md
+- semgrep/tags_history.md
+- sigstore-scaffolding-cloudsqlproxy/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- spark-operator/tags_history.md
+- spire-agent/tags_history.md
+- spire-oidc-discovery-provider/tags_history.md
+- spire-server/tags_history.md
+- temporal-ui-server/tags_history.md
+- wait-for-it/tags_history.md
+- zookeeper/tags_history.md
+
 # 2023-11-15
 New images added:
 

--- a/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:bf984bd9cd85ab6ae268178c2062372d114964d1767cbd9657c49f7ca153bc76` |
-|  `latest`     | November 9th  | `sha256:7c7ccae8d4bb38c06e91bbf6f4375d3f9bc6b7a4b96fc4d9ee39708edbb0c0c2` |
+|  `latest-dev` | November 15th | `sha256:d1f81cafe5851fd1c93420c79d2e7505e0e1c802178fce97e2ef4aa8e9d34208` |
+|  `latest`     | November 15th | `sha256:c38f9ff527877b471c92d5ad1b8b589ddceaa6013ceb635d2f3ddf41e3d63d9c` |
 

--- a/content/chainguard/chainguard-images/reference/argocd/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/argocd/image_specs.md
@@ -46,8 +46,8 @@ The table shows package distribution across variants.
 |                          | latest-dev | latest |
 |--------------------------|------------|--------|
 | `apk-tools`              | X          |        |
-| `argo-cd-2.8`            | X          | X      |
-| `argo-cd-2.8-compat`     | X          | X      |
+| `argo-cd-2.9`            | X          | X      |
+| `argo-cd-2.9-compat`     | X          | X      |
 | `bash`                   | X          |        |
 | `busybox`                | X          | X      |
 | `ca-certificates-bundle` | X          | X      |

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 14th | `sha256:e31a2eb8eabb67068ec633958c70f7b2a078367513c7836ad3fc59699d108219` |
-|  `latest`     | November 14th | `sha256:f844e5afc4adee1ba7f11efac57df1c4934f8f25450b44cd8c424b70bd807d86` |
+|  `latest-dev` | November 15th | `sha256:f9e61d22dd15f059c4bcf2cb85d924cf0ca92284b447d22300e8a5bcbc3f9933` |
+|  `latest`     | November 15th | `sha256:5e7b2eaf03c8ae6af7da906128858ec263d0b5993a12447b421f8b6fe3b7c497` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 14th | `sha256:55e4296093c20c461d5821a1d7801f0eb450b8690c41120f5c34c62cb10bf643` |
-|  `latest-dev` | November 14th | `sha256:e37715df874b988a847bca55bd289cdc06baae726e0509387fec4f0759788d51` |
+|  `latest-dev` | November 15th | `sha256:1ff29f59530867a30e99966a3988a05541bcb77777d67e36c892f6eb40daccbe` |
+|  `latest`     | November 15th | `sha256:07803f0ff2199f9d0bdf08d6af862ff849538d48e07dc6c39f0ea6f57dfe9974` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 12th | `sha256:0e4ac99f4dba4430507e454936d4c53b3e7b3d9a0ac9cc38d14a37193ab2d816` |
-|  `latest`     | November 12th | `sha256:5defb3fcd163d4505ede4a589bc3817f705955a255711fd5890f95e89d78afc2` |
+|  `latest-dev` | November 15th | `sha256:8a84b2a1e8650ca45e029f44b93306c3aaeca03c12728e76afa0b47d442d0ba5` |
+|  `latest`     | November 15th | `sha256:0bbe33399cfaf4e70ad2bc6ae8884303375251462ca307da768aafd42c3a3183` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-acmesolver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-acmesolver/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:e30f5258dbeeb1b48100981c7265717db521386ba5eb82cb0976de45fbc3c02a` |
+|  `latest-dev` | November 15th | `sha256:99b144a192b6da8645eb0c84b0d51b85c468809d16da2ca8c765f2116177f2c8` |
 |  `latest`     | October 30th  | `sha256:ed05df4250da9ef84db10f215b822bcd92f7132997bef1983f37543c0290dd75` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-cainjector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-cainjector/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:d507dea18c246975470852655c90b3216055e49f3ee86754767f84dbd16d8d26` |
+|  `latest-dev` | November 15th | `sha256:f36ebcf93b7609e43b52191e66e4c3e479aa99c937dafc6d386561f80297401c` |
 |  `latest`     | October 30th  | `sha256:6328d04e0df8f60b678dfe95fa434f71116a919b8a3623479167cc5fa96afc26` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:bb959baf199c728294440dcf88e64f8dde47d41f97a2ff4c81fc4cdf96e27cc1` |
+|  `latest-dev` | November 15th | `sha256:efa5653cb4a90ea0ff8d34d07db97bf2202851830b073ac4f2798741d813f207` |
 |  `latest`     | October 30th  | `sha256:7a18e131e88a2ea65838674c2d82c64304d5e6cabb21db814b41c49cdf90a41e` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-webhook/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-webhook/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:2bf57855b73945738d81a211731caae815ee79b96f1b636ddfcc031312a75ff5` |
+|  `latest-dev` | November 15th | `sha256:5472d9508f3aff05302849ca06d06c8418760b1608aa766d503631de6256c034` |
 |  `latest`     | October 30th  | `sha256:ce00821b940f1f5b43926ce66418872cbd98002742b12e8b07835f304fd97bdc` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:a326112f67e9261c8dac626f79c22b0ea61fe724ef3bb7130c4f1ddf5e3ff300` |
-|  `latest`     | November 11th | `sha256:448e5e0d6d2641caf2dbffda8660b0d3bcc1087d471b92cde9785918dd09bfd1` |
+|  `latest-dev` | November 15th | `sha256:7b7ae5fc4c301e0f875836f6fb8b4172cdc37f7268610f77dbac4ce8ceebad91` |
+|  `latest`     | November 15th | `sha256:df627887c42fde938625acce7fdf4cf9adfef1ec260a11b5094c33089009a878` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:89c23be92418caa7650ec368ed45026bd8c0598650018caf10c2547a61bd6e95` |
-|  `latest`     | October 30th  | `sha256:3c1d5f4b43f1275ce6f2a40552436c0701c370dc7d40fdb5601ccae3a8811f6e` |
+|  `latest`     | November 15th | `sha256:aede96cc79e47e0ca6ab8c420586460d7beef5c5192df022395927014e3175be` |
+|  `latest-dev` | November 15th | `sha256:f4ccf96c0d37b2f545f7d411065f71437db236521870815d3fae0c2dd1e969dd` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:317d0cfcf440fa286305a86cc3f9464ff53923b0456034ce3395640a493bdee8` |
-|  `latest`     | October 30th  | `sha256:5d69bd453a0451f0ae604261c2f56f07f52daac82d94a6f100781acdca5c32b8` |
+|  `latest-dev` | November 15th | `sha256:e33cf269825a7664101840a6ee0c5bad0e09eacb22ddb9fc25edfaf1bfd3a2a7` |
+|  `latest`     | November 15th | `sha256:056c26dee56885c5675fe4a353633cb0342a6d9a806bc3d61a7f6928ae69b2c9` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed  | Digest                                                                    |
 |----------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-splunk-dev` | November 13th | `sha256:e4a994f28e61bb3e11571285ca49b06ad533b2e8cf56009d618abb28d031ebf8` |
-|  `latest-splunk`     | November 13th | `sha256:64ec8a44dd38bee80b57ed7b2a86492fdd2d865bd2c93141e3d98a8f8c9d164c` |
-|  `latest`            | November 13th | `sha256:f8f60ad3fef2815d0f830a0c98d869875800f0a334d14222f00480bbe3cdaaf4` |
-|  `latest-dev`        | November 13th | `sha256:b8090aeb64b65d783785f4d092d694e4312f2d50deb9ea283d7f56f9b51d98ed` |
+|  `latest-dev`        | November 15th | `sha256:9fa3780d4a9c637d730cd6745007feb69e30b4c3b574a65e1c251b5d0e998f18` |
+|  `latest`            | November 15th | `sha256:c58769c63a6081ff9554af86e1fdf0bdb83bad9ecb37d09765b96e5b445ecc7f` |
+|  `latest-splunk-dev` | November 15th | `sha256:09f1c9f7ebba5b11ddbd335d7254dacba4da1a8c06005376a6725bcc8316ae7a` |
+|  `latest-splunk`     | November 15th | `sha256:7624679cc8bce3e9000ab3eb702b2247bc4b126f9ec5562d9188d180e674c685` |
 

--- a/content/chainguard/chainguard-images/reference/flux-kustomize-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/flux-kustomize-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:95c441b9da91d23edca3674ce4d1e7d8e5fe3ffc37118089ec5f1c4f4d370e80` |
-|  `latest`     | November 7th  | `sha256:4fc4262a5a5c2c192aa1b6d5fbaba434a9f7cd3e97cd031f9bdecce1f2d331cf` |
+|  `latest-dev` | November 15th | `sha256:544caa929cf789085ce7fa01018465e817e839164b8d8233ed4d7878c34d0956` |
+|  `latest`     | November 15th | `sha256:13dcb46fb1db1350fe6b4ffff01264df41bbb6b9cee59a7c3256d87641b0cdb9` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:bbba5f3476a9535d0434e994d95d0df39b1581f862ec492b461048f7fce8f4dd` |
-|  `latest`     | November 11th | `sha256:993e88e8d9f0abcbb5f25ab168ce2afdc17b8dc25b817a86c43149b54251fb90` |
+|  `latest`     | November 15th | `sha256:ecc7dc1703f053448d2e56ea4e970d25066630af6a05d09e2d2367de6312bee1` |
+|  `latest-dev` | November 15th | `sha256:609dcddcf0ad1f2c925dccdee39275f84967d2125446fd04f0234862bec3b390` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:8cb0ae3263b8b1dea0521f18616e09c2d19d19c63937feb9b96d0d2f699556e3` |
-|  `latest-dev` | November 13th | `sha256:20f7374599be48874ba9d985ec1d015231bdb9d0ace2f0137c3309fe2aba4036` |
+|  `latest-dev` | November 15th | `sha256:208bda515c30b9f42e53617e1df26bda28a152cd2492f08317a4943a8728c7a3` |
+|  `latest`     | November 15th | `sha256:a987b135fe90141fa86c10076370c91ff89f48a85e689185ced1b9217eda1235` |
 

--- a/content/chainguard/chainguard-images/reference/hugo/_index.md
+++ b/content/chainguard/chainguard-images/reference/hugo/_index.md
@@ -26,9 +26,34 @@ toc: true
 
 
 This is a minimal [Hugo](https://gohugo.io/) image. The image only contains
-`hugo` and supporting libraries.  The hugo process start in `/hugo` by default
+`hugo` and supporting libraries.  The hugo process starts in `/hugo` by default
 so this directory may be initialized with the Hugo site to serve.
 
+- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo)
+- [Image Variants](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/image_specs/)
+- [Provenance Info](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/provenance_info/)
+
+## Image Variants
+
+The following tagged variants are available without authentication:
+
+- `latest`: This is a distroless image for running hugo to generate a website. It does not include `apk-tools` or `bash`, so no shell will be available.
+- `latest-dev`: This is a development / builder image that includes `bash`, `apk-tools`, and `busybox`. This variant allows you to customize your final image with additional Wolfi packages.
+
+### Pulling the Image
+Run the following to pull the image to your local system and execute the command `hugo version`:
+
+```shell
+docker run --rm cgr.dev/chainguard/hugo version
+```
+
+You should get output similar to this:
+
+```
+hugo v0.119.0-b84644c008e0dc2c4b67bd69cccf87a41a03937e linux/amd64 BuildDate=2023-09-24T15:20:17Z
+```
+
+## Application Setup for End Users
 
 Here is an example using the Hugo image to run the
 ["quickstart"](https://gohugo.io/getting-started/quick-start/#commands) locally:
@@ -48,4 +73,8 @@ hugo server --bind 0.0.0.0 --port 8080
 ```
 
 Now open your browser to [localhost:8080](http://localhost:8080)!
+
+If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/chainguard-images).
+
+
 

--- a/content/chainguard/chainguard-images/reference/hugo/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/hugo/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:46e05d2fd4c730fc9fa9709aa3df22169a8570d82aac53afb92545375f4159b0` |
-|  `latest`     | October 30th  | `sha256:f922caf806ceddd3f8d364eec48038d9dcf39d02c6c2c9d3984c73e3bf3414f4` |
+|  `latest-dev` | November 15th | `sha256:c02a7695cfbd79832af28679009ad3c022598e9ec40a1927e98ae95a74f9cdf8` |
+|  `latest`     | November 15th | `sha256:916baa85f4da67c25d09c6a0ed03e94dde6dde10a4e39b9d53c2cf2ea5a9f5ad` |
 

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:429e54daa12700d99e519250fa5fd76a1ad0950e915876a82e7db3ba44a40aff` |
-|  `latest`     | November 10th | `sha256:d6cb0733f36d9e58d54b225a60d159d05d5acaf69c4a290345dec1c06b21a6af` |
+|  `latest-dev` | November 15th | `sha256:89966cd768bffd7fa24a58a19122f24ca926e3f538064a065311058ed73f1d4d` |
+|  `latest`     | November 15th | `sha256:29cade0dcc61d65dbf6943711732185491994512926877dad43abea59fcf6a45` |
 

--- a/content/chainguard/chainguard-images/reference/istio-install-cni/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/istio-install-cni/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 15th | `sha256:aff28e89d1712b65a0b27d26298aed5c01573dcdb5c721b94117a05bdec89707` |
 |  `latest`     | November 14th | `sha256:c96f9cf5539d54843e1ddede43c8ab4a21b8cd6075f6e11fa93fe9e82ed563aa` |
-|  `latest-dev` | November 14th | `sha256:ebc3d45c2ce2ce820ba5820bb016e55f500cb7371ed070adb710e2be178f1bb7` |
 

--- a/content/chainguard/chainguard-images/reference/istio-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/istio-operator/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 14th | `sha256:437064623d66f21b9f1c10709ecf8941fecd74e30f489051673140fb99809f25` |
+|  `latest-dev` | November 15th | `sha256:c09d0c8ffe426cc6a70dbab9ab98f5bade70abfb5b2928c249e9730f90705085` |
 |  `latest`     | November 14th | `sha256:c3ddb4b4d5e7909440c19aab547b4db6633bdf5b3ef02ecd31b8ba1dd1418f7f` |
 

--- a/content/chainguard/chainguard-images/reference/istio-pilot/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/istio-pilot/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | November 15th | `sha256:57ae518370c1d16bd95818cc2341c2dff63ec09623b4c5c93f1f818d29c69eec` |
 |  `latest`     | November 14th | `sha256:c9784864df0eac8c3bd46fd6b10df85df1fb6a3c36c99ca42145ecc9c84bd83a` |
-|  `latest-dev` | November 14th | `sha256:7ea3979b8d3f8490b56db49811a004d3904f12e35b58c1e84420531df2c41bc2` |
 

--- a/content/chainguard/chainguard-images/reference/istio-proxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/istio-proxy/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 14th | `sha256:bb9f115c9be6438faa963ff5a8c298ddfda6b6730c379f1cc8dfbd4ad991ceec` |
-|  `latest-dev` | November 14th | `sha256:436b6830775be13e12805ddf9532c5c8c0b50fb7cc7a16c77f57897c605c3c5a` |
+|  `latest-dev` | November 15th | `sha256:d2ce83eb6108474063bf04388df000f780d100334145bc437ae3d162ebde6f9a` |
+|  `latest`     | November 15th | `sha256:9ad63e0dc9864ab8854ff4a7039de599015df9f0de678a9789a4ba7b16a62de5` |
 

--- a/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 11th | `sha256:4ff613a57e63b0d1b867fbf04c330a216e4042c1375529eb4d4b131f1a114ec2` |
+|  `latest` | November 15th | `sha256:4ad63a06f66a994d7365e65197f3038a697c9a57f4024ece7b6731094969e0dd` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 13th | `sha256:7f8fa3a0d347e444c51210101b41edd64f05d68a3a4f251961158e975ea8da3b` |
-|  `latest`     | November 13th | `sha256:fd21bcc1b89cbfebcc8e6945c0629b577b7ec64802c01c7c81001920c747fee1` |
+|  `latest`     | November 15th | `sha256:e4ae30c56903aa532027258a1fa60a2ecaaf582108739653d4899e7170f386d6` |
+|  `latest-dev` | November 15th | `sha256:bfc303d3c4464a1fb59dd0c4b50f674bad828305b18ef3a244299cc1b216d3a2` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:0103238a8100cb1693e27bc216f0dc80b13535ef7cc9dc433a9f4a5effaa4f44` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 15th | `sha256:64d692dd601865b322ce7ec61a4568399fd0ad3e0692fb2b49fc9b9e962ae9a4` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:d791beb3ca26b298c02a37e0ab3c617140759ec603fb2e99b1d47385589b8251` |
-|  `latest-dev` | November 13th | `sha256:c76053523639b4f2e7700015e9adeb09846122206d9c2a53d10c6d72e765135d` |
+|  `latest`     | November 15th | `sha256:1a812ee65b27c27c7835785eb4ec73c965fcb58444e52f9a350d03e94ee5c3e3` |
+|  `latest-dev` | November 15th | `sha256:a5ff76eb245baa911ef025b853beff65dc6af025bc66c2fdd4d4e43047d299ac` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:2fe4857411f3f913679a56a4ec2e116c47a16f3b2cf407425e6357b64b6e6623` |
-|  `latest-dev` | November 13th | `sha256:32826dd766546843734c2623a821ee712a313cb39c75cea7ac1bbd9cb3630c46` |
+|  `latest`     | November 15th | `sha256:063deae51bdcce1368ff3d1a91aeb1ca8651aef46a1f26c51a82e63a3161f746` |
+|  `latest-dev` | November 15th | `sha256:e4c0b5068031852974966741bde42a1b0a11f6725724c516e5377f43557f79ae` |
 

--- a/content/chainguard/chainguard-images/reference/memcached-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/memcached-exporter/tags_history.md
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | October 30th | `sha256:707208ab263ec360b4fcabfc08cd0197ad4fe55ecc476382a0b524b017159aa3` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | November 15th | `sha256:af455e9eea850d2a45e012551666c1538f22d5de354c6b509a0a3d2d88170170` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:f8e389cd677749b6db51829dac8d421f0fe827b81b63f79d46706c559fff2646` |
-|  `latest`     | November 7th  | `sha256:5252c21e96b985ec5247ca0c99358896f28296de3db5d1934cb92a7d3c71428f` |
+|  `latest`     | November 15th | `sha256:fd092169c91f37d01a6b2e00afdf084420622e769fcfceec910428c5d5093ce9` |
+|  `latest-dev` | November 15th | `sha256:b7eeb7b06cf7fda8ccadd001d6eadd702bbefce44bdb23eb9317581e95ea7d45` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 13th | `sha256:b326e84f5b4103a6f943529ff0eb3b179860b334d5c82414fb441837e2de67cb` |
-|  `latest`     | November 13th | `sha256:08a67b305ec1e99197422db5638c052794eacc3ef084e43cf93dc21b4c3275c8` |
+|  `latest`     | November 15th | `sha256:1982815c8e591859316ced64398a9829837ff5b326aaaa8e860af84501917bf5` |
+|  `latest-dev` | November 15th | `sha256:e5eda0d78eaa277f8df8c541bf974e4c76f504589a4f8e878129a71d35aba800` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:d24930ccdd25a8a1da35962764ddc9599cff0d2cb1263b1d050f16ba24328458` |
-|  `latest`     | November 7th  | `sha256:dba7e5ed66fad9b969a6b50b538f1d2b112abdf9a3ec5124f1d347fdeee3bd1c` |
+|  `latest`     | November 15th | `sha256:ba3c05e9ebdf78e4faa7404e30f06e9b13b9082a8f65a89900478c3a5dd81e11` |
+|  `latest-dev` | November 15th | `sha256:ea939b8e8a62713750428e483064a8e7dd7ddf78e08414ddc6e0301c61f04745` |
 

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:54784225a2f4c0da6785da2281e447e49e719cdb8958d118e463ff78d38b2a44` |
-|  `latest`     | November 7th  | `sha256:a1ee69fe5de195642432a6b6b10702ceea5d51f08508f438d47fbe1878d6f317` |
+|  `latest-dev` | November 15th | `sha256:d492b87a94966529dfbe3ff82bc576e1750f7c5b2625d1d767f3de0303a35d4e` |
+|  `latest`     | November 15th | `sha256:d27bc5611fa57aeb27a4892b0eb315156cb1cf4e2ddb382b5a3373ad05463dc7` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:6f057aef09ffbd76d0a9a9473e0a33011d896d103072896e8146db646cfb24d3` |
-|  `latest-dev` | November 13th | `sha256:f526af1766bd24791507c3cf1302beb39e538728d17b5fcfe0105d00e1c0c290` |
+|  `latest-dev` | November 15th | `sha256:ce546cb7e6b8ed38eb3f9b89e6d6e90cc43fd6570b110e54de91cf8d58733ffa` |
+|  `latest`     | November 15th | `sha256:0cbae848e7f0a097a0da3dc0aa7cc5c0dbdd6b666c2bc23c99dc6a2ba8af86fa` |
 

--- a/content/chainguard/chainguard-images/reference/pgbouncer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pgbouncer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:d6ed1ec2f6cd81f5af2651eb5ed297b7739ccf262706d05b67478b9ed950edfe` |
-|  `latest`     | November 7th  | `sha256:1778c5791719cec632bdbffa8a05b737c5894b8c8550d81f337c673a8edc98b9` |
+|  `latest-dev` | November 15th | `sha256:0aec775dd2ade404b52790e836384acfff49462375e2cce58baeaadd2a5f1639` |
+|  `latest`     | November 15th | `sha256:e6e829e91db0cde5a1bd365361b81b06832536d1b9e0de8558e25f246cd07c2a` |
 

--- a/content/chainguard/chainguard-images/reference/php/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/php/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)           | Last Changed  | Digest                                                                    |
 |-------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-fpm-dev` | November 11th | `sha256:3009c98cf099eb945646d6a846661dea2272b7edd64376c6249b205f8aa2e3e2` |
-|  `latest-dev`     | November 11th | `sha256:e5ca49a891661e48cda6263012b0ac0d6640e504e5d1ac719ce6b7b78444c2e2` |
-|  `latest-fpm`     | November 7th  | `sha256:54c150fc0247b3dbd6ea0d07ba78b0ee0fb5a65d81e444762325fc24d69d4e03` |
-|  `latest`         | November 7th  | `sha256:28142ecf229b30b8710c69e21b97c0a42c5448e7c4a08b29b991075d6fe2a287` |
+|  `latest`         | November 15th | `sha256:3096d96253ca1eb6d92e67125338d87659c2c1b80accb8cf051961137a101ba9` |
+|  `latest-dev`     | November 15th | `sha256:d1cd96ae200eaa6eccf770e6bf776ecde8c80156effe7420ffddb2b5ed3a1497` |
+|  `latest-fpm`     | November 15th | `sha256:705e46069557c710862a30547adfb633f55bbec2912e85989184e2b5cb8b3f79` |
+|  `latest-fpm-dev` | November 15th | `sha256:fea594bed79637c1353cd6add8b2af95243b20bf756b2c0987cf9fd3d80168f5` |
 

--- a/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 11th | `sha256:86770afccb4c3daa0b34b599a8d332aea1cd5524622477c360ac8679da2be359` |
+|  `latest` | November 15th | `sha256:d8959d2c158d944e55d27d24e0665cf4a81a85cc6e57ecbced0507663fc0b5b8` |
 

--- a/content/chainguard/chainguard-images/reference/redis-cluster-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-cluster-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:6b93927f03d6d82540f42e0d6411e11aa6f7a516de8a67e7e425d08ecff0d765` |
-|  `latest-dev` | November 11th | `sha256:0fd643851885b6d57c85966d7c300516befb6224432faf4921f38b5d261f80b8` |
+|  `latest-dev` | November 15th | `sha256:5ad9176209a0591f10bb17251002c6d4b0015d9a701d0f54d03b7061b663af7a` |
+|  `latest`     | November 15th | `sha256:55316b348765123b084bec7761de1e1c88fee5716f90d805c03f572c59f95b79` |
 

--- a/content/chainguard/chainguard-images/reference/redis-sentinel-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-sentinel-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:950c6fb51bfd3dd126cfee9b9a39ea2799c4625c3dd8007d1e3e1c3c671fae28` |
-|  `latest-dev` | November 11th | `sha256:2303267e0c1d77cf12ec7298b8b5359aafbe56022193330bbb9fa64324164553` |
+|  `latest-dev` | November 15th | `sha256:90788aa623ed1afbb29783a0f92aae83e2b8ccc29305d0c86d52a2c4fb3dadf8` |
+|  `latest`     | November 15th | `sha256:0722107dd66cf419e7b8f2d247b400cfd0650e2d1d6eb97a63bab3ac8780573c` |
 

--- a/content/chainguard/chainguard-images/reference/redis-sentinel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-sentinel/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)               | Last Changed  | Digest                                                                    |
 |-----------------------|---------------|---------------------------------------------------------------------------|
-|  `six-dot-two-compat` | November 11th | `sha256:39b8c32ab16d9d40ca89e36af964d75fa436630866878e154a9f7dfc7060014a` |
+|  `six-dot-two-compat` | November 15th | `sha256:7d2bfc7217ee3f27f989e5f31cdf36a8ccaa9d1f7b0660d37325cee01910b20d` |
 

--- a/content/chainguard/chainguard-images/reference/redis-server-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/redis-server-bitnami/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:d7e1402fab85256ebb5eab6c755c8ef70d2b0d97a691c4b87b8f916db02c545f` |
-|  `latest-dev` | November 11th | `sha256:9f8f2cc55009d96d1249e11cfdf6666f1d14b39d51fb62e038072384ccef9d96` |
+|  `latest`     | November 15th | `sha256:265be056f5dbba2ac5534419fc042652391c1f87af93b5688c2a29b4157ed2d2` |
+|  `latest-dev` | November 15th | `sha256:b777e8e75ffdac38fd152843f185e1b0bc06fd2449a4cd2442f387dfee3d2c89` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:2d5096db4b8368d5b5a0a26da1fa8b24b11643231940598d411eb53dcbd37c00` |
-|  `latest-dev` | November 13th | `sha256:30b99db7e09f69a3cadd0ebad961b2e21d0c2bb465bd7c306efaf4e6a63a2458` |
+|  `latest-dev` | November 15th | `sha256:26e4845dbf055e109d7c8d01ca5852e907f1f202ea809788a68cae3281acce40` |
+|  `latest`     | November 15th | `sha256:6071cd2e213e4118c8c9a2083f396ec529932c5b87c145ba45d877ee0251461f` |
 

--- a/content/chainguard/chainguard-images/reference/sigstore-scaffolding-cloudsqlproxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/sigstore-scaffolding-cloudsqlproxy/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:7b5fcfbcdb92605a68351c6c4d60faeaf4d802bbe31bd37b31a96c3601a4b96f` |
-|  `latest`     | October 30th  | `sha256:76e148bbdd984d14de9945f1db02106d459c7dab86248096a03a569e02069663` |
+|  `latest-dev` | November 15th | `sha256:a7d14bdd6e8a449d4adcee50c50dd3b7a77ebf6209c829fb3464b5a276581a4f` |
+|  `latest`     | November 15th | `sha256:a8413d4a337e4e14c136cfabf0ff226c8dce83fe2d21d1cc624df71c4f92d56f` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 14th | `sha256:798fa5f939e34a49931675b99ebc496222a53dff30a2cd606c3ef18058b4e568` |
+|  `latest` | November 15th | `sha256:b235c9113f0897d54c7a778b77affb1b8cfaa79259cef84b09473fa1e8cd5c41` |
 

--- a/content/chainguard/chainguard-images/reference/spark-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spark-operator/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 11th | `sha256:5f5e3f789db1e3a69cb863f0237e4c7c22dabd286bc05b59fe276887fda816c6` |
-|  `latest`     | November 11th | `sha256:6c8f710d55dd0cbe516b2633755ac6039970851b92c3eb39007b393381124601` |
+|  `latest-dev` | November 15th | `sha256:f3efd29dd5df70f688e54371df4fc14b56c1766832123c60d88f437a7fcc9f9f` |
+|  `latest`     | November 15th | `sha256:cbc7af5f6211cc19e0d44d1ecf6f4126c17b1807066e215d3d1f3c34b1c1e1ff` |
 

--- a/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:7b343c4206219c997cc1de105bcdc42ad4c903ac3b8adc2e8ae1f4fb1bb60b42` |
-|  `latest-dev` | November 13th | `sha256:da6167275f5ca3c4dfe636f2571f41c6c1b7e2bbbb0cfe9d5f6880e0bb02bbd6` |
+|  `latest`     | November 15th | `sha256:3554c6dd0b4ddb5b164c25406d59c43e620590aa7b46da10980c1b24b7ea0800` |
+|  `latest-dev` | November 15th | `sha256:350d19f979913765e60e1daffe015a19a4f638857fed7b1be6e578bedcde3d08` |
 

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 13th | `sha256:60624f3bf3afee39e0c88252d628cec66c439d358153083ea5f337722c560123` |
-|  `latest-dev` | November 13th | `sha256:1e8fc6deefee0fc13335ae0754f5e9a5c2e69650546075bf4cc311255955bda0` |
+|  `latest-dev` | November 15th | `sha256:96106a86c4c9805e996dbff0554708ad153485280a5742d86f7641181efc26ed` |
+|  `latest`     | November 15th | `sha256:caff9c6811e6533a7e9277c2a2c3cbf06a9916d5d9801687cad2cd64169d47a3` |
 

--- a/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 13th | `sha256:65a725a5ea3b676e34803ef04eed2b107d8e2bd41e282ed4b21e2a1fb01aa6d2` |
-|  `latest`     | November 13th | `sha256:cb19c6c6359616b3d7a58c9fe4315c6b44d7dda7da4840fa2380fc250c808b1d` |
+|  `latest`     | November 15th | `sha256:7b9cecc45250ade208c1540bef79beff86e1e195ab03ae1c8040b0c01ab04c87` |
+|  `latest-dev` | November 15th | `sha256:bf3411f1cfae8b34168522b2dca37ecfcacbcc39d313be7b61044ac491155b4e` |
 

--- a/content/chainguard/chainguard-images/reference/temporal-ui-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/temporal-ui-server/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 14th | `sha256:dc5042be5c0efe39fdb7cc2a35d2a2f57a7f498905ef87ceb2949a650ef6c06f` |
-|  `latest`     | November 14th | `sha256:1240a90adf0f99ba8658be9c82e8cde423c4698a6d800e8b9a0cd646bfed958d` |
+|  `latest-dev` | November 15th | `sha256:eae31a4abdd0ff29b492b7b199083bac082e63ad9f459d68a0770dee91ef30cb` |
+|  `latest`     | November 15th | `sha256:38846a47bedfc6de237d933bff1d091dbd3e52b8a64c851d08555ce5424eb722` |
 

--- a/content/chainguard/chainguard-images/reference/wait-for-it/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wait-for-it/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 11th | `sha256:9118ef59ae1daf6cea53ce1c536d99f58018247c364d06e2abdb845877061c3e` |
+|  `latest` | November 15th | `sha256:f9d0533e0f4a97ab495b8fac73c872b7a0e86506f61c1b8e5725394ded15ff38` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 11th | `sha256:401d8700af9f2f79137d5db3a906a48a37f16c786f8fcd1276d0dd20c0b3b4bd` |
-|  `latest-dev` | November 11th | `sha256:043e2509960232f580f11bb9762ffb2d39d0c2616b4bc961a6f21b51354834bc` |
+|  `latest`     | November 15th | `sha256:1e7ba07fd5a1d9c346327312b00376a1273a7027e96ba5fe865a0a9c5c6d9cc3` |
+|  `latest-dev` | November 15th | `sha256:95463a5ffee7f3a25f12f9bc5323f14da825d7c1e2fb3a44a4db0e81d7cf3f64` |
 


### PR DESCRIPTION
Updated Docs:

- argocd/image_specs.md
- argocd-repo-server/tags_history.md
- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- buck2/tags_history.md
- cert-manager-acmesolver/tags_history.md
- cert-manager-cainjector/tags_history.md
- cert-manager-controller/tags_history.md
- cert-manager-webhook/tags_history.md
- cilium-agent/tags_history.md
- cilium-hubble-relay/tags_history.md
- cilium-operator-generic/tags_history.md
- fluentd/tags_history.md
- flux-kustomize-controller/tags_history.md
- gitlab-shell/tags_history.md
- guacamole-server/tags_history.md
- hugo/_index.md
- hugo/tags_history.md
- ingress-nginx-controller/tags_history.md
- istio-install-cni/tags_history.md
- istio-operator/tags_history.md
- istio-pilot/tags_history.md
- istio-proxy/tags_history.md
- jenkins/tags_history.md
- kube-logging-operator/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kubeflow-pipelines-frontend/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- memcached-exporter/tags_history.md
- newrelic-kube-events/tags_history.md
- newrelic-kubernetes/tags_history.md
- node/tags_history.md
- node-lts/tags_history.md
- openai/tags_history.md
- pgbouncer/tags_history.md
- php/tags_history.md
- pulumi/tags_history.md
- redis-cluster-bitnami/tags_history.md
- redis-sentinel/tags_history.md
- redis-sentinel-bitnami/tags_history.md
- redis-server-bitnami/tags_history.md
- semgrep/tags_history.md
- sigstore-scaffolding-cloudsqlproxy/tags_history.md
- slim-toolkit-debug/tags_history.md
- spark-operator/tags_history.md
- spire-agent/tags_history.md
- spire-oidc-discovery-provider/tags_history.md
- spire-server/tags_history.md
- temporal-ui-server/tags_history.md
- wait-for-it/tags_history.md
- zookeeper/tags_history.md