### PR TITLE
Revert "Set up a DNS zone and GCLB for edu. (#1342)"

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -10,7 +10,7 @@ provider "google-beta" { project = var.project_id }
 
 module "networking" {
   source  = "chainguard-dev/common/infra//modules/networking"
-  version = "0.4.6"
+  version = "0.2.0"
 
   name       = var.name
   project_id = var.project_id
@@ -66,33 +66,6 @@ resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthent
   member   = "allUsers"
 }
 
-resource "google_dns_managed_zone" "edu-zone" {
-  project     = var.project_id
-  name        = "edu-chainguard-dev"
-  dns_name    = "edu.chainguard.dev."
-
-  dnssec_config {
-    state = "on"
-  }
-}
-
-// Put the above domain in front of our regional services.
-module "serverless-gclb" {
-  source  = "chainguard-dev/common/infra//modules/serverless-gclb"
-  version = "0.4.6"
-
-  name       = var.name
-  project_id = var.project_id
-  dns_zone   = google_dns_managed_zone.edu-zone.name
-
-  // Regions are all of the places that we have backends deployed.
-  // Regions must be removed from serving before they are torn down.
-  regions         = keys(module.networking.regional-networks)
-  serving_regions = keys(module.networking.regional-networks)
-
-  public-services = {
-    "edu.chainguard.dev" = {
-      name = var.name
-    }
-  }
+output "urls" {
+  value = { for k, v in google_cloud_run_v2_service.chainguard-academy : k => v.uri }
 }


### PR DESCRIPTION
This reverts commit 31cb9ce0d6bc6141c0f4e306d5863545060b8b53.

https://github.com/chainguard-dev/edu/actions/runs/7835486863/job/21380982712 wasn't happy with the terraform changes.