### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,34 @@
+# 2023-11-21
+New images added:
+
+- qdrant
+
+Updated Docs:
+
+- busybox/tags_history.md
+- cilium-hubble-ui/tags_history.md
+- dex/tags_history.md
+- git/tags_history.md
+- influxdb/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-frontend/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- node/tags_history.md
+- node-lts/tags_history.md
+- opentofu/tags_history.md
+- pgbouncer/tags_history.md
+- pulumi/tags_history.md
+- semgrep/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- static/tags_history.md
+
 # 2023-11-20
 
 

--- a/content/chainguard/chainguard-images/reference/busybox/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/busybox/tags_history.md
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                | Last Changed  | Digest                                                                    |
 |----------------------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest`                              | November 20th | `sha256:51bda360d3ab73f7086426354e2f7128a919a5bc0a322298582ea6921e6a8fc1` |
 |  `latest-glibc`                        | November 16th | `sha256:6257c4c0158213c849264f8376a198839fbdcb82075ce8fb68e39e346808d355` |
-|  `latest`                              | November 12th | `sha256:0b4a9d13098b4546a52f3e173527ced1dbc85bff4bac73e526782649276beed7` |
 |  `1.36` `1` `1.36.1`                   | November 3rd  | `sha256:d6a7ed7843540fc638e70069e3b75f8422ac3d871162518abb5cbd0ee4bd1d38` |
 |  `glibc-1` `glibc-1.36.1` `glibc-1.36` | October 30th  | `sha256:8e3662a12cc913bc5d2aec46333589f4823910ef9560d8763f1fb04b2923aff1` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-hubble-ui/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-hubble-ui/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:62e1b23fe84af49fb3cab0fcb2502b0167765600449d93648115e9b27e03ab13` |
-|  `latest`     | November 19th | `sha256:ae68e366ab0a5561e55d2b6fc5a23d3398d3e1dc90915221c8458223fd89a47a` |
+|  `latest-dev` | November 20th | `sha256:3f9a4ab6196c033f56822c89ce5d65b543aeb6fc6eb183dab08960b6f60bf77b` |
+|  `latest`     | November 20th | `sha256:b8a24c955fd2a3b05fe4fc0fc657a7a496fb85e07fd15f50739d37f8a8d4cb7f` |
 

--- a/content/chainguard/chainguard-images/reference/dex/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dex/tags_history.md
@@ -23,11 +23,10 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)                                                                                              | Last Changed  | Digest                                                                    |
-|------------------------------------------------------------------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev`                                                                                        | November 19th | `sha256:fa26fd236d92d5eefe81e7aefe2bd12e4f33c61ffe6a0a4162bb31878509b740` |
-|  `latest`                                                                                            | November 18th | `sha256:20be4dbf49918a9f309875bb60d7ec8ec0a1448b9dbe6fca6d541792823aa9e9` |
-|  `v2.37.0-dev` `2.37.0-r8-dev` `2-dev` `2.37-dev` `2.37.0-dev` `v2.37-dev` `v2-dev` `v2.37.0-r8-dev` | November 3rd  | `sha256:a26d010dbcba8d421b8d87336c9d9cafc9d35a8e60ff9097f1b065aba8e761fd` |
-|  `2.37.0` `v2.37.0` `2` `v2` `v2.37` `2.37`                                                          | October 30th  | `sha256:66c186956513b3fe3fa72ed717148c3c0a71eb346a34567e5329e33a3384b315` |
-|  `v2.37.0-r7-dev` `2.37.0-r7-dev`                                                                    | October 29th  | `sha256:974083a8f09478d67ce41a64c46c6a68dbf6ac80de6372ce4f979bed6690e0a3` |
+| Tag (s)                                                             | Last Changed  | Digest                                                                    |
+|---------------------------------------------------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev`                                                       | November 19th | `sha256:fa26fd236d92d5eefe81e7aefe2bd12e4f33c61ffe6a0a4162bb31878509b740` |
+|  `latest`                                                           | November 18th | `sha256:20be4dbf49918a9f309875bb60d7ec8ec0a1448b9dbe6fca6d541792823aa9e9` |
+|  `v2.37.0-dev` `2-dev` `2.37-dev` `2.37.0-dev` `v2.37-dev` `v2-dev` | November 3rd  | `sha256:a26d010dbcba8d421b8d87336c9d9cafc9d35a8e60ff9097f1b065aba8e761fd` |
+|  `2.37.0` `v2.37.0` `2` `v2` `v2.37` `2.37`                         | October 30th  | `sha256:66c186956513b3fe3fa72ed717148c3c0a71eb346a34567e5329e33a3384b315` |
 

--- a/content/chainguard/chainguard-images/reference/git/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/git/tags_history.md
@@ -25,12 +25,12 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                  | Last Changed  | Digest                                                                    |
 |--------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest-root-dev`       | November 20th | `sha256:25492a2b18bfa8797a3d50015cab844f9c62fb9ca98f3ca1695d4341d8635299` |
+|  `latest-root`           | November 20th | `sha256:1e48774bd83728797ced847ddff895521189c882933ccf5dbc06202344c9f09b` |
+|  `latest`                | November 20th | `sha256:10755310d684cc81ee0c7198e7975bd7e765e687d9c815985f484033c366526f` |
+|  `latest-dev`            | November 20th | `sha256:20440e8e53f9a10a2866889c73f2bf1df72b25d39b6c381ccc99304142443d03` |
 |  `latest-glibc-root-dev` | November 19th | `sha256:f54c3a0526d0b11dc03b4cbaf575c5f987f18bf5c6f4b15085ff11dd225d042a` |
 |  `latest-glibc-root`     | November 19th | `sha256:986a44bb776f6db4c431934b6f252fdaff300d81923b86c017a5341aef9314dd` |
 |  `latest-glibc-dev`      | November 19th | `sha256:9654e3b997dbb37f5137569ad5caa62acf7e4de0e9a0c8d449cc213e8557aed7` |
 |  `latest-glibc`          | November 19th | `sha256:d87bf143438889af11f91e9f0b33e92a4b5a52a486fb8698a3550d6e27fb3b47` |
-|  `latest-dev`            | November 12th | `sha256:31281e045e8ee5ce38b7f45865508ab41cd34d36565be217ec1ae4904491b604` |
-|  `latest-root`           | November 12th | `sha256:5ce1c0cca3014e1a06cad83a506a457adb886f34fd5da59b05ce33f52ebfc36b` |
-|  `latest`                | November 12th | `sha256:c81fb057d751ae1e1baa95ea058ca66213a394215f9fec964c541de92d73f506` |
-|  `latest-root-dev`       | November 12th | `sha256:bddedefb53d5a0f3b927a3346b8fdd1fc816c2ce6b0a4a5c384ddc4b9183bbb4` |
 

--- a/content/chainguard/chainguard-images/reference/influxdb/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/influxdb/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:ce9d20c3bd9b02d20e9ebe529a375419f6b0d009687a03192f7b9176f638b09c` |
-|  `latest`     | November 16th | `sha256:e80db7d063f6a86a83dd0c8481ac2a71dbed45fcaa4f464b80b9cb32e3cf14f9` |
+|  `latest-dev` | November 20th | `sha256:10bf4843b43ce3b33bed6b7470b7c651c4de58975ca0f8fe6449cf142a4f0b0e` |
+|  `latest`     | November 20th | `sha256:42018c768f7bd5156e0c4b7404f6fe3b6fe61c6f1d032d44b79617d5739fb607` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:9fb95b3e1c17d51eb37c78148aa15867a4bbf2ecf2180e524a634929162535a4` |
-|  `latest`     | November 19th | `sha256:02868b4267fa43bbda02f7d686e959b1086b264de6f03df90bc974e18860a2fa` |
+|  `latest-dev` | November 20th | `sha256:1894005c07ae1f5ee8d3dad8839cc11e126e5e2ae063693592b08bab1db5f33b` |
+|  `latest`     | November 20th | `sha256:8deca54985a57ef387e157e061381b11d734d14106e3c4c4e15ed067899da382` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:c757dd7d3772723502c020e60ae0a8636b0fdfeea4f6b1a432188e0c3283fcf2` |
-|  `latest`     | November 19th | `sha256:715a08522326fa2ce0a23d04059d354bf1dd1c458597b218805857b6d4b2d650` |
+|  `latest-dev` | November 20th | `sha256:190e022bd7cd2cd0a657089d90416f2660f814c607edc6c5573712ed8a3b1eb3` |
+|  `latest`     | November 20th | `sha256:5933daf62d53230a16b70cbaa3e1a3f340ccb065812e82d393d556ed5b1c1d75` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:c680633fd4c7307e85c420abff2926b13b5ae5d284315b885d5eb58305a0f81f` |
-|  `latest`     | November 19th | `sha256:5d84d17561745a4fb9545cdd9a0e7fe280bb07edd5c150412b61055c81ff17d9` |
+|  `latest-dev` | November 20th | `sha256:38f6d88ed58a9b4496e5ba1c0e326f716f754e9461f57f2af3c9421bbfdac570` |
+|  `latest`     | November 20th | `sha256:1c0dfcc13a3475db4a7385ec4317a3d8adde8696ee74029914561b6b49b325c7` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:68909d41d7ee0e4762f8b0ab2da5a08fb1c63f1dddc9cfcb7517caf0077971e4` |
-|  `latest`     | November 19th | `sha256:b67cc7d849aba9de89fdad389540ca34d68b090dd17dc2847080a7f94e97b61c` |
+|  `latest-dev` | November 20th | `sha256:01eca1686e8b7b40497faa851e1cf36cde43b0ebdd07096d00077a6345c0e6ad` |
+|  `latest`     | November 20th | `sha256:8443cce2bfeb1f84cbdb6d2ec87becad4d8241b4089cdd662dd9b04216042854` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 19th | `sha256:ec2cc30410c57842e14f7f96cf0f3965fc424ee55e4e06c8ee8480e0c4ee01d7` |
-|  `latest-dev` | November 19th | `sha256:8e69327270cdc88d3e360d5551af8269f3f940580ea7b791acbdfc9571a76e60` |
+|  `latest-dev` | November 20th | `sha256:aff8a8b462d00c57dc7106563114be3b259e06961f4137d46e70c7a7606df2b7` |
+|  `latest`     | November 20th | `sha256:003423686fe15bfca4ab60266ee60c6c81015380b5027cfc32c37c38366036a9` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:31c98dc1e12c9f27dd872ccbb39afeb280fc49ce13b27da0ca509b7b2e2cd129` |
-|  `latest`     | November 19th | `sha256:5eaeef727d50ec49dc66918053ae760244dc1f1a1b39d01210903808d6e1579e` |
+|  `latest`     | November 20th | `sha256:02d1ec25433a3585f5999db8a8f6f2b7b71410ce9a09b24310f18a3ddfed5fc6` |
+|  `latest-dev` | November 20th | `sha256:c7b92b1b6762522cff23887487c4ff081350d45c37d81e10d8c17ed14e1f613c` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:5202eab6f22c25d0409a2d1396e95927d6761de9d9d2db4b9b99dc9c4751b7b8` |
-|  `latest`     | November 19th | `sha256:369500beb5970bc835fa61b21c4ff51e9a4e6d7734a062e86f4b381a54b062d4` |
+|  `latest`     | November 20th | `sha256:0f8a22c6d0d439cff2f7d8d195b9eec1f4028539ad6c8e150a4a29208af2ba35` |
+|  `latest-dev` | November 20th | `sha256:89734f8c26e76e7160f4c581dad607d3e2a384740cceebfa288c06465f98f994` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:2e65f46867e9aa2bfe378bf71e743589553dd51a5332a6e4089948be393c16ba` |
-|  `latest`     | November 19th | `sha256:57381cfe6c4de5ff4988837fe10081513a8f49112e3a062947e0d050e21cfb8c` |
+|  `latest-dev` | November 20th | `sha256:b7c8f2942930377fe9e7f3c9470f0c576e71cee599d0f16d29aa983ed0e0f7d0` |
+|  `latest`     | November 20th | `sha256:67005b3fec1fea25194c706309c3ecadec15fb0f2796ab74245b6fa263bf93ae` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:6198785909ac3283fe0e3e61ca63824e542447dac06c99b07b23688f19a9bbde` |
-|  `latest`     | November 19th | `sha256:fcae3ccb9cac342ef66b5ec977fcbce50ac814fc0a9a7aa7fdad7ea87027ec31` |
+|  `latest-dev` | November 20th | `sha256:600d10d7203e51764006782dfa585f19c9b50054dd4c18e7671abe77c8d7457d` |
+|  `latest`     | November 20th | `sha256:5cd48d375191fb747f35e5f1a2e2b6522fe5dd2d968f063991327843e373245e` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:a6d0d5a0446dfedc36493ca13ed8b3cbec25d478551191f276ea3a0c7e67fe0e` |
-|  `latest`     | November 19th | `sha256:9925690808b1ab580c1f905d1b945f2b133765dc7912472db35eac90b2f57009` |
+|  `latest`     | November 20th | `sha256:3976bc32f2759187cd8197d05b27db3afcc61671aa9da21d075c318ecf5c8f3d` |
+|  `latest-dev` | November 20th | `sha256:178f33b8a6cd6f8592e4709a09bdd4cb7b3d04ed2453097f65c659b4aca99f15` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:0858b25b2a47b322519d768e5b2055a0e5ee81f1bdb439ce355a378c47cb6305` |
-|  `latest`     | November 19th | `sha256:44fe5a65c7ac4f585b4129ac9e5051ea7ad2d00e55259afdcbafd37a318b5fc5` |
+|  `latest-dev` | November 20th | `sha256:04ce0fb23319e85793c9413e456d052b7dec5936a6cf323ad5745ee824b517c1` |
+|  `latest`     | November 20th | `sha256:bb28997d73a7315c8cae29f6fde8b93cfc4639424cc7e1ab32cd46189cf88b2f` |
 

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:8b5c6111d2804d726a15c94c889500650945745f4b52b51e7cea3d68eadfc8f8` |
-|  `latest`     | November 19th | `sha256:1682d0a06c248ac44922f9ffe4dd4a302ad7b6ced4a7cb028a0397810368efec` |
+|  `latest-dev` | November 20th | `sha256:4a8f2fb37f0d2b34460f1a86f106c504954917561a50af1fa310f615709079d1` |
+|  `latest`     | November 20th | `sha256:f0beb10925570efd0d6ab7e99d0151b3377ae27aa925b7e689e6d1cd46d7d195` |
 

--- a/content/chainguard/chainguard-images/reference/opentofu/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opentofu/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:7ec452032ec872b87aa1c978d5fac78b8b78438fd6915651e54afb249f137f55` |
-|  `latest`     | October 30th  | `sha256:747efe18870e3478339e87209c29b7591075b7fa9383ba73d91fa529a608d3a4` |
+|  `latest-dev` | November 20th | `sha256:eca8b699b4c2c168fdf911236f0f48b106485e53d07b9361dc2be1250d750d00` |
+|  `latest`     | November 20th | `sha256:fed6dddccfc04ca7e0b199965f6b69a10214f6477a2f620b66d08e2f8c48a169` |
 

--- a/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 19th | `sha256:bb98cf075a3d9ab43cdfef17966c14621ab37f206bcd48788407182bd382f6e9` |
+|  `latest` | November 20th | `sha256:fbd8c3757634bbe69e2172e417e7abe2638ebcf194306333db5088002565eb79` |
 

--- a/content/chainguard/chainguard-images/reference/qdrant/_index.md
+++ b/content/chainguard/chainguard-images/reference/qdrant/_index.md
@@ -1,0 +1,55 @@
+---
+title: "Image Overview: qdrant"
+linktitle: "qdrant"
+type: "article"
+layout: "single"
+description: "Overview: qdrant Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/qdrant/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/qdrant/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/qdrant/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/qdrant/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+[qdrant](https://github.com/qdrant/qdrant) Qdrant is a high-performance, massive-scale Vector Database for the next generation of AI.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/qdrant
+```
+
+## Using Qdrant
+
+This image should be a drop-in replacement for the upstream image, and works by default in the helm charts.
+
+To install, follow the steps here: https://qdrant.tech/documentation/guides/installation
+
+But override the image variable in the helm chart:
+
+```shell
+$ helm repo add qdrant https://qdrant.to/helm
+$ helm upgrade --install qdrant --set image.repository=cgr.dev/chainguard/qdrant --set image.tag=latest qdrant/qdrant
+```
+
+The only notable difference is that this image contains both a root and a non-root user, so you can't/don't need to use the `useUnprivileged` [helm variable](https://github.com/qdrant/qdrant-helm/blob/2ddefd61ccd9da092739eaf13f9a76b8b3cfd55e/charts/qdrant/values.yaml#L7C7-L7C7)
+
+Because the helm chart uses the same image for intializing file system permissions and running the final app, we have to run as a root user by default.
+The image can still be run as a non-root user (in this case `qdrant`), and the helm chart properly sets that up by default.
+

--- a/content/chainguard/chainguard-images/reference/qdrant/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/qdrant/image_specs.md
@@ -1,0 +1,75 @@
+---
+title: "qdrant Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public qdrant Chainguard Image variants"
+date: 2023-03-07T11:07:52+02:00
+lastmod: 2023-03-07T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/qdrant/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/qdrant/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/qdrant/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/qdrant/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **qdrant** Image.
+
+## Variants Compared
+The **qdrant** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                      | latest                          |
+|--------------|---------------------------------|---------------------------------|
+| Default User | `root`                          | `root`                          |
+| Entrypoint   | `/usr/lib/qdrant/entrypoint.sh` | `/usr/lib/qdrant/entrypoint.sh` |
+| CMD          | not specified                   | not specified                   |
+| Workdir      | `/qdrant`                       | `/qdrant`                       |
+| Has apk?     | yes                             | no                              |
+| Has a shell? | yes                             | yes                             |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/qdrant/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                          | latest-dev | latest |
+|--------------------------|------------|--------|
+| `apk-tools`              | X          |        |
+| `bash`                   | X          | X      |
+| `busybox`                | X          | X      |
+| `ca-certificates-bundle` | X          | X      |
+| `git`                    | X          |        |
+| `glibc`                  | X          | X      |
+| `glibc-locale-posix`     | X          | X      |
+| `ld-linux`               | X          | X      |
+| `libbrotlicommon1`       | X          |        |
+| `libbrotlidec1`          | X          |        |
+| `libcrypt1`              | X          | X      |
+| `libcrypto3`             | X          |        |
+| `libcurl-openssl4`       | X          |        |
+| `libexpat1`              | X          |        |
+| `libgcc`                 | X          | X      |
+| `libnghttp2-14`          | X          |        |
+| `libpcre2-8-0`           | X          |        |
+| `libssl3`                | X          |        |
+| `libstdc++`              | X          | X      |
+| `ncurses`                | X          | X      |
+| `ncurses-terminfo-base`  | X          | X      |
+| `openssl-config`         | X          |        |
+| `qdrant`                 | X          | X      |
+| `qdrant-oci-compat`      | X          | X      |
+| `qdrant-oci-entrypoint`  | X          | X      |
+| `wolfi-baselayout`       | X          | X      |
+| `zlib`                   | X          |        |
+

--- a/content/chainguard/chainguard-images/reference/qdrant/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/qdrant/provenance_info.md
@@ -1,0 +1,85 @@
+---
+title: "Provenance Information for qdrant Images"
+type: "article"
+unlisted: true
+description: "Provenance information for qdrant Chainguard Image"
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2022-11-01T11:07:52+02:00
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/qdrant/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/qdrant/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/qdrant/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/qdrant/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying qdrant Image Signatures
+The **qdrant** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/qdrant | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading qdrant Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the qdrant image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the qdrant image on `unix/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/qdrant | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying qdrant Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the qdrant image attestations:
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard/qdrant
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/qdrant --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/qdrant/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/qdrant/tags_history.md
@@ -1,8 +1,8 @@
 ---
-title: "pgbouncer Image Tags History"
+title: "qdrant Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the pgbouncer Chainguard Image"
+description: "Image Tags and History for the qdrant Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
 lastmod: 2023-06-22T11:07:52+02:00
 draft: false
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/pgbouncer/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/pgbouncer/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/pgbouncer/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/pgbouncer/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/qdrant/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/qdrant/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/qdrant/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/qdrant/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | November 20th | `sha256:b2e3df2bf74dd345bf16c6c20532c555fe946784f33feac9e9c3de7ad1715572` |
-|  `latest-dev` | November 20th | `sha256:8a9774a9c341b50a57c8c2bb9ec0cd499c110b04a1600043e324ffaa6881129c` |
+|  `latest`     | November 20th | `sha256:f9126669b66b8f388ff10ebead67cd25df20603a2f73088aea3e16d772878fae` |
+|  `latest-dev` | November 20th | `sha256:3337213faaca402e35f547cd801245469d6f049b4af532d8b56e83b75cbffd48` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | November 19th | `sha256:7318069f153519ba51839c3d9891ca1be5cee7877100070999be8aca5fc8d982` |
-|  `latest`     | November 19th | `sha256:9dc6ac0e381953afb58333cc8b2a586f5fbd7013d30bb0d91378068b6e9f64e9` |
+|  `latest`     | November 20th | `sha256:99e22d5042639ff9824c2e86ba0be4b5c9be3e7c12456d2aa12628534fc22b23` |
+|  `latest-dev` | November 20th | `sha256:110600907c07d7d07dd8b05ecc9182cae1e8dc96334453a99acc0db2ee195b6e` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | November 19th | `sha256:2bc0381bf2f1a32b8cddf9ea5e3861deecb4f8413e5cae3ed3b26ab094fcffe3` |
+|  `latest` | November 20th | `sha256:ebae681de6712edb0f2eb99ebfc8e9c387dc1e3c342869c3b5359945061bb4cd` |
 

--- a/content/chainguard/chainguard-images/reference/static/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/static/tags_history.md
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)         | Last Changed | Digest                                                                    |
-|-----------------|--------------|---------------------------------------------------------------------------|
-|  `latest`       | October 30th | `sha256:d3465871ccaba3d4aefe51d6bb2222195850f6734cbbb6ef0dd7a3da49826159` |
-|  `latest-glibc` | October 30th | `sha256:4b3878d73af9215d813ef80a08d0fee838a81b9597cc3cbe21364ecacf267b6d` |
+| Tag (s)         | Last Changed  | Digest                                                                    |
+|-----------------|---------------|---------------------------------------------------------------------------|
+|  `latest`       | November 20th | `sha256:676e989769aa9a5254fbfe14abb698804674b91c4d574bb33368d87930c5c472` |
+|  `latest-glibc` | October 30th  | `sha256:4b3878d73af9215d813ef80a08d0fee838a81b9597cc3cbe21364ecacf267b6d` |
 


### PR DESCRIPTION
New images added:

- qdrant

Updated Docs:

- busybox/tags_history.md
- cilium-hubble-ui/tags_history.md
- dex/tags_history.md
- git/tags_history.md
- influxdb/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-frontend/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- newrelic-kubernetes/tags_history.md
- node/tags_history.md
- node-lts/tags_history.md
- opentofu/tags_history.md
- pgbouncer/tags_history.md
- pulumi/tags_history.md
- semgrep/tags_history.md
- slim-toolkit-debug/tags_history.md
- static/tags_history.md