### PR TITLE
Add Istio getting-started

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -67,6 +67,15 @@ Thanks for using kind! 😊
 
 ## Install Istio using Chainguard Images
 
+We will be using the `istioctl` command to install Istio. In order to use the
+Chainguard images, we will need to set these following values:
+- `hub = cgr.dev/chainguard`
+- `tag = latest`
+- `values.pilot.image = istio-pilot`
+- `values.global.proxy.image = istio-proxy`
+- `values.global.proxy_init.image = istio-proxy`
+
+Those translate to the following `istioctl` command:
 ```
 istioctl install --set tag=latest --set hub=cgr.dev/chainguard \
   --set values.pilot.image=istio-pilot \
@@ -76,7 +85,12 @@ istioctl install --set tag=latest --set hub=cgr.dev/chainguard \
 
 ## Stand up a Gateway and a VirtualService 
 
-First, create a YAML file containing a Gateway and VirtualService to test the installation:
+To see the Istio installation in action, we will create two Istio resources:
+* An Istio gateway serving the "http://hello.example.com" domain
+* A VirtualService to always reply with "Hello, world!" to requests to the
+  "http://hello.example.com" domain 
+
+Create a YAML file with the following contents to define the Istio resources: 
 ```
 cat > example.yaml <<EOF
 apiVersion: networking.istio.io/v1alpha3
@@ -121,7 +135,7 @@ kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80
 
 In another terminal, send a request to the Istio Ingress Gateway:
 ```
-curl -H "Host: ingress.test.foo" localhost:8080
+curl -H "Host: hello.example.com" localhost:8080
 ```
 You should see `Hello, world!` output to the terminal.
 

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -43,7 +43,7 @@ installed.
 ## Start up a KinD cluster
 
 First, we'll start up a KinD cluster to install Istio
-```
+```sh
 kind create cluster
 ```
 

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -47,7 +47,7 @@ First, we'll start up a KinD cluster to install Istio
 kind create cluster
 ```
 
-You should see output similar to the following:
+This will return output similar to the following:
 ```
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -64,6 +64,8 @@ kubectl cluster-info --context kind-kind
 Thanks for using kind! 😊
 ```
 
+Following that, you can install the Istio Chainguard Image with `istioctl`.
+
 ## Install Istio using Chainguard Images
 
 We will be using the `istioctl` command to install Istio. In order to use the

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -23,7 +23,7 @@ offers a set of minimal, security-hardened Istio images, built on top the Wolfi
 OS.
 
 We will demonstrate how to get started with the Chainguard Istio images on an
-example KinD cluster. To get started, you'll need docker, KinD, kubectl, and istioctl
+example KinD cluster. To get started, you'll need Docker, KinD, `kubectl`, and `istioctl`
 installed.
 
 * [Docker](https://docs.docker.com/get-docker/)

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -123,7 +123,7 @@ EOF
 ```
 
 Apply the YAML file to the cluster:
-```
+```sh
 kubectl apply -f example.yaml
 ```
 

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -1,0 +1,130 @@
+---
+title: "Getting Started with the Chainguard Istio Images"
+type: "article"
+linktitle: "Istio"
+description: "Tutorial on how to get started with the Chainguard Istio Images"
+date: 2023-12-14T00:00:00+00:00
+lastmod: 2023-09-22T11:07:52+02:00
+tags: ["Chainguard Images", "Products"]
+draft: false
+images: []
+menu:
+  docs:
+    parent: "getting-started"
+weight: 610
+toc: true
+---
+
+[Istio](https://istio.io) extends Kubernetes to establish a programmable,
+application-aware network using the powerful Envoy service proxy. Working with
+both Kubernetes and traditional workloads, Istio brings standard, universal
+traffic management, telemetry, and security to complex deployments. Chainguard
+offers a set of minimal, security-hardened Istio images, built on top the Wolfi
+OS.
+
+We will demonstrate how to get started with the Chainguard Istio images on an
+example KinD cluster. To get started, you'll need docker, KinD, kubectl, and istioctl
+installed.
+
+* [Docker](https://docs.docker.com/get-docker/)
+* [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* [istioctl](https://istio.io/latest/docs/setup/getting-started/#download)
+
+
+{{< details "What is Wolfi" >}}
+{{< blurb/wolfi >}}
+{{< /details >}}
+
+{{< details "Chainguard Images" >}}
+{{< blurb/images >}}
+{{< /details >}}
+
+## Start up a KinD cluster
+
+First, we'll start up a KinD cluster to install Istio
+```
+kind create cluster
+```
+
+You should see output similar to the following:
+```
+❯ kind create cluster
+Creating cluster "kind" ...
+ ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 
+ ✓ Preparing nodes 📦  
+ ✓ Writing configuration 📜 
+ ✓ Starting control-plane 🕹️ 
+ ✓ Installing CNI 🔌 
+ ✓ Installing StorageClass 💾 
+Set kubectl context to "kind-kind"
+You can now use your cluster with:
+
+kubectl cluster-info --context kind-kind
+
+Thanks for using kind! 😊
+```
+
+## Install Istio using Chainguard Images
+
+```
+istioctl install --set tag=latest --set hub=cgr.dev/chainguard \
+  --set values.pilot.image=istio-pilot \
+  --set values.global.proxy.image=istio-proxy \
+  --set values.global.proxy_init.image=istio-proxy
+```
+
+## Stand up a Gateway and a VirtualService 
+
+First, create a YAML file containing a Gateway and VirtualService to test the installation:
+```
+cat > example.yaml <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: sample-gateway
+spec:
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "hello.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: sample-virtual-service
+spec:
+  gateways:
+  - sample-gateway
+  hosts:
+  - "hello.example.com"
+  http:
+  - directResponse:
+      status: 200
+      body:
+        string: "Hello, world!\n"
+EOF
+```
+
+Apply the YAML file to the cluster:
+```
+kubectl apply -f example.yaml
+```
+
+Now, in one terminal, start a port-forward to the Istio Ingress Gateway:
+```
+kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80
+```
+
+In another terminal, send a request to the Istio Ingress Gateway:
+```
+curl -H "Host: ingress.test.foo" localhost:8080
+```
+You should see `Hello, world!` output to the terminal.
+
+## Clean up your KinD cluster 
+
+Once you are done, you can delete your KinD cluster with `kind delete cluster`.

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -89,7 +89,7 @@ To see the Istio installation in action, we will create two Istio resources:
 * A VirtualService to always reply with "Hello, world!" to requests to the
   "http://hello.example.com" domain 
 
-Create a YAML file with the following contents to define the Istio resources: 
+Create a YAML manifest file with the following contents to define the Istio resources: 
 ```sh
 cat > example.yaml <<EOF
 apiVersion: networking.istio.io/v1alpha3

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -49,7 +49,6 @@ kind create cluster
 
 You should see output similar to the following:
 ```
-❯ kind create cluster
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 
  ✓ Preparing nodes 📦  

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Istio"
 description: "Tutorial on how to get started with the Chainguard Istio Images"
 date: 2023-12-14T00:00:00+00:00
-lastmod: 2023-09-22T11:07:52+02:00
+lastmod: 2023-12-14T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -23,11 +23,11 @@ offers a set of minimal, security-hardened Istio images, built on top the Wolfi
 OS.
 
 We will demonstrate how to get started with the Chainguard Istio images on an
-example KinD cluster. To get started, you'll need Docker, KinD, `kubectl`, and `istioctl`
-installed.
+example kind cluster. To get started, you'll need Docker, kind, `kubectl`, and `istioctl`
+installed. If you are missing any, you can follow the relevant link to get started.
 
 * [Docker](https://docs.docker.com/get-docker/)
-* [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/)
+* [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [istioctl](https://istio.io/latest/docs/setup/getting-started/#download)
 
@@ -40,14 +40,16 @@ installed.
 {{< blurb/images >}}
 {{< /details >}}
 
-## Start up a KinD cluster
+## Start up a kind cluster
 
-First, we'll start up a KinD cluster to install Istio
+First, we'll start up a kind cluster to install Istio.
+
 ```sh
 kind create cluster
 ```
 
 This will return output similar to the following:
+
 ```
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 
@@ -69,22 +71,26 @@ Following that, you can install the Istio Chainguard Image with `istioctl`.
 ## Install Istio using Chainguard Images
 
 We will be using the `istioctl` command to install Istio. In order to use the
-Chainguard images, we will need to set these following values:
+Chainguard Images, we will need to set these following values:
 - `hub = cgr.dev/chainguard`
 - `tag = latest`
 - `values.pilot.image = istio-pilot`
 - `values.global.proxy.image = istio-proxy`
 - `values.global.proxy_init.image = istio-proxy`
 
-Those translate to the following `istioctl` command:
-```
+We can set these values with the following `istioctl` command:
+
+```sh
 istioctl install --set tag=latest --set hub=cgr.dev/chainguard \
   --set values.pilot.image=istio-pilot \
   --set values.global.proxy.image=istio-proxy \
   --set values.global.proxy_init.image=istio-proxy
 ```
 
-The Istio Chainguard Image is now running on the KinD cluster you created previously. In the next section, you'll set up an Istio gateway and a VirtualService to test out this Image.
+The Istio Chainguard Image is now running on the kind cluster you created previously. 
+In the next section, you'll set up an Istio gateway and a VirtualService to test out 
+this image.
+
 ## Stand up a Gateway and a VirtualService 
 
 To see the Istio installation in action, we will create two Istio resources:
@@ -126,21 +132,33 @@ EOF
 ```
 
 Apply the YAML file to the cluster:
+
 ```sh
 kubectl apply -f example.yaml
 ```
 
 Now, in one terminal, start a port-forward to the Istio Ingress Gateway:
-```
+
+```sh
 kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80
 ```
 
 In another terminal, send a request to the Istio Ingress Gateway:
-```
+
+```sh
 curl -H "Host: hello.example.com" localhost:8080
 ```
-You should see `Hello, world!` output to the terminal.
+This will return `Hello, world!` to the terminal output.
 
-## Clean up your KinD cluster 
+## Clean up your kind cluster 
 
-Once you are done, you can delete your KinD cluster with `kind delete cluster`.
+Once you are done, you can delete your kind cluster:
+
+```sh
+kind delete cluster
+```
+
+This will delete the default cluster context, `kind`.
+
+## Advanced Usage
+{{< blurb/images-advanced image="Istio" >}}

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -90,7 +90,7 @@ To see the Istio installation in action, we will create two Istio resources:
   "http://hello.example.com" domain 
 
 Create a YAML file with the following contents to define the Istio resources: 
-```
+```sh
 cat > example.yaml <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway

--- a/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-istio.md
@@ -84,6 +84,7 @@ istioctl install --set tag=latest --set hub=cgr.dev/chainguard \
   --set values.global.proxy_init.image=istio-proxy
 ```
 
+The Istio Chainguard Image is now running on the KinD cluster you created previously. In the next section, you'll set up an Istio gateway and a VirtualService to test out this Image.
 ## Stand up a Gateway and a VirtualService 
 
 To see the Istio installation in action, we will create two Istio resources:


### PR DESCRIPTION
## Type of change
A getting started guide using Chainguard's Istio images.

### What should this PR do?
A getting started guide using Chainguard's Istio images.

### Why are we making this change?
We want to show how users can install Chainguard's Istio images using `istioctl`.

### What are the acceptance criteria? 
The instruction should be clear and working.

### How should this PR be tested?
We try out the commands in the instruction in a terminal.