### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,4 +1,15 @@
 # 2024-02-09
+
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- filebeat/tags_history.md
+- prometheus-alertmanager/image_specs.md
+- prometheus-alertmanager/tags_history.md
+
+# 2024-02-09
 New images added:
 
 - filebeat

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-09 16:09:07
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 8th | `sha256:82e933c603f2c3c57632ef97bac2dd0b4afcc7b80b79605b6685662c09163b0c` |
-|  `latest`     | February 7th | `sha256:9abf72435102c546dd7dbe0ee96932641a8f4c0567e4306aa291fe759e8b0cb2` |
+|  `latest`     | February 9th | `sha256:fb6b046b007a39ba955f94d477900d8026996a1069389e1f528035da82a3396a` |
+|  `latest-dev` | February 9th | `sha256:75b70652876c333584fd5186a6aebdb2919a57a9e116b8bb2fabc8216fa7411c` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-09 16:09:07
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 8th | `sha256:1e5a833bc524cf5bcc4969e9ca484deea78fef787f4a547d7d7f55dd39984d0a` |
-|  `latest`     | February 8th | `sha256:dd4cd9bddd79dbda0d4630055a26b3f5196b9d9992bad62d4a794df454d95126` |
+|  `latest-dev` | February 9th | `sha256:b34a4248ee18a0ee3b85d476bfd3da58948fd7162e57cfd8466930edc68c0df1` |
+|  `latest`     | February 9th | `sha256:e0240b14739256518430d39e9820a5638caade0aa8700c450b4176e5ed78c306` |
 

--- a/content/chainguard/chainguard-images/reference/filebeat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/filebeat/tags_history.md
@@ -3,8 +3,8 @@ title: "filebeat Image Tags History"
 type: "article"
 unlisted: true
 description: "Image Tags and History for the filebeat Chainguard Image"
-date: 2024-02-09 00:19:29
-lastmod: 2024-02-09 00:19:29
+date: 2023-06-22T11:07:52+02:00
+lastmod: 2024-02-09 16:09:07
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed | Digest                                                                    |
 |---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 8th | `sha256:067f584793f903de0c0f190a6cf5d4766c2cf5e6250aa8e60d760fdbdebf45b6` |
-|  `latest-dev` | February 8th | `sha256:af377bbeaf75c9bac9ef0f8f863e221c4c5a7e6701357bfad8fa512ccd033a9d` |
+|  `latest-dev` | February 9th | `sha256:2c3da92e686de5b0b02372ba1475a3a74b82d5f27185db8fe921fa0b7c08327e` |
+|  `latest`     | February 9th | `sha256:c5422859fa69d96e5765911b0683437461dc0a322bebf787167ec9cecf6cd919` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public prometheus-alertmanager Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-08 00:18:32
+lastmod: 2024-02-09 16:09:07
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -31,12 +31,12 @@ The table has detailed information about each of these variants.
 
 |              | latest-dev                                                                      | latest                                                                          |
 |--------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| Default User | `nonroot`                                                                       | `nonroot`                                                                       |
+| Default User | `alertmanager`                                                                  | `alertmanager`                                                                  |
 | Entrypoint   | `/usr/bin/alertmanager`                                                         | `/usr/bin/alertmanager`                                                         |
 | CMD          | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` |
 | Workdir      | not specified                                                                   | not specified                                                                   |
-| Has apk?     | yes                                                                             | no                                                                              |
-| Has a shell? | yes                                                                             | no                                                                              |
+| Has apk?     | yes                                                                             | yes                                                                             |
+| Has a shell? | yes                                                                             | yes                                                                             |
 
 Check the [tags history page](/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history/) for the full list of available tags.
 
@@ -45,31 +45,33 @@ The table shows package distribution across variants.
 
 |                           | latest-dev | latest |
 |---------------------------|------------|--------|
-| `apk-tools`               | X          |        |
+| `apk-tools`               | X          | X      |
 | `bash`                    | X          |        |
-| `busybox`                 | X          |        |
+| `busybox`                 | X          | X      |
 | `ca-certificates-bundle`  | X          | X      |
 | `git`                     | X          |        |
-| `glibc`                   | X          |        |
-| `glibc-locale-posix`      | X          |        |
-| `ld-linux`                | X          |        |
+| `glibc`                   | X          | X      |
+| `glibc-locale-posix`      | X          | X      |
+| `ld-linux`                | X          | X      |
 | `libbrotlicommon1`        | X          |        |
 | `libbrotlidec1`           | X          |        |
-| `libcrypt1`               | X          |        |
-| `libcrypto3`              | X          |        |
+| `libcrypt1`               | X          | X      |
+| `libcrypto3`              | X          | X      |
 | `libcurl-openssl4`        | X          |        |
 | `libexpat1`               | X          |        |
 | `libidn2`                 | X          |        |
 | `libnghttp2-14`           | X          |        |
 | `libpcre2-8-0`            | X          |        |
 | `libpsl`                  | X          |        |
-| `libssl3`                 | X          |        |
+| `libssl3`                 | X          | X      |
 | `libunistring`            | X          |        |
 | `ncurses`                 | X          |        |
 | `ncurses-terminfo-base`   | X          |        |
-| `openssl-config`          | X          |        |
+| `openssl-config`          | X          | X      |
 | `prometheus-alertmanager` | X          | X      |
 | `wget`                    | X          |        |
+| `wolfi-base`              | X          | X      |
 | `wolfi-baselayout`        | X          | X      |
-| `zlib`                    | X          |        |
+| `wolfi-keys`              | X          | X      |
+| `zlib`                    | X          | X      |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-09 16:09:07
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,10 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)                          | Last Changed | Digest                                                                    |
-|----------------------------------|--------------|---------------------------------------------------------------------------|
-|  `latest`                        | February 8th | `sha256:727d8f53ac6607e6c525bfab114f1b84ea874eb4846df557b28738ecc614e3b3` |
-|  `latest-dev`                    | February 8th | `sha256:83644c34fc4ce71f7c18d3a3d4efec90b13fc27959972c1dbcb1903c8a246329` |
-|  `0.26` `0` `0.26.0`             | February 8th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
-|  `0.26.0-dev` `0.26-dev` `0-dev` | February 8th | `sha256:4268fea189faa0b9aa37d2ec3319df930ff8072465f72e1a424ded9470f2bdb5` |
+| Tag (s)                                       | Last Changed | Digest                                                                    |
+|-----------------------------------------------|--------------|---------------------------------------------------------------------------|
+|  `latest-dev` `0.26.0-dev` `0.26-dev` `0-dev` | February 9th | `sha256:4268fea189faa0b9aa37d2ec3319df930ff8072465f72e1a424ded9470f2bdb5` |
+|  `latest` `0.26` `0` `0.26.0`                 | February 9th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
 


### PR DESCRIPTION
Updated Docs:

- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- filebeat/tags_history.md
- prometheus-alertmanager/image_specs.md
- prometheus-alertmanager/tags_history.md