### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,39 @@
+# 2024-01-19
+New images added:
+
+- statsd
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- cilium-agent/image_specs.md
+- cilium-agent/tags_history.md
+- cilium-hubble-relay/tags_history.md
+- cilium-operator-generic/tags_history.md
+- fluentd/tags_history.md
+- flux-image-automation-controller/tags_history.md
+- grype/tags_history.md
+- haproxy/tags_history.md
+- haproxy-ingress/tags_history.md
+- kube-fluentd-operator/tags_history.md
+- kubeflow-jupyter-web-app/tags_history.md
+- kubeflow-volumes-web-app/tags_history.md
+- kyverno/tags_history.md
+- kyverno-background-controller/tags_history.md
+- kyverno-cleanup-controller/tags_history.md
+- kyverno-cli/tags_history.md
+- kyverno-reports-controller/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- newrelic-prometheus/tags_history.md
+- openai/tags_history.md
+- prometheus-alertmanager/tags_history.md
+- rqlite/tags_history.md
+- sigstore-scaffolding-cloudsqlproxy/tags_history.md
+- solr/tags_history.md
+- temporal-ui-server/tags_history.md
+- zot/tags_history.md
+
 # 2024-01-18
 New images added:
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 17th | `sha256:b71ff283b99fd37dc9793464c47216ed8ff6cc0030695b9506c4618c07f81262` |
-|  `latest-dev` | January 17th | `sha256:3defb0fcba45fbbb18b3225ada31dcff394bd155f8bf303d484fab1517cc5f2f` |
+|  `latest-dev` | January 18th | `sha256:c1c7d15a96381b9063edc818c69dd3fba1a556a7f9696af1b5b1d4f1ffa5283a` |
+|  `latest`     | January 18th | `sha256:88534547f701b190323f5de8032e5524154e80f43bd053ccc604a69bdbdd0dca` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 17th | `sha256:9d0e1cc6bd75cbd20397ca521f5375821b8a0e4dca571ece408459b305b73dc7` |
-|  `latest-dev` | January 17th | `sha256:0bfb8d5fff1307484b60bc4f71ca77fb2ac54cd34153d965935ede8af5434216` |
+|  `latest-dev` | January 18th | `sha256:584616cf798cccdd58df6a9211965ce133a1c3cc89ed7b1da4d7c69c7a51133d` |
+|  `latest`     | January 18th | `sha256:23a9915352d05d9a3ab8091efb43c43a669b4e2b1cc7d8dcdb7eb08899f23890` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public cilium-agent Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -56,6 +56,7 @@ The table shows package distribution across variants.
 | `cilium-envoy`                 | X          | X      |
 | `clang-15`                     | X          | X      |
 | `clang-15-default`             | X          | X      |
+| `cni-plugins-loopback`         | X          | X      |
 | `cni-plugins-main`             | X          | X      |
 | `git`                          | X          |        |
 | `glibc`                        | X          | X      |

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 17th | `sha256:6ac5bf017afcd365663155be5dfcfd0ac11443db566cfb5852ed060c3a09e846` |
-|  `latest`     | January 17th | `sha256:ab1c4c5a3211f5f3a373be2f12996550e9be829e510bbd3c28ccfbdd7f899f0f` |
+|  `latest`     | January 18th | `sha256:583089489a4aca9c5f2617d97b0764ca0722abd1573f0e4c985330f3beb9b36b` |
+|  `latest-dev` | January 18th | `sha256:e2ebcebeaa36ed5df44ed0fd8ad18c9508cdf537ac321302cc946cd985ba348a` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-hubble-relay/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-hubble-relay Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 17th | `sha256:def271656feb4e672d9961543b2235b37d350bb154239b9900a670bb4b8f1291` |
-|  `latest`     | January 17th | `sha256:834a84c9592491d096fc932245dacff6a589633ab920dda000c4fdff2c050293` |
+|  `latest`     | January 18th | `sha256:8e8c7ab44589d5c2b24f991edd41836c8fcc2bc24e5b04ae13727e844a553959` |
+|  `latest-dev` | January 18th | `sha256:73e81f04cc38fcac56558fa6e275308b8df070ab8b64470daec6df1fb45836e9` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-operator-generic/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-operator-generic Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 17th | `sha256:9b4e0b101e17b4bdd97641dc375037c5c415d521082cfe359a1efa4969e97dec` |
-|  `latest`     | January 17th | `sha256:b0f2937326e0185884ba0700727a25fcd2fdc034de275ec78723070b7cedfb8f` |
+|  `latest`     | January 18th | `sha256:97d08445c350c3ebf2872d3a057e0def27aadca7ed45219260491a8c0365efb0` |
+|  `latest-dev` | January 18th | `sha256:0bed7bd71fe03c058542412334b5bdf2b69484e0f0c920add78cb550df23ce6f` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed | Digest                                                                    |
 |----------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-splunk`     | January 17th | `sha256:507364fcc8c9219e3220ae23e7a420bd814067a9f09fd1c766a4ff4adeb3a346` |
-|  `latest-splunk-dev` | January 17th | `sha256:661148795f43f70bf551dabd74e054e54c43075200f9def0ff87c04f73c45105` |
-|  `latest-dev`        | January 16th | `sha256:56bef585ae02bcda64cd215119940dd1f8394f2738f4196790c2557696618842` |
-|  `latest`            | January 16th | `sha256:006965326e8b497bb3144c5bc214ae1c4e4254028c6d03f8e1b566814c772d9d` |
+|  `latest-dev`        | January 18th | `sha256:f57e3e5562cf46fe6c14cdf76d6987af8e6faf57301599757e4def689eaea764` |
+|  `latest`            | January 18th | `sha256:3c0adf3611f4fd4bc5b049c04d9c6b06445a389c3d2d5088062dbe43a3e17767` |
+|  `latest-splunk`     | January 18th | `sha256:6270e69dd33abd451cc60c95113034e6552d1b8c55dba1a908a971f79de2494f` |
+|  `latest-splunk-dev` | January 18th | `sha256:2ffbc2b51f1656039f8154fa15032783f8be4064ae9adea5afd040e50edc7d70` |
 

--- a/content/chainguard/chainguard-images/reference/flux-image-automation-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/flux-image-automation-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the flux-image-automation-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                                                          | Last Changed | Digest                                                                    |
 |----------------------------------------------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `v0.37-dev` `v0.37.0-dev` `0.37-dev` `0-dev` `latest-dev` `v0-dev` `0.37.0-dev` | January 15th | `sha256:cbcb4302faafc6fa123484c892825468188418599e902578aafb9ba7a42b350c` |
-|  `v0.37.0` `0` `v0` `0.37.0` `v0.37` `0.37` `latest`                             | January 4th  | `sha256:937c02e723625f466c00534de96e11424e2896619cbbbaa67908938991253b98` |
+|  `v0.37.0` `0` `latest` `v0` `0.37` `v0.37` `0.37.0`                             | January 18th | `sha256:3284dc50c439db3c76e3367a451c3f75ba0ac08413e6aafe2b704375a8877631` |
+|  `0.37.0-dev` `0-dev` `v0.37.0-dev` `0.37-dev` `v0-dev` `v0.37-dev` `latest-dev` | January 18th | `sha256:63bd222355895a0e84f3bb872a2b287140391a6569c5385835d34cf6f67fbb0d` |
 

--- a/content/chainguard/chainguard-images/reference/grype/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/grype/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the grype Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 17th | `sha256:a812229ea0b7cf71e025c0b397200ad18e11d51f137065c08791542a9889aa67` |
-|  `latest`     | January 17th | `sha256:33a73211735654e33528fde22dffded7d4f0e326bed64917e3d5e8137a85c2c4` |
+|  `latest`     | January 18th | `sha256:41101396af3e3baf5b3570b27394ab7456f3cfb1259ca966b3fae6367a6231a8` |
+|  `latest-dev` | January 18th | `sha256:af19e6f6554c2cd0368bbc77385dd0dca8cbe3ca6db784aea8098bc857a3dad5` |
 

--- a/content/chainguard/chainguard-images/reference/haproxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/haproxy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the haproxy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:d9e3ddd7df1cf765f23599e6166e2fe63c961af2a048c3b8998d3163e830b114` |
+|  `latest` | January 18th | `sha256:00bf26208c416c5f77efcd97c160f9662c98640b1c93ecc31b72cd75a564b7c0` |
 

--- a/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-fluentd-operator Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 17th | `sha256:c8a95d63e59e88a39604fe31199ff149b9942deb0f992bed56058feb478bc213` |
+|  `latest` | January 18th | `sha256:40d3b6e2e5169c31e599d71bddfe41f70f6f004b5329423fd1256683fb6589b3` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-jupyter-web-app Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed | Digest                                                                    |
 |---------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `1.8.0-dev` `1.8-dev` `latest-dev` `1-dev` | January 16th | `sha256:6d9d77374c43fbd2dd59f348a37b9f61468f1a35d0dfcdfd82f8377a4f393651` |
-|  `latest` `1.8` `1` `1.8.0`                 | January 13th | `sha256:cab181d8364f651e5acaa61d6605e9d1ca36f0ff557937259f7e125c216a448c` |
+|  `1-dev` `latest-dev` `1.8.0-dev` `1.8-dev` | January 18th | `sha256:70ecb76bc60598613b50e6dc80cbfd5e74223f976cbb9043a97050124e78c588` |
+|  `1.8` `latest` `1` `1.8.0`                 | January 18th | `sha256:ed54a1ce8db478ebb5ee0164decba03d76c4dbf48cb09e962aa5a31f8cc7625e` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-volumes-web-app Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed | Digest                                                                    |
 |---------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` `1-dev` `1.8-dev` `1.8.0-dev` | January 16th | `sha256:480f75db10459c1413e3c652a4eed8c07fcae3be7329333b1456039bbd4efbe9` |
-|  `1` `1.8` `latest` `1.8.0`                 | January 13th | `sha256:f9762c15f285ae6e0f2abaf877126bb382a4ceffff6a8385471895e0cab0b193` |
+|  `latest` `1.8` `1.8.0` `1`                 | January 18th | `sha256:30d3d31f274e3fc8b31efd47a9325f57c0357fc625134e3aade14cdf668b68d8` |
+|  `1-dev` `latest-dev` `1.8.0-dev` `1.8-dev` | January 18th | `sha256:9e6f746251d6fc731bdcd6eb876d92afeb116e77a4a9e380f3fc2f4071612bd6` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-background-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:14df5eeff9c37a09be1a5c86851f7438f26c9e950387e205050f5511314125eb` |
+|  `latest` | January 18th | `sha256:3412a80885da370b26d1d34c8f082da641af92441ffe2e4c9a593622274522cb` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-cleanup-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:c3bee6b72d9bd572b883d0b67cc10bfa69400599bee3f8fd4515f689e6df28d9` |
+|  `latest` | January 18th | `sha256:a05550d28a28f7b2560621ce8a043b28a18d95e84bd0a594cf90374d6690c9f1` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:7623cb6d12e09259c9a54a77547f9a9c6cd39e60d5b9ee90b43befc472ecbf05` |
+|  `latest` | January 18th | `sha256:6cca2c2d0d5561decdaf906c0bf7553f46ec682ce21df2726f3590c35058c75e` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-reports-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:f584744961c7358c9ec6d9af677a0d4d62948dce255a6264e8e4c9fc03eb060c` |
+|  `latest` | January 18th | `sha256:8e3108c1b7d4adc577fcf3f18b7a244cdf64e1409f8d2ff4cd5816823e924c32` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 13th | `sha256:d496a0ad742a321a294fe9c6078ac39ce3894147749b44c7be97f156301a0495` |
+|  `latest` | January 18th | `sha256:e09be3b759dbbdfc9d2dbd8c7237829e64ac6bb6e6ce1c0651acd63d82dfffcd` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-infrastructure-bundle Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:4ebe0924d675b7709fe781d93c5328c94784035f05447e149597f77a68db70f6` |
-|  `latest-dev` | January 16th | `sha256:51b97b75b923341c6b714df8c3e177df09139475e5ed57592fe4508d4485f007` |
+|  `latest-dev` | January 18th | `sha256:37ac890b19c020136a31085f0bff4fa8cdb9edc40fe97f2fe0abaf6c3c823b65` |
+|  `latest`     | January 18th | `sha256:31036b758abea6dec631967b933e4203084713b60442dec3b49b5f68a0722883` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-prometheus/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-prometheus/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-prometheus Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:2c8c9755f1545407ca45def39c50b2c6f572318c35d1c332e6a56de9e1f4d3be` |
-|  `latest`     | January 13th | `sha256:45d9fff2c045a10ac0c0e8f08c37823cd3d04ffe1810f7c8c18a1f25cecd1607` |
+|  `latest-dev` | January 18th | `sha256:2b86a878267588fb3f89e16cdd72a2e23415c0b027a156b6079c5c0477c075ae` |
+|  `latest`     | January 18th | `sha256:02ae513b60ed8a882e20e5f216a04532c0fb85ebbf55fe2d3444d8007b59e2bf` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the openai Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 17th | `sha256:309290b907d7769a5d2d4a9ceaa46d62f5d3e33527f0109ad5f22f90bb6c67b5` |
-|  `latest-dev` | January 17th | `sha256:97b05d48b0d67df5967987b8c69e889e6b95a19e080860305591b2bdca9e8011` |
+|  `latest`     | January 18th | `sha256:a0251d0b3aa1a3be41ace1baf522b9f6d263e8fa64aa87c0523315e24f91a93a` |
+|  `latest-dev` | January 18th | `sha256:c4199f3d8dc11391d04e03bfd85f3ee0864104cec779cad0dd7eae839ce2049c` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-18 00:19:12
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest` `0.26` `0.26.0` `0`                 | January 17th | `sha256:d531f882d0a1b0b2ce9bfe540a503ccf6fc985aa720e89cb0b145dbff41b9308` |
-|  `latest-dev` `0.26-dev` `0-dev` `0.26.0-dev` | January 17th | `sha256:177436f533b8d068017618e715b2c7707f115652feb3ce461d0f7f142885553c` |
+|  `latest-dev` `0.26-dev` `0-dev` `0.26.0-dev` | January 18th | `sha256:177436f533b8d068017618e715b2c7707f115652feb3ce461d0f7f142885553c` |
+|  `latest` `0.26` `0.26.0` `0`                 | January 18th | `sha256:d531f882d0a1b0b2ce9bfe540a503ccf6fc985aa720e89cb0b145dbff41b9308` |
 

--- a/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the rqlite Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:072c251831b8c4ca72711245a681438c08c309222c68d821e6235c6a77ad4870` |
-|  `latest-dev` | January 16th | `sha256:08e97e56a0cf888773eb08dc2d97848a80ecff2325765d52752ba682297af45e` |
+|  `latest`     | January 18th | `sha256:36cc92252d391db791c76810db38b807ebf1e36bb6b0423a142b3e5b04a584d1` |
+|  `latest-dev` | January 18th | `sha256:bbb8f5e67c8472f61353cb2c85754564191ee8f7e88e8f5a17c2bc436f5fce4f` |
 

--- a/content/chainguard/chainguard-images/reference/sigstore-scaffolding-cloudsqlproxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/sigstore-scaffolding-cloudsqlproxy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the sigstore-scaffolding-cloudsqlproxy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:113d354656f87048a83aa8dd59e0e29915129441e67d34fcab78906d27c9dfe0` |
-|  `latest`     | January 11th | `sha256:715ed7e8615f9c3cc81e0ccc6fce4cd39684c8a3f0d27b207a883c4450f3974e` |
+|  `latest`     | January 18th | `sha256:361879c4d2d7bb040cd028925389cd02078491011a05c8825829363701e87c76` |
+|  `latest-dev` | January 18th | `sha256:5f2d21bb8e01cc77a3680133e402b059dc869094c5cccf681def729deeaecf74` |
 

--- a/content/chainguard/chainguard-images/reference/solr/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/solr/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the solr Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:3b94ec0b7e15afa9267d880bae1614602564d2fa851253f20cc4c8bd257a4de0` |
-|  `latest`     | January 13th | `sha256:d3f9b6e5f2f5eb9516691c0b6c04782ae045d0675d012a3f213b96cb3007ab7f` |
+|  `latest-dev` | January 18th | `sha256:bcb07e919a2ed40b7ba16a971e55ba9f48e41ea1e1a85ae82f62d31bbd7713cb` |
+|  `latest`     | January 18th | `sha256:e7d6424d64d68dbbd3a2cd3638e93f2d1d462cd8d8c090ebf0e48a05b98acad7` |
 

--- a/content/chainguard/chainguard-images/reference/statsd/_index.md
+++ b/content/chainguard/chainguard-images/reference/statsd/_index.md
@@ -1,0 +1,57 @@
+---
+title: "Image Overview: statsd"
+linktitle: "statsd"
+type: "article"
+layout: "single"
+description: "Overview: statsd Chainguard Image"
+date: 2024-01-19 00:16:42
+lastmod: 2024-01-19 00:16:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu: 
+  docs: 
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/statsd/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/statsd/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/statsd/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/statsd/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+<!--overview:start-->
+Daemon for easy but powerful stats aggregation
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/statsd:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+See the [statsd documentation](https://github.com/statsd/statsd?tab=readme-ov-file#usage) for more information on how to use statsd.
+
+You can also use a Helm chart to install this image on a Kubernetes cluster:
+
+```bash
+helm repo add keyporttech https://keyporttech.github.io/helm-charts/
+helm install my-release keyporttech/statsd \
+  --namespace statsd \
+  --create-namespace \
+  --set image.repository="cgr.dev/chainguard/statsd" \
+  --set image.tag="latest"
+```
+<!--body:end-->
+

--- a/content/chainguard/chainguard-images/reference/statsd/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/statsd/image_specs.md
@@ -1,0 +1,83 @@
+---
+title: "statsd Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public statsd Chainguard Image variants"
+date: 2024-01-19 00:16:42
+lastmod: 2024-01-19 00:16:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/statsd/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/statsd/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/statsd/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/statsd/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **statsd** Image.
+
+## Variants Compared
+The **statsd** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                | latest                    |
+|--------------|---------------------------|---------------------------|
+| Default User | `nonroot`                 | `nonroot`                 |
+| Entrypoint   | `node stats.js config.js` | `node stats.js config.js` |
+| CMD          | not specified             | not specified             |
+| Workdir      | `/usr/src/app`            | `/usr/src/app`            |
+| Has apk?     | yes                       | no                        |
+| Has a shell? | yes                       | no                        |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/statsd/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                          | latest-dev | latest |
+|--------------------------|------------|--------|
+| `apk-tools`              | X          |        |
+| `bash`                   | X          |        |
+| `busybox`                | X          |        |
+| `c-ares`                 | X          | X      |
+| `ca-certificates-bundle` | X          | X      |
+| `git`                    | X          |        |
+| `glibc`                  | X          | X      |
+| `glibc-locale-posix`     | X          | X      |
+| `icu`                    | X          | X      |
+| `ld-linux`               | X          | X      |
+| `libbrotlicommon1`       | X          | X      |
+| `libbrotlidec1`          | X          | X      |
+| `libbrotlienc1`          | X          | X      |
+| `libcrypt1`              | X          |        |
+| `libcrypto3`             | X          | X      |
+| `libcurl-openssl4`       | X          |        |
+| `libexpat1`              | X          |        |
+| `libgcc`                 | X          | X      |
+| `libidn2`                | X          |        |
+| `libnghttp2-14`          | X          | X      |
+| `libpcre2-8-0`           | X          |        |
+| `libproc-2-0`            | X          | X      |
+| `libpsl`                 | X          |        |
+| `libssl3`                | X          | X      |
+| `libstdc++`              | X          | X      |
+| `libunistring`           | X          |        |
+| `ncurses`                | X          | X      |
+| `ncurses-terminfo-base`  | X          | X      |
+| `nodejs-18`              | X          | X      |
+| `npm`                    | X          | X      |
+| `openssl-config`         | X          | X      |
+| `procps`                 | X          | X      |
+| `statsd`                 | X          | X      |
+| `wolfi-baselayout`       | X          | X      |
+| `zlib`                   | X          | X      |
+

--- a/content/chainguard/chainguard-images/reference/statsd/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/statsd/provenance_info.md
@@ -1,0 +1,88 @@
+---
+title: "Provenance Information for statsd Images"
+type: "article"
+unlisted: true
+description: "Provenance information for statsd Chainguard Image"
+date: 2024-01-19 00:16:42
+lastmod: 2024-01-19 00:16:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/statsd/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/statsd/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/statsd/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/statsd/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying statsd Image Signatures
+The **statsd** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/statsd | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading statsd Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the statsd image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the statsd image on `linux/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/statsd | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying statsd Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the statsd image attestations:
+
+```shell
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/statsd
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/statsd --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/statsd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/statsd/tags_history.md
@@ -1,9 +1,9 @@
 ---
-title: "haproxy-ingress Image Tags History"
+title: "statsd Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the haproxy-ingress Chainguard Image"
-date: 2023-06-22T11:07:52+02:00
+description: "Image Tags and History for the statsd Chainguard Image"
+date: 2024-01-19 00:16:42
 lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/haproxy-ingress/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/haproxy-ingress/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/haproxy-ingress/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/haproxy-ingress/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/statsd/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/statsd/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/statsd/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/statsd/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 18th | `sha256:17dd3c8e6ccadbe6e1c72785d81b0cee72da091e43debf5af8fa02487ad23d1b` |
-|  `latest-dev` | January 18th | `sha256:e29c41784ea48e1d3ae31433b81e8822dc027990fe3cc13aefe6ee7d4e1bd2f4` |
+|  `latest-dev` | January 18th | `sha256:a7fc67feed21ba2a0dfa10df0e2db188a1f7a6ffbc34fc3052ffcff48958cd73` |
+|  `latest`     | January 18th | `sha256:074f55d0a94e5e00c1235e706b315d627b6be364ac27819460cf89f916e88dd9` |
 

--- a/content/chainguard/chainguard-images/reference/temporal-ui-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/temporal-ui-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the temporal-ui-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-17 00:18:58
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 16th | `sha256:e70a392eea63bb0fa1da9ada4931b8c2dfe4d5b20e07644ac085bbb02c48f272` |
-|  `latest-dev` | January 16th | `sha256:e392e21d8aef3300842bf6f7772123459f2238ee7fb7ab6315d61ffd0df0c648` |
+|  `latest`     | January 18th | `sha256:0e4a9100e3186181ff0accc30ed070516cb8b72f0b1eaaf0b2bc55db44314491` |
+|  `latest-dev` | January 18th | `sha256:77124954ffd7d4c78959e9f9f27625160a81748e1192127833d0f2b2fc8c9ea8` |
 

--- a/content/chainguard/chainguard-images/reference/zot/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zot/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zot Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-16 00:27:48
+lastmod: 2024-01-19 00:16:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 15th | `sha256:41ac859e3f94e95655abb0d17f32b2556f1377928e4420c8cf48c65c4c2c0321` |
-|  `latest`     | January 13th | `sha256:e906ec03fc0e42640d4b061c7b2930c6421d5d1864dfbe2d5e06268c41dff39f` |
+|  `latest-dev` | January 18th | `sha256:49d01e78154f61dc0e8b133991e51a32d1db49d89e9091819e83e18feeebab5b` |
+|  `latest`     | January 18th | `sha256:efd545a8c094964e98fde3013d9605a63fd615b2c2e416fbbdf1d19c2875deea` |
 


### PR DESCRIPTION
New images added:

- statsd

Updated Docs:

- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- cilium-agent/image_specs.md
- cilium-agent/tags_history.md
- cilium-hubble-relay/tags_history.md
- cilium-operator-generic/tags_history.md
- fluentd/tags_history.md
- flux-image-automation-controller/tags_history.md
- grype/tags_history.md
- haproxy/tags_history.md
- haproxy-ingress/tags_history.md
- kube-fluentd-operator/tags_history.md
- kubeflow-jupyter-web-app/tags_history.md
- kubeflow-volumes-web-app/tags_history.md
- kyverno/tags_history.md
- kyverno-background-controller/tags_history.md
- kyverno-cleanup-controller/tags_history.md
- kyverno-cli/tags_history.md
- kyverno-reports-controller/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- newrelic-prometheus/tags_history.md
- openai/tags_history.md
- prometheus-alertmanager/tags_history.md
- rqlite/tags_history.md
- sigstore-scaffolding-cloudsqlproxy/tags_history.md
- solr/tags_history.md
- temporal-ui-server/tags_history.md
- zot/tags_history.md