### PR TITLE
Small fixes to images guides: PHP and Go

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/getting-started-go.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-go.md
@@ -170,7 +170,7 @@ The following Dockerfile will:
 
 ```Dockerfile
 FROM cgr.dev/chainguard/go AS builder
-COPY ../reference/go /app
+COPY . /app
 RUN cd /app && go build -o go-digester .
 
 FROM cgr.dev/chainguard/glibc-dynamic

--- a/content/chainguard/chainguard-images/getting-started/getting-started-php.md
+++ b/content/chainguard/chainguard-images/getting-started/getting-started-php.md
@@ -165,7 +165,7 @@ Copy this content to your own `Dockerfile`:
 ```Dockerfile
 FROM cgr.dev/chainguard/php:latest-dev AS builder
 USER root
-COPY ../reference/php /app
+COPY . /app
 RUN chown -R php /app
 USER php
 RUN cd /app && \


### PR DESCRIPTION
This PR has 2 small fixes to the PHP and Go guides. The path reference inside the code block was automatically changed when I moved these guides to outside the "reference" folder, and I only noticed it now when following the PHP guide.

I looked at all guides to be sure there aren't any other cases, only these two had the issue.