### PR TITLE
Fix search content position

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -332,7 +332,6 @@ h2[id^="chainctl"] {
 .search-content {
   position: absolute !important;
   left: 32px !important;
-  top: 64px !important;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -346,7 +345,7 @@ h2[id^="chainctl"] {
   font-size: 14px;
   line-height: 20px;
 
-  top: 60px !important;
+  top: 130px !important;
   height: auto;
   left: 24px !important;
   width: auto;


### PR DESCRIPTION
## Type of change
Fix

### What should this PR do?
Updates the position of search suggestions so that the input field remains visible.

| Before | After |
|-------|------|
| <img width="394" alt="Screenshot 2023-12-11 at 11 54 57 AM" src="https://github.com/chainguard-dev/edu/assets/227587/8977da80-6a67-4195-afee-c9143a0635bd"> | <img width="380" alt="Screenshot 2023-12-11 at 11 54 25 AM" src="https://github.com/chainguard-dev/edu/assets/227587/d8fdd3e1-f7ef-43f7-a040-244fe3de31fe"> |