### PR TITLE
adding Doc on retrieving Image SBOMs

### DIFF
--- a/content/chainguard/chainguard-images/retrieve-image-sboms.md
+++ b/content/chainguard/chainguard-images/retrieve-image-sboms.md
@@ -33,7 +33,7 @@ In order to follow this guide, you'll need the following installed on your local
 
 ## Using Cosign to retrieve an Image's SBOM
 
-Cosign includes a `download` command that allows you to retrieve a Chainguard Image's SBOM over the command line. To do so, you would use this command with syntax like the following.
+Cosign includes a `download` command that allows you to retrieve a Chainguard Image's attestation over the command line. To do so, you would use this command with syntax like the following.
 
 ```shell
 cosign download attestation \ 

--- a/content/chainguard/chainguard-images/retrieve-image-sboms.md
+++ b/content/chainguard/chainguard-images/retrieve-image-sboms.md
@@ -36,11 +36,12 @@ In order to follow this guide, you'll need the following installed on your local
 Cosign includes a `download` command that allows you to retrieve a Chainguard Image's attestation over the command line. To do so, you would use this command with syntax like the following.
 
 ```shell
-cosign download attestation \ 
-cgr.dev/chainguard/$IMAGE | jq -r .payload | base64 -d | jq .predicate
+cosign download attestation cgr.dev/chainguard/php | jq -r .payload | base64 -d | jq .predicate
 ```
 
-Notice that this example syntax includes `download attestation` rather than `download sbom`. You can generally think of an attestation as a an authenticated statement about a software artifact. There are different types of attestations [as defined by the SLSA 1.0 specification](https://slsa.dev/attestation-model), and they are typically referenced by their **predicate type**. One of the available predicate types is SPDX, an open standard for SBOM files. Because attestations must be signed, this is a way to verify the authenticity of the software producer, thereby ensuring the accuracy of the SBOM and the quality of the software.
+This example command downloads the attestation of our [php image](/chainguard/chainguard-images/reference/php/). 
+
+Notice that this example syntax includes `download attestation` rather than `download sbom`. You can generally think of an attestation as an authenticated statement about a software artifact. There are different types of attestations [as defined by the SLSA 1.0 specification](https://slsa.dev/attestation-model), and they are typically referenced by their **predicate type**. One of the available predicate types is SPDX, an open standard for SBOM files. Because attestations must be signed, this is a way to verify the authenticity of the software producer, thereby ensuring the accuracy of the SBOM and the quality of the software.
 
 This attestation data is encoded in base64, making it unreadable without further processing. This is why the output from the first part of the command is piped into `jq` in order to filter out the payload section of the output containing the SBOM. This filtered output is then passed into the `base64` command to be decoded before that output is piped into another `jq` command. The final `jq` command extracts the attestation predicate from the `base64` output and returns it to your terminal.
 
@@ -60,4 +61,6 @@ The other extra argument is the `--predicate-type` flag, required to specify whi
 
 ## Learn more
 
-We provide provenance information for every Chainguard Image in their respective [Reference docs](/chainguard/chainguard-images/reference/). After reaching the **Overview** for the image of your choice, navigate to the **Provenance** tab for information on how to retrieve the image's attestations, as well as how to verify the image's attestations and signatures. 
+We provide provenance information for every Chainguard Image in their respective [Reference docs](/chainguard/chainguard-images/reference/). After reaching the **Overview** for the image of your choice, navigate to the **Provenance** tab for information on how to retrieve the image's attestations, as well as how to verify the image's attestations and signatures.
+
+For example, if you're looking for the provenance information of the Python image, you can navigate to the [Python overview page](/chainguard/chainguard-images/reference/python/) and then click through to **Provenance** which will bring you to the following URL: [https://edu.chainguard.dev/chainguard/chainguard-images/reference/python/provenance_info/](/chainguard/chainguard-images/reference/python/provenance_info/).

--- a/content/chainguard/chainguard-images/retrieve-image-sboms.md
+++ b/content/chainguard/chainguard-images/retrieve-image-sboms.md
@@ -1,0 +1,66 @@
+---
+title: "How to Retrieve SBOMs for Chainguard Images"
+linktitle: "Retrieve an Image's SBOM"
+type: "article"
+description: "A brief tutorial on how to use Cosign to retrieve Chainguard Image SBOMs."
+date: 2023-11-17T11:07:52+02:00
+lastmod: 2023-11-17T11:07:52+02:00
+draft: false
+tags: ["Conceptual", "Chainguard Images", "SBOM"]
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 710
+toc: true
+---
+
+
+Chainguard Images contain only the minimum number of packages needed to use the software they contain. The purpose of this is to reduce the image's attack surface and minimize the risk that CVEs will impact software that depends on these container images. 
+
+Even though they contain the minimum number of packages, there may come a time when you want to know exactly what's running inside of a certain Chainguard Image. For this reason, we include a signed SBOM (also known as an *attestation*) with each image.
+
+[Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/) — a part of the Sigstore project — supports software artifact signing, verification, and storage in an [OCI (Open Container Initiative)](/open-source/oci/what-is-the-oci/) registry, as well as the retrieval of said artifacts. This tutorial outlines how you can use the `cosign` command to retrieve a Chainguard Image's SBOM using Cosign. 
+
+
+## Prerequisites
+
+In order to follow this guide, you'll need the following installed on your local machine:
+
+* **Cosign** — to retrieve SBOMs associated with Chainguard Images, check out [our guide on installing Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) to configure it.
+* **jq** — to process JSON, visit the [jq downloads](https://jqlang.github.io/jq/download/) page to set it up.
+
+
+## Using Cosign to retrieve an Image's SBOM
+
+Cosign includes a `download` command that allows you to retrieve a Chainguard Image's SBOM over the command line. To do so, you would use this command with syntax like the following.
+
+```shell
+cosign download attestation \ 
+cgr.dev/chainguard/$IMAGE | jq -r .payload | base64 -d | jq .predicate
+```
+
+Notice that this example syntax includes `download attestation` rather than `download sbom`. While there are a few [differences between SBOMs and attestations](/open-source/sbom/sboms-and-attestations/), you can generally think of an attestation as a more accurate representation of the contents of the container image than an SBOM. This is because attestations must be signed by the software producer, thereby ensuring the accuracy of the SBOM and the quality of the software. 
+
+This attestation data is encoded in base64, making it unreadable without further processing. 
+This is why the output from the first part of the command is piped into `jq` in order to filter out the payload section of the output containing the SBOM.
+
+This filtered output is then passed into the `base64` command to be decoded before that output is piped into another `jq` command. This final `jq` command extracts the attestation predicate from the `base64` output and returns it to your terminal.
+
+As an example, to retrieve the `argocd` image's attestation you would run a command like the following.
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/argocd | jq -r .payload | base64 -d | jq .predicate
+```
+
+This example includes two extra arguments not included in the example syntax outlined previously. First, it includes the `--platform` flag which allows you to download the attestation for a specific platform image. This example specifies the `linux/amd64` platform, but you could enter alternatives such as `linux/arm64` or `darwin/amd64`. Be aware, though, that in order to use the `--platform` option you'll need to have Cosign version 2.2.1 or newer installed.
+
+The other extra argument is the `--predicate-type` flag. This allows you to specify which format you'd like the SBOM you're downloading to follow. This example retrieves the SBOM in the SPDX format, but to download a CycloneDX SBOM you could instead have the `--predicate-type` option point to `https://cyclonedx.org/Document`.
+
+
+## Learn more
+
+We provide provenance information for every Chainguard Image in their respective [Reference docs](/chainguard/chainguard-images/reference/). After reaching the **Overview** for the image of your choice, navigate to the **Provenance** tab for information on how to retrieve the image's attestation, as well as how to verify the image's attestation and signatures. 


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This PR adds a short tutorial on how to retrieve the SBOM (well, attestation actually) for a given Chainguard Image. 


### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Resolves https://github.com/chainguard-dev/internal/issues/3308#issuecomment-1808809835

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

Everything should work (only one command really) but let me know if anything seems off. 

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Mostly a copy review, but open to any and all feedback!