### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,58 @@
+# 2023-12-07
+
+
+Updated Docs:
+
+- buildkit/_index.md
+- buildkit/tags_history.md
+- calico-cni/_index.md
+- calico-cni/tags_history.md
+- calico-csi/_index.md
+- calico-csi/tags_history.md
+- calico-kube-controllers/_index.md
+- calico-kube-controllers/tags_history.md
+- calico-node/_index.md
+- calico-node/tags_history.md
+- calico-node-driver-registrar/_index.md
+- calico-node-driver-registrar/tags_history.md
+- calico-pod2daemon-flexvol/_index.md
+- calico-pod2daemon-flexvol/tags_history.md
+- calico-typha/_index.md
+- calico-typha/tags_history.md
+- calicoctl/_index.md
+- calicoctl/tags_history.md
+- clang/_index.md
+- clang/tags_history.md
+- dependency-track/_index.md
+- erlang/_index.md
+- erlang/tags_history.md
+- haproxy-ingress/_index.md
+- haproxy-ingress/tags_history.md
+- helm/_index.md
+- helm/tags_history.md
+- hugo/_index.md
+- hugo/tags_history.md
+- jdk/tags_history.md
+- kubernetes-csi-external-provisioner/_index.md
+- kubernetes-csi-external-provisioner/tags_history.md
+- kubernetes-dashboard/_index.md
+- kubernetes-dashboard/tags_history.md
+- kubernetes-ingress-defaultbackend/_index.md
+- kubernetes-ingress-defaultbackend/tags_history.md
+- meilisearch/_index.md
+- node/_index.md
+- node/tags_history.md
+- skaffold/_index.md
+- skaffold/tags_history.md
+- spire-agent/_index.md
+- spire-agent/tags_history.md
+- spire-oidc-discovery-provider/_index.md
+- spire-oidc-discovery-provider/tags_history.md
+- spire-server/_index.md
+- spire-server/tags_history.md
+- vector/_index.md
+- vector/tags_history.md
+
 # 2023-12-06
 New images added:
 

--- a/content/chainguard/chainguard-images/reference/buildkit/_index.md
+++ b/content/chainguard/chainguard-images/reference/buildkit/_index.md
@@ -4,8 +4,8 @@ linktitle: "buildkit"
 type: "article"
 layout: "single"
 description: "Overview: buildkit Chainguard Image"
-date: 2023-12-06 18:44:36
-lastmod: 2023-12-06 18:44:36
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -24,4 +24,19 @@ toc: true
 {{</ tabs >}}
 
 
+
+<!--overview:start-->
+Buildkit is a concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit.
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/buildkit:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/buildkit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buildkit/tags_history.md
@@ -3,8 +3,8 @@ title: "buildkit Image Tags History"
 type: "article"
 unlisted: true
 description: "Image Tags and History for the buildkit Chainguard Image"
-date: 2023-12-06 18:44:36
-lastmod: 2023-12-06 18:44:36
+date: 2023-06-22T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)            | Last Changed | Digest                                                                    |
 |--------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-root`     | December 5th | `sha256:0348cf24ac319e7a65a16d2242017dfc769e3218aebfb019feac661495684596` |
-|  `latest-root-dev` | December 5th | `sha256:2006ec468ac9fb0db868775aa9845f8650d58c952ab875f6f901cd809722ef02` |
+|  `latest-root`     | December 6th | `sha256:93934054af67e7caf710ed962cb239327b27a483a4b3987965fa8957a434ba24` |
+|  `latest-root-dev` | December 6th | `sha256:8db1d8d662411218de5cf9078025a9fd1ac44ea387a52b1ea9073c1f4f958372` |
 

--- a/content/chainguard/chainguard-images/reference/calico-cni/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-cni/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-cni Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-cni/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-cni/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-cni Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:a95551d1423cd7e44bc01eaacd9474102ac4062c6a8b6fc7da19a9876785d3d5` |
+|  `latest` | December 6th | `sha256:95d99712f91f0f1ed8cc3750d00439ae72b726e37ccf6ffe05ebf5f4cb4f590a` |
 

--- a/content/chainguard/chainguard-images/reference/calico-csi/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-csi/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-csi Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-csi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-csi/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-csi Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:4b0545d654b55734099e86514e8b2ec4fc04ec74df3f2d1dd0f00b73d29348db` |
+|  `latest` | December 6th | `sha256:7b824e1e652e8be24b10a2e12f40bc205c8fcf532981c1e313a1918c437bc12d` |
 

--- a/content/chainguard/chainguard-images/reference/calico-kube-controllers/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-kube-controllers/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-kube-controllers Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-kube-controllers/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-kube-controllers/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-kube-controllers Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:c87a85cd1c5c1f57b234c45e47c5039c5978c2e1a6159be11f018441e33706bb` |
+|  `latest` | December 6th | `sha256:8d45aed9411203c884927ef28b1ba367f021441b6b52d60b26131a9b0c6b36ed` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-node-driver-registrar Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node-driver-registrar/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-node-driver-registrar Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:eef323a59ff64b581629c3af9492bcd9812123400c37701e695ec1beae535f42` |
+|  `latest` | December 6th | `sha256:eb9154ac205e0b0ebffcc1f1f406ab2983a6c7a42e2fff201d1308e78d3f5cef` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-node/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-node Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:ca687a9beb87cb440af746572ceba997dfbb843168c6b021ee41a22bca58cb0f` |
+|  `latest` | December 6th | `sha256:08a2d972a3525b8452f78800f33425f135a3f35d2084f92fac64402365fa3b56` |
 

--- a/content/chainguard/chainguard-images/reference/calico-pod2daemon-flexvol/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-pod2daemon-flexvol/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-pod2daemon-flexvol Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-pod2daemon-flexvol/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-pod2daemon-flexvol/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-pod2daemon-flexvol Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:5cd8dd3a0039d531a32e2e70adc336553764135f6177797674cbe332087b2979` |
+|  `latest` | December 6th | `sha256:796402224063b12116cfd5ed2ff6992be8f1ac15a18987fbc85b26318b648af1` |
 

--- a/content/chainguard/chainguard-images/reference/calico-typha/_index.md
+++ b/content/chainguard/chainguard-images/reference/calico-typha/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calico-typha Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calico-typha/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-typha/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-typha Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:cd1b484b4d0b6a3f19e9cec102e388618b6acfe992617d50a0a472d5b7f29292` |
+|  `latest` | December 6th | `sha256:d5f1e21ee1a48a3864d18824dbd283da8c438db8c3f9de0a1b3f0942299cafe1` |
 

--- a/content/chainguard/chainguard-images/reference/calicoctl/_index.md
+++ b/content/chainguard/chainguard-images/reference/calicoctl/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: calicoctl Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,6 +30,12 @@ toc: true
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/calico:latest
+```
 <!--getting:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/calicoctl/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calicoctl/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calicoctl Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | December 6th | `sha256:491c39011ae3c2878ff227702f49c5165985b99e8b7f29339232b35f71b39e58` |
+|  `latest` | December 6th | `sha256:7b0ec387bcef1cb49841e609ff0e5a822e2d57bdeb3fc42bd155cd8f1c5da1bf` |
 

--- a/content/chainguard/chainguard-images/reference/clang/_index.md
+++ b/content/chainguard/chainguard-images/reference/clang/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: clang Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,7 +26,7 @@ toc: true
 
 
 <!--overview:start-->
-[Clang](https://clang.llvm.org) is a compiler front end for the C, C++, Objective-C, and Objective-C++ programming languages, as well as the OpenMP, OpenCL, RenderScript, CUDA, SYCL, and HIP frameworks.
+[Clang](https://clang.llvm.org) is a compiler front end for the C, C++, Objective-C, and Objective-C++ programming languages, as well as the OpenMP, OpenCL, RenderScript, CUDA, SYCL, and HIP frameworks
 <!--overview:end-->
 
 <!--getting:start-->
@@ -87,3 +87,4 @@ docker run --rm -v /tmp:/work cgr.dev/chainguard/bash /work/hello
 Hello World!
 ```
 <!--body:end-->
+

--- a/content/chainguard/chainguard-images/reference/clang/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/clang/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the clang Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:8787e17e789df184bd834da47693ed6366037c8852d1fe16acea3bfd6e323e38` |
+|  `latest-dev` | December 6th | `sha256:d6ac29e7d2551a4fe3d720fc63f0b043a407504a421edadb134c88ca4aef4453` |
 |  `latest`     | December 6th | `sha256:abd7aca1f26e1cf338674215c34e7f838224bd375018a6499364087197decd07` |
 

--- a/content/chainguard/chainguard-images/reference/dependency-track/_index.md
+++ b/content/chainguard/chainguard-images/reference/dependency-track/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: dependency-track Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -25,16 +25,20 @@ toc: true
 
 
 
-
+<!--overview:start-->
 [Dependency Track](https://github.com/DependencyTrack/dependency-track) Dependency-Track is an intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain.
+<!--overview:end-->
 
+<!--getting:start-->
 ## Get It!
-
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/dependency-track
+docker pull cgr.dev/chainguard/dependency-track:latest
 ```
+<!--getting:end-->
+
+<!--body:start-->
 
 ## Using Dependency Track
 
@@ -141,4 +145,6 @@ $ docker run -p 8080:8080 cgr.dev/chainguard/dependency-track
 ```
 
 The admin console should then be available in your browser at [http://localhost:8080](http://localhost:8080).
+
+<!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/erlang/_index.md
+++ b/content/chainguard/chainguard-images/reference/erlang/_index.md
@@ -4,8 +4,8 @@ linktitle: "erlang"
 type: "article"
 layout: "single"
 description: "Overview: erlang Chainguard Image"
-date: 2023-12-06 18:44:36
-lastmod: 2023-12-06 18:44:36
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,16 +25,20 @@ toc: true
 
 
 
+<!--overview:start-->
 Container image for building Erlang applications.
+<!--overview:end-->
 
+<!--getting:start-->
 ## Get It!
-
 The image is available on `cgr.dev`:
 
 ```
 docker pull cgr.dev/chainguard/erlang:latest
 ```
+<!--getting:end-->
 
+<!--body:start-->
 ## Usage
 
 The image can be used to run the `erl` tool, or to compile and run Erlang scripts.
@@ -59,4 +63,5 @@ CMD [ "-noshell", "-eval", "hello:hello_world().", "-s", "init", "stop" ]
 ```
 
 Running this image should output `hello, world`.
+<!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/erlang/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/erlang/tags_history.md
@@ -3,8 +3,8 @@ title: "erlang Image Tags History"
 type: "article"
 unlisted: true
 description: "Image Tags and History for the erlang Chainguard Image"
-date: 2023-12-06 18:44:36
-lastmod: 2023-12-06 18:44:36
+date: 2023-06-22T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:f5b3b401f850148f42d2a58c296e182106dd29efdbbc5af20e89f378683c2523` |
+|  `latest-dev` | December 6th | `sha256:e95a2e6abf45a2846faba4fb5a99a309463f812ed6f046ae091b62385da266cf` |
 |  `latest`     | December 6th | `sha256:db4a296eb399f7472d019faab99190780e297b2c07855883f8315a5ee2042a9d` |
 

--- a/content/chainguard/chainguard-images/reference/haproxy-ingress/_index.md
+++ b/content/chainguard/chainguard-images/reference/haproxy-ingress/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: haproxy-ingress Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,14 +26,14 @@ toc: true
 
 
 <!--overview:start-->
-[HAProxy Ingress](https://haproxy-ingress.github.io/) is a Kubernetes ingress controller implementation for HAProxy.
+Kubernetes ingress controller implementation for HAProxy
 <!--overview:end-->
 
 <!--getting:start-->
 ## Get It!
-The image is available on `cgr.dev`.
+The image is available on `cgr.dev`:
 
-```shell
+```
 docker pull cgr.dev/chainguard/haproxy-ingress:latest
 ```
 <!--getting:end-->

--- a/content/chainguard/chainguard-images/reference/haproxy-ingress/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/haproxy-ingress/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the haproxy-ingress Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:c8f5314264bde95e507e9abc537002a42c5d28e512b4fa5cbf940185779521c2` |
-|  `latest-dev` | December 6th | `sha256:7250939bd1432b8a4086c6a333818289f4fa97c19d5f76cd25c3b19866ee537c` |
+|  `latest`     | December 6th | `sha256:3ea78ec3d7cf97ed65a5161ba5b77faebfe77e81507b30d14727e32f20db81fe` |
+|  `latest-dev` | December 6th | `sha256:30afc908a83a9fc1a7e5140ded804aff7bed06861ad2acb2fe84dbe17e9a0344` |
 

--- a/content/chainguard/chainguard-images/reference/helm/_index.md
+++ b/content/chainguard/chainguard-images/reference/helm/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: helm Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -31,7 +31,7 @@ Minimal image with [helm](https://helm.sh) binary. **EXPERIMENTAL**
 
 <!--getting:start-->
 ## Get It!
-The image is available on `cgr.dev`.
+The image is available on `cgr.dev`:
 
 ```
 docker pull cgr.dev/chainguard/helm:latest

--- a/content/chainguard/chainguard-images/reference/helm/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/helm/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the helm Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:d58f404ad6a6eb567a5c588540d95666902d632edda76a4593e4a3eb420c28a6` |
-|  `latest-dev` | December 6th | `sha256:e36f0b21cde354a326495471cccdacbe88ef2f03b51d20625a1ee183a304500a` |
+|  `latest`     | December 6th | `sha256:a782399205bceaf1f8bafa78dd8227fa40ef9350b8a74386142c7a248073996a` |
+|  `latest-dev` | December 6th | `sha256:273a68c1e1c8fcd6c34bfdb7902dde38495c501d03d66cc6bc7ade6e0d2d5dfa` |
 

--- a/content/chainguard/chainguard-images/reference/hugo/_index.md
+++ b/content/chainguard/chainguard-images/reference/hugo/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: hugo Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/hugo:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThis image only contains `hugo` and supporting libraries.  The Hugo process starts in `/hugo` by default so this directory may be initialized with the Hugo site to serve.<!--compatibility:end-->
+## Compatibility Notes
+
+This image only contains `hugo` and supporting libraries.  The Hugo process starts in `/hugo` by default so this directory may be initialized with the Hugo site to serve.
+<!--compatibility:end-->
 
 <!--body:start-->
 ## Application Setup for End Users

--- a/content/chainguard/chainguard-images/reference/hugo/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/hugo/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the hugo Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:31a0c9fd152d3a3b38a926ec832ceb25e3910dd288b83a8c725885c659ef78d8` |
-|  `latest-dev` | December 6th | `sha256:ddd2fb404a6cad2fbb0119dede68c7577f035e00f7cd0cfbcf94a9ab3c0ea310` |
+|  `latest-dev` | December 6th | `sha256:12258bc25a7211fa7dabbdb444b23a607de8296779f20957f099313604a3e93b` |
+|  `latest`     | December 6th | `sha256:5caa88c39b5c37d0353283e89c5d0a78019f582c2b0c33b5fc65ef627a99c3b1` |
 

--- a/content/chainguard/chainguard-images/reference/jdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | December 6th | `sha256:a31d3e5912de38e6daa75b18445da4d9d944b425d836e2d177272eb6b6840d63` |
 |  `latest`     | December 6th | `sha256:fd25c38b9c9a829f6bf850b51bb93c5d2afd5c4f0e578c4ad5a1c3e776c2c803` |
-|  `latest-dev` | December 6th | `sha256:36bb3726233cedb7c003b328fb682f7be5ecfa4cdf3936427a290fbcf8a0b5a6` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/_index.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: kubernetes-csi-external-provisioner Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/kubernetes-csi-external-provisioner:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe image runs as `root` so that it can mount a `CSI_ENDPOINT` socket.<!--compatibility:end-->
+## Compatibility Notes
+
+The image runs as `root` so that it can mount a `CSI_ENDPOINT` socket.
+<!--compatibility:end-->
 
 <!--body:start-->
 You can run it with the standard deployment with something like:

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-csi-external-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:20ea98561c3b529f612bff7e67ca3874e92003265e421f40f7912fd0dfd57931` |
-|  `latest`     | December 6th | `sha256:b9bd84d435d99ed4e67e5dff15868eeee902839d0ae0fd101f6f4f410a3fe1e3` |
+|  `latest`     | December 6th | `sha256:967e63f4be4f78f8aefe3a38c4b0576c5365698cd6ebd2fac5ae24fd2e246753` |
+|  `latest-dev` | December 6th | `sha256:e3864b30723f8e69028801dd91b8e6b8d937031472525ace952c3ece1d56dcd4` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-dashboard/_index.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-dashboard/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: kubernetes-dashboard Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/kubernetes-dashboard:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe dashboard listens on port `8443` by default.<!--compatibility:end-->
+## Compatibility Notes
+
+The dashboard listens on port `8443` by default.
+<!--compatibility:end-->
 
 <!--body:start-->
 You can run it with the standard deployment with something like:

--- a/content/chainguard/chainguard-images/reference/kubernetes-dashboard/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-dashboard/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-dashboard Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:0a06f0548051e6e972c505d032c26bc4b5126cef15b699fb4fea0a2888369c7a` |
-|  `latest-dev` | December 6th | `sha256:2b461a842916fe99bd7554389816d4b7ce6c0bedb80a7c4b01e989d571d616cd` |
+|  `latest-dev` | December 6th | `sha256:28d949722e5332eb58652078162be22f86a5b26d97628b477741d82de39de340` |
+|  `latest`     | December 6th | `sha256:5238df3260f59f63464b2eb74b417106298f9fb672d18a5de89d8c503afbb03d` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/_index.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: kubernetes-ingress-defaultbackend Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/kubernetes-ingress-defaultbackend:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe image runs as `non-root`.<!--compatibility:end-->
+## Compatibility Notes
+
+The image runs as `non-root`.
+<!--compatibility:end-->
 
 <!--body:start-->
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-ingress-defaultbackend Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:5730ccb98eac721163b7b2412cfaec11f8475cdceccaf8f9a57693cb33f49440` |
-|  `latest-dev` | December 6th | `sha256:45349bb6cd446d552ede3cce98bab5546520b26b4bce48019968fa971ac7e601` |
+|  `latest`     | December 6th | `sha256:4ce6c77e9834d96de36f642233915eb8a3ed8016e0b9304e8d7f82a44116088f` |
+|  `latest-dev` | December 6th | `sha256:5430c0c1bad7dd0656d836358d25040a04f47f57bb0f5e249c3bd4805be7aea7` |
 

--- a/content/chainguard/chainguard-images/reference/meilisearch/_index.md
+++ b/content/chainguard/chainguard-images/reference/meilisearch/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: meilisearch Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/meilisearch:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe image specifies a default non-root `meilisearch` user (UID 999), and a data and dump directory at `/var/data.ms`, owned by that `meilisearch` user, accessible to all users.<!--compatibility:end-->
+## Compatibility Notes
+
+The image specifies a default non-root `meilisearch` user (UID 999), and a data and dump directory at `/var/data.ms`, owned by that `meilisearch` user, accessible to all users.
+<!--compatibility:end-->
 
 <!--body:start-->
 ## Usage Example

--- a/content/chainguard/chainguard-images/reference/node/_index.md
+++ b/content/chainguard/chainguard-images/reference/node/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: node Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,9 +39,12 @@ docker pull cgr.dev/chainguard/node:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe image specifies a default non-root `node` user (UID 65532), and a working directory at `/app`, owned by that `node` user, and accessible to all users.
+## Compatibility Notes
+
+The image specifies a default non-root `node` user (UID 65532), and a working directory at `/app`, owned by that `node` user, and accessible to all users.
 
 It specifies `NODE_PORT=3000` by default.
+
 <!--compatibility:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:509f6709ee63b3b914af635517fd392bd2d508a6a76013cfafcb406ad494a88a` |
+|  `latest-dev` | December 6th | `sha256:41488c095c0b7a05e80ae8a7e07f91ee18d4d516fa061427c71ce1eb36487224` |
 |  `latest`     | December 6th | `sha256:71edad479d330985d95375326f9cccb03405f237a624eb23770d208a176929fa` |
 

--- a/content/chainguard/chainguard-images/reference/skaffold/_index.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: skaffold Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,7 +39,10 @@ docker pull cgr.dev/chainguard/skaffold:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility NotesThe image specifies a default non-root `skaffold` user (UID 65532), and a working directory at `/app`, owned by that `skaffold` user, and accessible to all users.<!--compatibility:end-->
+## Compatibility Notes
+
+The image specifies a default non-root `skaffold` user (UID 65532), and a working directory at `/app`, owned by that `skaffold` user, and accessible to all users.
+<!--compatibility:end-->
 
 <!--body:start-->
 

--- a/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the skaffold Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:65004b093f0092b1f516f5c410737043bf877006ad3ab7a5398f70d54c7f754e` |
-|  `latest`     | December 6th | `sha256:93733de1160afc5a0cb2311c051a1ac064641d1fc678af33d20c8e5f04e58b7b` |
+|  `latest`     | December 6th | `sha256:676dab72dcdd2f87da5ab3bba507d08cc8c6cc9e530367067f2e8a289604c48d` |
+|  `latest-dev` | December 6th | `sha256:6304ee4927d0836bf7e985c73936e7fcf85704ebb55a6fb72e0fcd042c0758af` |
 

--- a/content/chainguard/chainguard-images/reference/spire-agent/_index.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: spire-agent Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,9 +39,12 @@ docker pull cgr.dev/chainguard/spire:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility Notes**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
+## Compatibility Notes
+
+**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
 This is due to a constraint in the way it is typically deployed into Kubernetes clusters.
 See https://github.com/spiffe/spire/issues/1862 for more context.
+
 <!--compatibility:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:98fdd5f6c53a6ab449fec158538167cd45835fc280866bb190777374abf57517` |
-|  `latest-dev` | December 6th | `sha256:06247f30d29a7d9dd47615ebab2a847a273072896c503cac7b7fcd4c0e28aa6a` |
+|  `latest-dev` | December 6th | `sha256:649ba63d70390cfb95d58ade3f08c9a8f37d72f57328c7271293a131bebe08b5` |
+|  `latest`     | December 6th | `sha256:b70408a7a472551ec6173be1b7caf9d06e53da7f4a413cae0625a16221250f18` |
 

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/_index.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: spire-oidc-discovery-provider Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,9 +39,12 @@ docker pull cgr.dev/chainguard/spire:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility Notes**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
+## Compatibility Notes
+
+**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
 This is due to a constraint in the way it is typically deployed into Kubernetes clusters.
 See https://github.com/spiffe/spire/issues/1862 for more context.
+
 <!--compatibility:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-oidc-discovery-provider Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | December 6th | `sha256:9377806d0e20d7809853119bc75790b0752b446792515d3b63e1d16a4a9b494f` |
-|  `latest-dev` | December 6th | `sha256:f30caf895f8cf75e8e783d4d3503250a9ac3bb27d332fd487deb64415fa0e5d7` |
+|  `latest`     | December 6th | `sha256:16f5a49f524da6468a73e5b2e7989990dbf2a3fc284e14dbfb23475da314cf1a` |
+|  `latest-dev` | December 6th | `sha256:299486525b62ec2872b13e8bbbc68811b0efd0402add58026842aedf34257a29` |
 

--- a/content/chainguard/chainguard-images/reference/spire-server/_index.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: spire-server Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,9 +39,12 @@ docker pull cgr.dev/chainguard/spire:latest
 <!--getting:end-->
 
 <!--compatibility:start-->
-## Compatibility Notes**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
+## Compatibility Notes
+
+**Note**: Unlike most other Chainguard images, the `spire-agent` image must run as root.
 This is due to a constraint in the way it is typically deployed into Kubernetes clusters.
 See https://github.com/spiffe/spire/issues/1862 for more context.
+
 <!--compatibility:end-->
 
 <!--body:start-->

--- a/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | December 6th | `sha256:4c6eb2beddecaf41b30a2a5baa021f9f730a72f253d085617acf2f6ecce895a9` |
-|  `latest`     | December 6th | `sha256:922d2c7e65caea2080a4fdd4e2efbc478abc9b44c1e7cf948cb7987439a9abb6` |
+|  `latest-dev` | December 6th | `sha256:3235ae4760860892f859167c33e79653c0772005e1d456193556eb8bf8872d6c` |
+|  `latest`     | December 6th | `sha256:bc22c557df6f547ca6fa5d1ed3d71cad9c0cce5d538b7f4c528bffe6a77ccebe` |
 

--- a/content/chainguard/chainguard-images/reference/vector/_index.md
+++ b/content/chainguard/chainguard-images/reference/vector/_index.md
@@ -4,8 +4,8 @@ linktitle: "vector"
 type: "article"
 layout: "single"
 description: "Overview: vector Chainguard Image"
-date: 2023-11-30 00:18:09
-lastmod: 2022-11-01T11:07:52+02:00
+date: 2022-11-01T11:07:52+02:00
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,19 +25,20 @@ toc: true
 
 
 
-Minimalist [wolfi](https://github.com/wolfi-dev)-based image of [Vector]
-(https://github.com/vectordotdev/vector) for high-performance, end-to-end 
-(agent & aggregator) observability data pipeline that puts you in 
-control of your observability data
+<!--overview:start-->
+Minimal image with [Vector](https://vector.dev/), a high-performance, end-to-end (agent & aggregator) observability data pipeline
+<!--overview:end-->
 
-## Get It
-
+<!--getting:start-->
+## Get It!
 The image is available on `cgr.dev`:
 
 ```
 docker pull cgr.dev/chainguard/vector:latest
 ```
+<!--getting:end-->
 
+<!--body:start-->
 ## Testing
 
 Fortunately, we have a Helm Chart ready-to-use for testing this image. 
@@ -56,4 +57,5 @@ helm install --name vector \
 ```
 
 Once you run the commands above, you will end up having the application running on your cluster.
+<!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/vector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/vector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the vector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2023-12-06 18:44:36
+lastmod: 2023-12-07 00:19:49
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | December 6th | `sha256:56e0a9b88d2ff8e060f1e1791501e4622520adf0fefffb365676ded156799fae` |
 |  `latest`     | December 6th | `sha256:f18bc3b2d6673c62e7f1cf08b39de3981c8623179fd28ff09955f3fbbefb0612` |
-|  `latest-dev` | December 6th | `sha256:48f3d2b375c097b1152b777b22b937714586bf36fe2971239ec918f8b9e1f716` |
 


### PR DESCRIPTION
Updated Docs:

- buildkit/_index.md
- buildkit/tags_history.md
- calico-cni/_index.md
- calico-cni/tags_history.md
- calico-csi/_index.md
- calico-csi/tags_history.md
- calico-kube-controllers/_index.md
- calico-kube-controllers/tags_history.md
- calico-node/_index.md
- calico-node/tags_history.md
- calico-node-driver-registrar/_index.md
- calico-node-driver-registrar/tags_history.md
- calico-pod2daemon-flexvol/_index.md
- calico-pod2daemon-flexvol/tags_history.md
- calico-typha/_index.md
- calico-typha/tags_history.md
- calicoctl/_index.md
- calicoctl/tags_history.md
- clang/_index.md
- clang/tags_history.md
- dependency-track/_index.md
- erlang/_index.md
- erlang/tags_history.md
- haproxy-ingress/_index.md
- haproxy-ingress/tags_history.md
- helm/_index.md
- helm/tags_history.md
- hugo/_index.md
- hugo/tags_history.md
- jdk/tags_history.md
- kubernetes-csi-external-provisioner/_index.md
- kubernetes-csi-external-provisioner/tags_history.md
- kubernetes-dashboard/_index.md
- kubernetes-dashboard/tags_history.md
- kubernetes-ingress-defaultbackend/_index.md
- kubernetes-ingress-defaultbackend/tags_history.md
- meilisearch/_index.md
- node/_index.md
- node/tags_history.md
- skaffold/_index.md
- skaffold/tags_history.md
- spire-agent/_index.md
- spire-agent/tags_history.md
- spire-oidc-discovery-provider/_index.md
- spire-oidc-discovery-provider/tags_history.md
- spire-server/_index.md
- spire-server/tags_history.md
- vector/_index.md
- vector/tags_history.md