### PR TITLE
document looking up groups instead of creating them

### DIFF
--- a/content/chainguard/administration/iam-groups/rolebinding-terraform-gh/index.md
+++ b/content/chainguard/administration/iam-groups/rolebinding-terraform-gh/index.md
@@ -105,11 +105,11 @@ First, we will create a `main.tf` file which will set up the necessary Terraform
 
 This file will consist of the following lines.
 
-```
+```hcl
 terraform {
   required_providers {
     chainguard = {
-  	source = "chainguard/chainguard"
+      source = "chainguard-dev/chainguard"
     }
     github = {
       source = "integrations/github"
@@ -120,17 +120,11 @@ terraform {
 provider "github" {
   owner = "$GITHUB_ORG"
 }
-
-provider "chainguard" {
-  console_api = "https://console-api.enforce.dev"
-}
 ```
 
 The `terraform` block defines the sources for the `chainguard` and `github` providers.
 
-The first `provider` block sets up the `github` provider with one argument — `owner` — that points to the `GITHUB_ORG` variable you set previously.
-
-The second `provider` block sets up the Chainguard provider, passing the `console_api` argument in the body.
+The `provider` block sets up the `github` provider with one argument — `owner` — that points to the `GITHUB_ORG` variable you set previously.
 
 Create the `main.tf` file with the following command.
 
@@ -139,7 +133,7 @@ cat  <<EOF > main.tf
 terraform {
   required_providers {
     chainguard = {
-  	source = "chainguard/chainguard"
+      source = "chainguard-dev/chainguard"
     }
     github = {
       source = "integrations/github"
@@ -149,10 +143,6 @@ terraform {
 
 provider "github" {
   owner = "$GITHUB_ORG"
-}
-
-provider "chainguard" {
-  console_api = "https://console-api.enforce.dev"
 }
 EOF
 ```

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
@@ -58,7 +58,6 @@ This is a fairly barebones Terraform configuration file, but we will define the 
 
 Next, you can create the `sample.tf` file.
 
-
 ### `sample.tf`
 
 `sample.tf` will create a couple of structures that will help us test out the identity with a Bitbucket a workflow.

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-bitbucket-identity.md
@@ -66,19 +66,14 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-resource "chainguard_group" "example-group" {
-  name        = "example-group"
-  description = <<EOF
-    This group simulates an end-user group, which the bitbucket
-    pipeline identity can interact with via the identity in
-    bitbucket.tf.
-  EOF
+data "chainguard_group" "group" {
+  name = "my-customer.biz"
 }
 ```
 
-This section creates a Chainguard Enforce IAM group named `example-group`, as well as a description of the group. This will serve as some data for the identity — which will be created by the `bitbucket.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `bitbucket.tf` file — to access when we test it out later on.
 
-Now you can move on to creating the last of our Terraform configuration files, `bitbucket.tf`.
+Now you can move on to creating the rest of our Terraform configuration files, `bitbucket.tf`.
 
 ### `bitbucket.tf`
 
@@ -88,7 +83,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "bitbucket" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = chainguard_group.group.id
   name        = "bitbucket"
   description = <<EOF
     This is an identity that authorizes Bitbucket workflows
@@ -103,7 +98,7 @@ resource "chainguard_identity" "bitbucket" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` created by the `sample.tf` file; namely, the `example-group` group. The identity is named `bitbucket` and has a brief description.
+First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `bitbucket` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the Bitbucket pipeline tries to assume this identity later on, it must present a token matching the `audience`, `issuer` and `subject` specified here in order to do so. The `audience` is the intended recipient of the issued token, while the `issuer` is the entity that creates the token.
 
@@ -131,12 +126,12 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the `example-group`.
+The final section grants this role to the identity on the group.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.bitbucket.id
-  group    = chainguard_group.example-group.id
+  group    = chainguard_group.group.id
   role     = data.chainguard_roles.viewer.items[0].id
 }
 ```
@@ -277,11 +272,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. However, you'll need to destroy the `example-group` group yourself with `chainctl`.
-
-```sh
-chainctl iam groups rm example-group
-```
+This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-buildkite-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-buildkite-identity.md
@@ -45,7 +45,7 @@ The first file, which we will call `main.tf`, will serve as the scaffolding for 
 
 The file will consist of the following content.
 
-```
+```hcl
 terraform {
   required_providers {
     chainguard = {

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-buildkite-identity.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-buildkite-identity.md
@@ -48,9 +48,9 @@ The file will consist of the following content.
 ```
 terraform {
   required_providers {
-	chainguard = {
-  	source = "chainguard-dev/chainguard"
-	}
+    chainguard = {
+      source = "chainguard-dev/chainguard"
+    }
   }
 }
 ```
@@ -66,20 +66,14 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-resource "chainguard_group" "example-group" {
-  name    	= "example-group"
-  description = <<EOF
-	This group simulates an end-user group, which the buildkite
-	pipeline identity can interact with via the identity in
-	buildkite.tf.
-  EOF
+data "chainguard_dev" "root_group" {
+  name = "my-customer.biz"
 }
 ```
 
-This section creates a Chainguard Enforce IAM group named `example-group`, as well as a description of the group. This will serve as some data for the identity — which will be created by the `buildkite.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `buildkite.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `buildkite.tf`.
-
 
 ### `buildkite.tf`
 
@@ -89,7 +83,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "buildkite" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = chainguard_group.group.id
   name   	 = "buildkite"
   description = <<EOF
     This is an identity that authorizes Buildkite workflows
@@ -103,7 +97,7 @@ resource "chainguard_identity" "buildkite" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` created by the `sample.tf` file; namely, the `example-group` group. The identity is named `buildkite` and has a brief description.
+First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `buildkite` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the Buildkite workflow tries to assume this identity later on, it must present a token matching the `issuer` and `subject` specified here in order to do so. The `issuer` is the entity that creates the token, while the `subject` is the entity (here, the Buildkite pipeline build) that the token represents.
 
@@ -129,12 +123,12 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the `example-group`.
+The final section grants this role to the identity on the group.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.buildkite.id
-  group	= chainguard_group.example-group.id
+  group	= chainguard_group.group.id
   role 	= data.chainguard_roles.viewer.items[0].id
 }
 ```
@@ -144,7 +138,7 @@ Run the following command to create this file with each of these sections. Be su
 ```sh
 cat > buildkite.tf <<EOF
 resource "chainguard_identity" "buildkite" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = chainguard_group.group.id
   name    	= "buildkite"
   description = <<EOF
 	This is an identity that authorizes Buildkite workflows
@@ -167,7 +161,7 @@ data "chainguard_roles" "viewer" {
 
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.buildkite.id
-  group	= chainguard_group.example-group.id
+  group	= chainguard_group.group.id
   role 	= data.chainguard_roles.viewer.items[0].id
 }
 EOF
@@ -322,11 +316,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding and the identity created in this guide. However, you'll need to destroy the `example-group` group yourself with `chainctl`.
-
-```sh
-chainctl iam groups rm example-group
-```
+This will destroy the role-binding and the identity created in this guide. It will not delete the group.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
@@ -47,7 +47,7 @@ The first file, which we will call `main.tf`, will serve as the scaffolding for 
 
 The file will consist of the following content.
 
-```
+```hcl
 terraform {
   required_providers {
     chainguard = {

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-github-identity/index.md
@@ -68,17 +68,12 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-resource "chainguard_group" "example-group" {
-  name    	= "example-group"
-  description = <<EOF
-    This group simulates an end-user group, which the github
-    actions identity can interact with via the identity in
-    actions.tf.
-  EOF
+data "chainguard_dev" "root_group" {
+  name = "my-customer.biz"
 }
 ```
 
-This section creates a Chainguard Enforce IAM group named `example-group`, as well as a description of the group. This will serve as some data for the identity — which will be created by the `actions.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `actions.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `actions.tf`.
 
@@ -90,7 +85,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "actions" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = chainguard_group.group.id
   name    	= "github-actions"
   description = <<EOF
     This is an identity that authorizes the actions in this
@@ -104,7 +99,7 @@ resource "chainguard_identity" "actions" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` created by the `sample.tf` file; namely, the `example-group` group. The identity is named `github-actions` and has a brief description.
+First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `github-actions` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the GitHub Actions workflow tries to assume this identity later on, it must present a token matching the `issuer` and `subject` specified here in order to do so. The `issuer` is the entity that creates the token, while the `subject` is the entity (here, the Actions workflow) that the token represents.
 
@@ -126,12 +121,12 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the `example-group`.
+The final section grants this role to the identity on the group.
 
 ```
 resource "chainguard_role-binding" "view-stuff" {
   identity = chainguard_identity.actions.id
-  group	= chainguard_group.example-group.id
+  group	= chainguard_group.group.id
   role 	= data.chainguard_role.viewer.items[0].id
 }
 ```
@@ -244,7 +239,7 @@ Commit the workflow to your repository, then navigate back to the **Actions** ta
 
 ![Screenshot of the "Assume and Explore" workflow, with the "Run workflow" button showing.](actions-run-workflow.png)
 
-This indicates that the workflow can indeed assume the identity and interact with the `example-group` group.
+This indicates that the workflow can indeed assume the identity and interact with the group.
 
 ![Screenshot showing the output of the "Assume and Explore" workflow.](actions-workflow-output.png)
 
@@ -272,11 +267,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. However, you'll need to destroy the `example-group` group yourself with `chainctl`.
-
-```sh
-chainctl iam groups rm example-group
-```
+This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
@@ -82,17 +82,12 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-resource "chainguard_group" "example-group" {
-  name        = "example-group"
-  description = <<EOF
-    This group simulates an end-user group, which the Jenkins
-    pipeline identity can interact with via the identity in
-    jenkins.tf.
-  EOF
+data "chainguard_group" "group" {
+  name        = "my-customer.biz"
 }
 ```
 
-This section creates a Chainguard Enforce IAM group named `example-group`, as well as a description of the group. This will serve as some data for the identity — which will be created by the `jenkins.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `jenkins.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `jenkins.tf`.
 
@@ -104,7 +99,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "jenkins" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = chainguard_group.group.id
   name        = "jenkins"
   description = <<EOF
     This is an identity that authorizes Jenkins workflows
@@ -119,7 +114,7 @@ resource "chainguard_identity" "jenkins" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` created by the `sample.tf` file; namely, the `example-group` group. The identity is named `jenkins` and has a brief description.
+First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `jenkins` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the Jenkins workflow tries to assume this identity later on, it must present a token matching the `audience`, `issuer` and `subject` specified here in order to do so. The `audience` is the intended recipient of the issued token, while the `issuer` is the entity that creates the token. Finally, the `subject` is the entity (here, the Jenkins pipeline build) that the token represents.
 
@@ -149,12 +144,12 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the `example-group`.
+The final section grants this role to the identity on the group.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.jenkins.id
-  group    = chainguard_group.example-group.id
+  group    = chainguard_group.group.id
   role     = data.chainguard_role.viewer.items[0].id
 }
 ```
@@ -303,11 +298,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. However, you'll need to destroy the `example-group` group yourself with `chainctl`.
-
-```sh
-chainctl iam groups rm example-group
-```
+This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/identity-examples/enforce-jenkins-identity/index.md
@@ -47,13 +47,11 @@ The file will consist of the following content.
 ```
 terraform {
   required_providers {
-	chainguard = {
-  	source = "chainguard/chainguard"
-	}
+    chainguard = {
+      source = "chainguard-dev/chainguard"
+    }
   }
 }
-
-provider "chainguard" {}
 ```
 
 This is a fairly barebones Terraform configuration file, but we will define the rest of the resources in the other two files. In `main.tf`, we declare and initialize the Chainguard Terraform provider.


### PR DESCRIPTION
Our assumable identity example docs walk through listing repos in existing groups -- only groups previously created and populated will have any repos at all.

This also updates some references to the `chainguard/chainguard` TF provider, which was never released -- the one we released is at `chainguard-dev/chainguard`.