### PR TITLE
Add images logos

### DIFF
--- a/layouts/article/list-images.html
+++ b/layouts/article/list-images.html
@@ -23,7 +23,7 @@
                                         <div class="card flex-fill">
                                             <div class="card-body d-flex flex-column">
                                                 <h5 class="card-title mt-0">
-                                                    <a href="{{ .RelPermalink }}">{{ .Params.linktitle }}</a>
+                                                    <img src="https://storage.googleapis.com/chainguard-academy/logos/{{ .Params.linktitle}}/logo.svg" width="32px" height="32px" style="margin: 0 8px 0 0;" /><a href="{{ .RelPermalink }}">{{ .Params.linktitle }}</a>
                                                 </h5>
                                                 <p class="card-text">{{ .Params.description }}</p>
                                                 <div class="d-flex flex-fill align-items-end justify-content-between">

--- a/layouts/article/list-images.html
+++ b/layouts/article/list-images.html
@@ -21,11 +21,15 @@
                             {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
                                     <div class="col d-flex">
                                         <div class="card flex-fill">
-                                            <div class="card-body d-flex flex-column">
+                                                <div class="card-body d-flex flex-column text-center">
+                                                    <div class="d-block text-center mb-3">
+                                                        <a href="{{ .RelPermalink }}"><img src="https://storage.googleapis.com/chainguard-academy/logos/{{ .Params.linktitle }}/logo.svg" height="32" alt="{{ .Params.linktitle}}"></a>
+                                                    </div>
+
                                                 <h5 class="card-title mt-0">
-                                                    <img src="https://storage.googleapis.com/chainguard-academy/logos/{{ .Params.linktitle}}/logo.svg" width="32px" height="32px" style="margin: 0 8px 0 0;" /><a href="{{ .RelPermalink }}">{{ .Params.linktitle }}</a>
+                                                    <a href="{{ .RelPermalink }}">{{ .Params.linktitle }}</a>
                                                 </h5>
-                                                <p class="card-text">{{ .Params.description }}</p>
+                                                    <p class="card-text"><a href="{{ .RelPermalink }}">{{ .Params.description }}</a></p>
                                                 <div class="d-flex flex-fill align-items-end justify-content-between">
                                                     <a href="{{ .RelPermalink }}image_specs/" class="card-link">Variants</a>
                                                     <a href="{{ .RelPermalink }}tags_history/" class="card-link">Tags</a>

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -7,7 +7,7 @@
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net https://use.fontawesome.com;
        script-src 'self' edu.chainguard.dev *.googleapis.com cdn.jsdelivr.net *.googletagmanager.com 'sha256-vOgyKS2vkH4n5TxBJpeh9SgzrE6LVGsAeOAvEST6oCc=' 'sha256-R2OmoLN/NlJovrWBYuTwjPfAD+YHvBVdudGDjY2VLmI=' https://unpkg.com http://localhost:1313 http://localhost:8080 'unsafe-eval';
        connect-src 'self' *.google-analytics.com https://storage.googleapis.com https://packages.wolfi.dev;
-       img-src 'self' edu.chainguard.dev data:;
+       img-src 'self' edu.chainguard.dev https://storage.googleapis.com data:;
        base-uri 'self';
      ">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,7 +27,7 @@ HUGO_VERSION = "0.104.3"
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net;
        script-src 'self' edu.chainguard.dev 'unsafe-inline' *.googleapis.com cdn.jsdelivr.net *.netlify.app *.googletagmanager.com;
        connect-src 'self' edu.google-analytics.com; *.google-analytics.com *.googleapis.com;
-       img-src 'self' edu.chainguard.dev data:;
+       img-src 'self' *.chainguard.dev storage.googleapis.com data:;
        base-uri 'self';
     '''
 


### PR DESCRIPTION
This PR adds the image logos to the Images Reference Page. The content is now centralized.

For this to work as-is for all images, there is an assumption that all images have a logo.svg file available in our drive, at the location `https://storage.googleapis.com/chainguard-academy/logos/{{ .Params.linktitle }}/logo.svg`.

Preview: https://deploy-preview-1249--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/reference/

The caveat is that the logos must be synced to google cloud automatically to avoid broken images, as this is infused directly into layouts. I have tried several different tricks to load a default image when the logo is broken, but the ones that worked made the page extremely slow. I will leave this optimization for the experts :)