### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,40 @@
+# 2024-01-10
+
+
+Updated Docs:
+
+- aws-ebs-csi-driver/tags_history.md
+- bazel/tags_history.md
+- cilium-agent/tags_history.md
+- deno/tags_history.md
+- dynamic-localpv-provisioner/tags_history.md
+- falco-no-driver/tags_history.md
+- grype/tags_history.md
+- guacamole-server/tags_history.md
+- ingress-nginx-controller/image_specs.md
+- ingress-nginx-controller/tags_history.md
+- keda/tags_history.md
+- keda-adapter/tags_history.md
+- keda-admission-webhooks/tags_history.md
+- keycloak/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- netcat/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- prometheus-alertmanager/tags_history.md
+- qdrant/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- telegraf/tags_history.md
+- vector/tags_history.md
+- weaviate/tags_history.md
+- zookeeper/tags_history.md
+
 # 2024-01-09
 
 

--- a/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-ebs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 4th  | `sha256:01bbb3f26f01f9192ddc59ab2dc9c25f94346e8dd0b8485b9001bfbbfd7aa2cc` |
-|  `latest-dev` | January 4th  | `sha256:0cef1dc7dbe7ebfbd279ee4b36a33e706559e3921be758c423fedac15c4f7f75` |
+|  `latest-dev` | January 9th  | `sha256:f228e48051bb6725d78d947a3121678a877bf80793d016f8edb12a256ce66f35` |
+|  `latest`     | January 9th  | `sha256:b8dd75828822663c7338b5be36207bf8cc2f43756fcfe000ae6224f7c70bd4bf` |
 

--- a/content/chainguard/chainguard-images/reference/bazel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/bazel/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the bazel Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 4th  | `sha256:22776f159db080d24d77fcf61276e60bae4dd75495feb427a3fbad63752375e9` |
+|  `latest` | January 9th  | `sha256:ef4cfcffc36b5a37ad460261948df2415e9ed9c86308cc0f5eb6d7d3e068453e` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 4th  | `sha256:1058347e1fa8b709e42d03fd196ad97abbdcc0da05d313f2b2e5d2b66eeee992` |
-|  `latest-dev` | January 4th  | `sha256:dd8b05073b04a97251cda9c307236cad6cbfc37946fe76e09603e6e1f018bc95` |
+|  `latest`     | January 9th  | `sha256:fa6cd40e95a9d55f7ee69f5c32a2082a0a835d276f226bd8ff4b15e60090504c` |
+|  `latest-dev` | January 9th  | `sha256:e5fbcc9cd38f3735043515d6634826f123aa86f8adae9097d08c305329e25daf` |
 

--- a/content/chainguard/chainguard-images/reference/deno/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/deno/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the deno Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 5th  | `sha256:3b2973505452fa6f91205fd29210c1da1aece57ef253ede9926103d579826b3b` |
+|  `latest` | January 9th  | `sha256:d0633584025d032080e422d302788d55f83e528aea4f5a90becaad29cd6c296a` |
 

--- a/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dynamic-localpv-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 3rd  | `sha256:c52ee6785f481d73a4ddb0ea1dd3779777c45619dd0fa18d3a817438bfb3e4af` |
-|  `latest`     | January 3rd  | `sha256:a0d587da09201415dc86284eb06796a32ba93d57e4420ed7b76ef76248d854d9` |
+|  `latest-dev` | January 9th  | `sha256:bd7ce54519ec258e847b60f37d620acbe24a79d6397d255c2020e1044d83cd5f` |
+|  `latest`     | January 9th  | `sha256:eb98d7a28b59698bcc5035ba678797b7f9fea2c40df5eeb557f419e25aecee99` |
 

--- a/content/chainguard/chainguard-images/reference/falco-no-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/falco-no-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the falco-no-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 4th  | `sha256:5b4d9551c6eb64a50c73b9da8199a41975235dcd465467929723c77b0f330354` |
-|  `latest-dev` | January 4th  | `sha256:3d7f1f59be28ef8b82cc7593be127ca8ee300e418849a5829072fbac4df4b584` |
+|  `latest`     | January 9th  | `sha256:2c489d4ff4f87dfa2c393cdceb62bd115c92774aa5545972ce7b5e59171a6823` |
+|  `latest-dev` | January 9th  | `sha256:145d731227cf6b0ca011b5b47849830bc69ce14e8f18d49d1c72e03d16eecfd0` |
 

--- a/content/chainguard/chainguard-images/reference/grype/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/grype/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the grype Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 7th  | `sha256:ba4ac6b2409b46468c92ff083435918eea32e0ee3b6d4e641f2dfbdaf2dc7f74` |
-|  `latest-dev` | January 7th  | `sha256:d2a7ba292be6a2d306f225475acb63196581dab59d92228529675435f007092d` |
+|  `latest`     | January 9th  | `sha256:3475f46ffb478b43a5a9487c4f108295a65a5d04093220aa0b6db230f057b08f` |
+|  `latest-dev` | January 9th  | `sha256:f92d06497219493f6e71f4ed45a5dcf23479e26928cc9e62a979b11b2d850ae8` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the guacamole-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-09 00:33:48
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 8th  | `sha256:1c911f1330b9927e010e2d7a7b1e86ec0bd8fd92e796199d9e826fb358ae8967` |
-|  `latest`     | January 8th  | `sha256:83c4bcce44efe00580dc48cffba4f7fb0986eb04b819f880980e4cc53113772d` |
+|  `latest-dev` | January 9th  | `sha256:2c5fd794c2ab98aa24979c8a5754f124b32f448136bc4815dbc2d29805a9d45d` |
+|  `latest`     | January 9th  | `sha256:24af1f153fa633e44bb866a7bd2733e15ce0cee2160ddfe2ae67fe054a32a6b1` |
 

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public ingress-nginx-controller Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2023-03-07T11:07:52+02:00
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -114,7 +114,7 @@ The table shows package distribution across variants.
 | `mimalloc`                        | X          | X      |
 | `modsecurity`                     | X          | X      |
 | `modsecurity-config`              | X          | X      |
-| `msgpack`                         | X          | X      |
+| `msgpack-cxx`                     | X          | X      |
 | `ncurses`                         | X          | X      |
 | `ncurses-terminfo-base`           | X          | X      |
 | `openssh-client`                  | X          | X      |

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ingress-nginx-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 3rd  | `sha256:a14e7fed5f58ed1de232584ac33e006fed87632a27f092af92b74f23be5e048c` |
-|  `latest`     | January 3rd  | `sha256:2058aa7032eb974a536f7ebebce9fddd69a41daa6c8ca28027f7c8537c473246` |
+|  `latest`     | January 9th  | `sha256:605172be044c063bf628027dd5bbe71e6a41a1fad50e5554d20ee0c0d64a9d27` |
+|  `latest-dev` | January 9th  | `sha256:b2bd6f0fc66ff10e5952dd7d23afa8d191b3dc5f53aec6340b6c74a048a6228e` |
 

--- a/content/chainguard/chainguard-images/reference/keda-adapter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda-adapter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda-adapter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `2-dev` `2.12.1-dev` `2.12-dev` `latest-dev` | January 4th  | `sha256:b5aa2b001aafde9fcd83ea465c08d400da072a70609aa817d1d9ce9b93c351e8` |
-|  `2.12` `2.12.1` `2` `latest`                 | January 4th  | `sha256:5fe44e79179585648cfcce9ff0b5dd30b04c5f6503a775dd1302155feca14071` |
+|  `2.12.1-dev` `latest-dev` `2.12-dev` `2-dev` | January 9th  | `sha256:1b881c53c790bcd9dc874a5d445746cbddde05f8bb79c1dd26133c9b51abdac8` |
+|  `latest` `2` `2.12` `2.12.1`                 | January 9th  | `sha256:1f4149c1b21a6f373150ee895defb9a50828e15166587f742a1b9a586f6e0ed6` |
 

--- a/content/chainguard/chainguard-images/reference/keda-admission-webhooks/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda-admission-webhooks/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda-admission-webhooks Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `2-dev` `2.12.1-dev` `2.12-dev` `latest-dev` | January 4th  | `sha256:a1b8c9cbfe0372a6b09a5061bfc5cd9bb823cd818616ed6c88e24ea5aeec57df` |
-|  `2.12` `2.12.1` `2` `latest`                 | January 4th  | `sha256:ce867d772090db98fcec99d0df550309c9ee2af3242f8f38e5e06cfba903720c` |
+|  `2.12.1` `2` `latest` `2.12`                 | January 9th  | `sha256:1bf984f7182fe6f74cda4bcfd3973bea1a2411a3377a8c779188f35bd55573d0` |
+|  `2-dev` `2.12.1-dev` `2.12-dev` `latest-dev` | January 9th  | `sha256:b7c1d8e31075fd50987bf0ee2ad79c7c2f75d7bd1c5b9c271d702626db51e3ff` |
 

--- a/content/chainguard/chainguard-images/reference/keda/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `2.12-dev` `2.12.1-dev` `2-dev` `latest-dev` | January 4th  | `sha256:294a3ccefe3fcc45aa9faf2844fe92780edfce6790a2f4c21d0172067c1485f9` |
-|  `2` `2.12.1` `2.12` `latest`                 | January 4th  | `sha256:f1ef112d2bab4b0699ead535f6d53f9b47b0d014cd377dbe4efce76d6954621e` |
+|  `2.12-dev` `2.12.1-dev` `latest-dev` `2-dev` | January 9th  | `sha256:94b4d08f7b6b13c32c92e89bde60fa1ab9ff955a9f860412573bad4e5b1513e7` |
+|  `latest` `2.12` `2` `2.12.1`                 | January 9th  | `sha256:eb87f2148ffc6981065f30740f64282cbecce9f066947d7d3db6887543c04228` |
 

--- a/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keycloak Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 3rd  | `sha256:3b4a3d060c0925f19279e46a16b34f559ac31a01219d389a172528f97d2aae00` |
-|  `latest-dev` | January 3rd  | `sha256:5b89dea04b17ef0065e951f0f354e0cdb3ca69ba6522c1f8ea38cdeb2463e4f6` |
+|  `latest-dev` | January 9th  | `sha256:7842eb8bac5697776e5d3fe38958c1dba91fa2f08d450ce549370b75f9ece3ed` |
+|  `latest`     | January 9th  | `sha256:cd9a07224beeede0e7c052c721907e14f5f20cad091a3c3483ee6f231778228e` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-earlystopping-medianstop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-09 00:33:48
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0` `latest` `0` `0.16`                 | January 8th  | `sha256:71ff61a1afd781745365e04ca70a76a9f7d9193251c979e73bfff42b54a127f2` |
-|  `latest-dev` `0.16-dev` `0.16.0-dev` `0-dev` | January 8th  | `sha256:845d13a04a8f4ec9dcf311ffd1b3b49ec683621cbe4e9370203d55b2b1c783a8` |
+|  `0` `0.16` `latest` `0.16.0`                 | January 9th  | `sha256:580349c87a2a303d62a2861fef51f8cda6b64d2c876b030d08bf117ed928cce0` |
+|  `latest-dev` `0-dev` `0.16-dev` `0.16.0-dev` | January 9th  | `sha256:3227021be38be1add308d5cee4305d27bf6c1ad9334534b14e4fb6c34cd57c76` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-darts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0.16-dev` `latest-dev` `0-dev` | January 4th  | `sha256:b551261231826e38f137b84ffef556de32227c38d80ca1cf9c58909bee411764` |
-|  `0.16` `0.16.0` `0` `latest`                 | January 4th  | `sha256:e0b6f819c06fc8e1e7cb2da2c7b8131e62d9cfafdcd56369658fc6217d69abf9` |
+|  `0.16-dev` `0.16.0-dev` `latest-dev` `0-dev` | January 9th  | `sha256:a35f0295d848137bb083aa98457e8ced91e3f813bce87b5090715ced19d4ef5f` |
+|  `latest` `0` `0.16.0` `0.16`                 | January 9th  | `sha256:e9ee1f67c8dc3ac6e6ee48632b6fe295751d2a9755b49e868347ec4b037abc68` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperband Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0-dev` `0.16-dev` `latest-dev` `0.16.0-dev` | January 4th  | `sha256:635d82cd1d475e97adb7db926bde90da14abc397b967349f4e137106836d00a0` |
-|  `latest` `0` `0.16` `0.16.0`                 | January 4th  | `sha256:35cc605f908a4fc2a1e19ebce583869ceb0d1506dffcc3415c8e3d80bf4bef6c` |
+|  `0.16.0` `0.16` `latest` `0`                 | January 9th  | `sha256:e805d6eb8f9cf804b24af1e45438d0a3cdca00ce7b9419791c019c2eb9b6be40` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | January 9th  | `sha256:122a841b8031b38d559bf43d6b018331758e94bf1fc2f4b5ce6f5d4d2676a179` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16-dev` `0.16.0-dev` `latest-dev` `0-dev` | January 4th  | `sha256:4c1e66fef14c8fce88f065ad4ebdb66844b57bca2c394e960256e264e0e5db9b` |
-|  `0.16.0` `0.16` `0` `latest`                 | January 4th  | `sha256:e638f9d45bf9760c6de1f6ae73887479b83b2939d186770238486a6686e27db5` |
+|  `0.16-dev` `0-dev` `0.16.0-dev` `latest-dev` | January 9th  | `sha256:dbf528c76753d68d5c07558799ba4f7842e157f23c8058a49cf1e30380ba9ee7` |
+|  `0.16` `latest` `0` `0.16.0`                 | January 9th  | `sha256:5fb0a06f97b12f0e7abefaf44619c2c6b5e4bc8610c522eacc3ddc9f8d6405c3` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-optuna Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0` `0.16.0` `latest` `0.16`                 | January 4th  | `sha256:6f2aeeb24ab6ae81f7a0214b087ba2be50993af6879fd4158aa8e4592c798f2f` |
-|  `0.16.0-dev` `0-dev` `latest-dev` `0.16-dev` | January 4th  | `sha256:64a62c7dc7851869cd4fc652c215f66fb978a99e32a90d098f798c9d19ca6a2d` |
+|  `0-dev` `latest-dev` `0.16-dev` `0.16.0-dev` | January 9th  | `sha256:39c3bb33f1fe5ba704fdfc7db231d7dd26196add8bd532031329b5a2c0cb9009` |
+|  `0` `latest` `0.16` `0.16.0`                 | January 9th  | `sha256:4f0d80082c2eeab786bf264a4de7638906ea352f0d9a360d3b4333e61a0e8b78` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-pbt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0-dev` `latest-dev` `0.16-dev` | January 4th  | `sha256:972d29deaee4bb3f7436ede95a43855336aa53f900af9cf09d4891598efef637` |
-|  `0.16` `0` `latest` `0.16.0`                 | January 4th  | `sha256:cff1c640f9b1eab75d5367b5d377604bc8d486a303ae215ed5eea223f803a041` |
+|  `0` `0.16.0` `0.16` `latest`                 | January 9th  | `sha256:aa2c369c0fb159b96a39f7319d7f8b115a1893d02b157c9bdf53b72f0c25ede7` |
+|  `0.16-dev` `0.16.0-dev` `0-dev` `latest-dev` | January 9th  | `sha256:9d63599a2d8b0026842562dafbb503870f159386092bfc21baae42b39fee00e7` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-skopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0-dev` `latest-dev` `0.16-dev` | January 4th  | `sha256:3b4146a656092236904bad922a828fd8c61a223d89d38935799077cab74d4267` |
-|  `0.16.0` `latest` `0.16` `0`                 | January 4th  | `sha256:a7d14000f4ec4dc97ca16b521d167752ceb56b51800b6c3f989d8dcb3eff5a44` |
+|  `0-dev` `0.16-dev` `0.16.0-dev` `latest-dev` | January 9th  | `sha256:5b0a33dc481cd4f9a4640a4ca5c6fa0f1709795c82d414351b443606b47fbde1` |
+|  `0.16.0` `0.16` `0` `latest`                 | January 9th  | `sha256:6a0e7d38f132ed145b876fe1e3add75d06cad710a5f34b6ddaab2cbcb8e03538` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-writer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-09 00:33:48
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 8th  | `sha256:08471e735324ecca79ab3c4dd06bcd14ae78e6f7a7bf39138192ec0ec6aa3122` |
-|  `latest-dev` | January 8th  | `sha256:72914d4f45a0b7b1254b0b3ddd2a74d5772b4d02bfe54a3d007d1fbd71d27890` |
+|  `latest-dev` | January 9th  | `sha256:b7392cbd7f90fedb52400a93b5dc02ae6cf24bbd928d92c4d37b7b234682ec29` |
+|  `latest`     | January 9th  | `sha256:b7ec56e9487c78bfd4d5790b1f766e15fa325ede0020d39de96fa5670e26302c` |
 

--- a/content/chainguard/chainguard-images/reference/netcat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/netcat/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the netcat Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 3rd  | `sha256:838eee6406cbf2199ca9aef9e61c6826133225c385c8706391e604e00ffab8be` |
+|  `latest` | January 9th  | `sha256:c69df2639f806970834ee378f3200bb6cfdec1be532749e0100b01be65dec145` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-kubernetes Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 4th  | `sha256:b8377ad1af4cca66b0cefd0cab3ac8850da9e702ebe6a723beb12cc75c8fdeaa` |
-|  `latest`     | January 4th  | `sha256:af5384805c07411fafa565d6ee7ac43eb342d02c19f78188122b2fb80d50e821` |
+|  `latest-dev` | January 9th  | `sha256:464b4a839e7e7305486d081def648f46ed03661e8b0bebcb7cba948f4cb0894b` |
+|  `latest`     | January 9th  | `sha256:aec820d5ed2cfa12ac54a71a7e61aa86aa4548248a7115ee81aee41c215b0dc4` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-09 00:33:48
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest` `0` `0.26.0` `0.26`                 | January 8th  | `sha256:1079156af8a029b90c7f3accd0cdac6581cc0600ea37c33e3dad98c361b3862e` |
-|  `latest-dev` `0.26.0-dev` `0.26-dev` `0-dev` | January 8th  | `sha256:1c9ff9e34bd3b389eb4e69ff01378a2ff7cdf6fb8cde03b85bdb396c9b8038a2` |
+|  `latest-dev` `0.26.0-dev` `0.26-dev` `0-dev` | January 9th  | `sha256:1c9ff9e34bd3b389eb4e69ff01378a2ff7cdf6fb8cde03b85bdb396c9b8038a2` |
+|  `latest` `0` `0.26.0` `0.26`                 | January 9th  | `sha256:1079156af8a029b90c7f3accd0cdac6581cc0600ea37c33e3dad98c361b3862e` |
 

--- a/content/chainguard/chainguard-images/reference/qdrant/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/qdrant/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the qdrant Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 4th  | `sha256:7f20d6dd914b2dc9bd56b08d7d18b446d7fb8c7b2d0c74057b0a647ada58c387` |
-|  `latest-dev` | January 4th  | `sha256:fec850056acb1aed213f97a63db7c0fce12252a488f9a70cd96dab1178e89200` |
+|  `latest`     | January 9th  | `sha256:96d6462f56241f0138e5751eb4c7d282ad081515de99eb137b7cddf86df6eb5e` |
+|  `latest-dev` | January 9th  | `sha256:894a9c41d0b5040d3a3fb1be2d30cdaa9b9fe7c64a224a65da1b43d35fb0d736` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the slim-toolkit-debug Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-09 00:33:48
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 8th  | `sha256:9cb7fff3f1b11f2b8f699abb33e287b3edec0dd1efc81d085550f7c88731ec12` |
+|  `latest` | January 9th  | `sha256:9ef3a5d24f1899c9776b5a860cd95569d21f7bf8cdaba9fb5d2450ac6df4d0f9` |
 

--- a/content/chainguard/chainguard-images/reference/telegraf/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/telegraf/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the telegraf Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 3rd   | `sha256:4c4605db3e6feaf153ee8a31d21544f3383e98670fe11a921b043e6fe42e868e` |
-|  `latest`     | December 23rd | `sha256:c532c22f784e1a64ea6587a37a09d1c1871b149ba7c4fbd30da84b7ab8ed79f0` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 9th  | `sha256:e8cade49fc7bc02673235c65ac129c9149b86e87fb97a63828688d478b0f069b` |
+|  `latest`     | January 9th  | `sha256:8b5397a7cd328b46df5737a8262cc2991384e22a9b305b7b17c108426de0b9df` |
 

--- a/content/chainguard/chainguard-images/reference/vector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/vector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the vector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 4th  | `sha256:02de5d6e7f27175a4c18da95a1dceccedea4c59a02d750f55a2320c6898a0960` |
-|  `latest-dev` | January 4th  | `sha256:188155951f58bbac56a42c90173aea5413db1ef6a86024f17fc691df9ee386d6` |
+|  `latest-dev` | January 9th  | `sha256:2d9b7b53d93a3450ae9a42736e480d595fae2fb5dc2d3a9ab92a4770fc3a2d2d` |
+|  `latest`     | January 9th  | `sha256:33fefd3d93287571a0efae1e5d37b6dd9d5bb6e9cd101be66b9b520365d90830` |
 

--- a/content/chainguard/chainguard-images/reference/weaviate/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/weaviate/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the weaviate Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 5th  | `sha256:34097fc53da284a392091e60b5479abf020b3666cdf7580934760d39dcfc3572` |
-|  `latest-dev` | January 5th  | `sha256:6510130ec5a22ceeab7f9637cce853e5a58dc0f006184ab5f44d1c0a6f9ee604` |
+|  `latest-dev` | January 9th  | `sha256:d863fe3bbdb14259ca119bcf5260f097cc20eb02e5c98f9b5fb638fb15721ebe` |
+|  `latest`     | January 9th  | `sha256:c1cf1f36c48695c7502b72e158e04dd57dd656ffbde381a7ea353637dddb56cc` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zookeeper Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-08 00:20:41
+lastmod: 2024-01-10 00:20:19
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 3rd  | `sha256:6eb8f57b7908386caec51416852b06bf18b8bea284728be254a28123f239d26f` |
-|  `latest`     | January 3rd  | `sha256:da33809c9b091026292640713d122db4dc79201e138860e9640b30b12a0f0140` |
+|  `latest`     | January 9th  | `sha256:fc10788daa6e6871428663fd9ef486b74a43b47ecdad2f64b7cb2ce5fd3882e8` |
+|  `latest-dev` | January 9th  | `sha256:3e6d87b4ea0204bc03968d88fea76b814d1bb6c8c33ec29c3b9c1eecb6dc295f` |
 


### PR DESCRIPTION
Updated Docs:

- aws-ebs-csi-driver/tags_history.md
- bazel/tags_history.md
- cilium-agent/tags_history.md
- deno/tags_history.md
- dynamic-localpv-provisioner/tags_history.md
- falco-no-driver/tags_history.md
- grype/tags_history.md
- guacamole-server/tags_history.md
- ingress-nginx-controller/image_specs.md
- ingress-nginx-controller/tags_history.md
- keda/tags_history.md
- keda-adapter/tags_history.md
- keda-admission-webhooks/tags_history.md
- keycloak/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- netcat/tags_history.md
- newrelic-kubernetes/tags_history.md
- prometheus-alertmanager/tags_history.md
- qdrant/tags_history.md
- slim-toolkit-debug/tags_history.md
- telegraf/tags_history.md
- vector/tags_history.md
- weaviate/tags_history.md
- zookeeper/tags_history.md