### PR TITLE
Fix openapi pagewidth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ else
 	-v $$PWD:/home/inky/ \
 	-p 8080:8080 -p 1313:1313 \
 	-it --user root \
-	academy.local:latest-$arch
+	academy.local:latest-$(arch)
 endif

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -35,13 +35,6 @@
   color: var(--article-link-color);
 }
 
-// OpenAPI spec page is squished without this
-.docs-content > elements-api {
-  display: block;
-  margin: 0 -144px 0 -144px;
-  padding: 0
-}
-
 .button-description {
   margin-bottom: 12px;
 }

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -35,6 +35,13 @@
   color: var(--article-link-color);
 }
 
+// OpenAPI spec page is squished without this
+.docs-content > elements-api {
+  display: block;
+  margin: 0 -144px 0 -144px;
+  padding: 0
+}
+
 .button-description {
   margin-bottom: 12px;
 }

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -16,6 +16,11 @@
   }
   main.docs-content {
     width: 100% !important;
+    padding: 0 !important;
+  }
+  main.docs-content.has-toc {
+    max-width: calc(100dvw - 384px); 
+    margin: 0 48px 0 48px;
   }
   main h1 {
     font-size: 2.5rem !important;


### PR DESCRIPTION
## Type of change
enhancement

### What should this PR do?
This makes the OpenAPI page wider since it uses a 3 column layout. It also fixes the `make dev-container` target for aarch64.

### Why are we making this change?
Unsquishing the OpenAPI page.

### What are the acceptance criteria? 
netlify won't show it, but the width ought to look better. Here's a screenshot:

![Screenshot 2023-12-04 at 11 45 54 AM](https://github.com/chainguard-dev/edu/assets/328553/f7136e70-b0fa-4f3e-a960-5cf51c544432)


### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->