### PR TITLE
update assumable identity docs to pull images

### DIFF
--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
@@ -223,6 +223,7 @@ pipelines:
 
           # Assume the bitbucket pipeline identity
           - ./chainctl auth login --identity-token $BITBUCKET_STEP_OIDC_TOKEN --identity %bitbucket-identity%
+          - ./chainctl auth configure-docker --identity-token $BITBUCKET_STEP_OIDC_TOKEN --identity %bitbucket-identity%
 ```
 
 The important line is the `oidc: true` option, which enables OIDC for the individual step in the pipeline. This configuration is why the `subject_pattern` with a regular expression is used in the Terraform configuration, since each step gets its own UUID identifier, which is added to the `sub` field in the generated OIDC token. Since the step UUID is known known before the build, the subject match needs to use a regular expression.
@@ -230,10 +231,11 @@ The important line is the `oidc: true` option, which enables OIDC for the indivi
 Now you can add the commands for testing the identity like `chainctl images repos list` in the following example:
 
 ```
-. . .
+...
           # Assume the bitbucket pipeline identity
           - ./chainctl auth login --identity-token $BITBUCKET_STEP_OIDC_TOKEN --identity %bitbucket-identity%
           - ./chainctl images repos list
+          - docker pull cgr.dev/<group>/<repo>:<tag>
 ```
 
 Once you commit the `bitbucket-pipelines.yml` file the pipeline will run.
@@ -248,9 +250,6 @@ chainctl        	100%[===================>]  54.34M  6.78MB/s	in 13s
 
 Successfully exchanged token.
 Valid! Id: 3f4ad8a9d5e63be71d631a359ba0a91dcade94ab/d3ed9c70b538a796
-                         	ID                         	| 	NAME  	| DESCRIPTION |   MODE
-------------------------------------------------------------+---------------+-------------+-----------
-  3f4ad8a9d5e63be71d631a359ba0a91dcade94ab/42b8649dc3a3ea66 | trust-any-cgr |         	| ENFORCED
 ```
 
 If you'd like to experiment further with this identity and what the pipeline can do with it, there are a few parts of this setup that you can tweak. For instance, if you'd like to give this identity different permissions you can change the role data source to the role you would like to grant.
@@ -264,7 +263,6 @@ data "chainguard_roles" "editor" {
 You can also edit the pipeline itself to change its behavior. For example, instead of listing the repos the identity has access to, you could have the workflow inspect the groups.
 
 ```
-	. . .
           - ./chainctl images repos list
 ```
 

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
@@ -229,7 +229,8 @@ jobs:
       with:
         identity: <your actions identity>
 
-    - run: docker pull cgr.dev/<your group>/example-image:latest
+    - run: |
+      docker pull cgr.dev/<your group>/example-image:latest
 ```
 
 This workflow is named `actions assume example`. The `permissions` block grants `write` permissions to the workflow for the `id-token` scope. [Per the GitHub Actions documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings), you **must** grant this permission in order for the workflow to be able to fetch an OIDC token.

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-gitlab-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-gitlab-identity.md
@@ -228,9 +228,15 @@ assume-and-explore:
     chainctl auth login \
       --identity-token $ID_TOKEN_1 \
       --identity <your gitlab identity>
+    chainctl auth configure-docker \
+      --identity-token $ID_TOKEN_1 \
+      --identity <your gitlab identity>
 
     # Explore available images.
     chainctl images repos list
+
+    # Pull an image.
+    docker pull cgr.dev/<group>/<repo>:<tag>
 ```
 
 Let's go over what this configuration does.
@@ -241,7 +247,7 @@ Next, this configuration creates a JSON Web Token (JWT) with an [`id_tokens`](ht
 
 Following that, the job runs a few commands to download and install `chainctl`. It then uses `chainctl`, the JWT, and the Chainguard identity's `id` value to log in to Chainguard Enforce under the assumed identity. Be sure to replace `<your gitlab identity>` with the identity UIDP you noted down in the previous section.
 
-After logging in, the pipeline is able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repos associated associated with the `example-group` group.
+After logging in, the pipeline is able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repos associated associated with the `example-group` group, then pulls an image from the group's repository.
 
 After updating the configuration, commit the changes and the pipeline will run automatically. A status box in the dashboard will let you know whether the pipeline runs successfully.
 
@@ -266,8 +272,7 @@ chainctl iam roles list
 You can also edit the pipeline itself to change its behavior. For example, instead of inspecting the image repos the identity has access to, you could have the workflow inspect the groups like in the following exmaple.
 
 ```
-    # Explore
-    chainctl iam groups ls
+chainctl iam groups ls
 ```
 
 Of course, the GitLab pipeline will only be able to perform certain actions on certain resources, depending on what kind of access you grant it.

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
@@ -239,6 +239,7 @@ pipeline {
                         wget -O chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_linux_\$(uname -m)"
                         chmod +x chainctl
                         ./chainctl auth login --identity-token $token --identity <your jenkins identity>
+                        ./chainctl auth configure-docker --identity-token $token --identity <your jenkins identity>
                     '''
                 }
             }
@@ -249,14 +250,16 @@ pipeline {
 
 The important line is `withCredentials` option, which maps the generated OIDC token from the `oidc-token` credential parameter to `token` variable in the pipeline step.
 
-Now you can add the commands for testing the identity like `chainctl images repos list` in the following example:
+Now you can add the commands for testing the identity using `chainctl images repos list` in the following example:
 
 ```
 sh '''
     wget -O chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_linux_\$(uname -m)"
     chmod +x chainctl
     ./chainctl auth login --identity-token $token --identity <your jenkins identity>
+    ./chainctl auth configure-docker --identity-token $token --identity <your jenkins identity>
     ./chainctl images repos list
+    docker pull cgr.dev/<group>/<repo>:<tag>
 '''
 ```
 


### PR DESCRIPTION
Demonstrate `chainctl auth configure-docker` and `docker pull` to pull as the assumed identity.