### PR TITLE
Federate GCP auth right before it's used.

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -23,6 +23,19 @@ jobs:
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 
+    - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3
+      with:
+        node-version: 16
+
+    - name: Update themes
+      run: git submodule update --init --recursive
+
+    - name: npm install
+      run: npm install
+
+    - name: npm run build
+      run: npm run build
+
     - name: Authenticate to Google Cloud
       id: auth
       uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955 # v0
@@ -31,20 +44,7 @@ jobs:
         project_id: '${{ env.PROJECT_ID }}'
         workload_identity_provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'
         service_account: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-        
-    - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # v3
-      with:
-        node-version: 16
 
-    - name: Update themes
-      run: git submodule update --init --recursive
-        
-    - name: npm install
-      run: npm install
-        
-    - name: npm run build
-      run: npm run build
-      
     - name: Docker Auth
       id: docker-auth
       uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # v2
@@ -52,14 +52,14 @@ jobs:
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
         registry: '${{ env.REGISTRY_URL }}'
-      
+
     - name: Build and push
       uses: 'docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5' # v3
       with:
         context: .
         push: true
         tags: '${{ env.REGISTRY_URL }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}'
-    
+
     - name: Deploy to Cloud Run
       uses: 'google-github-actions/deploy-cloudrun@5081b8db809e5800ddffa3c692d71da0cb670a34' # v0.10.3
       with:


### PR DESCRIPTION
This reduces the window where the GCP token is exposed.

