### PR TITLE
Skip a test because we don't bundle jq in cilium

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-cilium/index.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-cilium/index.md
@@ -129,10 +129,12 @@ When all the Pods have have a status of `Running` or `Completed`, press `Ctrl+C`
 Cilium comes with the `connectivity test` command, which is useful for verifying whether the Cilium installation was successful. Run the following command to run the connectivity test:
 
 ```sh
+# We skip one of the test because it needs `jq` util on the agent image, which we don't bundle.
 cilium connectivity test \
     --external-cidr 8.0.0.0/8 \
     --external-ip 8.8.8.8 \
-    --external-other-ip 8.8.4.4
+    --external-other-ip 8.8.4.4 \
+    --test \!no-unexpected-packet-drops
 ```
 
 This should takes about 5 minutes to complete. It will return output similar to the following:


### PR DESCRIPTION
## Type of change
Doc update

### What should this PR do?
This PR updates a command on our Cilium getting started guide to make it work right w/ Chainguard Images.

### Why are we making this change?
Recent version of the cilium CLI bundles a test that needs `jq` which we don't bundle.

### What are the acceptance criteria? 
The instruction is clear.

### How should this PR be tested?
We tested the instruction in a terminal.