### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,76 @@
+# 2024-01-18
+New images added:
+
+- cass-config-builder
+
+Updated Docs:
+
+- apko/_index.md
+- argo-cli/tags_history.md
+- argo-exec/tags_history.md
+- argo-workflowcontroller/tags_history.md
+- argocd-repo-server/tags_history.md
+- atlantis/tags_history.md
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- aws-for-fluent-bit/tags_history.md
+- cert-manager-acmesolver/tags_history.md
+- cert-manager-cainjector/tags_history.md
+- cert-manager-controller/tags_history.md
+- cert-manager-webhook/tags_history.md
+- cilium-agent/image_specs.md
+- cilium-agent/tags_history.md
+- cilium-hubble-relay/tags_history.md
+- cilium-operator-generic/tags_history.md
+- consul/tags_history.md
+- crane/tags_history.md
+- crossplane/tags_history.md
+- fluent-bit/tags_history.md
+- fluentd/tags_history.md
+- grype/tags_history.md
+- helm/tags_history.md
+- jdk/tags_history.md
+- jdk-lts/tags_history.md
+- jre/tags_history.md
+- jre-lts/tags_history.md
+- kube-bench/tags_history.md
+- kube-fluentd-operator/tags_history.md
+- kubectl/tags_history.md
+- kubeflow-pipelines-cache-deployer/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- kubernetes-ingress-defaultbackend/tags_history.md
+- maven/tags_history.md
+- melange/tags_history.md
+- newrelic-fluent-bit-output/tags_history.md
+- nfs-subdir-external-provisioner/tags_history.md
+- node-problem-detector/tags_history.md
+- openai/tags_history.md
+- prometheus-alertmanager/tags_history.md
+- prometheus-pushgateway/tags_history.md
+- prometheus-pushgateway-bitnami/tags_history.md
+- promtail/tags_history.md
+- secrets-store-csi-driver/tags_history.md
+- skaffold/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- spire-agent/tags_history.md
+- spire-oidc-discovery-provider/tags_history.md
+- spire-server/tags_history.md
+- stakater-reloader/tags_history.md
+- tekton-controller/tags_history.md
+- tekton-entrypoint/tags_history.md
+- tekton-events/tags_history.md
+- tekton-nop/tags_history.md
+- tekton-resolvers/tags_history.md
+- tekton-sidecarlogresults/tags_history.md
+- tekton-webhook/tags_history.md
+- tekton-workingdirinit/tags_history.md
+- timoni/tags_history.md
+- trino/image_specs.md
+- trino/tags_history.md
+- vault/tags_history.md
+- vault-k8s/tags_history.md
+- wolfi-base/_index.md
+
 # 2024-01-17
 
 

--- a/content/chainguard/chainguard-images/reference/apko/_index.md
+++ b/content/chainguard/chainguard-images/reference/apko/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: apko Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,5 +39,8 @@ docker pull cgr.dev/chainguard/apko:latest
 <!--getting:end-->
 
 <!--body:start-->
+## Usage
+
+The [apko documentation](https://edu.chainguard.dev/open-source/apko/) can be found on Chainguard Academy. We encourage you to check out our guide on [getting started with apko](https://edu.chainguard.dev/open-source/apko/getting-started-with-apko/) which demonstrates how you can use Chainguard's apko image to build a base Wolfi image. 
 <!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/argo-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argo-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the argo-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:d889554139b2ff1527b63d2165f64c06cc5e2e3fec66f248a490210df9213fff` |
+|  `latest`     | January 17th | `sha256:8a4473ccdd9dd8fde92bca7af7e367d14e878ddc8a94a8a39ecb4e82bb8d6797` |
 |  `latest-dev` | January 3rd  | `sha256:10e1249be8e503c86e28732a6a094764d036ffea7c51b1d47fde904b239c5de5` |
 

--- a/content/chainguard/chainguard-images/reference/argo-exec/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argo-exec/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the argo-exec Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:e802c2f200ba98c41330c5407d859b0d7c38b8be23f42bded4f9320a8739af04` |
+|  `latest`     | January 17th | `sha256:d0d69150d6b585182a709f0b6286eab53c59b3ef4ac392f617849086a571df4c` |
 |  `latest-dev` | January 3rd  | `sha256:787aebb8566c2fe49bcb049106fd6cb412f550847063c88319b4cdbef606e196` |
 

--- a/content/chainguard/chainguard-images/reference/argo-workflowcontroller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argo-workflowcontroller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the argo-workflowcontroller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:ac84f1d3d405e9437f82b91c5166e7af5364d153bcafb7b8886d09338a7a8760` |
+|  `latest`     | January 17th | `sha256:6b89b0285fdaa3a8fa577dbeab6c0fc5646c6a73b99f243accde771a24b63d63` |
 |  `latest-dev` | January 3rd  | `sha256:0357a08eedaf67e10999ee0e191ad91d0af165f120e3d5cde4d85eabedd89439` |
 

--- a/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/argocd-repo-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the argocd-repo-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:c9dd34f62520c2228d770463075f5b0fc0d292480fc867b20fe0910496bb6f9c` |
-|  `latest-dev` | January 15th | `sha256:d218f1354066b4f663a93f5e15e7f7037c9ef993223e5383c4930ec440fa13e7` |
+|  `latest`     | January 17th | `sha256:8b5888aa4848733d21ca2b7ef4b305f6242a6a5c8cfaca2c2ab94a303d9ca674` |
+|  `latest-dev` | January 17th | `sha256:1f7831b94e06ef45854672076d49f9c355520b27d83076bb8a9b3b4a90cdaa64` |
 

--- a/content/chainguard/chainguard-images/reference/atlantis/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/atlantis/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the atlantis Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:a5729b2d9f20c830718782df65c92be0ce8261e913dfea7e71e2f0c8b119af9b` |
-|  `latest-dev` | January 15th | `sha256:e45004fadb8a15590c872bb1d2c4f38666cc51751dfe77b8b9e5b3e85f76d7cb` |
+|  `latest-dev` | January 17th | `sha256:1d45c2cc5174a33a5ac6255fc65de4a125b4ba7d4bc1cd183b49d28da47c4334` |
+|  `latest`     | January 17th | `sha256:6757124c39291b4b7d647b0d88026041776af912ba4bd26e90ad9c9e9a8ce875` |
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:7fce31270c1c9016af950ec06564e90385798a1bce57d048f347e9d759ce835f` |
-|  `latest`     | January 15th | `sha256:9866979b4e215b12223915d0f5f00c19440e16397fba444cd41c926ccf0b618f` |
+|  `latest`     | January 17th | `sha256:b71ff283b99fd37dc9793464c47216ed8ff6cc0030695b9506c4618c07f81262` |
+|  `latest-dev` | January 17th | `sha256:3defb0fcba45fbbb18b3225ada31dcff394bd155f8bf303d484fab1517cc5f2f` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:735eb0eecf0672fb58422f4118ef47abf115c1515bcd29bd8883a385f32e3d3c` |
-|  `latest`     | January 15th | `sha256:78f16f0e5306dfaa105fe11a9be8362de6e691c1da024a5b116062da9a0e6fd8` |
+|  `latest`     | January 17th | `sha256:9d0e1cc6bd75cbd20397ca521f5375821b8a0e4dca571ece408459b305b73dc7` |
+|  `latest-dev` | January 17th | `sha256:0bfb8d5fff1307484b60bc4f71ca77fb2ac54cd34153d965935ede8af5434216` |
 

--- a/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-for-fluent-bit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 15th | `sha256:eec77bdb178c66e6634cab89973a2bb5d82c1423afef2e47e4e0e12a453a7b1e` |
+|  `latest` | January 17th | `sha256:95f2ab2d3e08c0077a26492c10100e62c8de796aecf5223f71ade62eb2b4ef2a` |
 

--- a/content/chainguard/chainguard-images/reference/cass-config-builder/_index.md
+++ b/content/chainguard/chainguard-images/reference/cass-config-builder/_index.md
@@ -1,0 +1,93 @@
+---
+title: "Image Overview: cass-config-builder"
+linktitle: "cass-config-builder"
+type: "article"
+layout: "single"
+description: "Overview: cass-config-builder Chainguard Image"
+date: 2024-01-18 00:19:12
+lastmod: 2024-01-18 00:19:12
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu: 
+  docs: 
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/cass-config-builder/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+<!--overview:start-->
+Minimal [cass-config-builder](https://github.com/datastax/cass-config-builder) container image.
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/cass-config-builder:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+To use this image you can follow up the official documentation of installing the Helm Chart for K8ssandra Operator, [here](https://docs.k8ssandra.io/install/).
+
+In the [ImageConfiguration](https://docs.k8ssandra.io/install/image-config/) section which allows you to configure the K8ssandra images to use custom registries or custom images, you can use the the this image for the `cass-config-builder` image config, [here](https://github.com/k8ssandra/cass-operator/blob/ff5bc87f10b890ab09eb2d5c369edf2568169dd8/config/manager/image_config.yaml#L7) as an example:
+
+```yaml
+apiVersion: config.k8ssandra.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: image-config
+images:
+...
+  config-builder: "cgr.dev/chainguard/cass-config-builder:latest"
+...
+```
+
+If you do this change right after your installation, you might need to delete the pods under the `k8ssandra-operator` namespace for the changes to take effect by the pods being recreated but please verify that the pods are up and running before proceeding with the next steps.
+
+Next, to test the image whether it is actually working you should create `K8ssandraCluster` CR with the following spec, [here](https://docs.k8ssandra.io/install/local/single-cluster-helm/#deploy-the-k8ssandracluster):
+
+```yaml
+apiVersion: k8ssandra.io/v1alpha1
+kind: K8ssandraCluster
+metadata:
+  name: demo
+  namespace: k8ssandra-operator
+spec:
+  cassandra:
+    serverVersion: "4.0.1"
+    datacenters:
+      - metadata:
+          name: dc1
+        size: 3
+        storageConfig:
+          cassandraDataVolumeClaimSpec:
+            storageClassName: standard # make sure that you configure this to match your environment
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 5Gi
+        config:
+          jvmOptions:
+            heapSize: 512M
+        stargate:
+          size: 1
+          heapSize: 256M
+```
+
+After you created the `K8ssandraCluster` CR, there should be a pod with the name `demo-dc1-default-sts-0` under the `k8ssandra-operator` namespace up and running because the `cass-config-builder` image is going to be used as an initContainer so if the pod is up and running we can confirm that the image is working as expected.
+<!--body:end-->
+

--- a/content/chainguard/chainguard-images/reference/cass-config-builder/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/cass-config-builder/image_specs.md
@@ -1,0 +1,106 @@
+---
+title: "cass-config-builder Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public cass-config-builder Chainguard Image variants"
+date: 2024-01-18 00:19:12
+lastmod: 2024-01-18 00:19:12
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/cass-config-builder/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **cass-config-builder** Image.
+
+## Variants Compared
+The **cass-config-builder** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                  | latest                      |
+|--------------|-----------------------------|-----------------------------|
+| Default User | `nonroot`                   | `nonroot`                   |
+| Entrypoint   | `/usr/local/bin/entrypoint` | `/usr/local/bin/entrypoint` |
+| CMD          | not specified               | not specified               |
+| Workdir      | not specified               | not specified               |
+| Has apk?     | yes                         | no                          |
+| Has a shell? | yes                         | yes                         |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/cass-config-builder/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                          | latest-dev | latest |
+|--------------------------|------------|--------|
+| `alsa-lib`               | X          | X      |
+| `apk-tools`              | X          |        |
+| `bash`                   | X          | X      |
+| `busybox`                | X          | X      |
+| `ca-certificates`        | X          | X      |
+| `ca-certificates-bundle` | X          | X      |
+| `cass-config-builder`    | X          | X      |
+| `freetype`               | X          | X      |
+| `giflib`                 | X          | X      |
+| `git`                    | X          |        |
+| `glibc`                  | X          | X      |
+| `glibc-locale-posix`     | X          | X      |
+| `java-cacerts`           | X          | X      |
+| `java-common`            | X          | X      |
+| `keyutils-libs`          | X          | X      |
+| `krb5-conf`              | X          | X      |
+| `krb5-libs`              | X          | X      |
+| `lcms2`                  | X          | X      |
+| `ld-linux`               | X          | X      |
+| `libbrotlicommon1`       | X          | X      |
+| `libbrotlidec1`          | X          | X      |
+| `libbz2-1`               | X          | X      |
+| `libcom_err`             | X          | X      |
+| `libcrypt1`              | X          | X      |
+| `libcrypto3`             | X          | X      |
+| `libcurl-openssl4`       | X          |        |
+| `libexpat1`              | X          |        |
+| `libffi`                 | X          | X      |
+| `libgcc`                 | X          | X      |
+| `libidn2`                | X          |        |
+| `libjpeg-turbo`          | X          | X      |
+| `libnghttp2-14`          | X          |        |
+| `libpcre2-8-0`           | X          |        |
+| `libpng`                 | X          | X      |
+| `libpsl`                 | X          |        |
+| `libssl3`                | X          | X      |
+| `libstdc++`              | X          | X      |
+| `libtasn1`               | X          | X      |
+| `libunistring`           | X          |        |
+| `libverto`               | X          | X      |
+| `libx11`                 | X          | X      |
+| `libxau`                 | X          | X      |
+| `libxcb`                 | X          | X      |
+| `libxcomposite`          | X          | X      |
+| `libxdmcp`               | X          | X      |
+| `libxext`                | X          | X      |
+| `libxi`                  | X          | X      |
+| `libxrender`             | X          | X      |
+| `libxtst`                | X          | X      |
+| `ncurses`                | X          | X      |
+| `ncurses-terminfo-base`  | X          | X      |
+| `openjdk-8-default-jvm`  | X          | X      |
+| `openjdk-8-jre`          | X          | X      |
+| `openssl-config`         | X          | X      |
+| `p11-kit`                | X          | X      |
+| `p11-kit-trust`          | X          | X      |
+| `wolfi-baselayout`       | X          | X      |
+| `zlib`                   | X          | X      |
+

--- a/content/chainguard/chainguard-images/reference/cass-config-builder/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/cass-config-builder/provenance_info.md
@@ -1,0 +1,88 @@
+---
+title: "Provenance Information for cass-config-builder Images"
+type: "article"
+unlisted: true
+description: "Provenance information for cass-config-builder Chainguard Image"
+date: 2024-01-18 00:19:12
+lastmod: 2024-01-18 00:19:12
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/cass-config-builder/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying cass-config-builder Image Signatures
+The **cass-config-builder** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/cass-config-builder | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading cass-config-builder Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the cass-config-builder image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the cass-config-builder image on `linux/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/cass-config-builder | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying cass-config-builder Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the cass-config-builder image attestations:
+
+```shell
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/cass-config-builder
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/cass-config-builder --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/cass-config-builder/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cass-config-builder/tags_history.md
@@ -1,9 +1,9 @@
 ---
-title: "stakater-reloader Image Tags History"
+title: "cass-config-builder Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the stakater-reloader Chainguard Image"
-date: 2023-06-22T11:07:52+02:00
+description: "Image Tags and History for the cass-config-builder Chainguard Image"
+date: 2024-01-18 00:19:12
 lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/stakater-reloader/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/stakater-reloader/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/stakater-reloader/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/stakater-reloader/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/cass-config-builder/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cass-config-builder/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 17th | `sha256:d283298917341d58c3ff53e141bfbd4ff2639651c7deb29ed2566e14bcd95a2f` |
-|  `latest`     | January 17th | `sha256:6d81332f75f70a62a73e856b24cbcdb7b2bad6df02d3494f38d7c6769d0a9975` |
+|  `latest`     | January 17th | `sha256:f1bd12e67ffcf1128739f842669cd8a5a2d17f7a2ee12dcc07742ca1b3c92933` |
+|  `latest-dev` | January 17th | `sha256:b6187be647b4cc113723c9da73178c1eee7db35a113454370c545edfa2200c6d` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-acmesolver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-acmesolver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cert-manager-acmesolver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 16th  | `sha256:9af85d017b0d0a6d908c292ffc4fef641afb044da89f1411c90c49612db894a6` |
-|  `latest`     | December 20th | `sha256:7637b92ac38b2ca540d2e891e44a017c4bb9b0f08dd1c715ee4eb8865c575a80` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:9490bdb33d615e4d899ba2b88018ebb19b95c54e07ab094f336aca28b0f35921` |
+|  `latest`     | January 17th | `sha256:e53c45ed53a433aaee318355280869b14ffa7e065db5260a31dc8e57981d28df` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-cainjector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-cainjector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cert-manager-cainjector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 16th  | `sha256:c7872b46f720ba5d4eff0e245b28f252c9060fd7a9d499778beba5fefc14de62` |
-|  `latest`     | December 20th | `sha256:c5f61d5d916305bde7de74c06202256c445a465d509771dcd4243b15500dde42` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:8385b4fb55b56b14d75e19fd0e90b2ad1eefd264204d1c5b71f62c2947ffe7e8` |
+|  `latest`     | January 17th | `sha256:4a38be85bb0aee1ef2b3b984b4caa910c868177d9805366b5923f9ae81f924d3` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cert-manager-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 16th  | `sha256:93db6ad905d9270be709ea7572408542212de83311a969597594e7ec58fb9f5b` |
-|  `latest`     | December 20th | `sha256:f964422653472008bcc633cb3d1aea01309eb31fa86e3edf2ef9d6a45c884fa6` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | January 17th | `sha256:1e24fe7e4420c004167914dd722534bdfa4e578b9dee09c5ae13d609c85c3ccb` |
+|  `latest-dev` | January 17th | `sha256:25edef63e8c60b3b959271f08ba420b5cb6937e2ef24977db14d5eb0b6c759a0` |
 

--- a/content/chainguard/chainguard-images/reference/cert-manager-webhook/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cert-manager-webhook/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cert-manager-webhook Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 16th  | `sha256:9eccace3bf7f26abad0d8c50c0fdfc20b3b4d3cbef99c5e0b3096e4f5bf159cb` |
-|  `latest`     | December 20th | `sha256:cd3b1731984261ea3ebee2ac9e90bb3927fd7d3c0bb5a86b4cd99990c478ae50` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:393be570d3e50d6f756406370e047aea598fe9001a08909fe369054ea9df80fd` |
+|  `latest`     | January 17th | `sha256:5976de5bd0d13d567e234e844a6d1fb3bc3cacfddc5619fef740a1fcd35a786c` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public cilium-agent Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -56,7 +56,6 @@ The table shows package distribution across variants.
 | `cilium-envoy`                 | X          | X      |
 | `clang-15`                     | X          | X      |
 | `clang-15-default`             | X          | X      |
-| `cni-plugins`                  | X          | X      |
 | `cni-plugins-main`             | X          | X      |
 | `git`                          | X          |        |
 | `glibc`                        | X          | X      |

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:b06eb22f9ee0e738855658ef3cc1c0cd6c1ac7be6145b99481554b579d3ee82f` |
-|  `latest-dev` | January 16th | `sha256:cef6e53828dd125d46c5fee006b5e76e1fb9872a85fe780c51a7817ce0084b0d` |
+|  `latest-dev` | January 17th | `sha256:6ac5bf017afcd365663155be5dfcfd0ac11443db566cfb5852ed060c3a09e846` |
+|  `latest`     | January 17th | `sha256:ab1c4c5a3211f5f3a373be2f12996550e9be829e510bbd3c28ccfbdd7f899f0f` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-hubble-relay Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:5938e9eabd32df5e760353b3ef8be76f8f7df5cd133daf4b9aef31790c8e564d` |
-|  `latest`     | January 13th | `sha256:5adcc94af2d8690c3d35d5f320b27d871eedbeec1bce62f98e925546285f86f8` |
+|  `latest-dev` | January 17th | `sha256:def271656feb4e672d9961543b2235b37d350bb154239b9900a670bb4b8f1291` |
+|  `latest`     | January 17th | `sha256:834a84c9592491d096fc932245dacff6a589633ab920dda000c4fdff2c050293` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-operator-generic Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:191b7c2132f5d8b46ea4eda91a596b8aa7c800d125db73a499f0ae79e38db8e9` |
-|  `latest`     | January 13th | `sha256:d50e43a6787aa4f018e71e4c424de8182b00898d6ab836de2067921d1a3a8475` |
+|  `latest-dev` | January 17th | `sha256:9b4e0b101e17b4bdd97641dc375037c5c415d521082cfe359a1efa4969e97dec` |
+|  `latest`     | January 17th | `sha256:b0f2937326e0185884ba0700727a25fcd2fdc034de275ec78723070b7cedfb8f` |
 

--- a/content/chainguard/chainguard-images/reference/consul/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/consul/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the consul Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:126e19614aae7bbeb4a84c745c48569be3a781fcd0c8ed4f2d00c6f9341091d4` |
-|  `latest-dev` | January 15th | `sha256:ff27e51219a9d8572aa461f7bee7fe6bda89348859823864ac57821488314115` |
+|  `latest`     | January 17th | `sha256:9a89162a32ccc527e3dd859c6f7a57f51b54654edc2d0da23402465c0d220ae2` |
+|  `latest-dev` | January 17th | `sha256:ebe5bcbb751ad3ee74b54858f26482fb60fea69d8a274d55d0125e2d74c27c27` |
 

--- a/content/chainguard/chainguard-images/reference/crane/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/crane/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the crane Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:94fb19f5908e9c0af9d6d4942c53287d68f0be4fc6df4b5cfb93821f87a912d6` |
-|  `latest`     | January 5th  | `sha256:9ce24c8330fcd6d3cea1ecaf8c52b6d4712cd538322c4c8b87dd3047f343a12a` |
+|  `latest`     | January 17th | `sha256:460ab88b24e3e36c134886caaa299a458c1fb9e29ce950971d685cec2c3af08e` |
+|  `latest-dev` | January 17th | `sha256:0059965d511bc75a49f0f6ac92fdc042bd81da93fcdb02d228c2696705c80fb4` |
 

--- a/content/chainguard/chainguard-images/reference/crossplane/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/crossplane/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the crossplane Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:e79c372fbbcfda6515ab4204cd352c3e3feba40c386bdf44187f5f547060801b` |
-|  `latest`     | December 30th | `sha256:929c5f2232c6c7afe0eb68001121834afd067b2635c11a48048f920bbe96bcce` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:aa1baa6f717ce158c25d87e427c815bf9aff8630e90a290c83dc24370dfb34a3` |
+|  `latest`     | January 17th | `sha256:a73bf5741cd208be52ac6fa4d00261b0dc348919ae0d789f39d14e9cdc4b5705` |
 

--- a/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluent-bit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:bb1880d021e6fa0fa4b1aa25325d895c639c11c8a5d337a0b193743ee9ced15b` |
-|  `latest-dev` | January 15th | `sha256:7f3e7b2a7416988a5da67bab57c5f8deacb3414da60c7e119099dea302734f2e` |
+|  `latest-dev` | January 17th | `sha256:02c904b522aedaebdb8d5915bcdd557f62792e0d0f7df9fd1b777e9f53150ba7` |
+|  `latest`     | January 17th | `sha256:8a3caa5772052d374eb82510ba71351240dc309ee22f759a33ab74cb438fe257` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed | Digest                                                                    |
 |----------------------|--------------|---------------------------------------------------------------------------|
+|  `latest-splunk`     | January 17th | `sha256:507364fcc8c9219e3220ae23e7a420bd814067a9f09fd1c766a4ff4adeb3a346` |
+|  `latest-splunk-dev` | January 17th | `sha256:661148795f43f70bf551dabd74e054e54c43075200f9def0ff87c04f73c45105` |
 |  `latest-dev`        | January 16th | `sha256:56bef585ae02bcda64cd215119940dd1f8394f2738f4196790c2557696618842` |
 |  `latest`            | January 16th | `sha256:006965326e8b497bb3144c5bc214ae1c4e4254028c6d03f8e1b566814c772d9d` |
-|  `latest-splunk-dev` | January 16th | `sha256:3f491baf2f05328bce257da965d851b3f410953fb6c3f3aaa110729c957b30a9` |
-|  `latest-splunk`     | January 16th | `sha256:dbdeeeed9b4dd69a72e2ae7912f2fd09926dec2174ef7327325f76b33019e292` |
 

--- a/content/chainguard/chainguard-images/reference/grype/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/grype/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the grype Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:0669a7dd7ac56ac4ba6a228821f815365e013c298476e99fa005510087f1c033` |
-|  `latest`     | January 13th | `sha256:a445dadcdefe700435c8ba35c4ec43ca1d320366963daaf73433924be0417e0f` |
+|  `latest-dev` | January 17th | `sha256:a812229ea0b7cf71e025c0b397200ad18e11d51f137065c08791542a9889aa67` |
+|  `latest`     | January 17th | `sha256:33a73211735654e33528fde22dffded7d4f0e326bed64917e3d5e8137a85c2c4` |
 

--- a/content/chainguard/chainguard-images/reference/helm/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/helm/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the helm Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:6bb9ffac38851b74cfe02d4acf7a73dee95395062e9b997dc6c96514c2e522f8` |
-|  `latest`     | January 12th | `sha256:fffcb9b26d64d7cd6c82d2a4559428644fe69f98bdd3e8c501ee713a02e9d473` |
+|  `latest-dev` | January 17th | `sha256:6d6b548d9d1a485ee981b79561df9996a2c899e5327f37b24702003f36748ea7` |
+|  `latest`     | January 17th | `sha256:fdb16aaef85ba1f14f283bc89e57065f77c799058fef4a3671406770971c3e88` |
 

--- a/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:03f22f00772b2864d86e89ca9b8391719831bfeecd6b328f394cd5026cab11c3` |
-|  `latest`     | January 13th | `sha256:42200c77fc9ee262d7124a46483b1eada07ae637bbe0060fd21b8d9e33957bf3` |
+|  `latest`     | January 17th | `sha256:c0a6b89699802c57307cfad6533d1c8a1cfdf0bb6500b87f714176ac7f62ad33` |
+|  `latest-dev` | January 17th | `sha256:63d3ffa294953e6d4e627e3404e29bd7684611e8fa99e917b7575784ae27b156` |
 

--- a/content/chainguard/chainguard-images/reference/jdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:85075e9eaefcfefb4deb2353b0fd3b567dca0a30f7381de54c61522d98c04924` |
-|  `latest`     | January 13th | `sha256:199267782a1ea8dc573b764a13d64c70e73d0a72b6c8784ccd501fc31df774c8` |
+|  `latest-dev` | January 17th | `sha256:39b3ebd76ebe99bf303f05aa2b464e3eb279f1840be31691ece513478d322be0` |
+|  `latest`     | January 17th | `sha256:349d932b0404a2717593aed67f728e6a2a291ebfc806b98c5c7fb1b2b052033a` |
 

--- a/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:3ebcbad477d07c7c0a4094bff33189309d04531881cfe7b4431993a9ebd436dd` |
-|  `latest`     | January 13th | `sha256:ed04a0e5650ae0a0733223b9ae865494c95a7782d00301fb9bf284952d1675da` |
+|  `latest`     | January 17th | `sha256:5ecd7cd2c4d03b2da1f05bb7c8eb4d7fa6eef921a8c6c8ce39700acfc60c2432` |
+|  `latest-dev` | January 17th | `sha256:d0b4034ab0c86355aa1838cd75684ea1f3e304994cf244f34a6653221d00b96f` |
 

--- a/content/chainguard/chainguard-images/reference/jre/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:3f34d822c87d2edd30aa4b8839e2c3f1ec6159db79210763671317c47dfbe92d` |
-|  `latest`     | January 13th | `sha256:64b061fa07d059013e1779104e4847ab9c2ae3a4d585885530e1b76c7a66864f` |
+|  `latest-dev` | January 17th | `sha256:a04095f89d3bd9f1db383014065999f35e3101c24ceb41b3c8aa533f32bbb384` |
+|  `latest`     | January 17th | `sha256:5ea8e9d505f28fd4ba24b1d9ec39c66e0879d3446d82c2b9b75a803ad1623acb` |
 

--- a/content/chainguard/chainguard-images/reference/kube-bench/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-bench/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-bench Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:f4d85049e02621c3e0f251c25abde6f92f77de6f000955f4516ff6740a7e9b28` |
+|  `latest` | January 17th | `sha256:d75020d2f097bb42d89c81c70eecef51258f04d535dbeffb353ac4b19298467d` |
 

--- a/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-fluentd-operator Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:572ad3beefd2f34122faf99332163836bd274717b4aaa40681c5dc67d42ffa74` |
+|  `latest` | January 17th | `sha256:c8a95d63e59e88a39604fe31199ff149b9942deb0f992bed56058feb478bc213` |
 

--- a/content/chainguard/chainguard-images/reference/kubectl/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubectl/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubectl Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:12e2069aef13477f9c0e08fe7ba7cf8266b45e1d5624bf1fb2e1cdd102656ca7` |
-|  `latest`     | December 21st | `sha256:95f5f80fc6ab00f04bae2f7e2b3f880cb134003abafb61c4eb330c193526c8c1` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:3fe69e109028fb3f9b1a27bc6bf0653e36392657e3b2851c6e0d98ff8282b90e` |
+|  `latest`     | January 17th | `sha256:6b735e541e64eaca3313e61f8fed727d17a7d891687cf49ff3d571472762d424` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-cache-deployer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:10a391cec5f375d54ae0ba262717d164b99e9fcfd43ee850e23d05e8810223d8` |
-|  `latest-dev` | January 15th | `sha256:0b642ff2613754eed4d12c7832e75e89fbc8fb3f6e8fdf8ce8dc7c19aa8ca04d` |
+|  `latest-dev` | January 17th | `sha256:1432e7a33ba62109553a64dcb41ab264985620707a92e9b749cf49c0e5f6fec7` |
+|  `latest`     | January 17th | `sha256:79975d16c149776eabab5f0a551ccf0ea80d741452b1bdbd3e48a1933aa0690d` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-writer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:04328e8dca0413934a71bdb74c129c32690bab235768a68a8a7db452b3e61212` |
-|  `latest`     | January 15th | `sha256:75b8cd7000f6abea55960eb5439953880243876508ec20edc5f2f93356d28c7a` |
+|  `latest`     | January 17th | `sha256:c2d5dcef8da58642b2606406736ced663078fd448e9df98759b28a1d13b23099` |
+|  `latest-dev` | January 17th | `sha256:912d8f1da347caeb19297063697040e0e43bb96474e1e8d635af6e4fa0a014d6` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-ingress-defaultbackend/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-ingress-defaultbackend Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:45af6e4ab42cd84df076d467761b44b653149057a7ec0649ff24ac8ad142503f` |
-|  `latest`     | January 5th  | `sha256:41a979ab066616c5ce20e90bef179b21d6b000eae7a49468d02eb8cd079973fa` |
+|  `latest-dev` | January 17th | `sha256:9b5779e7141c59de4cff58d5754433bb98fb6d3a6e6ed168d376b8f189c7312d` |
+|  `latest`     | January 17th | `sha256:0a89e1975ae58ce2b971a36995b2e9e535ac0b098bc9ba097ece939942baee72` |
 

--- a/content/chainguard/chainguard-images/reference/maven/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/maven/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the maven Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,10 +25,10 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                        | Last Changed | Digest                                                                    |
 |--------------------------------|--------------|---------------------------------------------------------------------------|
+|  `openjdk-21`                  | January 17th | `sha256:d37fd8735de95510cf3536d4060d9806bffed3b07650366b6cba934443876b8b` |
+|  `openjdk-21-dev`              | January 17th | `sha256:011958a728893db30d3c6461fa83667e5f978b20b1bddc514c7fb7245e906071` |
 |  `openjdk-17-dev` `latest-dev` | January 15th | `sha256:40961bab6277b20d467210774f336b2ed7a6da5a89c0423da2c3992ac1475892` |
 |  `openjdk-11-dev`              | January 15th | `sha256:f9c85be93b334fdcceb3ed510bccde49bcd6e1bdfdfb62237d389f3e0d442d96` |
-|  `openjdk-21-dev`              | January 15th | `sha256:bd8a1e996094695a76aec4f8e3ad87bec808e05665d06286a51e44b60b80413e` |
 |  `latest` `openjdk-17`         | January 13th | `sha256:c02549885a2deed21cc5c553f426ac5042521705eaeb2cdad637acb7c091f458` |
-|  `openjdk-21`                  | January 13th | `sha256:ba16d3cac3d72cafca6a72a1930797a4250d0d2b20bfabb489c3ea553be4e4a0` |
 |  `openjdk-11`                  | January 13th | `sha256:3626668a96bee11095bfabe7c43bc98bcaf3aea5a49935ff215a023e1413912b` |
 

--- a/content/chainguard/chainguard-images/reference/melange/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/melange/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the melange Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:d7095a13066cebf577f64e5af2bf33a1ca5fd4f305024ce9ba8af83c44f74ba0` |
-|  `latest`     | January 13th | `sha256:f51e0680f2259846df0ee8a432c69025d7339b94398debeda865cc57f2528c18` |
+|  `latest-dev` | January 17th | `sha256:ad9eba6f5d6078bc886852f8bfe2e52d1b2b5a8a5f14c8ad9ddf76b3702b0ed5` |
+|  `latest`     | January 17th | `sha256:864686571d4e22aaeaeabc3a0700e4361f6fd3a05e41d17016c4d6cc1fa694e9` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-fluent-bit-output Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:3201059a6df9f0afa46901f91f4df793ebc39e149ae6cc09ec6e988c9277c192` |
-|  `latest-dev` | January 15th | `sha256:9e05a860108b42f0ae58b3efddb5c196d92d9b460763fea9636e9ad2b9b316dd` |
+|  `latest`     | January 17th | `sha256:ef0203fc2cb18f89780a8f182ca8db675db5e60e6d7acaa2fe2777e8c9524d6d` |
+|  `latest-dev` | January 17th | `sha256:5202643e69e3c3e6fcdb1243f19b94c7ac6b48a74ffac9f1c25f00a182ec16cc` |
 

--- a/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the nfs-subdir-external-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:a25d6af5ced791fbf452f214de811d0265272c0ba48e4f3bf174cc071fb72cf3` |
-|  `latest`     | January 13th | `sha256:8bb489820096461dd19c6ba31f1892168cad717a06f7c22a532ee4260b1dde9b` |
+|  `latest`     | January 17th | `sha256:f5e8080c17a132c754e8c430a6bb56d880c3aacb062f7b19717df4a5435964d9` |
+|  `latest-dev` | January 17th | `sha256:c5e9c207c19de8318425264e8ecab5d94ae70f2b44f3b3188ed8b4152230df7c` |
 

--- a/content/chainguard/chainguard-images/reference/node-problem-detector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-problem-detector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node-problem-detector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:ae31a042cf64d0e888fedc719e157a2a51ae7a944e3f25658e29e265cbdcad7b` |
-|  `latest`     | January 13th | `sha256:031b1c9173f02e8f5e954f841a7bf9ec4e33be84c32e229bb386a19c18b14a90` |
+|  `latest-dev` | January 17th | `sha256:b73ec5c1996afe01448ef6e490fff521148b23d01756bbdda7d8bb3ce6baf1be` |
+|  `latest`     | January 17th | `sha256:a4aa1b33f13085bb5d434bd3837a97931a5c5ab3656f34728fb5b03a16298cf3` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the openai Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:453cfefb1285ec8bf9e4eec576ea69449cb882aaf9388d21488f87f4986360f4` |
-|  `latest`     | January 13th | `sha256:6d50ec9daa75d9a1e5ce729032d1671d112633e8c60d6f2434579822515044db` |
+|  `latest`     | January 17th | `sha256:309290b907d7769a5d2d4a9ceaa46d62f5d3e33527f0109ad5f22f90bb6c67b5` |
+|  `latest-dev` | January 17th | `sha256:97b05d48b0d67df5967987b8c69e889e6b95a19e080860305591b2bdca9e8011` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest` `0.26` `0.26.0` `0`                 | January 16th | `sha256:d531f882d0a1b0b2ce9bfe540a503ccf6fc985aa720e89cb0b145dbff41b9308` |
-|  `latest-dev` `0.26-dev` `0-dev` `0.26.0-dev` | January 16th | `sha256:177436f533b8d068017618e715b2c7707f115652feb3ce461d0f7f142885553c` |
+|  `latest` `0.26` `0.26.0` `0`                 | January 17th | `sha256:d531f882d0a1b0b2ce9bfe540a503ccf6fc985aa720e89cb0b145dbff41b9308` |
+|  `latest-dev` `0.26-dev` `0-dev` `0.26.0-dev` | January 17th | `sha256:177436f533b8d068017618e715b2c7707f115652feb3ce461d0f7f142885553c` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-pushgateway-bitnami/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-pushgateway-bitnami/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-pushgateway-bitnami Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:435e3ce72daa2d55fdf4f15c5a5dd505a78e4bddfcc96254dfe561874a09cba3` |
-|  `latest`     | January 13th | `sha256:11b21479913fa5757573e1ef923a5265fe8d13124b899c63a7fb49572d81b509` |
+|  `latest-dev` | January 17th | `sha256:0aec97ce9967c78b9fc3804c35a6df3550243b3cde9009d4cc8f5d0ac1328423` |
+|  `latest`     | January 17th | `sha256:be23a7fb15f832ae8f6ad43eee2c63ce8af43e31a8e8066d3015f1e8642ade08` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-pushgateway/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-pushgateway/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-pushgateway Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed | Digest                                                                    |
 |---------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `1-dev` `1.6.2-dev` `latest-dev` `1.6-dev` | January 15th | `sha256:4ec4915a2b4ffb78fd24106d15b1c4066470ed6c6450886078b51918b0a26573` |
-|  `1.6` `1` `1.6.2` `latest`                 | January 4th  | `sha256:e87dd2b20a476a9ce057927f62583aa19d079670e255917cf450b80acca3184d` |
+|  `1.6` `latest` `1` `1.6.2`                 | January 17th | `sha256:0b63077524af30465e2990f9a670d1020042c18aac25c592156e00765f72fed7` |
+|  `1-dev` `1.6.2-dev` `latest-dev` `1.6-dev` | January 17th | `sha256:7bdec87913f05d54d5b2b99bc426ac09df63594add8632b6170ff715017faaf4` |
 

--- a/content/chainguard/chainguard-images/reference/promtail/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/promtail/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the promtail Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:9066b8158ea980aea5ee6d44568fd5c7fbb6f8303dcb989fdb9e72601671ab3c` |
-|  `latest`     | January 13th | `sha256:f6a4083f97c49523f05ffd835d023ad3694e83e79470dd29003060283019c6a2` |
+|  `latest-dev` | January 17th | `sha256:0e5603ce74a05eda66adbb56e865d0925fb38ec8db3b37f884067dc6dec80b76` |
+|  `latest`     | January 17th | `sha256:63cdeaa12e0e0ea308599cfa279f49863f7a7fafbbb978ea612e0c73869e291c` |
 

--- a/content/chainguard/chainguard-images/reference/secrets-store-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/secrets-store-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the secrets-store-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:10c790310e389b9bb3bd629ca8b3d3a21d0c279295f552402e85101dec142e10` |
-|  `latest`     | January 13th | `sha256:65d1407a236d66ed916a90e35779417af3d01ec40198bafe78b55689ae0d70b9` |
+|  `latest-dev` | January 17th | `sha256:c2cf0a2222c456189781a537d17b12e2098f5e1122e0e7ded6976b768e1171a8` |
+|  `latest`     | January 17th | `sha256:cdcf5359b9b84c2b71f82bed533144dff30fe2b9836730ae8a55982be2f83269` |
 

--- a/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the skaffold Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:084fcbc3e207504630f1a9cd455e0876a3c523b3c195cce4cc887a6ec6cb09d0` |
-|  `latest-dev` | January 16th | `sha256:933206f74a82f1bfac1790d89984acdc271ffd4fdfcce64f3cac9b2153fa5ff8` |
+|  `latest`     | January 17th | `sha256:c3dbe8121e8969f91adcbd76b29c916c0db1a6b6718a10e79bec5504b409a53a` |
+|  `latest-dev` | January 17th | `sha256:66d9ce4759ea6d4a7942101bcfce887f93bc8c290c899d92c21fd8b8f111cabf` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the slim-toolkit-debug Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 16th | `sha256:915fed69361c85c5fa70ed204651ac501324eeedc23491e9589d4a7b8db81c85` |
+|  `latest` | January 17th | `sha256:34fc5710c09e1599e350dd4f6a9028cd47274726e38bddbbeaf84c380d142a20` |
 

--- a/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:f2867bc9a3ac6aa8f92d13e7bde7c0a64d95837da148d74b397c999c547044b7` |
-|  `latest`     | January 15th | `sha256:85b1912893fb6807dc4edcabe08fadbc7b088c502b6c3c7d8dc1d02ef88e2ced` |
+|  `latest`     | January 17th | `sha256:dd3ee148ee64b7ef3268244ff6475b65d3db60026de5c3347c66903f0551ccde` |
+|  `latest-dev` | January 17th | `sha256:0789d00a39a67ab01581a4cf94c4aa4b4b531f2225df2ca786a40f9bcd82ec8f` |
 

--- a/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-oidc-discovery-provider/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-oidc-discovery-provider Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:47d115557d77bd4627bb5c1cdad60c24b6913080a1b04d99b06bc53f3a4cc704` |
-|  `latest`     | January 13th | `sha256:18992e50eefda5f390004b158c8733ed84022e4a9ffdca9a82856dae7fbfa635` |
+|  `latest`     | January 17th | `sha256:4c2b98013bbc7ceabacc16e9ccc770283dd3e4a2d8eb90c57acaa4ee540deee6` |
+|  `latest-dev` | January 17th | `sha256:b40af7a33b7a925dc4085b294694e9d95a8257399724aeb22bd476e69d6c0347` |
 

--- a/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/spire-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the spire-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:e83fafeb257dd0172fa85d5b1a1b1d71d61c0642e720365838fd3cbecd373adf` |
-|  `latest`     | January 13th | `sha256:003dbf08579cd5fd861b6b8a4332387097d4a86a2c674e2ebab414e6358b9b37` |
+|  `latest-dev` | January 17th | `sha256:0fccfaca8457c426c76dbdadeb653cbf3de2bce6a8c6926b7470749017a6dfb8` |
+|  `latest`     | January 17th | `sha256:5e3d2a05474605258530e6517995570ff197c747dea52d1b4f5581c37a856761` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:8706e713fb122fca8b542b8c65264f4eb7c5e6f612078328d83e60324e02c4d0` |
-|  `latest`     | December 29th | `sha256:653e1b1601d7bd269d365322491da8dec6dbf55533d161e720808302eda4dea4` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | January 17th | `sha256:5a368f68ae04a5dd08dfacd60ff577b9e83577248d788cf99275a9c5e428e62b` |
+|  `latest-dev` | January 17th | `sha256:e05aa442ba5181c74384d70a1f6cb8b0580b5626009585016b7ffaf763d55a37` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-entrypoint/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-entrypoint/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-entrypoint Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:a159c59a52f887a4388b90c07bd80d68a48d1f532662fe32c06ac882f71328e6` |
-|  `latest`     | December 29th | `sha256:8a2425d71b9e0aa23578320e8c77321fdde9ea0bf47a59f32bc00072af3aef68` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | January 17th | `sha256:79aeaa4d30ade0390da1e7704e4d8239a180cbeb4a96fd4c249e0b2b6ed5f44a` |
+|  `latest-dev` | January 17th | `sha256:fb0007bdae09455fe38b003ff3727b6d2471c9167f2b1c7db75e898204375edc` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-events/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-events/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-events Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:d1e17e90aff0b41be92e35febd2914bf62a02ad9e8baf86abebadc6dd08946ea` |
-|  `latest`     | December 29th | `sha256:e1e7929e5f5a0b737d8a62fd315d4e53347763a24332d4d14edce67fa58915cd` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:9b21c8cee89ebc96b3a891cf2b46ece0133ee6570bdac9027e0a83def135ea03` |
+|  `latest`     | January 17th | `sha256:1a100f128cc51a277b90920dd7a6c938a7cf2078d1966649e13b06729ffb8762` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-nop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-nop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-nop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:c73796b9faccf6a4ad2a8206e4fcb1a49c2a51df6ca3e21492e63698967e07e8` |
-|  `latest`     | December 29th | `sha256:42a38e619f6ba37fafbf2d9b0434592630bede372b2eb3064a51c104f7c3e32a` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | January 17th | `sha256:e307ed8d81b7d85fd9ac1a3eb2cce595efb43ddf8854498486972dac2c695fa2` |
+|  `latest-dev` | January 17th | `sha256:3fd273469c42af084bad85a493caf6a0413a956b27856b1b90816bda39f4156c` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-resolvers/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-resolvers/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-resolvers Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:e2740927a1468f235a49934dcc26eb2171cc7e551c03d37c7474fac5e9b17d3a` |
-|  `latest`     | December 29th | `sha256:4928f0657b7eeb52746ce5da5c19f26ff1383d40ec69398752e55876a49ea13b` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:115d55479b745e6e41e47eaaf437488c759c1c4f05d75d0ba864ca214afa9568` |
+|  `latest`     | January 17th | `sha256:c575626857e6e0b71fb156a67cbf79c6496a771040ab7e901464bd7b4f8f1c4e` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-sidecarlogresults/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-sidecarlogresults/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-sidecarlogresults Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:8f1000370ba3726f044036d54acb2622bef20d1b91714ca2aa698523c4266604` |
-|  `latest`     | December 29th | `sha256:6e257158447b2035d35ae8992f4a97fd0ce0eaf9062eb611d8a1c6185c9ecefe` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | January 17th | `sha256:d07b5f38faaa9a3a8ebf0324ce76c50f1d309ab9cdd3d40ce6466ea300ea085e` |
+|  `latest-dev` | January 17th | `sha256:a8d2f35139c8998ddc3917b368a3441d8d158ba08bec7998bb1bfeb64af4d815` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-webhook/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-webhook/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-webhook Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:15635bfed77ce7e28b785bb110f925f60132fe46a1a0f7c2ddaaadf406087544` |
-|  `latest`     | December 29th | `sha256:a633c62834a6b1e04360fce7b95b7f0c69a7aa469e699a3fb3283bb4925a6cee` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:0f1ea14664c2cb79939ca7149c4e5a5801e5b45617500f92cbe2bda8b4e5f40a` |
+|  `latest`     | January 17th | `sha256:ac60b26fbdc5c209d9c16fdd76179bb155bf88cec2d2253c4e5dd340145fa931` |
 

--- a/content/chainguard/chainguard-images/reference/tekton-workingdirinit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tekton-workingdirinit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tekton-workingdirinit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed  | Digest                                                                    |
-|---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th  | `sha256:b78e94db95e7fb2409d3749ae9ad381e8d5c2c7a39573492ad3b71b4f6e50d7b` |
-|  `latest`     | December 29th | `sha256:48f460921e005c61fd3f4d3b389a10e05cbfad21258933cf4df118f7e5e8b47e` |
+| Tag (s)       | Last Changed | Digest                                                                    |
+|---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | January 17th | `sha256:c63a3fe5343b6b7aa9e67e6232c62026d61c39c6af4f04e9ae2c958e6efc75d3` |
+|  `latest`     | January 17th | `sha256:2e1c9982779638e62e4856e4e48cadf1aa217141b47992c8ae98be4b82c70421` |
 

--- a/content/chainguard/chainguard-images/reference/timoni/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/timoni/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the timoni Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:b967aa4808143429ce06c6e8bd97f8a8884a28de62e38d3ef08b6c87233cdfac` |
-|  `latest`     | January 15th | `sha256:4f5c099918703688e01fae11f95ac7ccfc661ba6fdf9ae0f9895fd0682b8c81b` |
+|  `latest-dev` | January 17th | `sha256:b45743bf2fef59c0142969798a3d8b7c8f8006cac232f5ae9c703343e50cfcab` |
+|  `latest`     | January 17th | `sha256:03629b5df37d7bd055c41833211dfc682f4e58e9eae2ae31a3742d73008fed2c` |
 

--- a/content/chainguard/chainguard-images/reference/trino/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/trino/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public trino Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -82,9 +82,9 @@ The table shows package distribution across variants.
 | `mpdecimal`                        | X          | X      |
 | `ncurses`                          | X          | X      |
 | `ncurses-terminfo-base`            | X          | X      |
-| `openjdk-17-default-jvm`           | X          | X      |
-| `openjdk-17-jre`                   | X          | X      |
-| `openjdk-17-jre-base`              | X          | X      |
+| `openjdk-21-default-jvm`           | X          | X      |
+| `openjdk-21-jre`                   | X          | X      |
+| `openjdk-21-jre-base`              | X          | X      |
 | `openssl-config`                   | X          | X      |
 | `p11-kit`                          | X          | X      |
 | `p11-kit-trust`                    | X          | X      |

--- a/content/chainguard/chainguard-images/reference/trino/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trino/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the trino Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 12th | `sha256:283a8ea44d0661fb32cba0713b44a921ab96e25c62095feba8b2d62be14b6113` |
-|  `latest-dev` | January 12th | `sha256:9f047918cf1c96bd557e50b3a9370757c021a5782daa1f7d788283c6b3d4dce7` |
+|  `latest`     | January 17th | `sha256:51810f845147732d1c10ee0adae1382f2de576d2228dc2bbdf6398a6d5e547b8` |
+|  `latest-dev` | January 17th | `sha256:acf2c8f939ad19c0e3120c2d07c2f3019e24b15b9e87b8a4d20bbe42a70e4635` |
 

--- a/content/chainguard/chainguard-images/reference/vault-k8s/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/vault-k8s/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the vault-k8s Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:55574eceb13696b7d07ee3b9bbced61e733426e718147e645115681e81ec5a3d` |
-|  `latest`     | January 13th | `sha256:d5a74c8afb4870f2ee9d701fd85824a443406ac2bbf0a262c7ac8881fb5f2eea` |
+|  `latest`     | January 17th | `sha256:3eb84987c8dff4608409e9849e469663d778a18852a4fabb63793a6da4b02c39` |
+|  `latest-dev` | January 17th | `sha256:6303b517eb9f6445b36112938d9621594eff5d10c49ab95d5a697236f54e219a` |
 

--- a/content/chainguard/chainguard-images/reference/vault/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/vault/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the vault Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 15th | `sha256:d46e7731da80f7b8f446209cccf8944a605b0e1fd0b6a32038388dbb384ca84c` |
-|  `latest-dev` | January 15th | `sha256:aa1cb0bd13e6879834a795e9ef749f274e457772409b17b384a59d5357ae31db` |
+|  `latest`     | January 17th | `sha256:590a7198c32941ab9c57c61a8c0215186376052ada4242581e5c3ef619fd1eed` |
+|  `latest-dev` | January 17th | `sha256:088366ec3104b82c6b1109cd615ebde680810f901f03e815df83d095b7abba10` |
 

--- a/content/chainguard/chainguard-images/reference/wolfi-base/_index.md
+++ b/content/chainguard/chainguard-images/reference/wolfi-base/_index.md
@@ -5,12 +5,12 @@ type: "article"
 layout: "single"
 description: "Overview: wolfi-base Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2022-11-01T11:07:52+02:00
+lastmod: 2024-01-18 00:19:12
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
-menu:
-  docs:
+menu: 
+  docs: 
     parent: "images-reference"
 weight: 500
 toc: true
@@ -39,58 +39,45 @@ docker pull cgr.dev/chainguard/wolfi-base:latest
 <!--getting:end-->
 
 <!--body:start-->
-This is the base image for the [Wolfi Linux Distribution](wolfi.dev). It includes a shell and package manager, allowing further packages to be installed such as in a Dockerfile.
-
-This image is a great place to start when exploring Wolfi.
-
-## Image Variants
-
-As Wolfi is a rolling distribution, we only supply the "latest" tag. There are no point releases of
-Wolfi.
-
-## Get It!
-
-The image is available on `cgr.dev`:
-
-```
-docker pull cgr.dev/chainguard/wolfi-base:latest
-```
-
 ## Usage
 
-The image will start in a shell by default:
+The Chainguard `wolfi-base` Image includes a shell and package manager. The Image will start in a shell by default:
 
+```sh
+docker run -it cgr.dev/chainguard/wolfi-base
 ```
-$ docker run -it cgr.dev/chainguard/wolfi-base
-6d38c9b4f0d9:/# whoami
-root
-6d38c9b4f0d9:/# cat /etc/os-release
-ID=wolfi
-NAME="Wolfi"
-PRETTY_NAME="Wolfi"
-VERSION_ID="20230201"
-HOME_URL="https://wolfi.dev"
-6d38c9b4f0d9:/# exit
+```
+6d38c9b4f0d9:/#
 ```
 
-You can run commands directly:
+You can run commands from within the shell like this, or you can run commands directly on your local machine without opening a shell:
 
+```sh
+docker run cgr.dev/chainguard/wolfi-base ps
 ```
-$ docker run cgr.dev/chainguard/wolfi-base ps
+```
 PID   USER     TIME  COMMAND
     1 root      0:00 ps
 ```
 
-It's commonly used in Dockerfiles:
+This Image is commonly used in Dockerfiles, as in the following example:
 
 ```
-$ cat Dockerfile
 FROM cgr.dev/chainguard/wolfi-base
 
 RUN apk update && apk add redis
 
 ENTRYPOINT ["/usr/bin/redis-server"]
-$ docker build -t myredis --progress plain --no-cache .
+```
+
+This example Dockerfile will update `apk` and install the Redis server onto the base Image. 
+
+You could use a Dockerfile like this to build a new image:
+
+```sh
+docker build -t myredis --progress plain --no-cache .
+```
+```
 #0 building with "desktop-linux" instance using docker driver
 
 #1 [internal] load .dockerignore
@@ -120,19 +107,16 @@ $ docker build -t myredis --progress plain --no-cache .
 #6 writing image sha256:bde1c89d952e0e0155acb410ee8143b1daf542bd36a6b22c032250633d08bf76 done
 #6 naming to docker.io/library/myredis done
 #6 DONE 0.0s
+```
 
-$ docker run myredis
-1:C 23 Aug 2023 12:04:56.104 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
-1:C 23 Aug 2023 12:04:56.104 * Redis version=7.2.0, bits=64, commit=00000000, modified=0, pid=1, just started
-1:C 23 Aug 2023 12:04:56.104 # Warning: no config file specified, using the default config. In order to specify a config file use /usr/bin/redis-server /path/to/redis.conf
-1:M 23 Aug 2023 12:04:56.104 * monotonic clock: POSIX clock_gettime
-1:M 23 Aug 2023 12:04:56.105 * Running mode=standalone, port=6379.
-1:M 23 Aug 2023 12:04:56.105 * Server initialized
-1:M 23 Aug 2023 12:04:56.105 * Ready to accept connections tcp
+Following that, you can run the new image built from the `wolfi-base` Image.
+
+```
+docker run myredis
 ```
 
 ## Further Reading
 
-The [edu.chainguard.dev](https://edu.chainguard.dev) site contains extensive documentation on [getting started with Wolfi](https://edu.chainguard.dev/open-source/wolfi/overview/).
+To learn more, we encourage you to visit [Chainguard Academy](https://edu.chainguard.dev) which contains extensive documentation on [getting started with Wolfi](https://edu.chainguard.dev/open-source/wolfi/overview/).
 <!--body:end-->
 


### PR DESCRIPTION
New images added:

- cass-config-builder

Updated Docs:

- apko/_index.md
- argo-cli/tags_history.md
- argo-exec/tags_history.md
- argo-workflowcontroller/tags_history.md
- argocd-repo-server/tags_history.md
- atlantis/tags_history.md
- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- aws-for-fluent-bit/tags_history.md
- cert-manager-acmesolver/tags_history.md
- cert-manager-cainjector/tags_history.md
- cert-manager-controller/tags_history.md
- cert-manager-webhook/tags_history.md
- cilium-agent/image_specs.md
- cilium-agent/tags_history.md
- cilium-hubble-relay/tags_history.md
- cilium-operator-generic/tags_history.md
- consul/tags_history.md
- crane/tags_history.md
- crossplane/tags_history.md
- fluent-bit/tags_history.md
- fluentd/tags_history.md
- grype/tags_history.md
- helm/tags_history.md
- jdk/tags_history.md
- jdk-lts/tags_history.md
- jre/tags_history.md
- jre-lts/tags_history.md
- kube-bench/tags_history.md
- kube-fluentd-operator/tags_history.md
- kubectl/tags_history.md
- kubeflow-pipelines-cache-deployer/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- kubernetes-ingress-defaultbackend/tags_history.md
- maven/tags_history.md
- melange/tags_history.md
- newrelic-fluent-bit-output/tags_history.md
- nfs-subdir-external-provisioner/tags_history.md
- node-problem-detector/tags_history.md
- openai/tags_history.md
- prometheus-alertmanager/tags_history.md
- prometheus-pushgateway/tags_history.md
- prometheus-pushgateway-bitnami/tags_history.md
- promtail/tags_history.md
- secrets-store-csi-driver/tags_history.md
- skaffold/tags_history.md
- slim-toolkit-debug/tags_history.md
- spire-agent/tags_history.md
- spire-oidc-discovery-provider/tags_history.md
- spire-server/tags_history.md
- stakater-reloader/tags_history.md
- tekton-controller/tags_history.md
- tekton-entrypoint/tags_history.md
- tekton-events/tags_history.md
- tekton-nop/tags_history.md
- tekton-resolvers/tags_history.md
- tekton-sidecarlogresults/tags_history.md
- tekton-webhook/tags_history.md
- tekton-workingdirinit/tags_history.md
- timoni/tags_history.md
- trino/image_specs.md
- trino/tags_history.md
- vault/tags_history.md
- vault-k8s/tags_history.md
- wolfi-base/_index.md