### PR TITLE
Remove true colour setting.

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-python.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-python.md
@@ -186,12 +186,12 @@ prints a representation of that file to the terminal:
 
 ```python
 '''import climage module to display images on terminal'''
-from climage import convert, color_to_flags, color_types
+from climage import convert
 
 
 def main():
     '''Take in PNG and output as ANSI to terminal'''
-    output = convert('inky.png', is_unicode=True, **color_to_flags(color_types.truecolor))
+    output = convert('inky.png', is_unicode=True)
     print(output)
 
 if __name__ == "__main__":

--- a/content/open-source/wolfi/wolfi-with-dockerfiles.md
+++ b/content/open-source/wolfi/wolfi-with-dockerfiles.md
@@ -69,12 +69,12 @@ For your reference, here is the complete `inky.py` script:
 
 ```python
 '''import climage module to display images on terminal'''
-from climage import convert, color_to_flags, color_types
+from climage import convert
 
 
 def main():
     '''Take in PNG and output as ANSI to terminal'''
-    output = convert('inky.png', is_unicode=True, **color_to_flags(color_types.truecolor))
+    output = convert('inky.png', is_unicode=True)
     print(output)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Don't use true colour in Python example as it breaks on some terminals.

## Type of change
Minor fix to python code example.

### What should this PR do?
Simplifies python code and ensures compatibility.

### Why are we making this change?
Make sure our docs works for everyone!

### What are the acceptance criteria? 
New code works for everyone!

### How should this PR be tested?
If you can run the python code and make sure the output looks ok, that would be appreciated.