### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,64 @@
+# 2024-02-06
+
+
+Updated Docs:
+
+- aws-efs-csi-driver/tags_history.md
+- bazel/tags_history.md
+- buck2/tags_history.md
+- busybox/tags_history.md
+- cassandra/tags_history.md
+- cassandra-reaper/tags_history.md
+- clang/tags_history.md
+- dependency-track/tags_history.md
+- fluentd/tags_history.md
+- flux/tags_history.md
+- flux-helm-controller/tags_history.md
+- gcc-glibc/tags_history.md
+- gitlab-exporter/tags_history.md
+- go/tags_history.md
+- guacamole-server/tags_history.md
+- ingress-nginx-controller/tags_history.md
+- jdk/tags_history.md
+- jdk-lts/tags_history.md
+- jenkins/tags_history.md
+- jre/tags_history.md
+- jre-lts/tags_history.md
+- keycloak/tags_history.md
+- ko/tags_history.md
+- kube-logging-operator-fluentd/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-metadata-envoy/tags_history.md
+- kubeflow-volumes-web-app/tags_history.md
+- kyverno-policy-reporter/tags_history.md
+- maven/tags_history.md
+- newrelic-kube-events/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- newrelic-prometheus-configurator/tags_history.md
+- node/tags_history.md
+- node-lts/tags_history.md
+- openai/tags_history.md
+- opensearch/tags_history.md
+- php/tags_history.md
+- prometheus-alertmanager/tags_history.md
+- python/tags_history.md
+- rqlite/tags_history.md
+- ruby/tags_history.md
+- rust/tags_history.md
+- semgrep/tags_history.md
+- solr/tags_history.md
+- stunnel/tags_history.md
+- tomcat/tags_history.md
+- trino/tags_history.md
+- zig/tags_history.md
+- zookeeper/tags_history.md
+
 # 2024-02-05
 
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 3rd | `sha256:760a4eba664270046a9ad18bb606b74e1793f325d0941774cf31c32ad590f00b` |
-|  `latest`     | February 3rd | `sha256:e33c869d78ac02e127954d9e743e129787cd4ad5a97ecc862fafd31248f59da6` |
+|  `latest-dev` | February 5th | `sha256:e9df07130bc4d339676226c0b2d38801bc80ddb6cc05c8945018eccc3bced870` |
+|  `latest`     | February 5th | `sha256:6786d49bb8b6e24385c6367524f732ed7e1b6884197e657793f232ab04b7178e` |
 

--- a/content/chainguard/chainguard-images/reference/bazel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/bazel/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the bazel Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 31st | `sha256:04d39abdfa32fa044db18c0e2162a6f3c59391b19394e548127ebfedf0e075e4` |
+|  `latest` | February 5th | `sha256:371eecd1d626814ebfe5c27ed152ff1ee4793d431af0714f363745be7bc8da65` |
 

--- a/content/chainguard/chainguard-images/reference/buck2/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/buck2/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the buck2 Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:bf4eb0db63a36dcca5141765848b7d1a4066bd39b6782516e53abf9bc6eb3d71` |
-|  `latest-dev` | January 31st | `sha256:e589c52d3153694ef27a9e04232c194efb57643474e3163e2994619bd983bf53` |
+|  `latest-dev` | February 5th | `sha256:e8559adf762e20a5164a07163d0b0a71ed002ca591c1e895ab9e6dc201bd36bf` |
+|  `latest`     | February 5th | `sha256:2259ac3bb07c0de370e86d640ee27ba092b1a5f405fc72bf36120f6c0d48951c` |
 

--- a/content/chainguard/chainguard-images/reference/busybox/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/busybox/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the busybox Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-02 00:19:02
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)         | Last Changed | Digest                                                                    |
 |-----------------|--------------|---------------------------------------------------------------------------|
-|  `latest`       | February 1st | `sha256:b43c87a65db0cfa5f5e3eaf34cb40c6393252df5d97ae3dd9c1d1e98a5080437` |
+|  `latest`       | February 5th | `sha256:0cfcf4f8f9342758d943899ac1a55fff97611b3214c968bf2e2cd2bb1112df38` |
 |  `latest-glibc` | January 31st | `sha256:1467acc24f5f460817342c5a843c197daedc68973c1733240b5d65fb7dd6aabb` |
 

--- a/content/chainguard/chainguard-images/reference/cassandra-reaper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cassandra-reaper/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cassandra-reaper Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 3rd | `sha256:335cc02c589b9ff83ac8f3d1a9aee4e4f4be335467dd858d21529bed6cdd7065` |
-|  `latest-dev` | February 3rd | `sha256:18d4c556c869fd088b4e274a3bd8a14eee3b3ea4ca3738d1caa5f55b2b5e1382` |
+|  `latest`     | February 5th | `sha256:4c9488230a43578184f141b5c38d530b6bfafc9ce0c6a79fe1a74368bc46f3ea` |
+|  `latest-dev` | February 5th | `sha256:a3ecbd6e00dc842b4cba59a5b84fec5a5d758eb13d851fe7dd3a57a31c3272cd` |
 

--- a/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/cassandra/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the cassandra Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 4th | `sha256:b3d59c2a544003e4688381fe16d3dcebdd672fc03aec5932f737d0a5ed889a8a` |
-|  `latest`     | February 4th | `sha256:77fbf50d8e86afe51d07d6ff44617722bce7b6e7c4afeee4ec7044703b98da7a` |
+|  `latest-dev` | February 5th | `sha256:04b7a31c413e209af9df7a7608f73e0b12ec451fc176968b5f797ed8c4119728` |
+|  `latest`     | February 5th | `sha256:fea91bbf6a344ae6c0a56237e9278ff99b58611aeaa50c8455e3667e82b7227b` |
 

--- a/content/chainguard/chainguard-images/reference/clang/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/clang/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the clang Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:ac08d5dcc4d87019845c9a69f63b6754d94ca45bcb9e9a3e64030072f78fcff3` |
-|  `latest-dev` | January 31st | `sha256:98c1595b8023846567bc00db83c2f369b83b5fb53cd66ad713a2085c52afae1d` |
+|  `latest-dev` | February 5th | `sha256:7b3787b0e59d7efcf83ce91d21c84380ed05fb879fc49c6d4cf239268fd78851` |
+|  `latest`     | February 5th | `sha256:f067373ce6858df0374e43235f9a27a5e76545a0992d834c509528ebdb8ad62b` |
 

--- a/content/chainguard/chainguard-images/reference/dependency-track/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dependency-track/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dependency-track Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:4659fb5af3f312e84401c7f3986b8c926d698d52bbc0c0eb4b43512e08cf96d3` |
-|  `latest`     | January 31st | `sha256:55c65f1e38549bb9af94b580ebf2ef5a6bdf9e832e02f5bd1a45939d34b66269` |
+|  `latest-dev` | February 5th | `sha256:83ddcea4ba04d2f902675e2b9d3604d00448d38797b6aaa8db07b72e9002db29` |
+|  `latest`     | February 5th | `sha256:ce78b450bcdc47aca0079ab50ff757d8b6c773ed6cac7a9b1d5603ee7a53493f` |
 

--- a/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)              | Last Changed | Digest                                                                    |
 |----------------------|--------------|---------------------------------------------------------------------------|
+|  `latest-splunk`     | February 5th | `sha256:4f892d54d5d59c078607acde736f17f3b0fef2531f3b3f3c04d3533146846750` |
+|  `latest-dev`        | February 5th | `sha256:43abc68e0db7598955c86a8e7e0eb44de0c63f1cbcf904636319294688875aa0` |
+|  `latest-splunk-dev` | February 5th | `sha256:290776172d77b5f39b2b7e5209c6ec020a31d2750591812d5292fa7d47338349` |
 |  `latest`            | February 3rd | `sha256:534bc1ec58b3b271c94aa4bb9cc0697dc9f14f19b8e817e095fbdcaf4220795a` |
-|  `latest-dev`        | February 3rd | `sha256:59b7f4a0c52361eeb74a290e19456f82bd60a72d7e8a375cd24e4f3bee892f8e` |
-|  `latest-splunk-dev` | February 3rd | `sha256:d0cc8f6b93e01133c4bccfa8854652fba62df7326c9632d30ec9e116ad6bc9a9` |
-|  `latest-splunk`     | February 3rd | `sha256:c98f377cdbf9fd4261737092d9f2b78bbf2c3d4286ec1b6ce2cdce03a8989664` |
 

--- a/content/chainguard/chainguard-images/reference/flux-helm-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/flux-helm-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the flux-helm-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,7 +25,9 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                                                          | Last Changed | Digest                                                                    |
 |----------------------------------------------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `v0.37` `0` `0.37` `latest` `v0` `0.37.3` `v0.37.3`                             | February 1st | `sha256:83b6e5de267c34880aa6134fb9eb15cd9343b5fd76ee503074ce6e88b6683597` |
-|  `0.37-dev` `latest-dev` `v0.37-dev` `0.37.3-dev` `0-dev` `v0-dev` `v0.37.3-dev` | February 1st | `sha256:546215b2d2d2de3fc471bd9abfdf25d7371b813c32c55bb5948d9cfdc09ac858` |
+|  `latest-dev` `v0.37-dev` `0-dev` `v0.37.4-dev` `v0-dev` `0.37-dev` `0.37.4-dev` | February 5th | `sha256:3fc4a60bdbeadb35f8682db88a764d6752c82c87500f07fc93a5d102423f822d` |
+|  `v0` `0.37` `v0.37.4` `0` `v0.37` `0.37.4` `latest`                             | February 5th | `sha256:ef89b496e650fd06db1ba5f76504180aff69bb37cd31fdf99388434d6fea14e2` |
+|  `0.37.3-dev` `v0.37.3-dev`                                                      | February 1st | `sha256:546215b2d2d2de3fc471bd9abfdf25d7371b813c32c55bb5948d9cfdc09ac858` |
+|  `0.37.3` `v0.37.3`                                                              | February 1st | `sha256:83b6e5de267c34880aa6134fb9eb15cd9343b5fd76ee503074ce6e88b6683597` |
 |  `v0.37.2-dev` `0.37.2-dev`                                                      | January 31st | `sha256:c7a87dd98110f536b8b80a22d8c306dfd9839b07faf7420712337dde064597e5` |
 

--- a/content/chainguard/chainguard-images/reference/flux/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/flux/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the flux Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                                                      | Last Changed | Digest                                                                    |
 |------------------------------------------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `2.2` `latest` `v2` `2` `2.2.2` `v2.2.2` `v2.2`                             | January 31st | `sha256:d49263efebf826acdf937db5bcd6dc2dc35a41aa7c7d882fb0451865a14ee479` |
-|  `v2-dev` `v2.2-dev` `2-dev` `2.2.2-dev` `v2.2.2-dev` `2.2-dev` `latest-dev` | January 31st | `sha256:abcfee6348d7658c1e989f99c6d402cd800b4b062b190a31da79b41628f28ec1` |
+|  `2.2-dev` `v2.2-dev` `2-dev` `2.2.3-dev` `v2-dev` `latest-dev` `v2.2.3-dev` | February 5th | `sha256:1fc0f3bce8e1bc9e86ff37a4788347af9408d4ecf7151cea3e91d4e49d6aa03d` |
+|  `2.2` `latest` `v2.2.3` `v2` `2` `v2.2` `2.2.3`                             | February 5th | `sha256:cd0850dd6f207ad5dd1b348e32996050ed2ebae4922f6ad40e8cb1a1a0e91501` |
+|  `2.2.2` `v2.2.2`                                                            | January 31st | `sha256:d49263efebf826acdf937db5bcd6dc2dc35a41aa7c7d882fb0451865a14ee479` |
+|  `2.2.2-dev` `v2.2.2-dev`                                                    | January 31st | `sha256:abcfee6348d7658c1e989f99c6d402cd800b4b062b190a31da79b41628f28ec1` |
 

--- a/content/chainguard/chainguard-images/reference/gcc-glibc/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gcc-glibc/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gcc-glibc Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 31st | `sha256:bd6885b7d7767238fb04f39d58442bdb5e3a40f1ab005f1a277d619d387619d7` |
+|  `latest` | February 5th | `sha256:47671427044503fa6ddc64edc50f4c96026fb1e46f34074e4f8d82f6d53f9302` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:32b13df437071572d37ab6df656947c8de458a3edaba52c502ef3fbe0f2d1775` |
-|  `latest`     | January 31st | `sha256:78cff06e662b14ee07a6901f1fd4c89773cb86187006018bd9da52e7bb4dc79f` |
+|  `latest-dev` | February 5th | `sha256:0176ca105a3e0ea3019dc8054fd1ec2773d37b4713368ba76ba9e5f700cdeb5d` |
+|  `latest`     | February 5th | `sha256:3a2141e20aca3f85f5ed2dc136092f9acedf25cd93027850162181528bbb5cf6` |
 

--- a/content/chainguard/chainguard-images/reference/go/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/go/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the go Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:5d5abab93c240e0190be34d08c24f32f552cf0aa235ec5a8bbd645071c89c415` |
-|  `latest-dev` | January 31st | `sha256:b7a533f934788eb5ac9c793400fd7dc94c8db0ce7a25207f1f54fdba55b75413` |
+|  `latest`     | February 5th | `sha256:f29f9a9808d26acbbbfd71f0312c21c8bd89a1184971a5eee188f1070e148bef` |
+|  `latest-dev` | February 5th | `sha256:3c9c3083d2e2e90d784a77edbebb8e390b8e4ab6f7be77c0f345c157bb2882c0` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the guacamole-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-02 00:19:02
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | February 5th | `sha256:484f5c74578ceafc9517bcd5d0dc6cca0dbc803c5ad9823f2f686cada1e1e540` |
 |  `latest-dev` | February 1st | `sha256:c91111f15ba165b1a9c485c42b73b3be51fbf8fce32ced7248fe328e505f1bed` |
-|  `latest`     | February 1st | `sha256:790487ae34e159c22d8acade3af9a275a702b06dbaa3cb13f3387e672d9bb100` |
 

--- a/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ingress-nginx-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ingress-nginx-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:8156233225b7eeabe7fe09fc9e252b2abaa0d828d4fb4ba93359a3a6f805ed34` |
-|  `latest-dev` | January 31st | `sha256:35a68ae31ea75f822b6e5ba23bfd880cafb6efb6f4177a90403c34b31620aaa6` |
+|  `latest-dev` | February 5th | `sha256:6d021bdde36856a85ae9e946316f5e62ce66aa8b7ed6951c452548a23472bf49` |
+|  `latest`     | February 5th | `sha256:7ab85df40f911fe35fa679d49f353d2b7d57fb9068cf61a98c861dc85913bd00` |
 

--- a/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:317f3496b2eec7dd84f4054bc1a4974e855afc97db449ab487e2900516eac62c` |
-|  `latest-dev` | January 31st | `sha256:b8ffdf6ecd18da61028d6c192a40e4341a3159064f2b2ce0d1e4052f4c2d4991` |
+|  `latest`     | February 5th | `sha256:58ec6c17701c21d5ac894cd4e2b6001aaa4e2215594b7521347c82d62938397b` |
+|  `latest-dev` | February 5th | `sha256:1786d1a57727524f4520e1033838d175f2585dce7c57aa968f34e14979eac368` |
 

--- a/content/chainguard/chainguard-images/reference/jdk/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jdk/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jdk Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:472a0a366e03eda61f657b5c6f5dae2a40658918b736dc6013fc52c5a34735de` |
-|  `latest-dev` | January 31st | `sha256:7a8d492df6f33c9b994144a426232c3be33b6fb5e377bb037ebee3fbf2caa354` |
+|  `latest`     | February 5th | `sha256:a2691cd94d82062664ebd73d5ed13442e266ffe834af5a0a5d8b07caf265312c` |
+|  `latest-dev` | February 5th | `sha256:c9d618bda321aef9e22681b0b25cc4484a45b15a227c4f70005b3a61fe4d6432` |
 

--- a/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jenkins/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jenkins Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-02 00:19:02
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 1st | `sha256:8e70815c315dd78c6a80be76af8ef8cc7618e93b9a4ef9cc01a4e8b3e16bbe50` |
-|  `latest-dev` | February 1st | `sha256:3aa330589c7718c4c07833a43b5ef1ea4e22ea38b7e76a8454575024487f52f3` |
+|  `latest-dev` | February 5th | `sha256:1aa41fd1a24aaab0dc83b9b0699b055621e8f61bfc156acaef6f16362b0e2628` |
+|  `latest`     | February 5th | `sha256:9d779a92ab8b59ed67da22cedbcbb6276f9624e737b79b4feda0c3649e2f57f9` |
 

--- a/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:5a077949a1ceca9a8908508b6fd5d7420f6bab40feb9ea6fc92c28722d39b80d` |
-|  `latest`     | January 31st | `sha256:198a1fb4480cce84a39abedd881664cab6cd579aa20ca1d0b1f01803beb082cb` |
+|  `latest-dev` | February 5th | `sha256:5fb6e8476107042730370a20c02165566fdce22f40be66533f4843c29d3518ff` |
+|  `latest`     | February 5th | `sha256:5d4a7926a0f9c370d0ade8c2c71f291ac22f1f302134504f6ff6a6aff337ceaf` |
 

--- a/content/chainguard/chainguard-images/reference/jre/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/jre/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the jre Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:58565c5cab3a63ff2b84592e1c544418a0ee9d2fa8129f5076a8e3acf7366b01` |
-|  `latest-dev` | January 31st | `sha256:604998da0615580eddd2a6f7d7f51a4f61f4001cb17f0df0331873ef4dfad23a` |
+|  `latest-dev` | February 5th | `sha256:7ba281c98561f73a6cbfaaae83ef368e0779738c24b5c5ea99b2b0686c95b5ec` |
+|  `latest`     | February 5th | `sha256:1781a0a64630db7a631c5e570594e19af95f24e232e06e41e81003988e27c5dc` |
 

--- a/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keycloak/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keycloak Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 2nd | `sha256:e0854c77bdb09c9f8f24e5eec0458702d001f4c4bf01a7f5d1df89897ded8297` |
-|  `latest-dev` | February 2nd | `sha256:d671b835f521b8851ba04f61c092c7837061701e12748efd65fa7abc206510a7` |
+|  `latest-dev` | February 5th | `sha256:17dea81a3040231fdf8add026d9a88dceba7b89eee2239cee3079206a547ab08` |
+|  `latest`     | February 5th | `sha256:6c35d047681c68c6462d60e9aa0bcece38a2838ba8e70abf73ee295a0f706164` |
 

--- a/content/chainguard/chainguard-images/reference/ko/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ko/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ko Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | February 3rd | `sha256:04cd099bfd90766fdcfd55b713342252acd373a8924c7a37b3d0d95a514ecd2e` |
+|  `latest` | February 5th | `sha256:bba9252ad45f7a30eae65af02f71bc9dbdfbcd66de8c0841bc76c63d74da47e5` |
 

--- a/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kube-logging-operator-fluentd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kube-logging-operator-fluentd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 2nd | `sha256:7da8a27453981ca6afe6b0054c27f6115034cabac9ebf568c14158efcd8916ca` |
-|  `latest-dev` | February 2nd | `sha256:cad4279c085c3b2e7a81f342d0601e0ac0d21f53d0f75002115ca1aa247f0d8c` |
+|  `latest-dev` | February 5th | `sha256:637f1922d5e0563f05f88662b215e234f1237f106d9e00d79ca703804ed40894` |
+|  `latest`     | February 5th | `sha256:7d49af31755eb21f60a55a485cacb28406c3dce0b6319c5a6ac0ccc0303673ac` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-earlystopping-medianstop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0` `0` `0.16` `latest`                 | February 3rd | `sha256:fb148357952bdff56dbfd5bbbb60a9d42bfb33a9da4a40e8645606714b6155e7` |
-|  `latest-dev` `0-dev` `0.16-dev` `0.16.0-dev` | February 3rd | `sha256:f71a4e668ff231c44ac4e77fb5dc3c0868ca724b847a11ea780878d32218edaa` |
+|  `latest` `0.16` `0.16.0` `0`                 | February 5th | `sha256:be65399fb8a08fce6cb18a7f6b6494c5321c9717548342b53446ebb32f28edb4` |
+|  `latest-dev` `0.16-dev` `0-dev` `0.16.0-dev` | February 5th | `sha256:89cde3a2c5006a5576db16a13456da9a345d481c5af140c8b912599209504e94` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-darts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0` `0.16` `latest` `0`                 | February 3rd | `sha256:3e9fd4dbfa03f980a59b6f162ef0928cb083e748efdbde013360f5624eaea440` |
-|  `latest-dev` `0.16-dev` `0.16.0-dev` `0-dev` | February 3rd | `sha256:1ee326b9a620b8058e36cc92f5bc571c8db2aed41e75231e12b86661c8a98fa5` |
+|  `0-dev` `0.16.0-dev` `0.16-dev` `latest-dev` | February 5th | `sha256:92e58a1dfe6336176c3d8bc1bf5b44f03962c127129a89864f680f46433fb64c` |
+|  `latest` `0.16` `0` `0.16.0`                 | February 5th | `sha256:78508a70b0831aa814db740bb11a98e01c9ac4cae2f3551955612032c769d012` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperband Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0-dev` `latest-dev` `0.16.0-dev` `0.16-dev` | February 3rd | `sha256:ba899756f5f1459854e33280186555034ce1532f0a8b93ce955d8ca67c1e6644` |
-|  `0` `0.16.0` `0.16` `latest`                 | February 3rd | `sha256:f848b6b766f118bce2d35d89183cfe083ff242045a4f73155d510e35922f5612` |
+|  `0.16.0` `latest` `0.16` `0`                 | February 5th | `sha256:b7a05d53c25ef3a6cf60387d70892e942ab620164968e5af00f95cda77152665` |
+|  `latest-dev` `0.16-dev` `0.16.0-dev` `0-dev` | February 5th | `sha256:afeb81392e6c5fed41e5141b9334f0e5aa7cde44bcc98996b55f2d28393f09e5` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0` `0` `0.16` `latest`                 | February 3rd | `sha256:a44b8321311b5d66919f0ea0e7535283c2617f5595e9024731dac29ec081a981` |
-|  `0-dev` `0.16.0-dev` `0.16-dev` `latest-dev` | February 3rd | `sha256:78e234904b86133e910eb7eec38d2a034f2cfa5f45d0a73a31de96bac9e455bc` |
+|  `0.16.0` `latest` `0.16` `0`                 | February 5th | `sha256:45429e4056331409c318f46b12f479837cfe1a94aed47c0bfcc3def1640436ce` |
+|  `0.16-dev` `0.16.0-dev` `latest-dev` `0-dev` | February 5th | `sha256:7c1305f6dc1be93abb276b7a899dacbf90eaeec4088a543c217cddd872f6153a` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-optuna Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest` `0.16` `0.16.0` `0`                 | February 3rd | `sha256:1d6a7d19d46ce8931d9898afcf8fcf749fc3a9f9943f2c8be67a5c7951ae56eb` |
-|  `0.16-dev` `0.16.0-dev` `0-dev` `latest-dev` | February 3rd | `sha256:7f95d8d1f9d439227cc785dd7a317a3bddc9ec33326db4f6fe90c11668e18853` |
+|  `latest-dev` `0.16-dev` `0-dev` `0.16.0-dev` | February 5th | `sha256:afdfa4fe43fd145ffda30bdff97c9f066516d2977542d6002d608131eda4240f` |
+|  `latest` `0.16` `0` `0.16.0`                 | February 5th | `sha256:7dff5971a927218ae33350029e20eb10ead878a755322ae885161674b88294c8` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-pbt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` `0.16-dev` `0-dev` `0.16.0-dev` | February 3rd | `sha256:2866bc54475782fcc38eb146e61698d685d45b890ba4fd0be9529834d8553b48` |
-|  `0.16.0` `0` `latest` `0.16`                 | February 3rd | `sha256:73f1112bc39d2596b68a869f6abdb4fb1f7628ec48d22962c7d0f11817337a16` |
+|  `latest-dev` `0.16.0-dev` `0-dev` `0.16-dev` | February 5th | `sha256:7ae04ee8694d925ae92431d40e6f08bfb1f28cb5d84cbccfd8b20b18a3a68d40` |
+|  `0.16` `0.16.0` `0` `latest`                 | February 5th | `sha256:25af29908b120d97f0ed597711e32ed695952c279ef396afac35917722655abc` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-skopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0.16-dev` `0-dev` `latest-dev` | February 3rd | `sha256:df704afee863991d4c1f73829e7a9d458ac6ff8e44e731a74e490cc99cd3f1a0` |
-|  `0.16` `0.16.0` `0` `latest`                 | February 3rd | `sha256:cfa997aa48749104bab1d1ffa0e2fb2da39cd661bafd28d576120db70e51a1b7` |
+|  `latest-dev` `0.16.0-dev` `0.16-dev` `0-dev` | February 5th | `sha256:99828f023edca5591343b86ebb6ab8d11ce585dfcf7c8b501f2af2a9c318c77f` |
+|  `0.16` `0.16.0` `latest` `0`                 | February 5th | `sha256:b756ce6585bf08144d17fc3515de5ebfd38a03a2f01c4b72d7978005f07f1dce` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-envoy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:366f315c805dd46efacbadb3ba39290185d80ddb7b4aaab0fdfd1fe8ba084568` |
-|  `latest-dev` | January 31st | `sha256:7effbe08eefed4aa708a5bd09e7731435e7c7b97e94c59e06f8f8d7803871fb7` |
+|  `latest-dev` | February 5th | `sha256:20745af22dc727b15c0ca2063b7f3f085eec7798f6e66b719f5479e7f2c0c54a` |
+|  `latest`     | February 5th | `sha256:fa37f8f3437c6267aa863d7ecb14760b3da236ae8923f924c01cc3f948d59ad6` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-volumes-web-app Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed | Digest                                                                    |
 |---------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `1.8.0-dev` `1-dev` `1.8-dev` `latest-dev` | January 31st | `sha256:061d2c4797bedf7e981d4051a82d906642c68adc35b15a7d32bda221276c9b61` |
-|  `latest` `1.8.0` `1` `1.8`                 | January 31st | `sha256:1dc2b8ecec4df4e699b99028e0d5202514646d6daebe8be0a3bf5941054851c7` |
+|  `1.8.0-dev` `1.8-dev` `latest-dev` `1-dev` | February 5th | `sha256:af85b2d774f3979c8e5ebee8ea8c64be3937d52fd607f05812858074b4d2d2e2` |
+|  `1` `1.8` `latest` `1.8.0`                 | February 5th | `sha256:2aeccc4284b53e4356f6902aa644f9351eeb919cb66c0ecf8f0ad2408d89df7d` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-policy-reporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:932b8acff32e4de4f030c68b98e8571f72e18eefd59cf84da95ce0d84aa96e04` |
-|  `latest`     | January 13th | `sha256:2206ea2ac50c9d0a364cf3f8998e2ea562b1545fc28d560976e881d9f7a7374c` |
+|  `latest-dev` | February 5th | `sha256:438b8f85d9433d557491a3e0f55c30854565c1df215f1803f97b69aebc6f0fa7` |
+|  `latest`     | February 5th | `sha256:8a4d38758384fa4d2b222e508f4f8b349643f7cf60e96966fb7fe97d7ff48d85` |
 

--- a/content/chainguard/chainguard-images/reference/maven/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/maven/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the maven Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,10 +25,10 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                        | Last Changed | Digest                                                                    |
 |--------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest` `openjdk-17`         | January 31st | `sha256:3f24af47a2885c2fe7e667005a9bfaa9af2c017e104f75cc668369010fdd03a0` |
-|  `latest-dev` `openjdk-17-dev` | January 31st | `sha256:f5381300015413e7f69da95aaeab280adb390282a12456a0439d0bdaa67bffa1` |
-|  `openjdk-21`                  | January 31st | `sha256:8c17bf5422a11be8de16c49c1eb458c778eda0312d29a3fc008fd4e40b9de6fe` |
-|  `openjdk-21-dev`              | January 31st | `sha256:5cff5cfaa5481d51ddc1887f9b2dd42bc789962acb2078493c3fe0f101756b89` |
-|  `openjdk-11-dev`              | January 31st | `sha256:09cb24daddcf38e9d79f6cc6bb94423c66becd54f621355a0d50a41375a6fa96` |
-|  `openjdk-11`                  | January 31st | `sha256:fb81b15589611da9bc1c9082ca08e89c169e57e5306157b4760eef71ca73bb13` |
+|  `openjdk-17` `latest`         | February 5th | `sha256:22269d978e6f287822f14f567fb9ef90897d6a6e4d2716d154b410405b02ce3d` |
+|  `openjdk-17-dev` `latest-dev` | February 5th | `sha256:bba64197fac4b0e42dcf439db80bc78f7acc8634123939e825b0b5b0598520b6` |
+|  `openjdk-21-dev`              | February 5th | `sha256:8072346b46eac2621fff3c82c475b253f3fff2b02e70a8c964f0b127ee78e592` |
+|  `openjdk-11-dev`              | February 5th | `sha256:7f7d36c2f2251c9f9fb3652093f3e02cc9dab5b6ddf4313b130e7e01275ce360` |
+|  `openjdk-21`                  | February 5th | `sha256:50d183d0cdc9cbc4f4809d74c297f487a3ab1bda31864bfd29c78e70dca6bfd5` |
+|  `openjdk-11`                  | February 5th | `sha256:84f7405e21a8cff16d5b3b91de73c04b6d035e425ae26d2808e4dae34e3832e0` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-kube-events Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:3ebd9786f1869dc1909800de8d2da4832d03e2e13f17f47e17263e80f1ee7b74` |
-|  `latest-dev` | January 31st | `sha256:c616d4e6fa11ef58ef596fbb2ce5f00abe40c67e70d9525db440cc48a8891bb5` |
+|  `latest`     | February 5th | `sha256:7b5133241f04cfb09e9ae432fb8854443acc6ede9ce7332eb88d2aaf44a988e2` |
+|  `latest-dev` | February 5th | `sha256:94764302f7158c1ddeb160aeb34a7a67f1679feb7c838779daf39440b268c61d` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-kubernetes Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:05e1620fef740c68f8f8c105419613fcd7a1e477f56ef5e37afc5df806be7b9a` |
-|  `latest-dev` | January 31st | `sha256:46abc83774537119d96ca4ca6cd6c2b7b6a5a9ab4e58a7f7e25c6ecdeaa203da` |
+|  `latest-dev` | February 5th | `sha256:87e3829230c620cfff37803c8da0cf9a2417b4cf751c2d37d9c3e6fd4119e052` |
+|  `latest`     | February 5th | `sha256:e9964c2a5e7f192599c079f698b0f96ae1f877669f4655d44cd70d7524d599bd` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-prometheus-configurator/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-prometheus-configurator/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-prometheus-configurator Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:1618ee463cc402267b853f0cb376cad1a649c9e6bed58cd90556343dd8945497` |
-|  `latest`     | January 22nd | `sha256:8b5042f30f82e0c952b5cade0ffe95afaacfd9f995530c4a51268dc4bf9b6b56` |
+|  `latest-dev` | February 5th | `sha256:c1b6791ce7534196b2ce1ff0cee5715b9aa52798faa8811856f2c36fc4139658` |
+|  `latest`     | February 5th | `sha256:b6fc2514a8f0b1e46d8101a08fbf9c7b91bf9aede848ab12331ca5097dc7c9fa` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:df3e3dda1589591709e5ffbceecb7846a1ca9e84eea93eed158a6f901f3433e7` |
+|  `latest-dev` | February 5th | `sha256:e76b15753926038bd197f6ff207f6a491db63d1740a221f6398036dbc3dd451d` |
 |  `latest`     | January 31st | `sha256:719a1e0618906d0d8f36ba3e1581331b89178752ad682ba04947febaafe549b0` |
 

--- a/content/chainguard/chainguard-images/reference/node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 5th | `sha256:ed0d2635cde795ba4a1dbb2740ee4167102cd8f27ed4049604b424a3501442af` |
 |  `latest`     | January 31st | `sha256:e2d1c83e4347daa78414331bc245834f751ab342d78fd333629f2f0a03b73b28` |
-|  `latest-dev` | January 31st | `sha256:c6fa059f0cd3d36701f34cfaae860d034b2ffced462e23330df1214425e6c663` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the openai Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 3rd | `sha256:e83ba1efe6e62797ca80a62e1f961e49431e8dfb0cebfa8f4573af0171665a19` |
-|  `latest`     | February 3rd | `sha256:3ce4f96927e759857a8836c27092b4b0aa81ebeee2558fe0f78feb736a00355c` |
+|  `latest-dev` | February 5th | `sha256:b3b4732d91e4d17e54be104f5b76acaa52311e5564b76c24c86be71bc9b211c6` |
+|  `latest`     | February 5th | `sha256:a5105593aa758fad0a59c0f6b48a4a295736eab4e0806d07a6ed2ea376d1a402` |
 

--- a/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opensearch/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the opensearch Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:c7d1ff936631990b53f34032f43b89347e65ae0bcf01157635787f6ef5f61c86` |
-|  `latest-dev` | January 31st | `sha256:a20f106541c099ec4b74e6d2178fd46e0c80f78c1639a74111d2668c3529ef75` |
+|  `latest-dev` | February 5th | `sha256:71b19b3bd9b2c831d8919de58ab27acbe0da012f084492dbfb08cf8e33f3a7ca` |
+|  `latest`     | February 5th | `sha256:fe66a3938a2dca8b612d9c1cb286b2a92bcb9437265ec67e96f384a1ae8c2bae` |
 

--- a/content/chainguard/chainguard-images/reference/php/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/php/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the php Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,8 +25,8 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)           | Last Changed | Digest                                                                    |
 |-------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-fpm-dev` | January 31st | `sha256:48bfdf749e85637d4a7f601f9cd1bfca036ec90de813096c8973617a4f319c1a` |
-|  `latest-fpm`     | January 31st | `sha256:54254b25b579e9d767bdba1cfac37608900f7a9ba34ab7d5f8cd9f41eb636625` |
-|  `latest-dev`     | January 31st | `sha256:184c7ce1e859b5b964528a0b440c372f66d03a72f9c34d3825a648866a7c49bd` |
-|  `latest`         | January 31st | `sha256:eb6ae602ceced4f52bf1f0b7163dcab2977a3481cd2e7b0d4e7702f3594dbf2f` |
+|  `latest-fpm-dev` | February 5th | `sha256:5ea3979e6dbb422361be6a3b07f73e97d0719f0e976f3a0cfef0d21e5b6efc83` |
+|  `latest-dev`     | February 5th | `sha256:63b7c9493963660ffdc324b160f65c359295eb7b7e41b53acf66b7215628b952` |
+|  `latest`         | February 5th | `sha256:d807f7ee43e36057da55c35d2d1699f497294375929db0b88b2d6ded4cc8e35f` |
+|  `latest-fpm`     | February 5th | `sha256:dfaa5413465a8e1debfbd3254237afa122f14ec9798628160149e6d95b187fb4` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed | Digest                                                                    |
 |-----------------------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` `0.26-dev` `0.26.0-dev` `0-dev` | February 4th | `sha256:2466354206c0d830d1b808d6ddd0111a4d95c0e154c2034269f046052d104bae` |
-|  `latest` `0.26.0` `0` `0.26`                 | February 4th | `sha256:094ea24acd6e25150abb05ba8050fa099073a82ce12cf7903da588844bbcf698` |
+|  `latest-dev` `0.26-dev` `0.26.0-dev` `0-dev` | February 5th | `sha256:2466354206c0d830d1b808d6ddd0111a4d95c0e154c2034269f046052d104bae` |
+|  `latest` `0.26.0` `0` `0.26`                 | February 5th | `sha256:094ea24acd6e25150abb05ba8050fa099073a82ce12cf7903da588844bbcf698` |
 

--- a/content/chainguard/chainguard-images/reference/python/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/python/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the python Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:c7983b23312cfc4fcbebbf8c0fcb1ed83c3d4634ced078b7fbc10fac93044b36` |
+|  `latest-dev` | February 5th | `sha256:7af0b89d0dea414f33dd1db87a3942744108d73648f8902af09948baa35baac1` |
 |  `latest`     | January 31st | `sha256:a640f1a266988d5a44bc75c15fdd34892183b4019550f8d66aa9e3c885018658` |
 

--- a/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the rqlite Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 3rd | `sha256:f9a6071bf2ccfa2db8bc332739b36a85aca8bb48b44858d4b47b1ddb425f697b` |
-|  `latest`     | February 3rd | `sha256:7117e58ee79c14507fa4881227b2ad4698a18a33967f657a5f17c28759b8263a` |
+|  `latest-dev` | February 5th | `sha256:bacfa3ed523bade412d8ff8a932e8c1303f567f383fb8428c709be23ea92b22e` |
+|  `latest`     | February 5th | `sha256:592d865bb7e6c6a3e5678b04b2a5ce97edf0e5d1c4d4730bb305ea272bb12e86` |
 

--- a/content/chainguard/chainguard-images/reference/ruby/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/ruby/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the ruby Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:c3eb57722234754990f8148b39284726d4fe755dd10c47bf97cc331c596b316d` |
+|  `latest-dev` | February 5th | `sha256:3c7977bd853f24931390abc1f5d5b6c2448d44fadc3847a941789c55fc6ff79b` |
 |  `latest`     | January 31st | `sha256:985997f4de4ea1bcbc7491b9cc6cf4501d5a305c014314b2a3127de1f5a8f83d` |
 

--- a/content/chainguard/chainguard-images/reference/rust/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rust/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the rust Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:74832cf1aaaac81ca8ede84f81bbabdb88d878ff8d09d955e8abd18c0ce7f122` |
-|  `latest-dev` | January 31st | `sha256:67a2a5d93e9be04b92f618ce63b5cc307cab2a4940b0ce1967cd88c3057c49b2` |
+|  `latest-dev` | February 5th | `sha256:7bd5c15b0bfa14ac3490c6249394b1efa53191518027f7e67a1c08fcbfebe9be` |
+|  `latest`     | February 5th | `sha256:7be3e7b73d01ed0ad9d914d40f95df2bde72e8d22a08cef6f5ef9bb8cb4dbe14` |
 

--- a/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/semgrep/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the semgrep Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | February 5th | `sha256:6ec29535226242f23f9344d5bb2b1c0037b3b865e6bee0a5b96bd976c3062ff2` |
 |  `latest-dev` | February 3rd | `sha256:49f3e140985c415b48fc07edf29026aed113061c396b4bf34953576baebbdc43` |
-|  `latest`     | February 3rd | `sha256:2e58241c30c172c7f0a6c620df559442c9dbf1363370c0adbc53c09354aac247` |
 

--- a/content/chainguard/chainguard-images/reference/solr/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/solr/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the solr Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:2ae8f2dae470a419f221f2bca67aa6f4b16b24e3ff6f4cfbf4172f5ff48ab0e3` |
-|  `latest-dev` | January 31st | `sha256:684aa569cffe7d6654c00347c9df46e5c305ee4143081d8c7669ec944805d669` |
+|  `latest-dev` | February 5th | `sha256:629e0a5542db70a26f833a11e525fab0517769f180c8af4508cf43a5ef785049` |
+|  `latest`     | February 5th | `sha256:0c0c28493371d98e7291329f8387128d02cad5df86d622b6422cb95393393ad5` |
 

--- a/content/chainguard/chainguard-images/reference/stunnel/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/stunnel/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the stunnel Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
+|  `latest`     | February 5th | `sha256:a55d83192d72f0eb9daef007345a4886f9829dd9dc7a4dd58d97d2fcee3670af` |
 |  `latest-dev` | January 31st | `sha256:07d832959faf783f9b0097521b7f4e520fa7c04bd2c7ae89390e650aabe2c108` |
-|  `latest`     | January 31st | `sha256:36bfe91c359694093952a2167258da8b653e9a14da3ea49202acacfa745def6a` |
 

--- a/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/tomcat/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the tomcat Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed | Digest                                                                    |
 |-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | February 4th | `sha256:95c8bfe3136ff931d3c8945558986f5d288de79e70bec1b54bb45332c48ea90f` |
+|  `latest` | February 5th | `sha256:f7b0d9fa5a3ff86826c67b4b2da20857a33d5d66698f7fad1a34aec1febf8f3c` |
 

--- a/content/chainguard/chainguard-images/reference/trino/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trino/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the trino Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:f7246e62317a80da51260853e40418c2d1dee5b61e66407abaf484b675e2e295` |
-|  `latest-dev` | January 31st | `sha256:7fd6e148b1c616088e047e36843bde5c8d691f532438c619a57e6388887e201d` |
+|  `latest`     | February 5th | `sha256:19fcf73b7c5d9525d5b64526c1e3dad2ac18688108eb183c1b34f3b05812857b` |
+|  `latest-dev` | February 5th | `sha256:f147ad222c9a783ea1c07a200f78281339433fd76f69237b7a1d404707065eac` |
 

--- a/content/chainguard/chainguard-images/reference/zig/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zig/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zig Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:44643cf9f150315da17f0e53dfe332acde2441707971e29d1b6d02677ef89b45` |
-|  `latest`     | January 31st | `sha256:9cde0814d800b66ee181984c9ebdcc1f716cf62cfeeaf935ce53ec7c4a260d7d` |
+|  `latest`     | February 5th | `sha256:8f6041edd081b883b4d5e1cd430dde56ee3fcb20866a98e449a19ca30ac32af5` |
+|  `latest-dev` | February 5th | `sha256:5522fb8991daefcc868d70a0b21a19d77f4138272570e460736b172528eeb2cb` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zookeeper Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-06 00:18:29
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:64cd7a652e98f0f0b0621c3585551aec7e8771bdf5c987232c64ae17b305fec4` |
-|  `latest`     | January 31st | `sha256:c4a2f6e135f821c7ed57ecbbc6dec4e4deb8a8a6230b415b10e22f8abd6836de` |
+|  `latest`     | February 5th | `sha256:a52f265aed599c4e637adebf6cb6e0362a66b2c5efdf1cfb142b1f7acca7362e` |
+|  `latest-dev` | February 5th | `sha256:752a0a8da6af7e53532b67e49d57994b2dfcbc1e8190cedf6b7cade7328a1161` |
 


### PR DESCRIPTION
Updated Docs:

- aws-efs-csi-driver/tags_history.md
- bazel/tags_history.md
- buck2/tags_history.md
- busybox/tags_history.md
- cassandra/tags_history.md
- cassandra-reaper/tags_history.md
- clang/tags_history.md
- dependency-track/tags_history.md
- fluentd/tags_history.md
- flux/tags_history.md
- flux-helm-controller/tags_history.md
- gcc-glibc/tags_history.md
- gitlab-exporter/tags_history.md
- go/tags_history.md
- guacamole-server/tags_history.md
- ingress-nginx-controller/tags_history.md
- jdk/tags_history.md
- jdk-lts/tags_history.md
- jenkins/tags_history.md
- jre/tags_history.md
- jre-lts/tags_history.md
- keycloak/tags_history.md
- ko/tags_history.md
- kube-logging-operator-fluentd/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-metadata-envoy/tags_history.md
- kubeflow-volumes-web-app/tags_history.md
- kyverno-policy-reporter/tags_history.md
- maven/tags_history.md
- newrelic-kube-events/tags_history.md
- newrelic-kubernetes/tags_history.md
- newrelic-prometheus-configurator/tags_history.md
- node/tags_history.md
- node-lts/tags_history.md
- openai/tags_history.md
- opensearch/tags_history.md
- php/tags_history.md
- prometheus-alertmanager/tags_history.md
- python/tags_history.md
- rqlite/tags_history.md
- ruby/tags_history.md
- rust/tags_history.md
- semgrep/tags_history.md
- solr/tags_history.md
- stunnel/tags_history.md
- tomcat/tags_history.md
- trino/tags_history.md
- zig/tags_history.md
- zookeeper/tags_history.md