### PR TITLE
Updates and reorg

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -149,12 +149,6 @@
   parent = "products"
 
 [[footer]]
-  name = "Chainguard Enforce"
-  url = "https://www.chainguard.dev/chainguard-enforce"
-  parent = "products"
-  weight = 2
-
-[[footer]]
   name = "Chainguard Services"
   url = "https://www.chainguard.dev/services"
   weight = 3

--- a/content/chainguard/administration/custom-idps/azure-ad/index.md
+++ b/content/chainguard/administration/custom-idps/azure-ad/index.md
@@ -7,7 +7,7 @@ type: "article"
 date: 2023-04-17T08:48:45+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Chainguard Images", "Procedural"]
+tags: ["Chainguard Images", "Procedural"]
 images: []
 weight: 020
 ---

--- a/content/chainguard/administration/custom-idps/custom-idps/index.md
+++ b/content/chainguard/administration/custom-idps/custom-idps/index.md
@@ -7,7 +7,7 @@ type: "article"
 date: 2023-04-17T08:48:45+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Chainguard Images", "Overview"]
+tags: ["Chainguard Images", "Overview"]
 images: []
 weight: 005
 ---

--- a/content/chainguard/administration/custom-idps/okta/index.md
+++ b/content/chainguard/administration/custom-idps/okta/index.md
@@ -7,7 +7,7 @@ type: "article"
 date: 2023-04-17T08:48:45+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Chainguard Images", "Procedural"]
+tags: ["Chainguard Images", "Procedural"]
 images: []
 weight: 010
 ---

--- a/content/chainguard/administration/custom-idps/ping-id/index.md
+++ b/content/chainguard/administration/custom-idps/ping-id/index.md
@@ -7,7 +7,7 @@ type: "article"
 date: 2023-04-17T08:48:45+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Chainguard Images", "Procedural"]
+tags: ["Chainguard Images", "Procedural"]
 images: []
 weight: 015
 ---

--- a/content/chainguard/administration/how-to-install-chainctl.md
+++ b/content/chainguard/administration/how-to-install-chainctl.md
@@ -1,23 +1,23 @@
 ---
 title: "How to Install chainctl"
 linktitle: "Install chainctl"
+aliases: 
+- /chainguard/chainguard-enforce/how-to-install-chainctl
 type: "article"
 description: "Install the chainctl command line tool to work with Chainguard Enforce and Images"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2023-03-22T15:56:52-07:00
+lastmod: 2023-12-07T15:56:52-07:00
 draft: false
-tags: ["Enforce", "chainctl", "Product"]
+tags: ["chainctl", "Product"]
 images: []
 menu:
   docs:
-    parent: "chainguard-enforce"
+    parent: "administration"
 toc: true
-weight: 998
+weight: 005
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
-The Chainguard Enforce command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard Enforce provides, and enable you to make queries into the state of your clusters and policies registered with the platform.
+The Chainguard command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard provides, and enable you to make queries into the state of your Chainguard resources.
 
 The tool uses the familiar `<context> <noun> <verb>` style of CLI interactions. For example, to list groups within the context of Chainguard Identity and Access Management (IAM), you can run `chainctl iam groups list` to receive relevant output.
 
@@ -120,6 +120,28 @@ Verified OK
 ```
 
 If you do not see the line `Verified OK` then there is a problem with your `chainctl` binary and you should reinstall it using the instructions at the beginning of this page.
+
+## Authenticating
+
+With chainctl installed, you can authenticate into Chainguard with the following command:
+
+```sh
+chainctl auth login
+```
+
+This will open your browser window and take you through a workflow to login with your OIDC provider. 
+
+## Configure a Docker credential helper
+
+You can configure a Docker credential helper with chainctl by running:
+
+```sh
+chainctl auth configure-docker
+```
+
+This will update your Docker config file to call chainctl when an auth token is needed. A browser window will open when the token needs to be refreshed.
+
+For guidance on pull tokens, please review [authenticating with a pull token](/chainguard/chainguard-registry/authenticating/#authenticating-with-a-pull-token).
 
 ## Updating `chainctl`
 

--- a/content/chainguard/administration/iam-groups/_index.md
+++ b/content/chainguard/administration/iam-groups/_index.md
@@ -6,7 +6,7 @@ date: 2023-04-13T08:49:15+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
 images: []
-weight: 005
+weight: 010
 ---
 
 Example tutorials on integrating various Identity Providers (IDPs) with Chainguard.

--- a/content/chainguard/administration/iam-groups/how-to-manage-iam-groups-in-chainguard.md
+++ b/content/chainguard/administration/iam-groups/how-to-manage-iam-groups-in-chainguard.md
@@ -3,12 +3,13 @@ title: "How to Manage Chainguard IAM Groups"
 linktitle: "Manage IAM Groups"
 aliases:
 - /chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-manage-iam-groups-in-chainguard-enforce/
+- /chainguard/administration/iam-groups/how-to-manage-iam-groups-in-chainguard-enforce/
 type: "article"
 description: "Understanding Identity and Access Management in Chainguard"
 date: 2022-07-15T15:22:20+01:00
-lastmod: 2023-10-26T15:22:20+01:00
+lastmod: 2023-12-07T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Product", "Procedural"]
+tags: ["Product", "Procedural"]
 images: []
 menu:
   docs:
@@ -17,10 +18,7 @@ weight: 010
 toc: true
 ---
 
-Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. Once authenticated, you can set up a desired structure for managing and delegating policies.
-
-Each Chainguard policy needs to be associated with a **group**, and will be effective for that group as well as all the groups descending from it. Each cluster needs to be associated with a group and will be enforced based on that group’s policies.
-
+Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. Once authenticated, you can set up a desired group management structure.
 
 ## Logging in
 
@@ -30,7 +28,7 @@ To authenticate into the Chainguard platform, use the following login command.
 chainctl auth login
 ```
 
-A web browser window will open to prompt you to login via Google’s OIDC flow (more methods to authenticate are coming soon). Select an account with which you wish to register. Once authenticated, you can set up a desired group structure for managing and delegating policies.
+A web browser window will open to prompt you to login via your chosen OIDC flow. Select an account with which you wish to register. Once authenticated, you can set up a desired group structure for managing and delegating.
 
 ## Creating a Group
 
@@ -40,13 +38,13 @@ Begin by creating an organization tied to the account you just used to authentic
 chainctl iam groups create $NAME --no-parent
 ```
 
-After creating the organization, you can create your desired group hierarchy. Keep in mind that policies roll down, meaning that any policy created at the root level will be inherited by its children.
+After creating the organization, you can create your desired group hierarchy. Keep in mind that access will roll down, meaning that any assets available at the root level will be inherited by its children.
 
 ```sh
 chainctl iam group create $CHILD_NAME --parent $ROOT_ID
 ```
 
-We recommend creating a group structure that outlines how your team organizes and delegates permissions.  A sample starting point can include dev, staging, and prod.
+We recommend creating a group structure that outlines how your team organizes and delegates permissions. A sample starting point can include dev, staging, and prod.
 
 ```sh
 |- root
@@ -114,4 +112,4 @@ To invite team members, auditors, or others to your desired groups, securely dis
 chainctl auth login --invite-code $INVITE_CODE
 ```
 
-Chainguard’s IAM ensures that you can set up policies specific to certain groups, and also allows you to manage your users and what access they have.
+Chainguard’s IAM ensures that you can have a specific desired set up for certain groups, and also allows you to manage your users and what access they have.

--- a/content/chainguard/administration/iam-groups/how-to-manage-iam-groups-in-chainguard.md
+++ b/content/chainguard/administration/iam-groups/how-to-manage-iam-groups-in-chainguard.md
@@ -28,7 +28,7 @@ To authenticate into the Chainguard platform, use the following login command.
 chainctl auth login
 ```
 
-A web browser window will open to prompt you to login via your chosen OIDC flow. Select an account with which you wish to register. Once authenticated, you can set up a desired group structure for managing and delegating.
+A web browser window will open to prompt you to log in via your chosen OIDC flow. Select an account with which you wish to register. Once authenticated, you can set up a desired group structure for managing and delegating.
 
 ## Creating a Group
 

--- a/content/chainguard/administration/iam-groups/overview-of-enforce-iam-model.md
+++ b/content/chainguard/administration/iam-groups/overview-of-enforce-iam-model.md
@@ -7,9 +7,9 @@ type: "article"
 description: "Chainguard Identity and Access Management"
 lead: "Chainguard Identity and Access Management"
 date: 2022-07-15T15:22:20+01:00
-lastmod: 2023-10-26T15:22:20+01:00
+lastmod: 2023-12-07T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Product", "Reference"]
+tags: ["Product", "Reference"]
 images: []
 menu:
   docs:
@@ -18,7 +18,7 @@ weight: 005
 toc: true
 ---
 
-Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. Once authenticated, you can set up a desired structure for managing and delegating policies.
+Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. Once authenticated, you can set up a desired structure for managing and delegating Chainguard assets.
 
 ## Role Bindings
 
@@ -31,10 +31,10 @@ There are four built-in role bindings in Chainguard's IAM model (excluding expir
 
 You can review the capabilities of each of these roles by running `chainctl iam role list` in order to review the specific capabilities of each of these roles.
 
-**Owner** is the role with the most privileges. An **owner** can create, delete, view (list), and modify (update) across policies, groups, account associations, role bindings, and subscriptions. Additionally, an **owner** can create, delete, and view clusters and group invites. An **owner** has read-only access to roles and records.
+**Owner** is the role with the most privileges. An **owner** can create, delete, view (list), and modify (update) across images, policies, groups, account associations, role bindings, and subscriptions. Additionally, an **owner** can create, delete, and view clusters and group invites. An **owner** has read-only access to roles and records.
 
-**Editor** is the role with read access and limited creation and modification access. An **editor** can create, delete, and view clusters, role bindings, and subscriptions. Additionally, an **editor** can modify role bindings and subscriptions. As opposed to the owner role, an **editor** can view policies, records, groups (and group invites), roles, and account association; but an **editor** cannot make changes to policies, records, groups, roles, and account associations. An editor cannot invite users to groups.
+**Editor** is the role with read access and limited creation and modification access. An **editor** can create, delete, and view images, clusters, role bindings, and subscriptions. Additionally, an **editor** can modify role bindings and subscriptions. As opposed to the owner role, an **editor** can view images, policies, records, groups (and group invites), roles, and account association; but an **editor** cannot make changes to images, policies, records, groups, roles, and account associations. An editor cannot invite users to groups.
 
-**Viewer** is a role that generally only has read-only access. That is, a **viewer** can list policies, groups (and group invites), clusters, records, roles and role bindings, subscriptions, and account associations.
+**Viewer** is a role that generally only has read-only access. That is, a **viewer** can list images, policies, groups (and group invites), clusters, records, roles and role bindings, subscriptions, and account associations.
 
 **Gulfstream** is a role used for Chainguard's proprietary controller infrastructure, also known as Gulfstream. You can check out our [Gulfstream Overview](/chainguard/chainguard-enforce/concepts/gulfstream-overview/) to learn more about how Gulfstream works.

--- a/content/chainguard/administration/iam-groups/rolebinding-terraform-gh/index.md
+++ b/content/chainguard/administration/iam-groups/rolebinding-terraform-gh/index.md
@@ -6,7 +6,7 @@ type: "article"
 date: 2023-06-10T08:48:45+00:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Product", "Procedural"]
+tags: ["Product", "Procedural"]
 images: []
 weight: 050
 ---

--- a/content/chainguard/administration/iam-groups/verified-orgs.md
+++ b/content/chainguard/administration/iam-groups/verified-orgs.md
@@ -6,7 +6,7 @@ type: "article"
 date: 2023-08-15T14:22:23-07:00
 lastmod: 2023-10-26T15:22:20+01:00
 draft: false
-tags: ["Enforce", "Product", "Conceptual"]
+tags: ["Product", "Conceptual"]
 images: []
 menu:
   docs:

--- a/content/chainguard/administration/manage-chainctl-config.md
+++ b/content/chainguard/administration/manage-chainctl-config.md
@@ -1,20 +1,22 @@
 ---
 title: "How to Manage chainctl Configuration"
 linktitle: "chainctl Config"
+aliases: 
+- /chainguard/chainguard-enforce/manage-chainctl-config/
 type: "article"
 date: 2023-07-07T05:56:52-07:00
-lastmod: 2023-08-16T05:56:52-07:00
+lastmod: 2023-12-07T05:56:52-07:00
 draft: false
-tags: ["Enforce", "chainctl", "Product"]
+tags: ["chainctl", "Product"]
 images: []
 menu:
   docs:
-    parent: "chainguard-enforce"
+    parent: "administration"
 toc: true
-weight: 999
+weight: 006
 ---
 
-The Chainguard Enforce command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard Enforce provides, and enable you to make queries into the state of your clusters and policies registered with the platform.
+The Chainguard command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard provides, and enable you to make queries into what's available to you on the Chainguard platform.
 
 ## chainctl config CLI 
 
@@ -30,28 +32,29 @@ You'll receive output like the following.
 Local config file commands for chainctl.
 
 Usage:
-chainctl config [command]
+  chainctl config [command]
 
 Available Commands:
-edit Edit the current chainctl config file.
-reset Remove local chainctl config files and restore defaults.
-save Save the current chainctl config to a config file.
-set Set an individual configuration value property.
-unset Unset a configuration property and return it to default.
-view View the current chainctl config.
+  edit        Edit the current chainctl config file.
+  reset       Remove local chainctl config files and restore defaults.
+  save        Save the current chainctl config to a config file.
+  set         Set an individual configuration value property.
+  unset       Unset a configuration property and return it to default.
+  validate    Run diagnostics on local config.
+  view        View the current chainctl config.
 
 Flags:
--h, --help help for config
+  -h, --help   help for config
 
 Global Flags:
---api string The url of the Chainguard platform API. (default "http://api.api-system.svc")
---audience string The Chainguard token audience to request. (default "http://api.api-system.svc")
---config string A specific chainctl config file.
---console string The url of the Chainguard platform Console. (default "http://console-ui.api-system.svc")
---issuer string The url of the Chainguard STS endpoint. (default "http://issuer.oidc-system.svc")
--o, --output string Output format. One of: ["", "table", "tree", "json", "id", "wide"]
---timestamp-authority string The url of the Chainguard Timestamp Authority endpoint. (default "http://tsa.timestamp-authority.svc")
--v, --v int Set the log verbosity level.
+      --api string                   The url of the Chainguard platform API. (default "https://console-api.enforce.dev")
+      --audience string              The Chainguard token audience to request. (default "https://console-api.enforce.dev")
+      --config string                A specific chainctl config file.
+      --console string               The url of the Chainguard platform Console. (default "https://console.enforce.dev")
+      --issuer string                The url of the Chainguard STS endpoint. (default "https://issuer.enforce.dev")
+  -o, --output string                Output format. One of: ["", "json", "id", "table", "terse", "tree", "wide"]
+      --timestamp-authority string   The url of the Chainguard Timestamp Authority endpoint. (default "https://tsa.enforce.dev")
+  -v, --v int                        Set the log verbosity level.
 
 Use "chainctl config [command] --help" for more information about a command.
 ```

--- a/content/chainguard/administration/network-requirements.md
+++ b/content/chainguard/administration/network-requirements.md
@@ -13,6 +13,7 @@ aliases:
 tags: ["Chainguard Images", "Chainguard Enforce", "Product", "Reference"]
 images: []
 toc: true
+weight: 001
 ---
 
 This document provides an overview of network requirements for using [Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs) and [Chainguard Enforce](https://www.chainguard.dev/chainguard-enforce?utm_source=docs). To use Chainguard products in environments with firewalls, VPNs, and IDS/IPS systems, you will need to add some rules to allow traffic into and out of your networks.

--- a/content/chainguard/chainctl/_index.md
+++ b/content/chainguard/chainctl/_index.md
@@ -4,13 +4,13 @@ lead: ""
 description: "chainctl Reference Documentation"
 type: "article"
 date: 2022-09-20
-lastmod: 2020-09-20
+lastmod: 2023-12-207
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []
 weight: 100
 ---
 
-The CLI tool `chainctl` helps you interact with the account model that Chainguard Enforce provides, and enables you to make queries into the state of your clusters and policies registered with the platform. The tool uses the familiar `<context> <noun> <verb>` style of CLI interactions. Below find the current reference for `chainctl`.
+The CLI tool `chainctl` helps you interact with the account model that Chainguard provides. The tool uses the familiar `<context> <noun> <verb>` style of CLI interactions. Below find the current reference for `chainctl`.
 
-To install `chainctl`, follow the [installation guide](/chainguard/chainguard-enforce/how-to-install-chainctl/).
+To install `chainctl`, follow the <ins>[installation guide](/chainguard/chainguard-enforce/how-to-install-chainctl/)</ins>.

--- a/content/chainguard/chainguard-enforce/annotation-based-caching.md
+++ b/content/chainguard/chainguard-enforce/annotation-based-caching.md
@@ -17,8 +17,6 @@ weight: 050
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce for Kubernetes can leverage annotations on Kubernetes objects to cache verification results to reduce the amount of traffic made to container registries in order to improve latency and scalability of the admission webhook.
 
 This feature will soon be the default for all users. In the meantime, in order to try out this feature on your Kubernetes cluster, you can use a feature flag setting in the ConfigMap `config-policy-controller` within the `cosign-system` namespace.

--- a/content/chainguard/chainguard-enforce/authentication/connecting-to-private-registries.md
+++ b/content/chainguard/chainguard-enforce/authentication/connecting-to-private-registries.md
@@ -18,8 +18,6 @@ weight: 020
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce supports two methods of authenticating to private registries:
 
 - Using image pull secrets in your tenant clusters

--- a/content/chainguard/chainguard-enforce/authentication/log-in-chainguard-enforce/index.md
+++ b/content/chainguard/chainguard-enforce/authentication/log-in-chainguard-enforce/index.md
@@ -16,8 +16,6 @@ weight: 005
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce, which you will need access to in order to follow along. You can request access through selecting **Chainguard Enforce** on our [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce currently offers login and authentication through three different OpenID Connect identity providers: Google, GitHub, and GitLab. [OpenID Connect](https://openid.net/connect/) (OIDC) provides an identity layer on top of the OAuth 2.0 protocol, and it is integrated with both the Chainguard Enforce Console web browser interface and `chainctl` on the command line. This document will walk through both of these workflows.
 
 ## Signing in through the Chainguard Enforce Console

--- a/content/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding.md
+++ b/content/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding.md
@@ -16,8 +16,6 @@ weight: 005
 toc: true
 ---
 
-> _This provides user onboarding for Chainguard Enforce. In order to follow the onboarding, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce is a supply chain security solution for containerized workloads. Chainguard Enforce enables you to build, manage, ensure continuous compliance, and enforce policies that protect organizations from supply chain threats. Using open source projects and standards that are trusted by the community — like [Cosign](https://docs.sigstore.dev/cosign/overview) and [Fulcio](https://docs.sigstore.dev/fulcio/overview) from the [Sigstore](https://sigstore.dev) project — Chainguard Enforce offers a robust approach to securing your workloads.
 
 This guide will walk you through using Chainguard Enforce on a Kubernetes cluster running on your laptop with [kind](https://kind.sigs.k8s.io/). We will be using Chainguard Enforce to achieve the following:

--- a/content/chainguard/chainguard-enforce/cloud-account-associations/index.md
+++ b/content/chainguard/chainguard-enforce/cloud-account-associations/index.md
@@ -17,9 +17,6 @@ weight: 030
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
-
 Chainguard Enforce for Kubernetes allows you to associate a cloud provider account with an Enforce IAM group. Cloud account association allows the Chainguard Enforce platform to access cloud resources on your behalf to enable several features, including:
 
 - Verifying policies against containers hosted in private cloud container registries

--- a/content/chainguard/chainguard-enforce/concepts/detect-log4shell-demo/index.md
+++ b/content/chainguard/chainguard-enforce/concepts/detect-log4shell-demo/index.md
@@ -17,8 +17,6 @@ weight: 050
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Apache Log4j is a popular logging framework for Java applications, developed and maintained by the Apache Software Foundation. In November 2021, [a vulnerability was discovered in Log4j2](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) that allowed attackers to intercept data and potentially run malicious code remotely on applications where it was installed. The vulnerability became known as "Log4Shell."
 
 Although the exploit was patched shortly after it was announced, the near-ubiquity of Apache Log4j in Java applications meant that millions of devices were vulnerable if they weren't upgraded. Ultimately, Log4Shell became recognized as among the most widespread, if not the most widespread, cybersecurity vulnerabilities of all time.

--- a/content/chainguard/chainguard-enforce/concepts/understanding-continuous-verification.md
+++ b/content/chainguard/chainguard-enforce/concepts/understanding-continuous-verification.md
@@ -17,8 +17,6 @@ weight: 020
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 One feature unique to Chainguard Enforce is its ability to check whether a container or cluster contains any vulnerabilities continually over time. This feature is referred to as "continuous verification."
 
 To better understand why this might be useful, imagine an organization using typical container analysis tools to scan its containers before each deployment. Say that one day, prior to a new deployment, the organization scans all its running containers like usual. Not finding any vulnerabilities, they continue on with the deployment.

--- a/content/chainguard/chainguard-enforce/enforce-overview/index.md
+++ b/content/chainguard/chainguard-enforce/enforce-overview/index.md
@@ -17,8 +17,6 @@ weight: 001
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. You can request access to Chainguard Enforce through selecting **Chainguard Enforce** on our [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 An organization's software supply chain can contain many possible points of entry for malicious actors and lots of potential for unintended vulnerabilities. Indeed, with recent high-profile security incidents like the SolarWinds breach and the discovery of the Log4Shell vulnerability, [software supply chain security](/software-security/what-is-software-supply-chain-security/) has become a top priority for many organizations.
 
 **Chainguard Enforce** offers a supply chain security solution for containerized workloads, which can help keep organizations' software supply chains secure by default. Enabling engineering and security teams to ensure continuous compliance, Chainguard Enforce protects organizations from supply chain threats through policy enforcement. Using open source projects and standards that are trusted by the community — like Cosign and Fulcio from the Sigstore project — Chainguard Enforce offers a robust approach to securing your workloads, allowing you to do the following:

--- a/content/chainguard/chainguard-enforce/how-to-connect-kubernetes-clusters.md
+++ b/content/chainguard/chainguard-enforce/how-to-connect-kubernetes-clusters.md
@@ -18,8 +18,6 @@ weight: 020
 toc: true
 ---
 
-> _This documentation is related to Chainguard Enforce. You can request access to the product by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Connecting Kubernetes clusters to Chainguard Enforce allows you to assess the current state of the supply chain of your containerized workloads and enforce policy once your workloads match your desired state. 
 
 

--- a/content/chainguard/chainguard-enforce/installation/alternative-installation-methods.md
+++ b/content/chainguard/chainguard-enforce/installation/alternative-installation-methods.md
@@ -18,8 +18,6 @@ weight: 010
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 There are currently three recommended approaches to installing the Chainguard Enforce Agent. This guide will walk you through each of these approaches.
 
 Our [getting started guide](/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding/) provides more detailed information on how to set up Chainguard Enforce, and this document provides a reference for three alternative methods to align best with your team's existing Kubernetes workflow.

--- a/content/chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation.md
+++ b/content/chainguard/chainguard-enforce/installation/configure-enforcer-options-during-installation.md
@@ -17,8 +17,6 @@ weight: 20
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 There is currently a limited list of enforcer options that can be configured when installing Chainguard into a current Kubernetes cluster. This guide will walk you through each of these Enforcer configuration settings.
 
 Our [getting started guide](/chainguard/chainguard-enforce/chainguard-enforce-user-onboarding/) provides more detailed information on how to set up Chainguard Enforce, and this document provides a reference on how to configure different behaviors for your cluster.

--- a/content/chainguard/chainguard-enforce/policies/chainguard-enforce-policy-examples.md
+++ b/content/chainguard/chainguard-enforce/policies/chainguard-enforce-policy-examples.md
@@ -16,8 +16,6 @@ weight: 075
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce for Kubernetes allows users to create their own security policies that they can enforce in their clusters. Here are a few example policies to help you get started. You can also review the [policy catalogue](https://console.enforce.dev/policies/catalog) in the Chainguard Enforce Console.
 
 You may also review the [Sigstore Policy Controller documentation](https://docs.sigstore.dev/policy-controller/overview). In particular, we encourage you to review the Policy Controller documentation relating to the [Admission of images](https://docs.sigstore.dev/policy-controller/overview/#admission-of-images) to learn how to admit images through the cluster image policy.

--- a/content/chainguard/chainguard-enforce/policies/chainguard-enforce-rego-policies.md
+++ b/content/chainguard/chainguard-enforce/policies/chainguard-enforce-rego-policies.md
@@ -15,8 +15,6 @@ weight: 010
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access by selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 Chainguard Enforce supports the [Rego Policy Language](https://www.openpolicyagent.org/docs/latest/policy-language/), which is a declarative policy language that is used to evaluate structured input data such as Kubernetes manifests and JSON documents. This feature enables users to apply policies that can evaluate Kubernetes admission requests and object metadata to make comprehensive decisions about the workloads that are admitted to their clusters. Rego support also enables users to enhance existing cloud-native policies by adding additional software supply chain security checks all within Chainguard Enforce.
 
 There are several Rego policy templates that you can customize within the [Chainguard Enforce Policy Catalog](https://console.enforce.dev/policies/catalog). If you would like to write one from scratch, or learn more about how to use this format, you can follow this guide. 

--- a/content/chainguard/chainguard-enforce/policies/how-to-disable-policy-enforcement.md
+++ b/content/chainguard/chainguard-enforce/policies/how-to-disable-policy-enforcement.md
@@ -16,8 +16,6 @@ weight: 040
 toc: true
 ---
 
-> _This document relates to Chainguard Enforce. In order to follow along, you will need access to Chainguard Enforce. You can request access through selecting **Chainguard Enforce** on the [inquiry form](https://www.chainguard.dev/contact?utm_source=docs)._
-
 In the event of an incident response or another situation where you may need to modify Chainguard Enforce to _warn_ about instead of _fail_ a given policy, you can modify the policy configuration.
 
 In an Enforce policy, images that fail to meet requirements will cause the image not to be admitted by default. To instead allow these through and warn the user that this operation did not meet the criteria, you can use the `mode` configuration option under `ClusterImagePolicy`. When set to `warn`, the policy will not block the admission, but instead will allow it through and emit a warning.

--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -4,7 +4,7 @@ linktitle: "FAQs"
 type: "article"
 description: "Frequently asked questions about Chainguard Images"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2023-08-22T08:49:31+00:00
+lastmod: 2023-12-07T08:49:31+00:00
 draft: false
 tags: ["Chainguard Images", "FAQ", "Product"]
 images: []
@@ -29,11 +29,11 @@ We call Wolfi an undistro because unlike a typical Linux distribution, Wolfi is 
 
 ## Which images are available?
 
-There are currently over 100 Chainguard Images available, which are segmented as **Public** or **Enterprise**. You can read more about this in the [next question](#what-options-do-i-have-to-use-chainguard-images).
+There are currently over 100 Chainguard Images available, which are segmented as **Developer** or **Production**. You can read more about this in the [next question](#what-options-do-i-have-to-use-chainguard-images).
 
 To review all available Chainguard Images, you can check out the Chainguard Console at [https://console.enforce.dev/images/catalog](https://console.enforce.dev/images/catalog) (you will need to be logged in).
 
-To review Public Chainguard Images, you can check out either the [Chainguard Images Reference Docs](https://edu.chainguard.dev/chainguard/chainguard-images/reference/) or the  [GitHub Repository](https://github.com/chainguard-images).
+To review Chainguard's Developer Images, you can check out either the [Chainguard Images Reference Docs](https://edu.chainguard.dev/chainguard/chainguard-images/reference/) or the  [GitHub Repository](https://github.com/chainguard-images).
 
 Chainguard Images are available through the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
 
@@ -41,7 +41,7 @@ Chainguard Images are available through the [Chainguard Registry](/chainguard/ch
 
 You can get free Chainguard Images for your organization; you can also upgrade for more versions, SLAs, and dedicated support.
 
-Public | Chainguard Enterprise 
+Developer | Production 
 -------|-----------------------
 Free for everyone, anywhere. | [Contact us](https://www.chainguard.dev/contact?utm_source=docs) for pricing.
 Latest versions | Major and minor versions
@@ -61,6 +61,12 @@ Chainguard Images are designed to be minimalist, and many of them don't come wit
 
 ## How often are Chainguard Images updated?
 Chainguard Images are rebuilt every night to ensure that new package versions and security updates in upstream Wolfi are quickly applied.
+
+## What does Chainguard do when a CVE is published, but a patch is not available from the owner of the OSS code?
+Chainguard investigates the CVE and marks relevant images as affected or not. If Chainguard can identify a patch that's unreleased, Chainguard may apply a patch before it lands upstream. In either case, when the patch lands upstream, Chainguard picks it up and rolls it out.
+
+## I added software on top of one of Chainguard's base images, why are there CVEs?
+Chainguard is not responsible for CVEs in software you add on top of base images. 
 
 ## Do I need to authenticate into Chainguard to use Chainguard Images?
 Logging in is optional if you are only using `:latest` and `:latest-dev` tags or image digests.


### PR DESCRIPTION
This is a big batch of updates:

* Update Images FAQs based on some Product Enablement feedback
* Move standalone `chainctl` docs into Administration top level bucket
* Update `chainctl` installation guide based on feedback [thread](https://chainguard-dev.slack.com/archives/C03H64P08UT/p1701883753763409)
* Remove Enforce language from docs under the Administration bucket
* Remove Enforce tag from docs under the Administration bucket
* Remove Enforce "contact us" note from all the docs (I did not update the dates here)
* Remove Enforce from the footer