### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,75 @@
+# 2024-02-13
+
+
+Updated Docs:
+
+- atlantis/tags_history.md
+- aws-cli/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- caddy/tags_history.md
+- coredns/tags_history.md
+- dask-gateway-server/tags_history.md
+- falcoctl/tags_history.md
+- flux-source-controller/tags_history.md
+- gitlab-exporter/tags_history.md
+- gitlab-kas/tags_history.md
+- gitlab-pages/tags_history.md
+- gitlab-shell/tags_history.md
+- guacamole-server/tags_history.md
+- keda/tags_history.md
+- keda-adapter/tags_history.md
+- keda-admission-webhooks/tags_history.md
+- kubeflow-centraldashboard/image_specs.md
+- kubeflow-centraldashboard/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-api-server/tags_history.md
+- kubeflow-pipelines-cache-deployer/image_specs.md
+- kubeflow-pipelines-cache-deployer/tags_history.md
+- kubeflow-pipelines-cache-server/image_specs.md
+- kubeflow-pipelines-cache-server/tags_history.md
+- kubeflow-pipelines-frontend/image_specs.md
+- kubeflow-pipelines-frontend/tags_history.md
+- kubeflow-pipelines-metadata-envoy/image_specs.md
+- kubeflow-pipelines-metadata-envoy/tags_history.md
+- kubeflow-pipelines-metadata-writer/image_specs.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- kubeflow-pipelines-persistenceagent/image_specs.md
+- kubeflow-pipelines-persistenceagent/tags_history.md
+- kubeflow-pipelines-scheduledworkflow/image_specs.md
+- kubeflow-pipelines-scheduledworkflow/tags_history.md
+- kubeflow-pipelines-viewer-crd-controller/image_specs.md
+- kubeflow-pipelines-viewer-crd-controller/tags_history.md
+- management-api-for-apache-cassandra/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- newrelic-k8s-events-forwarder/tags_history.md
+- newrelic-kube-events/tags_history.md
+- newrelic-kubernetes/tags_history.md
+- nfs-subdir-external-provisioner/tags_history.md
+- node-lts/image_specs.md
+- node-lts/tags_history.md
+- opentelemetry-collector-contrib/tags_history.md
+- prometheus/tags_history.md
+- prometheus-alertmanager/_index.md
+- prometheus-alertmanager/image_specs.md
+- prometheus-alertmanager/tags_history.md
+- pulumi/image_specs.md
+- pulumi/tags_history.md
+- python/tags_history.md
+- slim-toolkit-debug/tags_history.md
+- solr/tags_history.md
+- sqlpad/image_specs.md
+- sqlpad/tags_history.md
+- statsd/image_specs.md
+- statsd/tags_history.md
+- traefik/tags_history.md
+- vector/tags_history.md
+
 # 2024-02-12
 
 

--- a/content/chainguard/chainguard-images/reference/atlantis/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/atlantis/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the atlantis Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 10th | `sha256:b5f32066fad97f7a53306ad553c52abea89597bd0c4575af067f4cf03083d7d2` |
-|  `latest-dev` | February 10th | `sha256:40603c240f658dfb69db75bc154824c2f999ec9c93e99e96647f81051509f014` |
+|  `latest`     | February 12th | `sha256:c4f2a9e174e38d3c0f0ddad62bdd0299c98a9c9cc338812f7a796e66595b5bd3` |
+|  `latest-dev` | February 12th | `sha256:6e01b26bc0b38ffced8fa6291227fbfb0f402d970cbed5ec7fe1645646809ca7` |
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 10th | `sha256:229cde5ef959adb95808bc99db22d50d62ab46f2190592ef6b4637a37b81b5e1` |
-|  `latest-dev` | February 10th | `sha256:528d976084af2568e5c5882fd90c74d399f4b623a80ebd4421438a79551d615d` |
+|  `latest-dev` | February 12th | `sha256:7446c00f10e32240bf8c6556da66c740c235f4ba8e6edf298aff468eac71e4c8` |
+|  `latest`     | February 12th | `sha256:db89a007f56721189a35db1636bafc37bd5b52edbdc38adc958f62a8eaf90a83` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:65933298f0158aa47003798e50b3cfce9fe60370c637cc514abd917023bedc44` |
-|  `latest`     | February 10th | `sha256:e1e47b385a936f26cd3310b02431004673520f2fde5f6ca6fb28dc749440a327` |
+|  `latest`     | February 12th | `sha256:708311719b3bb0a1e3d1335a5562bb414d2da0bd525a742a5ac208f3913635f9` |
+|  `latest-dev` | February 12th | `sha256:d977d759f5d5a0c51b4972282e08abb2e6e203510b2fe844b8c802ee9be7bbda` |
 

--- a/content/chainguard/chainguard-images/reference/caddy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/caddy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the caddy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,5 +26,4 @@ Please note that digests and timestamps only change when there is a change to th
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
 |  `latest-dev` | February 10th | `sha256:fc5faa60c37e38f029c1b7aaf2a225561f100b435c70927273b6857d2281cfb2` |
-|  `latest`     | January 13th  | `sha256:e8db4d902da983464c372ce48aab20c7209751793a3f85f0693c20e8c42e6986` |
 

--- a/content/chainguard/chainguard-images/reference/coredns/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/coredns/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the coredns Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,5 +26,4 @@ Please note that digests and timestamps only change when there is a change to th
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
 |  `latest-dev` | February 10th | `sha256:fddfe0e5173ddcc05f18590174337c0eadabea3f135b6aa85abbd0354b13ccaa` |
-|  `latest`     | January 12th  | `sha256:238f7d4cff40ffa7262ae5508481722fe3213e4aae1e61a1425f07f4ae2e4d71` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dask-gateway-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:b34f8655d802c7d76bc66da45e6e517ed57261e270ce93e91a3236a5fe84fba6` |
-|  `latest`     | February 7th  | `sha256:f147a3270fc789fe2f30e247acfb581ef906cac10c085918eec3a15b867ae872` |
+|  `latest`     | February 12th | `sha256:cd1967c321b6bece522273ee6a13c7cc24ad3dd10b406bd177988048cc4c495b` |
+|  `latest-dev` | February 12th | `sha256:504ee70e447f64735db34fd05e3efb3b671f97c3f93580758fa7315956488adf` |
 

--- a/content/chainguard/chainguard-images/reference/falcoctl/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/falcoctl/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the falcoctl Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:102595da921341fc0409aec7addcc1bbff6e872ea69b864491662bf73205c109` |
-|  `latest`     | January 31st  | `sha256:d20f7bef53ca03877072000a97b3633036020fce84544a3ea39e5a594a6c443d` |
+|  `latest-dev` | February 12th | `sha256:e1294b35d52041031924e1a258a3452fe7d6a9f624493392143dac19c332a0d1` |
+|  `latest`     | February 12th | `sha256:b2eed346041501d6d24eafc218d88b488b218f84756f53631dba51244bbcf103` |
 

--- a/content/chainguard/chainguard-images/reference/flux-source-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/flux-source-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the flux-source-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -28,5 +28,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `v1.2.4-dev` `v1.2-dev` `1.2-dev` `1-dev` `1.2.4-dev` `latest-dev` `v1-dev` | February 10th | `sha256:3544e6de30071b1c410b826b7a224f896a869a23df2d0f8baff1f51b2762cd9e` |
 |  `v1.2` `latest` `1.2` `1.2.4` `v1` `1` `v1.2.4`                             | February 1st  | `sha256:f2e7628451262b8e190b31477abd494d01555274b54242e46d4370609bf2dfc8` |
 |  `v1.2.3-dev` `1.2.3-dev`                                                    | January 31st  | `sha256:c07944d19115ac40a748e51bc1370c0180e25b31c72257e748c87f8467972965` |
-|  `v1.2.3` `1.2.3`                                                            | January 12th  | `sha256:8121513233b1c8859330b1e37def22150242e0ab0bae373ac75842914c3a950d` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:b48f08b8639279bb21a6c46654dd8ead10c4053f08b96b0270292b180ffb69b1` |
-|  `latest`     | February 9th  | `sha256:f2c14e750956016f1c118740bc27f6fcafd77dccf799c03d2bd2a74d09bcfbdc` |
+|  `latest`     | February 12th | `sha256:16b2e5d745688055af5f6c6da6d885e54987cb778855b66dd760974527120048` |
+|  `latest-dev` | February 12th | `sha256:788e2e18559e9b26ca92784b2ee7450064ed63f51d7a7141f6e1e3aafc2d6021` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-kas/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-kas/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-kas Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:7e03126625a027373aa18e995131fe30ccc8657d862571c9acd2c0626f72e572` |
+|  `latest-dev` | February 12th | `sha256:ad92e2ea2341987717f168f95e74d2587fa779c6018d752c2bf07f97bfdd6ee4` |
+|  `latest`     | February 12th | `sha256:a51d935c8f5bc09247126d8c50ae88cb267ebe04a2af155b898e092c44a07c58` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-pages Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:aa37a06216fac6f8055eefc9132b67a55005198c1233aa7050a683708d8d6952` |
-|  `latest`     | February 8th  | `sha256:fcbbcb095c2e268a5ffaf170259038cdd4cdc22961154ce7b5c9db26a509f027` |
+|  `latest`     | February 12th | `sha256:572672256df2c75b576e7cdf4ca54e498a81b107f66a9b56a213ab53a659080d` |
+|  `latest-dev` | February 12th | `sha256:317488a9542e6943f14381df0ac8b59b625ca2d283ea53033ba0c81474b1a01a` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-shell Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:3ce0c72fb12feab0d2b4e7b845e4d7a35d071c2264bdb6b9c5b8c3461304811f` |
-|  `latest`     | February 8th  | `sha256:37d69cdcc61b941fcb49fbd79240e991cc5d8fa7bf3f2b18d652b828824e1fb6` |
+|  `latest-dev` | February 12th | `sha256:65a074a3f91da98355a9e46d470050599409f555c761ba18ee8af683d02ba78b` |
+|  `latest`     | February 12th | `sha256:07b41370d62fd9d66f228fce10251b6f8343952f1584c93fbd815b7bc98b88a5` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the guacamole-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:4e46486ede4b8c6688391609d923d9dc84f102a2575eb7c8c28839106da30825` |
-|  `latest`     | February 8th  | `sha256:e5079e6c29849c4da034d65611104aa5e041f8c86a00c43164c2e026a8b95597` |
+|  `latest`     | February 12th | `sha256:154f33fe15bca81c73ca31b5428dce4372d2f653d5a4ba2d0b190572a635aeea` |
+|  `latest-dev` | February 12th | `sha256:f782420b67963463d856cd15ef9236b7b87dd8f63d64d12d90f825010fda5c80` |
 

--- a/content/chainguard/chainguard-images/reference/keda-adapter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda-adapter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda-adapter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -28,5 +28,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `latest-dev` `2.13-dev` `2.13.0-dev` `2-dev` | February 10th | `sha256:0262efa558e2c355ab0f5b494dc1a48ff73e966960371dafce1aa544ef84688a` |
 |  `2` `2.13` `latest` `2.13.0`                 | February 8th  | `sha256:dc0e0023029ea203ad26b12e782d14b1e6373a395d2c06ee84035a7dddf3fcff` |
 |  `2.12.1-dev` `2.12-dev`                      | January 15th  | `sha256:17d90d69174bb40fe90597afb80f2298c1d6093102bac5d787ea9fe01b9f88a0` |
-|  `2.12.1` `2.12`                              | January 13th  | `sha256:407fc264d2e4ba2578f00478b9f5d8113cdf49682c46da8e23992a26fb8a32e5` |
 

--- a/content/chainguard/chainguard-images/reference/keda-admission-webhooks/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda-admission-webhooks/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda-admission-webhooks Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -28,5 +28,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `latest-dev` `2.13.0-dev` `2-dev` `2.13-dev` | February 10th | `sha256:c645e40c27a002157a31898b52330a988c2df7edc0c1916ed66c4b0d14c912b9` |
 |  `latest` `2` `2.13` `2.13.0`                 | February 8th  | `sha256:d990781b50485feb006ff9237b30b118aa39fb3ec1551a0a09c351e6780b206d` |
 |  `2.12-dev` `2.12.1-dev`                      | January 15th  | `sha256:70da4f0d71c648d6fbb1455fe15ccc1148cfa2808df8a73ee4197853ed4f702d` |
-|  `2.12.1` `2.12`                              | January 13th  | `sha256:418dec53221c20257b7b8b169777dd522027594b60677fb9e1e28b506ff967d4` |
 

--- a/content/chainguard/chainguard-images/reference/keda/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/keda/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the keda Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -28,5 +28,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `2.13.0-dev` `latest-dev` `2-dev` `2.13-dev` | February 10th | `sha256:63c41726e31a6216c6242925da267227d0fd1cd470bc35b1d0fd20f42b42f92d` |
 |  `2` `latest` `2.13` `2.13.0`                 | February 8th  | `sha256:6b9f4c0d234e59cd77266ce563948655140ea64cdfe0f499ae3f3bd317c56fbc` |
 |  `2.12.1-dev` `2.12-dev`                      | January 15th  | `sha256:4b637da1fa948fa1f572b95daf176810e4e9857a521511c7da99a4627ef625b1` |
-|  `2.12.1` `2.12`                              | January 13th  | `sha256:a1c78614d6a09e666c44832caaa2b4cfae22215d711425ff4efce7553211d1ef` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-centraldashboard Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-08 00:18:32
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -71,6 +71,7 @@ The table shows package distribution across variants.
 | `libssl3`                   | X          | X      |
 | `libstdc++`                 | X          | X      |
 | `libunistring`              | X          |        |
+| `libuv`                     | X          | X      |
 | `ncurses`                   | X          |        |
 | `ncurses-terminfo-base`     | X          |        |
 | `nodejs-18`                 | X          | X      |

--- a/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-centraldashboard/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-centraldashboard Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:8cfecd1de5e871f9e2e3335f0e30e22d45ae5bd967c58a4d2dded27d96c3baff` |
-|  `latest`     | February 8th  | `sha256:7b49c260cfec38fdf95432fe5eac9b1cca287fb28d652f56e8e8ccdf4867df22` |
+|  `latest-dev` | February 12th | `sha256:b78c525aff14ed5df241be1ff0a435cfef3d7cd41de64966f5588c382eeb95b4` |
+|  `latest`     | February 12th | `sha256:3bc9a09a45c2af8178c6a62d7c8042a134fd6640b1c2a764f4745be46c7f4085` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-earlystopping-medianstop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16-dev` `0.16.0-dev` `latest-dev` `0-dev` | February 10th | `sha256:e32d3b48d3c152a0b724f911b45619451785748c13a139486425ba388de41ca2` |
-|  `0` `latest` `0.16.0` `0.16`                 | February 7th  | `sha256:f679e6eeb9346fe357949f959b7c8beaa7ade69053bc0d5fe3cda70286a97097` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 13th | `sha256:d5933ab0d525db2f20091c269b77f4f698589f45990897b16c7f465c3070256f` |
+|  `latest` `0` `0.16.0` `0.16`                 | February 13th | `sha256:97730b78cc2426716b66cc31ce2a33dbc96fb15014995df6226eae180d59e41e` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-darts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` `0-dev` `0.16.0-dev` `0.16-dev` | February 10th | `sha256:24854590df717ef3dd513bd7601cbf91fb5addc4793b081d28382c70f020e554` |
-|  `latest` `0` `0.16` `0.16.0`                 | February 7th  | `sha256:bcd2e53a7315f2140cc96b13e3457e1d21803b02ba368763e2fe57b1afe4f5ab` |
+|  `0.16.0-dev` `0.16-dev` `latest-dev` `0-dev` | February 13th | `sha256:60f4f298a7e1f9b225448f52cdd729b498ea542140a7b3c97349a794999a9de6` |
+|  `0.16.0` `latest` `0.16` `0`                 | February 13th | `sha256:951e448f6a7df4707f72f1a7480dba9c3f99349517b3b762f8e3f78ebfd42dc2` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperband Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0-dev` `0.16-dev` `latest-dev` | February 10th | `sha256:5707bb3057b7cfbeb10b5148bf8199a2f363db7121f54bbbbd8e988bd7ce3dd4` |
-|  `0.16.0` `0` `latest` `0.16`                 | February 8th  | `sha256:9b2ce59eb3464986463e8572b0d1816c023e03d9e07af941426a532f46396813` |
+|  `latest-dev` `0.16.0-dev` `0.16-dev` `0-dev` | February 13th | `sha256:5379ec888b24e78e28dcc74464ef5a9e6509c31870d21a936c9662d5afd21230` |
+|  `0.16.0` `0.16` `0` `latest`                 | February 13th | `sha256:39c2546e94c739505cb97059c85049b693fc9761baa2322dbfa810117da03c45` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0-dev` `0.16-dev` `latest-dev` | February 10th | `sha256:50181117a5a3059e620c4ef60bc73b151bef5757f730362807f9300c4ea96e16` |
-|  `0` `0.16` `latest` `0.16.0`                 | February 7th  | `sha256:d15630311cc744903ccd740c1fa19eb5a8a3e3725e1b765bd4e4c1244f2ebe7d` |
+|  `latest` `0` `0.16.0` `0.16`                 | February 13th | `sha256:5e02639394fa9f2482cbb40842fa2e56c4b90eb0808ddac2f5cbcbe1cc65e45c` |
+|  `0.16-dev` `0-dev` `latest-dev` `0.16.0-dev` | February 13th | `sha256:598549b4231878bceb49de0a068e4d2b7d93bdcd16bb03b959cc54329cd41ced` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-optuna Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16-dev` `0-dev` `latest-dev` `0.16.0-dev` | February 10th | `sha256:6ecf938db02002499110b60ebc80c50388b23471d2e103d4119bac0e6e599935` |
-|  `0` `latest` `0.16` `0.16.0`                 | February 7th  | `sha256:701bf7d9f6d37184a0b885f77018be64e353bf6af09cb5cf93bed061f259c008` |
+|  `0-dev` `0.16-dev` `0.16.0-dev` `latest-dev` | February 13th | `sha256:00b85e2f08f1b65571ab26cf6400c84ae028ed9b2ffe44578c67997af5efc0ee` |
+|  `latest` `0.16.0` `0.16` `0`                 | February 13th | `sha256:05f222a1420a55542396aae6ea371f59240660d67916cfe6ae9c166fb3d82916` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-pbt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0-dev` `0.16-dev` `latest-dev` `0.16.0-dev` | February 10th | `sha256:e9b99cfa5cf5d33fa5e403583e5bb6f849d2bdbda3d21fdd5b64df112145e61d` |
-|  `latest` `0.16` `0.16.0` `0`                 | February 7th  | `sha256:3b4ba88d171d963a98d8cc5ac8ec4df40167bf395e52fcd3915d9f3d423652ed` |
+|  `0.16.0` `0` `latest` `0.16`                 | February 13th | `sha256:2073af73940440d878812f8ce9a24c9171ab7b978e01291d9f120879866734d9` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 13th | `sha256:9073906e4653ebfd352e9dfa82850af0dea89e60acc786295f744fbe4977a269` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-skopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16-dev` `0-dev` `0.16.0-dev` `latest-dev` | February 10th | `sha256:236db77d0b4f91c8eb4177f917c558159bbbf98df355262883e07c328cb8293c` |
-|  `0.16` `0` `latest` `0.16.0`                 | February 7th  | `sha256:dac68c73753391148d0e930b3155796dbb55a918d87e87633ac2d6fc33f0ad0f` |
+|  `0` `latest` `0.16.0` `0.16`                 | February 13th | `sha256:a671726eaa0bd3efad1659301c79f4362f8ba37d37f5a0d307435158dd1f01ff` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 13th | `sha256:c1df15c33c082e82a9c0974b3f8ae01f9982fa86aad1a1da3809caebc9ef5f90` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-api-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-api-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-api-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:efdf4306b07919ebd7dac6c5a7a30e08b1acb519f8612f3d942c19d7ddb4f0c9` |
-|  `latest-dev` | January 31st | `sha256:a0c6bd0fb528c017faf5581bc34c0da6128880ddae5a2c1d1f9da971ed210a00` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:ebb3849314816654fe43da352343a8419313d3bb31576502e0fd1a1ec851fd40` |
+|  `latest-dev` | February 12th | `sha256:f2993c4e0e73396e0178d9a3dab8bcfb1653c50fe67704883750e29e2faf9eff` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-cache-deployer Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -74,6 +74,7 @@ The table shows package distribution across variants.
 | `openssl`                                  | X          | X      |
 | `openssl-config`                           | X          | X      |
 | `openssl-provider-legacy`                  | X          | X      |
+| `wget`                                     | X          |        |
 | `wolfi-baselayout`                         | X          | X      |
 | `zlib`                                     | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-deployer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-cache-deployer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:6a6e12fa1baafaf5de0e48aa610a1df7fa22139e29c5a1b58c8d37f9f20c383d` |
-|  `latest`     | January 31st | `sha256:be0bffff18a58e621866e737e5548d3ca8311e4ea37c98be0452f9066bc57ff8` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 12th | `sha256:d0db0663663102d86a3b1a52f058fa9895cc0f14ee6be5e3e1fdbf924e080376` |
+|  `latest`     | February 12th | `sha256:487dec8215eef540ef6bad425487e160f8e8f5791a24e99ff03910743e2cf399` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-cache-server Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-12 00:39:30
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -69,6 +69,7 @@ The table shows package distribution across variants.
 | `ncurses`                         | X          |        |
 | `ncurses-terminfo-base`           | X          |        |
 | `openssl-config`                  | X          |        |
+| `wget`                            | X          |        |
 | `wolfi-baselayout`                | X          | X      |
 | `zlib`                            | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-cache-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-cache-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | January 31st | `sha256:e70e01588f2245c821725707260b0e06cb72fb50d8269bbee2a8f1ddcea5ab72` |
-|  `latest-dev` | January 31st | `sha256:26e8bffcf7131683099767295f2d69ece10eb37245dac551f965a935ff15fdfe` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 12th | `sha256:9c503f39925a111c02a14601de0d774004cd2f4e129d525e5fcb063bc68d5904` |
+|  `latest`     | February 12th | `sha256:f6d81d288fc4330580a805aaf4dd9e71cbdd27419ce65d244986dfece617b730` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-frontend Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -71,6 +71,7 @@ The table shows package distribution across variants.
 | `libssl3`                     | X          | X      |
 | `libstdc++`                   | X          | X      |
 | `libunistring`                | X          |        |
+| `libuv`                       | X          | X      |
 | `ncurses`                     | X          |        |
 | `ncurses-terminfo-base`       | X          |        |
 | `nodejs-20`                   | X          | X      |

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-frontend/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-frontend Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:cc51964e13e52bcf99bb0db7a92d7c8dfe8b996c4618e63bad0d9e7ae8141421` |
-|  `latest`     | January 31st | `sha256:7287cde0b178b3b1b4da9cf17125348f377f2a7cf5ea63c07e26d60896cd972a` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:e510a2d7b83af4559e10323c353dd3784671777c2fe52371bc866cd62c0ab6c4` |
+|  `latest-dev` | February 12th | `sha256:f70a592cc041c0ad3a29c5eaba94e8b022d722e4490eb4ca570acd10f2740599` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-metadata-envoy Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-30 00:32:13
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -78,6 +78,7 @@ The table shows package distribution across variants.
 | `openssl`                                  | X          | X      |
 | `openssl-config`                           | X          | X      |
 | `openssl-provider-legacy`                  | X          | X      |
+| `wget`                                     | X          |        |
 | `wolfi-baselayout`                         | X          | X      |
 | `xz`                                       | X          | X      |
 | `zlib`                                     | X          | X      |

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-envoy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-envoy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-06 00:18:29
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 5th | `sha256:20745af22dc727b15c0ca2063b7f3f085eec7798f6e66b719f5479e7f2c0c54a` |
-|  `latest`     | February 5th | `sha256:fa37f8f3437c6267aa863d7ecb14760b3da236ae8923f924c01cc3f948d59ad6` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 12th | `sha256:07a8cc004646b1be97d41ed3539b4b290c8c91de7807f9b256e268a889752519` |
+|  `latest`     | February 12th | `sha256:4ba17d2f46056d42a861a4000c4e56cbc5302f7e609f1d0f4f4f6db894db3b20` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-metadata-writer Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-25 00:19:46
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -113,6 +113,7 @@ The table shows package distribution across variants.
 | `re2`                                       | X          | X      |
 | `readline`                                  | X          | X      |
 | `sqlite-libs`                               | X          | X      |
+| `wget`                                      | X          |        |
 | `wolfi-baselayout`                          | X          | X      |
 | `xz`                                        | X          | X      |
 | `yaml`                                      | X          | X      |

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-writer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 2nd | `sha256:b912a079e5b5626ef1868eea970248f412a5a45a8a7ea16736e84c1328b44d24` |
-|  `latest-dev` | February 2nd | `sha256:c9c643e5953f7822f9f003d772e6215e3775373c6da08103ebfe427bad8ebcbd` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:dc68949e93f61b6a9d54536ab7792f8885fe9211ad5bbcc343cace8f2c0d3637` |
+|  `latest-dev` | February 12th | `sha256:64e7a97c62b84d423109ba72fe867e5a0dfd1314475d6e173b0269c8bfad209e` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-persistenceagent Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-12 00:39:30
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -69,6 +69,7 @@ The table shows package distribution across variants.
 | `ncurses`                              | X          |        |
 | `ncurses-terminfo-base`                | X          |        |
 | `openssl-config`                       | X          |        |
+| `wget`                                 | X          |        |
 | `wolfi-baselayout`                     | X          | X      |
 | `zlib`                                 | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-persistenceagent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-persistenceagent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:c955e0748a721fe86dc1aa5ccfc53ad5be03094ae9f3e1c740579cd77316a3eb` |
-|  `latest`     | January 31st | `sha256:b9fed08fc45df104abbb6d1d467d6f3e96f980242ea0c99354b5e8d8cef30a81` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:358d4a2a4bf947e431ffead83f5a03286e166db7fb1bba814a5aab5e06c55f66` |
+|  `latest-dev` | February 12th | `sha256:c17ba58d0037025d898ec57a8cdbfc3e40795c4c6164cccce0fcc5c435ecf4cb` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-scheduledworkflow Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -69,6 +69,7 @@ The table shows package distribution across variants.
 | `ncurses`                              | X          |        |
 | `ncurses-terminfo-base`                | X          |        |
 | `openssl-config`                       | X          |        |
+| `wget`                                 | X          |        |
 | `wolfi-baselayout`                     | X          | X      |
 | `zlib`                                 | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-scheduledworkflow/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-scheduledworkflow Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:bfbb9416ae9bae4739afed2dc20685e3da97d725d8dc14573bbec9c09a990ff8` |
-|  `latest`     | January 31st | `sha256:f98c6ece3acf8b03db52ee9c4e14912b72127802ff3c07fe0ba1fbd738bfa338` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:e2196458a30ab50097f3fe5c5f593d3d96471ce1d483ec1bd2987252c9470892` |
+|  `latest-dev` | February 12th | `sha256:4908ee5378dbccd0400638d7cd264f541604b5309cc09973575fc9a65279456e` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public kubeflow-pipelines-viewer-crd-controller Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -69,6 +69,7 @@ The table shows package distribution across variants.
 | `ncurses`                                  | X          |        |
 | `ncurses-terminfo-base`                    | X          |        |
 | `openssl-config`                           | X          |        |
+| `wget`                                     | X          |        |
 | `wolfi-baselayout`                         | X          | X      |
 | `zlib`                                     | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-viewer-crd-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-viewer-crd-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | January 31st | `sha256:7e6f5c77ed3d458be9707648e5b4a28090bbf2ec0f2594771adbea611c9742ef` |
-|  `latest`     | January 31st | `sha256:2053c02bf77e3c20836e0c9e06779ad02b6b90726708ef48d7599e6cf164e55c` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest`     | February 12th | `sha256:34642d95f3ee60330f8062410bf72ef2e015053fa387dcfc8800790c0725459a` |
+|  `latest-dev` | February 12th | `sha256:aff604927639e6f766b7190ceac1242c8c58301533f032fdc933f6fae49c9d89` |
 

--- a/content/chainguard/chainguard-images/reference/management-api-for-apache-cassandra/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/management-api-for-apache-cassandra/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the management-api-for-apache-cassandra Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:55873e00ef5ba48312b21d0834dac3c116d0b67f3dc0b22c62d02e667b4cbe9f` |
-|  `latest`     | February 9th  | `sha256:a23ba7d5e7c4cadbe8e24d4286dca910558d1e5425288e8fed50c4915eded201` |
+|  `latest`     | February 12th | `sha256:6f9167d81dd6446bc092c2cf4fda907e11e796ba94fe7faea8602faa4115331b` |
+|  `latest-dev` | February 12th | `sha256:e9ba3b507572379ce47413671408fba93cb259564cd26fdf0b9695b431702ce7` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-infrastructure-bundle Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:f736d38acfcde8250d40f0a591fe062dded929047b0bacb00a4870466e25bbff` |
-|  `latest`     | February 8th  | `sha256:f5b0ef1ed3fa5814592095f6325020027ab0da39de647ccfd222867ed974e0be` |
+|  `latest`     | February 12th | `sha256:e765d040bc22c39f877ae05aaea5ef6142f192b9ea3f590b557e56c7a8252d73` |
+|  `latest-dev` | February 12th | `sha256:2575f6fcf1e4ce71164c2bb70860ec89289bd7e42ff159e27ad8b0b6bbd1795e` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-k8s-events-forwarder/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-k8s-events-forwarder/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-k8s-events-forwarder Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:a030ec3d9a924d9765f06afcdebb3296738641ad65683e701736bf97d25cc678` |
-|  `latest`     | February 7th  | `sha256:acb55de3095dec560c19186c2a1f78a7dccb39daa6b3ded9b731279fb4645758` |
+|  `latest`     | February 12th | `sha256:a0845e1f0c425824bd117f52b53fc384223219be30eeacc000111938646c23a6` |
+|  `latest-dev` | February 12th | `sha256:556bf6da31005d9888c5620734544008eb38bc8ea17b647ed57826105d006fe9` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kube-events/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-kube-events Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:f4a63656768f017fd3fcd2bdad8f2640fb2687d1b85dd26b8846586af171ed28` |
-|  `latest`     | February 8th  | `sha256:e8ab949bf67cef3f8fa1a067b15e38c143dfaccbd4d8b45657ebbf9ee6df4b8b` |
+|  `latest-dev` | February 12th | `sha256:d09eee421a450872409e112d53467f93cee97addc56c25a6172c27790741e625` |
+|  `latest`     | February 12th | `sha256:36f15d08b1fb3e0e221a0232a1aa5db02cab45cb74d97081f8544ad6d4c49137` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-kubernetes/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-kubernetes Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:ddacd41049bac38faf1ceb4742a93258bc5c40b9ace62a6875ddc3a335786ef9` |
-|  `latest`     | February 8th  | `sha256:e2aae94072a5a4441210cc28159d0facd751407baaff8be91bfe05cf4dee38a7` |
+|  `latest-dev` | February 12th | `sha256:f622e8ec2a5366828f84af389a9dae1c969ddc9eba026f80927adf34be1becb3` |
+|  `latest`     | February 12th | `sha256:74b12d079d69c9bf979b11d0f0ef879bb09a8fc052e44266a2528c2176f9342b` |
 

--- a/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the nfs-subdir-external-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:214d3dd3a4c30283f23106dcca6efce15072d231a7fe17b6127ee7262974d5d7` |
-|  `latest`     | February 8th  | `sha256:04cf339dbab5768e54564f072403f7c8211c200a12a0ec5ec4167aafbe14044f` |
+|  `latest-dev` | February 12th | `sha256:65a56033ff1e4c3004ac2d933c3b047fbaad42328a9986de873377c5f7766b03` |
+|  `latest`     | February 12th | `sha256:ce474be7e5ca8b5de28ab1a313af235cb4af085390e676668016a2c04afc9eaa` |
 

--- a/content/chainguard/chainguard-images/reference/node-lts/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public node-lts Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-08 00:18:32
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -84,6 +84,7 @@ The table shows package distribution across variants.
 | `libstdc++`              | X          | X      |
 | `libstdc++-dev`          | X          |        |
 | `libunistring`           | X          |        |
+| `libuv`                  | X          | X      |
 | `linux-headers`          | X          |        |
 | `make`                   | X          |        |
 | `mpc`                    | X          |        |

--- a/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-lts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node-lts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:f904f72d6f51f653dd8e1895cc06205e2c033fcfefb0e2c081c80e5e7ae71a8d` |
-|  `latest`     | February 8th  | `sha256:4319dda8d2964e94f9f3f09371454c9a144d862469ec4d7041424ad699205d9d` |
+|  `latest-dev` | February 12th | `sha256:3ef6a580d975fd306c83d05b0648f5dbeee24f248ab3747570639c30eeffb8b4` |
+|  `latest`     | February 12th | `sha256:bc095c329bc1d41f9feb2619c2f6b9db02a5138be88b03f52dfef5026f9de031` |
 

--- a/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the opentelemetry-collector-contrib Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 8th | `sha256:5afc03980fc4226c38350af13d13258841785e6fbb69da3efe0e9a23a9043204` |
-|  `latest`     | February 7th | `sha256:1f146bc5afe47e265868bc36b81f143fa461ea52510a1416268eb51d951cd447` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 12th | `sha256:e6f5226aa89e1410a6d24ff6b64fc7e92d9d89d614533a75f8e2b2dde31a306d` |
+|  `latest`     | February 12th | `sha256:daf7507c260b1438cb4751f4f9da1252455ad8a8536087bd05e0508c208d465c` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/_index.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: prometheus-alertmanager Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,7 +26,7 @@ toc: true
 
 
 <!--overview:start-->
-Minimal Prometheus Image
+Minimalist Wolfi-based image for Prometheus Alertmanager. Handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing to the correct receiver.
 <!--overview:end-->
 
 <!--getting:start-->
@@ -34,45 +34,94 @@ Minimal Prometheus Image
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/prometheus:latest
+docker pull cgr.dev/chainguard/prometheus-alertmanager:latest
 ```
 <!--getting:end-->
 
 <!--body:start-->
+
 ## Usage
+For full instructions on prometheus-alertmanager, refer to the
+[official documentation](https://prometheus.io/docs/alerting/latest/alertmanager).
+The GitHub repository can also be [found here](https://github.com/prometheus/alertmanager).
 
-This requires a prometheus configuration file to run.
-An example is provided at `/etc/prometheus/prometheus.yml`.
-The values from this example can be found in the [Prometheus source tree](https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus.yml).
+### Default config settings
+The upstream docker image, overrides some of the default values for
+alertmanager, for example, [see here](https://github.com/prometheus/alertmanager/blob/main/Dockerfile#L20).
+We replicate the same behaviour in the chainguard image to provide parity with
+the upstream image.
 
-THe default port that prometheus listens on is 9090.
-The web browser can be viewed locally over that port by mapping that in with `-p 9090:9090`.
+### Helm
+To deploy via helm, please refer to the upstream
+[helm charts documentation](https://github.com/prometheus-community/helm-charts)
+for comprehensive instructions, which includes
+[supported parameters](https://github.com/prometheus-community/helm-charts/blob/main/charts/alertmanager/values.yaml).
 
-To test:
+Below is an example of how to use the helm chart, overriding the image with the
+chainguard image:
 
-```shell
-% docker run -p 9090:9090 cgr.dev/chainguard/prometheus:latest --config.file=/etc/prometheus/prometheus.yml
-ts=2022-12-27T02:32:45.181Z caller=main.go:512 level=info msg="No time or size retention was set so using the default time retention" duration=15d
-ts=2022-12-27T02:32:45.181Z caller=main.go:556 level=info msg="Starting Prometheus Server" mode=server version="(version=2.41.0, branch=master, revision=WolfiLinux)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:561 level=info build_context="(go=go1.19.4, platform=linux/arm64, user=@dag-wfjfq, date=19700101-00:00:00)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:562 level=info host_details="(Linux 5.10.104-linuxkit #1 SMP PREEMPT Thu Mar 17 17:05:54 UTC 2022 aarch64 98fc282ede4c (none))"
-ts=2022-12-27T02:32:45.181Z caller=main.go:563 level=info fd_limits="(soft=1048576, hard=1048576)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:564 level=info vm_limits="(soft=unlimited, hard=unlimited)"
-ts=2022-12-27T02:32:45.183Z caller=web.go:559 level=info component=web msg="Start listening for connections" address=0.0.0.0:9090
-ts=2022-12-27T02:32:45.184Z caller=main.go:993 level=info msg="Starting TSDB ..."
-ts=2022-12-27T02:32:45.185Z caller=tls_config.go:232 level=info component=web msg="Listening on" address=[::]:9090
-ts=2022-12-27T02:32:45.185Z caller=tls_config.go:235 level=info component=web msg="TLS is disabled." http2=false address=[::]:9090
-ts=2022-12-27T02:32:45.185Z caller=head.go:562 level=info component=tsdb msg="Replaying on-disk memory mappable chunks if any"
-ts=2022-12-27T02:32:45.186Z caller=head.go:606 level=info component=tsdb msg="On-disk memory mappable chunks replay completed" duration=1.417µs
-ts=2022-12-27T02:32:45.186Z caller=head.go:612 level=info component=tsdb msg="Replaying WAL, this may take a while"
-ts=2022-12-27T02:32:45.186Z caller=head.go:683 level=info component=tsdb msg="WAL segment loaded" segment=0 maxSegment=0
-ts=2022-12-27T02:32:45.186Z caller=head.go:720 level=info component=tsdb msg="WAL replay completed" checkpoint_replay_duration=21.5µs wal_replay_duration=473.791µs wbl_replay_duration=84ns total_replay_duration=509.416µs
-ts=2022-12-27T02:32:45.187Z caller=main.go:1014 level=info fs_type=794c7630
-ts=2022-12-27T02:32:45.187Z caller=main.go:1017 level=info msg="TSDB started"
-ts=2022-12-27T02:32:45.188Z caller=main.go:1197 level=info msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
-ts=2022-12-27T02:32:45.188Z caller=main.go:1234 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml totalDuration=434.958µs db_storage=875ns remote_storage=709ns web_handler=208ns query_engine=417ns scrape=123.25µs scrape_sd=15.084µs notify=17.208µs notify_sd=5.75µs rules=1.208µs tracing=2.875µs
-ts=2022-12-27T02:32:45.188Z caller=main.go:978 level=info msg="Server is ready to receive web requests."
-ts=2022-12-27T02:32:45.188Z caller=manager.go:953 level=info component="rule manager" msg="Starting rule manager..."
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+helm install prom-alertmanager prometheus-community/alertmanager \
+ --set image.repository=cgr.dev/chainguard/prometheus-alertmanager \
+ --set image.tag=latest
 ```
+
+The [upstream helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager)
+provides some default `config:` values, but if you intend to deploy with
+additional configuration, i.e defining routes and receivers, you'll need to
+create your own custom values.yaml and pass this into the chart at deployment.
+
+### Docker
+
+#### Create config file
+Before running the container, you'll need to create a configuration file. This
+contains all the necessary configurations for Alertmanager, such as alerting
+routes, receivers, and integrations.
+
+Refer to the [official documentation](https://prometheus.io/docs/alerting/latest/alertmanager)
+for more information. Below is a simple example:
+
+```yaml
+# Save this as 'alertmanager.yml')
+global:
+  resolve_timeout: 11m
+  pagerduty_url: https://example-pagerduty.com/v2/test
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10m
+  repeat_interval: 1h
+receivers:
+  - name: 'example-webhook'
+    webhook_configs:
+    - url: 'http://example.com/hook'
+```
+
+In order to ensure the 'nonroot' container user can access the file when
+volume mounted (below step), ensure you've set read-only permissions:
+
+```bash
+chmod 400 alertmanager.ym
+```
+
+#### Run container
+
+> **IMPORTANT**: Prometheus looks for a file mounted as 'alertmanager.yml' (i.e not .yaml).
+
+```bash
+# TODO: Update '$(pwd)/alertmanager.yml' accordingly to reference your locally
+# created config file.
+docker run -p 9093:9093 \
+  -v $(pwd)/alertmanager.yml:/etc/alertmanager/alertmanager.yml \
+  --name alertmanager \
+  cgr.dev/chainguard/prometheus-alertmanager:latest
+```
+
+Verify that Alertmanager is running correctly by accessing http://localhost:9093
+on your browser.
+
 <!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public prometheus-alertmanager Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-09 16:09:07
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -31,12 +31,12 @@ The table has detailed information about each of these variants.
 
 |              | latest-dev                                                                      | latest                                                                          |
 |--------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| Default User | `alertmanager`                                                                  | `alertmanager`                                                                  |
+| Default User | `nonroot`                                                                       | `nonroot`                                                                       |
 | Entrypoint   | `/usr/bin/alertmanager`                                                         | `/usr/bin/alertmanager`                                                         |
 | CMD          | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` |
 | Workdir      | not specified                                                                   | not specified                                                                   |
-| Has apk?     | yes                                                                             | yes                                                                             |
-| Has a shell? | yes                                                                             | yes                                                                             |
+| Has apk?     | yes                                                                             | no                                                                              |
+| Has a shell? | yes                                                                             | no                                                                              |
 
 Check the [tags history page](/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history/) for the full list of available tags.
 
@@ -45,33 +45,31 @@ The table shows package distribution across variants.
 
 |                           | latest-dev | latest |
 |---------------------------|------------|--------|
-| `apk-tools`               | X          | X      |
+| `apk-tools`               | X          |        |
 | `bash`                    | X          |        |
-| `busybox`                 | X          | X      |
+| `busybox`                 | X          |        |
 | `ca-certificates-bundle`  | X          | X      |
 | `git`                     | X          |        |
-| `glibc`                   | X          | X      |
-| `glibc-locale-posix`      | X          | X      |
-| `ld-linux`                | X          | X      |
+| `glibc`                   | X          |        |
+| `glibc-locale-posix`      | X          |        |
+| `ld-linux`                | X          |        |
 | `libbrotlicommon1`        | X          |        |
 | `libbrotlidec1`           | X          |        |
-| `libcrypt1`               | X          | X      |
-| `libcrypto3`              | X          | X      |
+| `libcrypt1`               | X          |        |
+| `libcrypto3`              | X          |        |
 | `libcurl-openssl4`        | X          |        |
 | `libexpat1`               | X          |        |
 | `libidn2`                 | X          |        |
 | `libnghttp2-14`           | X          |        |
 | `libpcre2-8-0`            | X          |        |
 | `libpsl`                  | X          |        |
-| `libssl3`                 | X          | X      |
+| `libssl3`                 | X          |        |
 | `libunistring`            | X          |        |
 | `ncurses`                 | X          |        |
 | `ncurses-terminfo-base`   | X          |        |
-| `openssl-config`          | X          | X      |
+| `openssl-config`          | X          |        |
 | `prometheus-alertmanager` | X          | X      |
 | `wget`                    | X          |        |
-| `wolfi-base`              | X          | X      |
 | `wolfi-baselayout`        | X          | X      |
-| `wolfi-keys`              | X          | X      |
-| `zlib`                    | X          | X      |
+| `zlib`                    | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest` `0.26` `0` `0.26.0`                 | February 11th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
-|  `latest-dev` `0-dev` `0.26-dev` `0.26.0-dev` | February 11th | `sha256:4b20efb3fb96c0c96fafc551c8951f64e04510488d8095ab51d8b7db4891545f` |
+|  `latest-dev` `0-dev` `0.26-dev` `0.26.0-dev` | February 12th | `sha256:4b20efb3fb96c0c96fafc551c8951f64e04510488d8095ab51d8b7db4891545f` |
+|  `latest` `0.26` `0` `0.26.0`                 | February 12th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -30,5 +30,4 @@ Please note that digests and timestamps only change when there is a change to th
 |  `2.49.0-dev`                                 | January 15th  | `sha256:aab44022797cb4ce8d8fd175a1050710f532886c4ef8384fcabc2116bd2655ae` |
 |  `2.49.0`                                     | January 15th  | `sha256:95f2c499c2dc78eb8e88ce744f4ac374f2105632da39663edc8a1a6af5b6125d` |
 |  `2.48-dev` `2.48.1-dev`                      | January 15th  | `sha256:53d7547c7869a07f33054fa3b2de9f54bb00eb8371654ed42f47bc0469e15194` |
-|  `2.48.1` `2.48`                              | January 13th  | `sha256:e153ea7d07625680a34669a4b36f2c52ed16a218a0598cdc7be9589e1c6bbba1` |
 

--- a/content/chainguard/chainguard-images/reference/pulumi/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public pulumi Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-08 00:18:32
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -101,6 +101,7 @@ The table shows package distribution across variants.
 | `libtasn1`                | X      |
 | `libunistring`            | X      |
 | `libunwind`               | X      |
+| `libuv`                   | X      |
 | `linux-headers`           | X      |
 | `lttng-ust`               | X      |
 | `make`                    | X      |

--- a/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/pulumi/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the pulumi Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 10th | `sha256:d63a02a3c7afc417a5d49f17e85d1f504bed6d9e96c7043819d32c29d7d476e6` |
+|  `latest` | February 12th | `sha256:d93a6c023da20d5d461158771d91e994be209ce6ffc3d267a7afe8b2b3e046ac` |
 

--- a/content/chainguard/chainguard-images/reference/python/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/python/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the python Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:70c73efc79e14f6676775f563cfda36c0856ff831234072c6cf4f59093d08e90` |
+|  `latest-dev` | February 12th | `sha256:39127d839ce8b5a00b2f18a6851deab0c5d206d6ebc3d66ab2d2530bed5bfec3` |
 |  `latest`     | February 7th  | `sha256:2ada7aa3b53df8980a65429f2a94865ed29b5d454d36ff78bb89b850c73d54ba` |
 

--- a/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/slim-toolkit-debug/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the slim-toolkit-debug Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 10th | `sha256:3fa66ec8eb498ecb8ffbb46f990b26f7430f83067e2d6f92ba2b936464559feb` |
+|  `latest` | February 12th | `sha256:368af1df599a342f00abbac112922cdf28cc5031d2251ebf4c911e11d1274d1a` |
 

--- a/content/chainguard/chainguard-images/reference/solr/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/solr/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the solr Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:69cdf9e722a9fc77e4012dc8498cacdd9d8754b1e47fb79699941c1974303286` |
-|  `latest`     | February 8th  | `sha256:72eb0bb8ae5b3ac4507509b701ed62db4afe2a103434b6be4593fabfe8dfd09b` |
+|  `latest`     | February 12th | `sha256:3fc5b43193cf4d3df8b06c87bbb71e7fe954f7c0d500a606322cf6634b7db8de` |
+|  `latest-dev` | February 12th | `sha256:3b4a17b7fcb4fee0ed88b7bd13496cb2a7ee3e69a64a349e97b25f7b93128f39` |
 

--- a/content/chainguard/chainguard-images/reference/sqlpad/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/sqlpad/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public sqlpad Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -70,6 +70,7 @@ The table shows package distribution across variants.
 | `libssl3`                | X          | X      |
 | `libstdc++`              | X          | X      |
 | `libunistring`           | X          |        |
+| `libuv`                  | X          | X      |
 | `ncurses`                | X          |        |
 | `ncurses-terminfo-base`  | X          |        |
 | `nodejs-18`              | X          | X      |

--- a/content/chainguard/chainguard-images/reference/sqlpad/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/sqlpad/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the sqlpad Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:98fb3dd96b6f6cc30ec0f2500870f7bdfcb1e5a92c80dd614e6493045c019286` |
-|  `latest`     | February 8th  | `sha256:dc17d2e691d592a1b4d9fe5818fafe90793fa1c91f47aaf892ed02914ec1ea87` |
+|  `latest`     | February 12th | `sha256:897065ab7bd690cc91ad764c34d7dd73d51f38c59dff5942c532c7d4daa54ce8` |
+|  `latest-dev` | February 12th | `sha256:8d372ea5c28dc289c8e3f8c8ff401e23d18533657b379497ce4634b172b0a975` |
 

--- a/content/chainguard/chainguard-images/reference/statsd/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/statsd/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public statsd Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -71,6 +71,7 @@ The table shows package distribution across variants.
 | `libssl3`                | X          | X      |
 | `libstdc++`              | X          | X      |
 | `libunistring`           | X          |        |
+| `libuv`                  | X          | X      |
 | `ncurses`                | X          | X      |
 | `ncurses-terminfo-base`  | X          | X      |
 | `nodejs-18`              | X          | X      |

--- a/content/chainguard/chainguard-images/reference/statsd/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/statsd/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the statsd Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:19ae471930779ab3d28cb8759c22f2b8ec74c6c35a653a71de2e6d912d130b6e` |
-|  `latest`     | January 31st  | `sha256:b14eacb650851b125cf7d1dc110b1d0a52e639b179ee41d6247d83f7f497191b` |
+|  `latest`     | February 12th | `sha256:6d8e6e77dff3721ac551dddc40ffb4a7e9bcf76288acc42ff0ec71d0ef9bf430` |
+|  `latest-dev` | February 12th | `sha256:ab3c8a9e2a386c43a46dbc7e37b846d422d6f2ada3056d11bdbfd3aa6bd6d229` |
 

--- a/content/chainguard/chainguard-images/reference/traefik/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/traefik/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the traefik Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-01-15 00:20:04
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 12th | `sha256:9921dde9066941353369b0c5c43835296bd5569f3b03d18e940f208c486bf728` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | February 12th | `sha256:f5d42821a6d85c05e4255a30e4df1ae099ddb264fc695bf0ccda236b18356e59` |
 

--- a/content/chainguard/chainguard-images/reference/vector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/vector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the vector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-13 00:34:25
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:4dd7d2d01af0cbf90c1151ac0a65f3a53a19da150eaf0552a851d67854155742` |
-|  `latest`     | February 8th  | `sha256:2f6ecf9a267cd6588c581df2f0856295910b01686a30e563b54e93748b0d36ec` |
+|  `latest`     | February 12th | `sha256:f4349f6a0d9cd12eb95185fb86a66584cb780d63985fad146d164fd3bac225e1` |
+|  `latest-dev` | February 12th | `sha256:362d774e98aaf7c8ef75d5badd365198d5b8008413c3ace493da0d0d9cff42d1` |
 


### PR DESCRIPTION
Updated Docs:

- atlantis/tags_history.md
- aws-cli/tags_history.md
- aws-efs-csi-driver/tags_history.md
- caddy/tags_history.md
- coredns/tags_history.md
- dask-gateway-server/tags_history.md
- falcoctl/tags_history.md
- flux-source-controller/tags_history.md
- gitlab-exporter/tags_history.md
- gitlab-kas/tags_history.md
- gitlab-pages/tags_history.md
- gitlab-shell/tags_history.md
- guacamole-server/tags_history.md
- keda/tags_history.md
- keda-adapter/tags_history.md
- keda-admission-webhooks/tags_history.md
- kubeflow-centraldashboard/image_specs.md
- kubeflow-centraldashboard/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-api-server/tags_history.md
- kubeflow-pipelines-cache-deployer/image_specs.md
- kubeflow-pipelines-cache-deployer/tags_history.md
- kubeflow-pipelines-cache-server/image_specs.md
- kubeflow-pipelines-cache-server/tags_history.md
- kubeflow-pipelines-frontend/image_specs.md
- kubeflow-pipelines-frontend/tags_history.md
- kubeflow-pipelines-metadata-envoy/image_specs.md
- kubeflow-pipelines-metadata-envoy/tags_history.md
- kubeflow-pipelines-metadata-writer/image_specs.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- kubeflow-pipelines-persistenceagent/image_specs.md
- kubeflow-pipelines-persistenceagent/tags_history.md
- kubeflow-pipelines-scheduledworkflow/image_specs.md
- kubeflow-pipelines-scheduledworkflow/tags_history.md
- kubeflow-pipelines-viewer-crd-controller/image_specs.md
- kubeflow-pipelines-viewer-crd-controller/tags_history.md
- management-api-for-apache-cassandra/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- newrelic-k8s-events-forwarder/tags_history.md
- newrelic-kube-events/tags_history.md
- newrelic-kubernetes/tags_history.md
- nfs-subdir-external-provisioner/tags_history.md
- node-lts/image_specs.md
- node-lts/tags_history.md
- opentelemetry-collector-contrib/tags_history.md
- prometheus/tags_history.md
- prometheus-alertmanager/_index.md
- prometheus-alertmanager/image_specs.md
- prometheus-alertmanager/tags_history.md
- pulumi/image_specs.md
- pulumi/tags_history.md
- python/tags_history.md
- slim-toolkit-debug/tags_history.md
- solr/tags_history.md
- sqlpad/image_specs.md
- sqlpad/tags_history.md
- statsd/image_specs.md
- statsd/tags_history.md
- traefik/tags_history.md
- vector/tags_history.md