### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,69 @@
+# 2024-01-26
+New images added:
+
+- cassandra-medusa
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- aws-for-fluent-bit/tags_history.md
+- bazel/tags_history.md
+- buck2/tags_history.md
+- calico-node/tags_history.md
+- cass-config-builder/tags_history.md
+- cassandra/tags_history.md
+- cilium-agent/tags_history.md
+- clang/tags_history.md
+- dask-gateway-server/tags_history.md
+- dependency-track/tags_history.md
+- dynamic-localpv-provisioner/tags_history.md
+- fluent-bit/tags_history.md
+- fluentd/tags_history.md
+- git/tags_history.md
+- gitlab-exporter/tags_history.md
+- gitlab-pages/tags_history.md
+- gitlab-shell/tags_history.md
+- gradle/tags_history.md
+- guacamole-server/tags_history.md
+- ingress-nginx-controller/tags_history.md
+- jdk/tags_history.md
+- jdk-lts/tags_history.md
+- jenkins/tags_history.md
+- jre/tags_history.md
+- jre-lts/tags_history.md
+- kafka/tags_history.md
+- keycloak/tags_history.md
+- kube-bench/tags_history.md
+- kube-fluentd-operator/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kubeflow-centraldashboard/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-frontend/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- maven/tags_history.md
+- newrelic-fluent-bit-output/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- node/tags_history.md
+- node-lts/tags_history.md
+- opensearch/tags_history.md
+- opentelemetry-collector-contrib/tags_history.md
+- prometheus-alertmanager/tags_history.md
+- prometheus-cloudwatch-exporter/tags_history.md
+- prometheus-mysqld-exporter/tags_history.md
+- r-base/tags_history.md
+- ruby/tags_history.md
+- solr/tags_history.md
+- sqlpad/tags_history.md
+- statsd/tags_history.md
+- tomcat/tags_history.md
+- trino/tags_history.md
+- wavefront-proxy/tags_history.md
+- wolfi-base/tags_history.md
+- zig/tags_history.md
+- zookeeper/tags_history.md
+
 # 2024-01-25
 
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:618b74b54159b8e0399f9f0786e6c3119327fac8168aaefc18a6a6dfc0fddc9b` |
-|  `latest`     | January 24th | `sha256:a2b79f38aafba95211a90f8656eb881dffb7ae1aca03fe685681e80e3ff0b672` |
+|  `latest`     | January 25th | `sha256:d0d1be7f9fc80ec55049b6edc59761a73688d3d451493d25c57937ecd199c7c9` |
+|  `latest-dev` | January 25th | `sha256:13e598eb2763bab3414d244e516f89f27e2e447e09809cd82f90289d6fe97951` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:cd0ae44988ee23e4b75e44b64cff548f89c096b33ad9427ba269b5a60db38e20` |
-|  `latest-dev` | January 24th | `sha256:0a037fdbabb90f1d02e6591afeac7c221e54f62030b1f8313f7681cf59e79e0e` |
+|  `latest-dev` | January 25th | `sha256:d5bd3d24d563f83257cbc450ad040c1cd7bd0ed5cb9677329c5316dfb3ebec0b` |
+|  `latest`     | January 25th | `sha256:fa9e86ab320cd9cbfc9ff66d80bda544b46251fcc792bbfcf1acfe3c01e26531` |
 

--- a/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-for-fluent-bit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-for-fluent-bit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 23rd | `sha256:186029bbba158a3d11d4b4ce90b21bfc43a37dd235ddaf324d39be352f5ce79f` |
+|  `latest` | January 25th | `sha256:1424fadc9cd9553795b457b61bf8fdb90533b459d2a17cba068b050fba749555` |
 

--- a/content/chainguard/chainguard-images/reference/bazel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/bazel/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the bazel Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 24th | `sha256:397365d31664abfacf72e05e7e73951f1e4d90f7d30a1a91925cdf6874ae31c4` |
+|  `latest` | January 25th | `sha256:d337591a725c15823532344442432c917325b5ab2dad51018b5e189b46c13e94` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the buck2 Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:1351d7b818cb4d403baa827085cfac49db054904cc4c1e857b92bf4abcc5fdc9` |
-|  `latest`     | January 23rd | `sha256:1ecf328ba1dfd252006cffad311829427b53e1abfc3c82524dbb81f1aafa752d` |
+|  `latest`     | January 25th | `sha256:3ed4c56416b4de836aee29a857d9dc20db29323d123ceb39348f29b56e849e7b` |
+|  `latest-dev` | January 25th | `sha256:12cbf29c630c21dd5e9887ef1e8d7825f112282be8021f5a0c50a4cf204a139b` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 24th | `sha256:d5cbe3e7b64d5ea5371e69a75542a6043326f0177335641d7d1c41dd24062ae6` |
+|  `latest` | January 25th | `sha256:87e28aea0a79661630728efcf29805793b2e9be3c2cac6bc0bf0a38c04a88add` |
 

--- a/content/chainguard/chainguard-images/reference/cass-config-builder/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cass-config-builder/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cass-config-builder Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:f23337a74755bf00c4a994d18da99ca3bbde870087a7922037f6e0f0aa78a788` |
-|  `latest-dev` | January 24th | `sha256:b81cbe29660c09444ccb456de0bcae13a8be5a8f404705010ee4e9b2ac2e1bbe` |
+|  `latest`     | January 25th | `sha256:ea5f954cb39642b48ea1532d66b6271b260459423ef83d6b803847843ca6b4d7` |
+|  `latest-dev` | January 25th | `sha256:204be675e5a589dbf04a05bc0c6ca3d7ee5dd9fe5f5a4b22c4b40273c55b7016` |
 

--- a/content/chainguard/chainguard-images/reference/cassandra-medusa/_index.md
+++ b/content/chainguard/chainguard-images/reference/cassandra-medusa/_index.md
@@ -1,0 +1,123 @@
+---
+title: "Image Overview: cassandra-medusa"
+linktitle: "cassandra-medusa"
+type: "article"
+layout: "single"
+description: "Overview: cassandra-medusa Chainguard Image"
+date: 2024-01-26 00:21:35
+lastmod: 2024-01-26 00:21:35
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu: 
+  docs: 
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/cassandra-medusa/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+<!--overview:start-->
+[cassandra-medusa](https://github.com/thelastpickle/cassandra-medusa), is a Apache Cassandra Backup and Restore Tool.
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/cassandra-medusa:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+## Usage
+Medusa for Apache Cassandra® is deployed by a K8ssandra Operator install, based on the Medusa Custom Resource Definition (CRD). Once K8ssandra Operator is deployed, you can refer to the [official documentation](https://docs.k8ssandra.io/tasks/backup-restore/) for further usage of Medusa 
+
+To use our minimal, wolfi-based image with this Helm chart you'll need to override the image used by the official helm chart and specify the chainguard image as per below example:
+
+```shell
+kubectl create ns cassandra-medusa
+
+helm repo add k8ssandra https://helm.k8ssandra.io/stable
+helm repo update
+
+helm install cassandra-medusa k8ssandra/k8ssandra-operator -n cassandra-medusa
+
+# create a secret, needed for medusa
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+ name: medusa-bucket-key
+ namespace: cassandra-medusa
+type: Opaque
+stringData:
+ # Note that this currently has to be set to credentials!
+ credentials: |-
+   [default]
+   aws_access_key_id = k8ssandra
+   aws_secret_access_key = k8ssandra
+EOF
+
+# create a K8ssandraCluster using Chainguard's cassandra-medusa image
+cat <<EOF | kubectl apply -n ${NAMESPACE} -f -
+apiVersion: k8ssandra.io/v1alpha1
+kind: K8ssandraCluster
+metadata:
+  name: demo
+  namespace: "${NAMESPACE}"
+spec:
+  cassandra:
+    serverVersion: "4.0.1"
+    datacenters:
+      - metadata:
+          name: dc1
+        size: 1
+        storageConfig:
+          cassandraDataVolumeClaimSpec:
+            storageClassName: standard
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 5Gi
+        config:
+          jvmOptions:
+            heapSize: 512M
+        stargate:
+          size: 1
+          heapSize: 256M
+  medusa:
+    containerImage:
+      registry: cgr.dev
+      repository:chainguard
+      name: cassandra-medusa
+      tag: latest
+      pullPolicy: Always
+    storageProperties:
+    #   storageProvider: s3_compatible
+      bucketName: k8ssandra-medusa
+      prefix: test
+      storageSecretRef:
+        name: medusa-bucket-key
+    #   host: minio-service.minio.svc.cluster.local
+    #   port: 9000
+      secure: false
+EOF
+```
+
+For further checks and operations on backup and restore with Medusa, please refere to this [official documentaion](https://docs.k8ssandra.io/tasks/backup-restore/)
+
+As per [project documentation](https://github.com/k8ssandra/k8ssandra-operator/blob/main/docs/content/en/install/local/single-cluster-helm/_index.md#deploy-cert-manager), by default, the Helm installation requires cert-manager to be present in the Kubernetes installation. If you do not have cert-manager installed, follow the steps at (https://cert-manager.io/docs/installation/helm/)[cert-manager's] documentation.
+<!--body:end-->
+

--- a/content/chainguard/chainguard-images/reference/cassandra-medusa/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/cassandra-medusa/image_specs.md
@@ -1,0 +1,86 @@
+---
+title: "cassandra-medusa Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public cassandra-medusa Chainguard Image variants"
+date: 2024-01-26 00:21:35
+lastmod: 2024-01-26 00:21:35
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/cassandra-medusa/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **cassandra-medusa** Image.
+
+## Variants Compared
+The **cassandra-medusa** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev                             | latest                                 |
+|--------------|----------------------------------------|----------------------------------------|
+| Default User | `cassandra`                            | `cassandra`                            |
+| Entrypoint   | `/home/cassandra/docker-entrypoint.sh` | `/home/cassandra/docker-entrypoint.sh` |
+| CMD          | not specified                          | not specified                          |
+| Workdir      | `/home/cassandra/`                     | `/home/cassandra/`                     |
+| Has apk?     | yes                                    | no                                     |
+| Has a shell? | yes                                    | yes                                    |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/cassandra-medusa/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                               | latest-dev | latest |
+|-------------------------------|------------|--------|
+| `apk-tools`                   | X          |        |
+| `bash`                        | X          | X      |
+| `busybox`                     | X          | X      |
+| `ca-certificates-bundle`      | X          | X      |
+| `gdbm`                        | X          | X      |
+| `git`                         | X          |        |
+| `glibc`                       | X          | X      |
+| `glibc-locale-posix`          | X          | X      |
+| `grpc-health-probe`           | X          | X      |
+| `ld-linux`                    | X          | X      |
+| `libbrotlicommon1`            | X          |        |
+| `libbrotlidec1`               | X          |        |
+| `libbz2-1`                    | X          | X      |
+| `libcrypt1`                   | X          | X      |
+| `libcrypto3`                  | X          | X      |
+| `libcurl-openssl4`            | X          |        |
+| `libexpat1`                   | X          | X      |
+| `libffi`                      | X          | X      |
+| `libgcc`                      | X          | X      |
+| `libidn2`                     | X          |        |
+| `libnghttp2-14`               | X          |        |
+| `libpcre2-8-0`                | X          |        |
+| `libpsl`                      | X          |        |
+| `libssl3`                     | X          | X      |
+| `libstdc++`                   | X          | X      |
+| `libunistring`                | X          |        |
+| `mpdecimal`                   | X          | X      |
+| `ncurses`                     | X          | X      |
+| `ncurses-terminfo-base`       | X          | X      |
+| `openssl-config`              | X          | X      |
+| `py3-cassandra-medusa`        | X          | X      |
+| `py3-cassandra-medusa-compat` | X          | X      |
+| `python-3.11`                 | X          | X      |
+| `readline`                    | X          | X      |
+| `sqlite-libs`                 | X          | X      |
+| `wolfi-baselayout`            | X          | X      |
+| `xz`                          | X          | X      |
+| `zlib`                        | X          | X      |
+

--- a/content/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info.md
@@ -1,0 +1,88 @@
+---
+title: "Provenance Information for cassandra-medusa Images"
+type: "article"
+unlisted: true
+description: "Provenance information for cassandra-medusa Chainguard Image"
+date: 2024-01-26 00:21:35
+lastmod: 2024-01-26 00:21:35
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying cassandra-medusa Image Signatures
+The **cassandra-medusa** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/cassandra-medusa | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading cassandra-medusa Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the cassandra-medusa image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the cassandra-medusa image on `linux/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/cassandra-medusa | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying cassandra-medusa Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the cassandra-medusa image attestations:
+
+```shell
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/cassandra-medusa
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/cassandra-medusa --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/cassandra-medusa/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cassandra-medusa/tags_history.md
@@ -1,9 +1,9 @@
 ---
-title: "jdk Image Tags History"
+title: "cassandra-medusa Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the jdk Chainguard Image"
-date: 2023-06-22T11:07:52+02:00
+description: "Image Tags and History for the cassandra-medusa Chainguard Image"
+date: 2024-01-26 00:21:35
 lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/jdk/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/jdk/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/jdk/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/jdk/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/cassandra-medusa/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/cassandra-medusa/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 25th | `sha256:e0595bfab7781d2a4ac13743bd3a4235bb0c5c0030c6007f1bbda6083946d32a` |
-|  `latest`     | January 25th | `sha256:fbc931d2c6033d87307f397b7e148237b5991cc3054a1851e977fca906575c46` |
+|  `latest`     | January 25th | `sha256:09d6ee6e7cdfde990b13e314bd4b32feef7e1b72a7c83759951a2c20272fb742` |
+|  `latest-dev` | January 25th | `sha256:d5bbc9b11462eadebe53d199b35c032cd27b3ead5d67f1d5667be9352322a7ab` |
 

--- a/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cassandra Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:f3b8be578a34511ce9b7faac683c33da1f4c781e3d07461d47ac5fe4e9cf70c9` |
-|  `latest`     | January 24th | `sha256:0a65d0656306839d84c5e4f50a60fcace193cb80b2d5fc9c8368c2d2cc3ae364` |
+|  `latest`     | January 25th | `sha256:8c1ae968569fda96ec73342b4b027b72d8ccaf75201bc00d3a695d3453b94955` |
+|  `latest-dev` | January 25th | `sha256:88574022082f388bb026311a837fe9ad500334d2d82cc26ee031726176a06028` |
 

--- a/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cilium-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cilium-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:32719d8cbc2dc2cd70e1d42d0ee2758fdf5997c536e15a563044770f685f2e4d` |
-|  `latest`     | January 24th | `sha256:589aa1420f3e72e943d831647624311b73105d4268140e83919d5ee5b57c644d` |
+|  `latest`     | January 25th | `sha256:c5cfb2f321dd17775741254550d7daafae6ee4c08bca6773854d2dadfe680759` |
+|  `latest-dev` | January 25th | `sha256:61d9d87311e7ee34889eaf2451e6baf3a27b529eabe11d038a68d7c4e0a5b491` |
 

--- a/content/chainguard/chainguard-images/reference/clang/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/clang/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the clang Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:dbadfb9357336dc58f1face3db1666448fc68c26df1ab3c08acd2aa40c478caf` |
-|  `latest-dev` | January 23rd | `sha256:8ef2b467d5f7b8b51d1e5300ee2a4d7543a13fa5f10389f8579807d8648c4b7f` |
+|  `latest`     | January 25th | `sha256:ed73e988581cf5b04bfdb759a7d4f513c63f34c6e3d143aed1737edcbe02d3ef` |
+|  `latest-dev` | January 25th | `sha256:63a11b394f5dc954ec8b19d1e465680af9d95f87982d8124f2a678ba4c95c474` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dask-gateway-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:dcd5c420a45621eaf9665e2ed9441f1da30c53349df90fd86c5fb447e3056d1f` |
-|  `latest`     | January 24th | `sha256:a62ff111ad521e1da4fd893d774e14754ee24a667a5ea5cb023cce7ab79a9c58` |
+|  `latest-dev` | January 25th | `sha256:e5106e3cd67213a294b900d66bba21bb3e7036f9d668bdbab49cde4d173e8aba` |
+|  `latest`     | January 25th | `sha256:bbba475c14c0147ad7b4f715b900886b08d5ea9910a1f22da9ba6d1eb810ceec` |
 

--- a/content/chainguard/chainguard-images/reference/dependency-track/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dependency-track/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dependency-track Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:dbb4220fbf616eea17bebbc0ec45c6102039f05a5569ec25351837865318498a` |
-|  `latest-dev` | January 24th | `sha256:d9ebd831e496f5a231298124cff0951e7515e56b8d1686debf655a2fd5ce2f70` |
+|  `latest`     | January 25th | `sha256:273266c221c4a97420f7f5e6929be14a9028345aecac4cc651cb7ccaacd24b72` |
+|  `latest-dev` | January 25th | `sha256:d9e673bf0e7990dcf2a8e497b8b5a2671aef13677f208fa6fb9cdc17847fa4a0` |
 

--- a/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dynamic-localpv-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:0b58fd5c26dbd0e7f6527c7f54522775933c66d1cb990ca53965cf296d99a445` |
-|  `latest`     | January 23rd | `sha256:c473f2b7c60fca1642e24d4d44b48ef4a11f8d7edee594e52d3220bcbbbf7085` |
+|  `latest-dev` | January 25th | `sha256:db74b97f9920da83958a6fc189531cb9922ff6f8a2b291f7104dde7f5946ad17` |
+|  `latest`     | January 25th | `sha256:6db628fc548e164bcb7b010828f99edbc90b6234321151508d7682693ada5bf4` |
 

--- a/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluent-bit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluent-bit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:6d2c8e1d4edb049af99e6a8df918bd81e02fcc83d498a5f1469b6986ef2007da` |
-|  `latest-dev` | January 23rd | `sha256:be186aa29b111d603f680fa0000e63e15e6ebae3fd63f7c839bd40e6958ad043` |
+|  `latest`     | January 25th | `sha256:1697e789b3d484e3224fbbd44c10812997a8877ee6b9bca2e0286f23b0d51390` |
+|  `latest-dev` | January 25th | `sha256:08fda75e2f9f7913b01363b7bceadd47a6b95084a2764779037dcfbaf5e4ea0d` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed | Digest                                                                    |
 |----------------------|--------------|---------------------------------------------------------------------------|
-|  `latest`            | January 24th | `sha256:cdeea31135680330c56fc11af4eb9792bca9c4915b052ae5f9d9e2395d6f7e6f` |
-|  `latest-dev`        | January 24th | `sha256:36714d8ba3fa425d3c4649b529ede68d7a0d71accd950453e4ed98e8b35201b5` |
-|  `latest-splunk`     | January 24th | `sha256:b130f7db8b77ab19316b6ea8af63bba987d603c1bf02f02d55bbbce9ee531c30` |
-|  `latest-splunk-dev` | January 24th | `sha256:3d691489501352825787483e4f603c74286b8ebb554a84c0f05c1c63677067e0` |
+|  `latest`            | January 25th | `sha256:ebf62123ea332f1ae181beef34b65183680840b6be144fc415397d709f216208` |
+|  `latest-dev`        | January 25th | `sha256:5b5c1d207fead6f26b955b3e16afee9efbdfe99ef907433dec01acdfe9bed220` |
+|  `latest-splunk-dev` | January 25th | `sha256:f283ef52727e2f2336ac1cd7038c071e60eaf7d54975b4f504e7a20b6d6fdc70` |
+|  `latest-splunk`     | January 25th | `sha256:22daec68ba956069fc2708b599201834e4125a9e6a045d4a8f99b4daf178f9f4` |
 

--- a/content/chainguard/chainguard-images/reference/git/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/git/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the git Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,10 +25,10 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                  | Last Changed | Digest                                                                    |
 |--------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-root`           | January 24th | `sha256:23a503f0286f4291520d302d3d6295ab65c531570abf5e2ae83605380199fa9a` |
-|  `latest-dev`            | January 24th | `sha256:badb57f1a04d3b98e627c5a5caaff8bf578ec437715156924ef7cb68af74936c` |
-|  `latest-root-dev`       | January 24th | `sha256:51694d5fac2cb32b2459ed9f680e9c002829486e1e242cadcdc5849ad68756f4` |
-|  `latest`                | January 24th | `sha256:9f56188a6d1fcc5b1c9ca79e49ac8ec2b69a076beeba454d4d1dcffd2959601c` |
+|  `latest-dev`            | January 25th | `sha256:a5241514b1c60bc717e21b75c1b900bee4a18b394e1bb9baaccc4b608d8dcabc` |
+|  `latest`                | January 25th | `sha256:c21c877139dce81d714c4fb697e4fd1baa5b2964ad869e8c3142d56183ee31a8` |
+|  `latest-root-dev`       | January 25th | `sha256:9fb6f266d9d43f9a62a382f865b2ef0510c9d1cd02b7dfe667ecf833efbd5d82` |
+|  `latest-root`           | January 25th | `sha256:7e388f4ad3317b0c2dde26d66f2c643fa09899f06c23df6838a3a1d6d3d0ccb7` |
 |  `latest-glibc-root-dev` | January 24th | `sha256:a5121694ab2bc888036f2db00660aa0009c4764294d36b106c354b4fedfa42e6` |
 |  `latest-glibc-dev`      | January 24th | `sha256:7b5d92aea073570b0da0b8fd812b17b6b891a4ad4058161fe928566233ed6970` |
 |  `latest-glibc-root`     | January 24th | `sha256:a639e27fbe4f4e07678bd164ebe68249fe002d54ab9ac2a8cb4ac7d6d8a27c26` |

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:a68555fb8bf4614366b3a3e7099d8245aa2ccec42d2faf6370de139adcad2c21` |
-|  `latest`     | January 24th | `sha256:1006910e7f63fa8ad971aad8d9813f3fde7b3da5943610c3bbde8fbafd646e22` |
+|  `latest`     | January 25th | `sha256:a035948058556de426e040efbca2e98505771166c39096d16110e9914a7f4dc3` |
+|  `latest-dev` | January 25th | `sha256:d901225a8849465adb09a2a5ccaec99e6fe084616382ecabd89b9bf79c9d1bfa` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-pages Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:81333992167b5a25362b34ca13d1cf6105f3b99dc1e5cc819ee1988e82ff2f42` |
-|  `latest-dev` | January 23rd | `sha256:7e67149446b3eec367aeda5b59751cd0d874f2d656e8e140c1e361e8a967e2ef` |
+|  `latest`     | January 25th | `sha256:58f9e576e48967fcefcbc0eabd8172860d172da459b2524e55e9ee97dc2d35fb` |
+|  `latest-dev` | January 25th | `sha256:3b2d4f9a9d9b3039170b271c23f5f928917b69e0971f47e37e0af3420d76eba1` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-shell Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:16f0896314f82657a184f8c587b4806a6932768fc085b5ac271a7ee6afece6f2` |
-|  `latest`     | January 24th | `sha256:2ec293e84492fda3152af050116696fcf1af3c3c4b9dd960126a0f9a9f4173a6` |
+|  `latest`     | January 25th | `sha256:5c4903b405f95e4650fd44f61cff7f97844b660bf2cea5398df211b5dd70ff23` |
+|  `latest-dev` | January 25th | `sha256:268edd07b30d925e95dd5bad8193d759de3bd874862169605f2658756500030c` |
 

--- a/content/chainguard/chainguard-images/reference/gradle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gradle/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gradle Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 23rd | `sha256:555e95e1b42ca5ffcacf74d43fb4ca0c4aca61ee3b73ad84a142100e5987012e` |
+|  `latest` | January 25th | `sha256:d520daaf1f3b89f3c33b2359daac0642f73af6c13142846a23530edb08717669` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the guacamole-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:b5eef14d879a3f3e5bd32a3abab9db12b2d5a469c0500121aac0914a0e9eb16a` |
-|  `latest`     | January 24th | `sha256:bf4e40513e66d08ad9be64b93b4719a7d18873226d37d1b86468f45f40fea12c` |
+|  `latest-dev` | January 25th | `sha256:fcf9610eb3aadacadbfdfb146f0847cfa6f9ed71d6658650e0b388b08fb806f7` |
+|  `latest`     | January 25th | `sha256:b904b4826e651b9ea0eafa211e3b3227e8ca1ae30c0866537cb9460e9a7508d2` |
 

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ingress-nginx-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:ae78174cb924817a5fcde3edf956091485582a47b35c90941b95f5d1bd89ccba` |
-|  `latest`     | January 24th | `sha256:fa27ef4427430cd75c95ec1735021f4a6ecc2ae1438b0eabc07113a5703fe21e` |
+|  `latest`     | January 25th | `sha256:06dea68263209ce6bf7dcea9fac1f10518ed844fe23f39a3880de554b8f7aa0e` |
+|  `latest-dev` | January 25th | `sha256:f98729be6c44b2029909d06dd0df9b1e6a4b24dbfb3f616499e865098a24d9b9` |
 

--- a/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:2b4be1f5e06d6c527857e9d52f9936d6d4f75dd17e766d5a9e54e1920464c19a` |
-|  `latest`     | January 24th | `sha256:a5ef1c03d64efa7283a3292139dfb3ceac9ee034ffdedfebb46c146a42243070` |
+|  `latest`     | January 25th | `sha256:81624dcccd228fd6f9dc8121acd02ac0e62c8b73e967b2d319c533847902b753` |
+|  `latest-dev` | January 25th | `sha256:9bd143070d1e7c4fec462c4f6ad1ecccb25f364256dce4be58b71036598b4697` |
 

--- a/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jenkins Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:032be49726456f1ceda3ebd6b5f8ff058b78a5ab982a78a1ee02ba2f838d8b9e` |
-|  `latest`     | January 24th | `sha256:523700243f8b9c5677ef83ff91854992e9de703a24e3537276fd9ddac732a2b5` |
+|  `latest`     | January 25th | `sha256:19454b9f895d94553616e327f78020338f9a69fa8f27334412b8e1629ae486d3` |
+|  `latest-dev` | January 25th | `sha256:537b3fca25b7fce81f8985541bace2b1f72b2fd12928ff43d5bb03b8fad89e3a` |
 

--- a/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:b3c63ddc55ee58603be301dfec97d3bead98d6fb5a43a4877e4ef3b9b5b8b50c` |
-|  `latest`     | January 24th | `sha256:94ad9ee55ec3c8b0b443b49298da5aa8e3aadfebb1a24d74e0ee99808d0422de` |
+|  `latest`     | January 25th | `sha256:33108c656ba6b1d0c17104b06f408fd17e267e4fa475497927653318ed08cc01` |
+|  `latest-dev` | January 25th | `sha256:d82be8b5c5845821ca657699b0c1aa3512df5446b7195ff1992ec2e58e495b4b` |
 

--- a/content/chainguard/chainguard-images/reference/jre/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:363736922c74191633e49e9801bbbaa2ca1c38898e0f48ef027710d1d501f51f` |
-|  `latest`     | January 24th | `sha256:d84e96dac88133294172b3aa3eb8c69ada6d722fde4e9cdb536ec8d4df3242a8` |
+|  `latest-dev` | January 25th | `sha256:735a5d77fe8862be1c87246a9e72c0098f8aca41ef876a6b10e47d4a1c396cc8` |
+|  `latest`     | January 25th | `sha256:12fe7f6a4a7515dce201c601841683683ebdb85c778b4af49e089f107928d0be` |
 

--- a/content/chainguard/chainguard-images/reference/kafka/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kafka/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kafka Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:4e772fdcc97b49c32971608ca6d67d323513c4590821dd5bca701e9d872a311a` |
-|  `latest-dev` | January 23rd | `sha256:bb5cf69b063cce0dd8b73e4be5caf7c0e91ff63601b368d155addabb3a100510` |
+|  `latest-dev` | January 25th | `sha256:e02966591cd00f73798020f735482a8e3b31e6d6532c4f80ee909d4c037b01e5` |
+|  `latest`     | January 25th | `sha256:ce22b280e83d14fa06e3120edaad5f8f9f0d316208d6492b1118962bee46d3c5` |
 

--- a/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keycloak Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:4f5c119cb5c0e82d9545e292a86f891cd37aeb427df6837eaea41a36c9608a20` |
-|  `latest-dev` | January 23rd | `sha256:0f54af8b06b4e973e1efbbf23ee39f2d17a10b02892f1b737b1c21d2b8e5fe44` |
+|  `latest`     | January 25th | `sha256:e3ec1af82798ad73d1fe1a27e5980347eb4469069829a70afa6b419f048e8767` |
+|  `latest-dev` | January 25th | `sha256:2fae0f92b5446a7f8141bfa409533ecd0bf2d08cf01622bee654d346833da1ef` |
 

--- a/content/chainguard/chainguard-images/reference/kube-bench/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-bench/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-bench Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 23rd | `sha256:3d9ce5bac89319ebeaff97577f97331e59b301bda1c7a0b97d5ce4a3f5cf78bd` |
+|  `latest` | January 25th | `sha256:0b31e9da05851d31b1adc016bcb6db13b6232a685c7e29ef57f24c2233cebece` |
 

--- a/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-fluentd-operator/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-fluentd-operator Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 24th | `sha256:61343f6c96657832f208210eb22056be685ce12a9b291a0ee081f717fa26c159` |
+|  `latest` | January 25th | `sha256:1478339b7b1b5b44cb066701a1e86ac2cf8b1ca11bdf7decb1bd12064580f605` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-logging-operator-fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:3ab113203aa97e7b76488c6ffeabdfd5d3b8022b90023cd314f0ffb410d34cd6` |
-|  `latest-dev` | January 24th | `sha256:bd03fd9749e768c8bd93e2fe033d32bee82b60d1fa5ec36c429c4204f732dc1c` |
+|  `latest-dev` | January 25th | `sha256:fc7a3de63067d602f4f686069b3257c3d6e6dea440916d525de3b48f507c4188` |
+|  `latest`     | January 25th | `sha256:419acc4d1f72fe41124cc76916119448727b40435fe9762b4dc23704ba6e6a6a` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-centraldashboard Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:907c07b900ddca0e431fa6eef7af1ea44ec968b1bb46bf17a2b45a4c41a44723` |
-|  `latest`     | January 23rd | `sha256:1affbb78680e85d84a5d7e06bf854ae668537516e2fd0d7de33e7f2dd61903f1` |
+|  `latest-dev` | January 25th | `sha256:d7d45b1680ab4ee08af8ef5d3317ddd40738c7dc50c122ee428934dba8d3b2eb` |
+|  `latest`     | January 25th | `sha256:b837873496260b1f071d77671843478f9670f00c25ce171aa7718878e3e74012` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-earlystopping-medianstop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0.16-dev` `0-dev` `latest-dev` | January 24th | `sha256:18bf5535103e7fe1862cd0bde9123db01472cc07bbedc0f36736984d3953a377` |
-|  `latest` `0` `0.16` `0.16.0`                 | January 24th | `sha256:060496df974a67a27fda986eabdc954d679337e69ef682ee403dde22fffbf3c0` |
+|  `0.16` `latest` `0.16.0` `0`                 | January 25th | `sha256:b5f3f6f3e54a4b8c5493f54e6d75c9243e7268e17eb6061f8ff578a8d64c63ad` |
+|  `0.16.0-dev` `latest-dev` `0.16-dev` `0-dev` | January 25th | `sha256:01da9263e69a5d40d37af7712536d9168ef10c73960d832046b99b378f925253` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-skopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16` `latest` `0.16.0` `0`                 | January 24th | `sha256:f5faaf064c57e76fd42ed7754eb3fcc861fa23f6c07e3470bc3e55a7a6310a58` |
-|  `0.16-dev` `0.16.0-dev` `latest-dev` `0-dev` | January 24th | `sha256:a454a696dbb0e6fb91c61ba071f2afa02f082376acf2ed084428177bcb975e0c` |
+|  `latest` `0.16` `0.16.0` `0`                 | January 25th | `sha256:1303df8fb5a08944894854a7bff825c4bc7383e0d415c09982551b8ea79eabee` |
+|  `0.16-dev` `latest-dev` `0.16.0-dev` `0-dev` | January 25th | `sha256:ad180207f491e23461404d1b8624e07812a25707ea59e88b1aeae8c33a1ff496` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-frontend Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:e756e6294f107136f9ca01e2ab8b3a798b937eef11550a34984e03a02cf87d06` |
-|  `latest-dev` | January 23rd | `sha256:57a7d69b0032a48194a66cdfe00e8f8d5a78cd95efd161f86d5885139cdef903` |
+|  `latest-dev` | January 25th | `sha256:e6789984f31f5beb7d89ac4a36820607e0cc67f33ae44405841bada636f13f38` |
+|  `latest`     | January 25th | `sha256:2fabb58e974a56bcc792627f0d30a8e02f46af52716d4988e92c7ca664708607` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-writer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:3e6bd81c0e52c7a67c9fff38015e69902648e35b8d225dc334a61b87a8cba528` |
-|  `latest-dev` | January 24th | `sha256:0b37d6d1a015a9429109db344ff3f0503fe867fb13abf6975499c83039fc8f09` |
+|  `latest-dev` | January 25th | `sha256:3c2110d3cf161fb2a6541d1cba4b338d896401d8a1a86133c44744c123e86fc9` |
+|  `latest`     | January 25th | `sha256:b8e6e892dd8a6192192612d81b49e70c4d814c1b12bcf82908352fcfba68a378` |
 

--- a/content/chainguard/chainguard-images/reference/maven/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/maven/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the maven Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,10 +25,10 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                        | Last Changed | Digest                                                                    |
 |--------------------------------|--------------|---------------------------------------------------------------------------|
-|  `openjdk-21-dev`              | January 24th | `sha256:bd67b4d0e4cc31d74f1bfbc5c8ed34e78156e344346afa140b1ffadd7048822c` |
-|  `openjdk-21`                  | January 24th | `sha256:19822910a57d6edc1ec33cb9a4d5a0d7aee882fcecd5e184d9dab623290ead78` |
-|  `openjdk-17-dev` `latest-dev` | January 24th | `sha256:63c1c6b65581e5d0c96a58deb1cb2f72c065db96a6095709840d37f92211526c` |
-|  `openjdk-17` `latest`         | January 24th | `sha256:8b76d00138a257c48e413baf43a0a151e1c6e0149684c6cca9366e5c7f7711c5` |
-|  `openjdk-11`                  | January 24th | `sha256:aa6f9cf7ca5faae63bb446db34c04aa551d1b625aa8ca88ec514f9fd964df3d3` |
-|  `openjdk-11-dev`              | January 24th | `sha256:3a0f17cb20e9fe7057a771b29eb065f133796c9929381153b44c30b507d48202` |
+|  `latest-dev` `openjdk-17-dev` | January 25th | `sha256:93d4692adc89d87bdce173157dff1f04118f81f23d0c530f89347060a2be8f50` |
+|  `openjdk-17` `latest`         | January 25th | `sha256:b530d13de88837043447a54cfebe509f1f773054bad4173cc16cbbf4cf12e4f5` |
+|  `openjdk-11`                  | January 25th | `sha256:d714dffdcfb598567daffbb29e417eb429a11df44f8cbed9e694e0e08f0b36d1` |
+|  `openjdk-11-dev`              | January 25th | `sha256:60e37082eef08cf0809cc90f29606135741c5d92afa210e1dadbb23fc7c9681c` |
+|  `openjdk-21`                  | January 25th | `sha256:a4c5e183845c104d3a229451b6149a303b87114a3aa7b1794ceae284f8dbfd9e` |
+|  `openjdk-21-dev`              | January 25th | `sha256:2c3f8c9cb9940afc02aa259ba6945d9ef628376b91d8cf9b96eec6da513546a0` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-fluent-bit-output/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-fluent-bit-output Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:1106dfdde2528f0d767aa0929bb8efc771faa08365b711ecf820149727828500` |
-|  `latest`     | January 23rd | `sha256:0c6a3b253fe18f7eeeaf6b094dfda86de524f2171481e51607503ca3932384a5` |
+|  `latest-dev` | January 25th | `sha256:6bd7da63f5a9cd5b18645cc89090c30dc875ccd86690f84ff0b3c4ed779b35ec` |
+|  `latest`     | January 25th | `sha256:759e7cf68cbb4c527c53505639529a71ab35333695bcffd4e3896d5cb11cba5f` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-infrastructure-bundle Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:2c8cebce153bea7862ae5fe3f32d6daab95390bc5f56fd7c5019040edc37fb16` |
-|  `latest-dev` | January 24th | `sha256:9cd5e2b82d9a1613d8490b51958bf5135248de7ffd1c700d33cdfd3a4dca32d0` |
+|  `latest-dev` | January 25th | `sha256:d03f11d4e48eac230ecb9c6fb59b6cea4a88a85f1b2e8251b3f915d0c49ab33d` |
+|  `latest`     | January 25th | `sha256:912d4ed3c6901279b816bf57ec64d214d4eae8d1de249492b2c835f250cb3246` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:8b2662b1eb5a2024529ac2e684a6f8c113dca0b1ea47761628abc24b546a96e3` |
-|  `latest-dev` | January 24th | `sha256:6f9dc7a2352bb9a0618cb81516a3ea38e96db623a0825b914db1657b98043a60` |
+|  `latest`     | January 25th | `sha256:0a70f3d61566f7d42a9ea12461c065bda41fc72933498ce7fc960695546d17d8` |
+|  `latest-dev` | January 25th | `sha256:d00fd2ca45da42637ffc0d63be3c09eda54c6e7f79c9f849827cf02d02b2b3f7` |
 

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:bb7a3d0b697dd59e60c5929ae81ffdf92a99b988bc768d3e083933fef06af288` |
-|  `latest`     | January 24th | `sha256:666075700b1330074c1a997a52b9092cb7e777945c43ae159c32a62deaa56109` |
+|  `latest-dev` | January 25th | `sha256:eb094deaa51a8f6aae28c849f40519b9f494c6e6b4517bc2a85c72d1c7ccdbad` |
+|  `latest`     | January 25th | `sha256:b164027bd9bb9b32b4fbb847a6b1e5a4161f0c97ce544ad3dacc023caae4ebf4` |
 

--- a/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the opensearch Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:512aa41ec2c361b24c2ac95832e6b3852e6468e6fa22bdc470a8a1a66c876cb6` |
-|  `latest-dev` | January 23rd | `sha256:325d89190431db2a8c7e193f047df7ae826e9dcb26f2d8d202ed583cfd737713` |
+|  `latest-dev` | January 25th | `sha256:1afe9c911e320fb4e53e99823611fa9dad8fc78026e11d82fcb65409ef4d52f9` |
+|  `latest`     | January 25th | `sha256:da1e7bf04708e5655e887475a63f65fae5348add81ef4dd88c9a6f49fceeea24` |
 

--- a/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the opentelemetry-collector-contrib Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:e666f0ce01f0076f2efbdf69f580086b78ed6368d5da9a9f8b922fcc860c0fa8` |
-|  `latest`     | January 13th | `sha256:ed45d97e733135edbe73abe15e2386f4848543db109a91798ea9db549b70a6d0` |
+|  `latest`     | January 25th | `sha256:668585681d3b44b3b36cfb4e0f41a129f60e5ab83295e0fd61aa1d0364a2af14` |
+|  `latest-dev` | January 25th | `sha256:e0d2d08031fd4929b7303beea116ca30e169df422312b891ffb73adc2d9b0e6b` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                          | Last Changed | Digest                                                                    |
 |----------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest`                        | January 24th | `sha256:727d8f53ac6607e6c525bfab114f1b84ea874eb4846df557b28738ecc614e3b3` |
-|  `latest-dev`                    | January 24th | `sha256:c5c59fd7075253276646752780264792b59dbaa21c5d34bdce89a1c1ca3bb3c9` |
-|  `0.26.0-dev` `0.26-dev` `0-dev` | January 23rd | `sha256:dcdcb467745f091e48744ec0dd9a1a643f2c7c1996270de5b1342978b1ea6e5e` |
-|  `0.26.0` `0.26` `0`             | January 23rd | `sha256:55e18fed4e151318350e7dcb556d000f72131792a8fd908cc9dff50be114e84d` |
+|  `latest`                        | January 25th | `sha256:727d8f53ac6607e6c525bfab114f1b84ea874eb4846df557b28738ecc614e3b3` |
+|  `latest-dev`                    | January 25th | `sha256:c5c59fd7075253276646752780264792b59dbaa21c5d34bdce89a1c1ca3bb3c9` |
+|  `0-dev` `0.26.0-dev` `0.26-dev` | January 25th | `sha256:435861e5511df3b40b6691fede3c3a4295babc922a6a4aa9ae0f86ca4d0d8df5` |
+|  `0.26.0` `0` `0.26`             | January 25th | `sha256:6b33505ee094c4643b5e53b0fc311b74d93e77b58825648dc0be04c6e0420f76` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-cloudwatch-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-cloudwatch-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-cloudwatch-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:14f6ea494ced52cab8165571818dc4a6db74be808330ec6e1586504713118b68` |
-|  `latest`     | January 23rd | `sha256:59f2060119522b7b8690075000ae427f802d0205a703296508165c38b6ad62aa` |
+|  `latest`     | January 25th | `sha256:d9aa0cb9d526b9ec1e67a723635af28a463806469936e422a18e4ada90f0fb22` |
+|  `latest-dev` | January 25th | `sha256:2866ff9cb1bf68bc93909af05e01a28251fba7a5db2a117f5ad0612312be2921` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-mysqld-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-mysqld-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-mysqld-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.15.1` `latest` `0.15` `0`                 | January 23rd | `sha256:b2bd7214af707fa2438cfc9dd540a740cd9b43e19dcd11b83963c939bff86271` |
-|  `0.15.1-dev` `0.15-dev` `latest-dev` `0-dev` | January 23rd | `sha256:c0abb3e022b6c98267f2f8243da2d372ee8255aef935230a6ba6e7160ea79a0e` |
+|  `0.15` `0.15.1` `latest` `0`                 | January 25th | `sha256:de4cb7a89e7e57976ef00984b61ae998a6f5b5617000d037285ce0834f6c1e83` |
+|  `0.15.1-dev` `0-dev` `0.15-dev` `latest-dev` | January 25th | `sha256:3ef2b556879a309f29de4e67d9a0a298cc4bb18a26076af54e21b44b49d1f0c3` |
 

--- a/content/chainguard/chainguard-images/reference/r-base/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/r-base/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the r-base Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:790011c0c2cefc717a735f5eb93400521e26a58dcb058f39a46294364f9cb1a1` |
-|  `latest`     | January 24th | `sha256:302b6947112a22410490fbb99656c150f25bb2a12171147d021e17ac4cf7b82c` |
+|  `latest-dev` | January 25th | `sha256:da6d7ab300326e9142372dd36fbe00abec0bf9ab24b4637d1650fae56202243c` |
+|  `latest`     | January 25th | `sha256:6624bf66f2a838b50208c70ebec0aaec636f29328344239af3ba4747b7c7c0d3` |
 

--- a/content/chainguard/chainguard-images/reference/ruby/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ruby/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ruby Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 24th | `sha256:056207293edd5f0b4a73d1eb2bb24558de9228ee7186441210a7ef1ed5b3d20b` |
-|  `latest-dev` | January 24th | `sha256:9b7f4011b854f94cbc28f50f055dc30821e395a95637e5ff1db66940f01eccf4` |
+|  `latest-dev` | January 25th | `sha256:5b26f3da9a4162e50050799d70f8865a15667a5d35db5f952be67511ba7c1bd2` |
+|  `latest`     | January 25th | `sha256:0d3f8ea1aba2ed9f61875362c87ee90fbcd954dbd134a05a8cf65413873c73b3` |
 

--- a/content/chainguard/chainguard-images/reference/solr/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/solr/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the solr Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:32386f2ad33135325f799b5e4d59b5d3ef1a8e75c418e3020aef09c8a20366da` |
-|  `latest-dev` | January 23rd | `sha256:43e9bb1758eaa0694b6b37d4d3c8b61be99b44678444f3e2c4e4ad9a47fa6016` |
+|  `latest-dev` | January 25th | `sha256:0e34074dec153295c012afef4dd559fa4c1ab5df475031086e62dcee6f7751e7` |
+|  `latest`     | January 25th | `sha256:cf03b1171181dee75cceb028645d9c8f151f2484afd1329f024cca992cd1b74d` |
 

--- a/content/chainguard/chainguard-images/reference/sqlpad/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/sqlpad/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the sqlpad Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:7c793979a3094e83afe5f3e15ceb90c259fd8bdb66832fcc9b0df85f9dd52fd4` |
-|  `latest-dev` | January 23rd | `sha256:4bbc3103e02cfb98fae872879647255f15f069f503511d72f1bf77feadbc8e0d` |
+|  `latest-dev` | January 25th | `sha256:1aea3859648a1358357233d25368bae3b4e4a2aebaaaa995ef16457f13f624c1` |
+|  `latest`     | January 25th | `sha256:7db9b25ffa06d385f654a8b8b898ac738ee879cc90f326ce3d6ef8747e7b4201` |
 

--- a/content/chainguard/chainguard-images/reference/statsd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/statsd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the statsd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 23rd | `sha256:385c6ef842d3cff45ced0a1c005af154a203a352e0c3f7a9e2992802eaf12cc4` |
-|  `latest-dev` | January 23rd | `sha256:e5747d73283b67af1f8218e019f584aa10dad2fc79935d6c04807e152d0cbce4` |
+|  `latest-dev` | January 25th | `sha256:c782c6066016a1beeb0e4a14b73896420f950819e0cdc2b33ac7ea8ea7c1d438` |
+|  `latest`     | January 25th | `sha256:7df65013f047e54fe014b4bde83fb14b9b033b4daa5ff6dc91048f83dad02e2c` |
 

--- a/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tomcat Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 23rd | `sha256:af816e66e2ec7dedd39a61d32d2e51561087689fa44b48f8d3f8f4492b026e6a` |
+|  `latest` | January 25th | `sha256:fe2b4377fddeb48cba65296b5c679a3310fd7fb5ef66e44bcc56337aa042daa2` |
 

--- a/content/chainguard/chainguard-images/reference/trino/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trino/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the trino Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:748ca9219ad020735791b36cc05493883489199e722660ffc3ca18540eba593b` |
-|  `latest`     | January 24th | `sha256:8e24a1cb126282e6ce896c0fbab3695598402349c46217674739b2b0f741d196` |
+|  `latest-dev` | January 25th | `sha256:a8b54092454951518915e2c92bde58966ad5970495c0f9121ead33a995084831` |
+|  `latest`     | January 25th | `sha256:1a4ae4374eaa4dfabc3e649d4e75def56078bf65bf833e38185d45aa8754d93a` |
 

--- a/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wavefront-proxy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the wavefront-proxy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:feeab3d59ab68146ca7903e0e45aa7eb2f1c0e648c4b8abf7c2f577e96bc7187` |
-|  `latest`     | January 23rd | `sha256:22d6da88afe9e0571b8222a726f5aac9ab955632c45fa85e5e2b08fd1d5f639d` |
+|  `latest`     | January 25th | `sha256:b904eb403c1a4ea16d106de0c1479e22d64aee056e8e920f1d0252b761bb560f` |
+|  `latest-dev` | January 25th | `sha256:1141f78b6be3eb2eadc40528ae2c78f61af680e480dcc3ea4480431b4e25d5a7` |
 

--- a/content/chainguard/chainguard-images/reference/wolfi-base/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wolfi-base/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the wolfi-base Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 23rd | `sha256:449cb4113f5aa30a43a0041023f84ab44b66576bb4c0833290830721caf5e621` |
+|  `latest` | January 25th | `sha256:af8a06428ec2679884374891296754df12d5247ccaf95d2cc5d844d915a2218f` |
 

--- a/content/chainguard/chainguard-images/reference/zig/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zig/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zig Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-24 00:37:09
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 23rd | `sha256:a58316182b3420df45d9cd2a69e820e6d2f4a081a4719ba28e00c94bed0bf06e` |
-|  `latest`     | January 23rd | `sha256:9f3ffeb4a3432d923319d7e81332dc030f23d96d785edab51a25425f5a894a2e` |
+|  `latest`     | January 25th | `sha256:3ec61f14ec9a89ccd871ac04e9fffc1ee268da1ee68b161ac3ed69c82ae4fd73` |
+|  `latest-dev` | January 25th | `sha256:f69b8b9b2f1efc91e917d214218231a466c1b7f56e1124d9c64578d92e215247` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zookeeper Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-01-26 00:21:35
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 24th | `sha256:83700b3295986f1d17055579920c9371acff131372cc123388448513a1d536fe` |
-|  `latest`     | January 24th | `sha256:4232b9e731d84fad4248ca4e76bb8da5b7bf7090107a7b27ed25a248b3baa420` |
+|  `latest-dev` | January 25th | `sha256:2cb5e6ceed3538e1f02dceec4d2b81d0bc0874994ebe59e6c1bc0ffe2eb91ca9` |
+|  `latest`     | January 25th | `sha256:442fd33fd4853b5965b6d8202e040c134f10352229c6864ffff12048a573bf2a` |
 


### PR DESCRIPTION
New images added:

- cassandra-medusa

Updated Docs:

- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- aws-for-fluent-bit/tags_history.md
- bazel/tags_history.md
- buck2/tags_history.md
- calico-node/tags_history.md
- cass-config-builder/tags_history.md
- cassandra/tags_history.md
- cilium-agent/tags_history.md
- clang/tags_history.md
- dask-gateway-server/tags_history.md
- dependency-track/tags_history.md
- dynamic-localpv-provisioner/tags_history.md
- fluent-bit/tags_history.md
- fluentd/tags_history.md
- git/tags_history.md
- gitlab-exporter/tags_history.md
- gitlab-pages/tags_history.md
- gitlab-shell/tags_history.md
- gradle/tags_history.md
- guacamole-server/tags_history.md
- ingress-nginx-controller/tags_history.md
- jdk/tags_history.md
- jdk-lts/tags_history.md
- jenkins/tags_history.md
- jre/tags_history.md
- jre-lts/tags_history.md
- kafka/tags_history.md
- keycloak/tags_history.md
- kube-bench/tags_history.md
- kube-fluentd-operator/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kubeflow-centraldashboard/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-frontend/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- maven/tags_history.md
- newrelic-fluent-bit-output/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- node/tags_history.md
- node-lts/tags_history.md
- opensearch/tags_history.md
- opentelemetry-collector-contrib/tags_history.md
- prometheus-alertmanager/tags_history.md
- prometheus-cloudwatch-exporter/tags_history.md
- prometheus-mysqld-exporter/tags_history.md
- r-base/tags_history.md
- ruby/tags_history.md
- solr/tags_history.md
- sqlpad/tags_history.md
- statsd/tags_history.md
- tomcat/tags_history.md
- trino/tags_history.md
- wavefront-proxy/tags_history.md
- wolfi-base/tags_history.md
- zig/tags_history.md
- zookeeper/tags_history.md