### PR TITLE
Update text to use older Cilium CLI version

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-cilium/index.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-cilium/index.md
@@ -25,6 +25,8 @@ We will demonstrate how to get started with the Chainguard Cilium images on an e
 * [k3d](https://k3d.io/#installation)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [cilium CLI](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli)
+> Note: Please use a Cilium CLI version <= v0.15.17, as the connectivity tests in version v0.15.18 or later make
+> of `jq`, which we do not bundle in the Chainguage Images for cilium.
 
 {{< details "What is Wolfi" >}}
 {{< blurb/wolfi >}}


### PR DESCRIPTION
## Type of change
Update to Cilium getting started guide.

### What should this PR do?
We instruct users to use `cilium` CLI version v0.15.17 or older, because newer versions include a test suite that requires `jq` in the images, which we did not include.

### Why are we making this change?
Because newer Cilium CLI versions include a test suite that requires `jq` in the images, which we did not include.

### What are the acceptance criteria? 
The instruction is clear and correct.

### How should this PR be tested?
We tried this in an older version of Cilium.