### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,39 @@
+# 2024-02-14
+
+
+Updated Docs:
+
+- aws-cli/tags_history.md
+- aws-ebs-csi-driver/tags_history.md
+- aws-efs-csi-driver/tags_history.md
+- calico-node/tags_history.md
+- guacamole-server/tags_history.md
+- istio-proxy/tags_history.md
+- k3s/tags_history.md
+- k3s-allinone/tags_history.md
+- kubeflow-jupyter-web-app/tags_history.md
+- kubeflow-pipelines-metadata-writer/tags_history.md
+- kubeflow-volumes-web-app/tags_history.md
+- kubernetes-csi-external-snapshot-controller/tags_history.md
+- kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
+- kubernetes-csi-external-snapshotter/tags_history.md
+- management-api-for-apache-cassandra/tags_history.md
+- mariadb/tags_history.md
+- newrelic-infrastructure-bundle/tags_history.md
+- nfs-subdir-external-provisioner/tags_history.md
+- node-problem-detector/tags_history.md
+- postgres/tags_history.md
+- postgres-helm-compat/tags_history.md
+- prometheus-alertmanager/image_specs.md
+- prometheus-alertmanager/tags_history.md
+- proxysql/tags_history.md
+- r-base/tags_history.md
+- rqlite/tags_history.md
+- secrets-store-csi-driver/tags_history.md
+- temporal-server/image_specs.md
+- temporal-server/tags_history.md
+- zookeeper/tags_history.md
+
 # 2024-02-13
 
 

--- a/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 12th | `sha256:7446c00f10e32240bf8c6556da66c740c235f4ba8e6edf298aff468eac71e4c8` |
-|  `latest`     | February 12th | `sha256:db89a007f56721189a35db1636bafc37bd5b52edbdc38adc958f62a8eaf90a83` |
+|  `latest`     | February 13th | `sha256:afe4582a78d1ca6b42f326d91056694680ab7b0562aedc38c8b224c44d8ec0c0` |
+|  `latest-dev` | February 13th | `sha256:6f433d380b0e5b630ddb9d9573fb8b551be40ad1ff275311d80652bf5c1bef83` |
 

--- a/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-ebs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-ebs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:49f2687898831267bd043381c0206af3f58cf39c0bcbed8f10557d4b8a0ee97a` |
-|  `latest`     | February 9th  | `sha256:594a93b9e821ccb02a9af9f0fc74cb549801bbec484dc2b1f8dade77c0532a16` |
+|  `latest-dev` | February 13th | `sha256:a98ee988547a41da03bf40fd3cb7a4526e42ef197e557eca7738f6e89763304b` |
+|  `latest`     | February 13th | `sha256:8c48a0e0f581f5c4add0fb59bc6d322ebc0510c6e944b8cd9ed5d0a361fd6ef3` |
 

--- a/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/aws-efs-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the aws-efs-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 12th | `sha256:708311719b3bb0a1e3d1335a5562bb414d2da0bd525a742a5ac208f3913635f9` |
-|  `latest-dev` | February 12th | `sha256:d977d759f5d5a0c51b4972282e08abb2e6e203510b2fe844b8c802ee9be7bbda` |
+|  `latest`     | February 13th | `sha256:7d4794d46cc30dfcb864ca3a626db81c459757daa6b936880f38f35c219a299a` |
+|  `latest-dev` | February 13th | `sha256:3e1f868cdedaa415d75e24291fdf6d9dad31f47adbc3b6421ac26264d89e4b18` |
 

--- a/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/calico-node/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the calico-node Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-09 00:19:29
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | February 8th | `sha256:94b1b40afef03eec52d606f89b98470512280a2d79ef76ea01a7b3eecc78cb52` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | February 13th | `sha256:7952f6608e35e87a10cac70085ab98ce81f277b434c5a4a0438789c676941da0` |
 

--- a/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/guacamole-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the guacamole-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 12th | `sha256:154f33fe15bca81c73ca31b5428dce4372d2f653d5a4ba2d0b190572a635aeea` |
-|  `latest-dev` | February 12th | `sha256:f782420b67963463d856cd15ef9236b7b87dd8f63d64d12d90f825010fda5c80` |
+|  `latest-dev` | February 13th | `sha256:093c015f466bfe15c90d781f2d91693487c4393dba6fc7ca8fe1e76b94adad6b` |
+|  `latest`     | February 13th | `sha256:59e88f275bf44b67e6b3d8e61d6f17746ea18bb6380d7004b61f8cc29505e02a` |
 

--- a/content/chainguard/chainguard-images/reference/istio-proxy/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/istio-proxy/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the istio-proxy Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:f37a5e8c2a549db814373808181e67d1f49b9f8611146502911830e44f270f30` |
-|  `latest`     | February 10th | `sha256:c7c757061a783827df10bf65f17a6451b5cf1d70b4ac4b4ec61e03778b2cd57a` |
+|  `latest`     | February 13th | `sha256:9aed0d6c935e8d8351fe165d28a63cef2059adcb689c4bdd49de233a87cbb4d1` |
+|  `latest-dev` | February 13th | `sha256:c3a7b30cde959b159de76b2b1d108905a930ea47ac09116843bc2202260401ce` |
 

--- a/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k3s-allinone/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the k3s-allinone Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `1-dev` `1.29.0-dev` `1.29-dev` `latest-dev` | February 10th | `sha256:79fa3d0d7e6d244f4f7a20de901476cb6d2ff5e8374d49e5e8931c996c7fa076` |
-|  `1.29.0` `latest` `1` `1.29`                 | February 8th  | `sha256:fb67d09466003566c47bdd3c6f67d629dfb6cd2c11f430348b5b24db3cc266be` |
+|  `1.29` `1` `1.29.0` `latest`                 | February 13th | `sha256:e9d0ab40496b9993cd41aff63642baa07f05ed3487fbd4e3ea512d0f0cf2cc63` |
+|  `1.29-dev` `latest-dev` `1-dev` `1.29.0-dev` | February 13th | `sha256:7b92676abbc19c0e31f4467aa6892beca9b161594a0aebd38d5508d15ca50876` |
 

--- a/content/chainguard/chainguard-images/reference/k3s/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/k3s/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the k3s Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `1-dev` `1.29-dev` `1.29.0-dev` `latest-dev` | February 10th | `sha256:9dabe47c491a42463ca78220703a877ab95eb1073bee9758cb7e7fb1ec39bfcc` |
-|  `latest` `1` `1.29` `1.29.0`                 | February 8th  | `sha256:c4d28581d06a5c049a744936c800e7f066d058d7aa7a50ffe22215a4c514159f` |
+|  `1.29.0-dev` `latest-dev` `1.29-dev` `1-dev` | February 13th | `sha256:ce5a3c0d227600fb365f9b8118ce42fb5f2a21f1f037798ae0390076c0ee6c9c` |
+|  `latest` `1.29` `1.29.0` `1`                 | February 13th | `sha256:c1b42df6bf9ea871f187ee371a93cf096b9277e248d7d7e68aa2ab1873d4f2ef` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-jupyter-web-app/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-jupyter-web-app Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed  | Digest                                                                    |
 |---------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `1-dev` `latest-dev` `1.8.0-dev` `1.8-dev` | February 10th | `sha256:79b1ee51a368ead87e1fdfe313682b855fbe78b78314020c3941ab35cbf565f8` |
-|  `1.8.0` `1` `1.8` `latest`                 | February 7th  | `sha256:2c084850450d2beb3a73f9a1a7c710219f0be2c6206bef5830b992977553948b` |
+|  `latest` `1.8` `1` `1.8.0`                 | February 13th | `sha256:b2279c3493956b01af8e1e6ade1ab9254582adea00a2535af88f0e0d16c19aaa` |
+|  `1.8-dev` `1-dev` `1.8.0-dev` `latest-dev` | February 13th | `sha256:658458c041a9d435d0524e15b15d95690e66a87ef42fc42e379c474da1c5390f` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-metadata-writer/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-metadata-writer Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 12th | `sha256:dc68949e93f61b6a9d54536ab7792f8885fe9211ad5bbcc343cace8f2c0d3637` |
-|  `latest-dev` | February 12th | `sha256:64e7a97c62b84d423109ba72fe867e5a0dfd1314475d6e173b0269c8bfad209e` |
+|  `latest`     | February 13th | `sha256:e3d95edf0d87347f627a147af9ca7894064ba3f9322c7faac124bfb901e231a3` |
+|  `latest-dev` | February 13th | `sha256:f92fc4cd701e5603d8c0d7e250b401a12334465ce945d9a5bafacfdfd8d02321` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-volumes-web-app/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-volumes-web-app Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                     | Last Changed  | Digest                                                                    |
 |---------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` `1.8.0-dev` `1-dev` `1.8-dev` | February 10th | `sha256:6fc20c49448c0320d0a3e9035e5b229601b86707e5190a4d23ce98ac2e0cfbcd` |
-|  `1` `1.8` `1.8.0` `latest`                 | February 7th  | `sha256:f05c2f7356d43c18ce83cc76c1334a639470dcaa7a200a41373206b03004b0d3` |
+|  `latest` `1.8.0` `1` `1.8`                 | February 13th | `sha256:cf27f2b8103e6d198c37c855d2e977f43fb76322455474d229d24961d8d72fb9` |
+|  `1.8.0-dev` `latest-dev` `1-dev` `1.8-dev` | February 13th | `sha256:1c3cde85d857a61a9688eb0fc5b143d0bc6233ce65d48d0bbe831ffa232dad16` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-csi-external-snapshot-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:b67861ca8036f7fcc9abc412b86753ab6e15635bf61cd00f2045b88f8e5949c3` |
-|  `latest`     | January 31st  | `sha256:e1543769b866932a301a868458b3826a852b86c29115acd47ffe2e19966056e7` |
+|  `latest-dev` | February 13th | `sha256:eb55063117b5f5f37d82087817d2f955769c9488de4b7010edebd214ad055f77` |
+|  `latest`     | February 13th | `sha256:b96296d2a81c1d00a755aa2d9333e3959535cde67901d4c666edccb2c923c5a1` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-csi-external-snapshot-validation-webhook Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 31st | `sha256:06d8d4191df4c7e8aa832437a879bb715ae4afcd8e15f88be1b544e38ce1a22d` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | February 13th | `sha256:afb54b73524a21286b1d233d6dae30964d3c31bed62a616fa3f93b0e0ec7acb1` |
 

--- a/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshotter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubernetes-csi-external-snapshotter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubernetes-csi-external-snapshotter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-01 00:31:15
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,7 +23,7 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)   | Last Changed | Digest                                                                    |
-|-----------|--------------|---------------------------------------------------------------------------|
-|  `latest` | January 31st | `sha256:b754b4e5a8ce97ed84747d3fa83dd3fb87e464882dce166deabb329375d66f81` |
+| Tag (s)   | Last Changed  | Digest                                                                    |
+|-----------|---------------|---------------------------------------------------------------------------|
+|  `latest` | February 13th | `sha256:3e34127ab679f6c9cb2adaf2eedf9c787772864694ec7ea51f220ee8331ddffd` |
 

--- a/content/chainguard/chainguard-images/reference/management-api-for-apache-cassandra/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/management-api-for-apache-cassandra/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the management-api-for-apache-cassandra Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 12th | `sha256:6f9167d81dd6446bc092c2cf4fda907e11e796ba94fe7faea8602faa4115331b` |
-|  `latest-dev` | February 12th | `sha256:e9ba3b507572379ce47413671408fba93cb259564cd26fdf0b9695b431702ce7` |
+|  `latest`     | February 13th | `sha256:69cb71b5441b4c8ec1263c5e12e41855fc49dc0b337db78e00a56bc61390997e` |
+|  `latest-dev` | February 13th | `sha256:1bd25def32f94c4ee455a4c6e12d0f1878f31acf520373be866527d63f2a1321` |
 

--- a/content/chainguard/chainguard-images/reference/mariadb/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/mariadb/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the mariadb Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:0d5ab20e7ffd96cc593886b54710643b716ae3e3754a79bea0ec000594bc0324` |
-|  `latest`     | February 9th  | `sha256:7a4572d6511b3814d42469e6ed18168ce61079623ccfde9f33713ff261c691c4` |
+|  `latest-dev` | February 13th | `sha256:11b6962429df1a3b95f8c80b615705c7c2ef3e2f7aea7b1ca54789a2cb5f0295` |
+|  `latest`     | February 13th | `sha256:f42ceb45ec03460ec35262da922b186ffa0dfc6a3bb84c567139c51284c8bd39` |
 

--- a/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/newrelic-infrastructure-bundle/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the newrelic-infrastructure-bundle Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 12th | `sha256:e765d040bc22c39f877ae05aaea5ef6142f192b9ea3f590b557e56c7a8252d73` |
-|  `latest-dev` | February 12th | `sha256:2575f6fcf1e4ce71164c2bb70860ec89289bd7e42ff159e27ad8b0b6bbd1795e` |
+|  `latest-dev` | February 13th | `sha256:284f28e49f1263bf383a3b241e2905a5de69ea6244f04d7faf43c6ae3dca6cb0` |
+|  `latest`     | February 13th | `sha256:d8c38dd99291bec2532740680cb6e152def8b220ddb5db8fbeb4ec1e8eeb5c98` |
 

--- a/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/nfs-subdir-external-provisioner/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the nfs-subdir-external-provisioner Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 12th | `sha256:65a56033ff1e4c3004ac2d933c3b047fbaad42328a9986de873377c5f7766b03` |
-|  `latest`     | February 12th | `sha256:ce474be7e5ca8b5de28ab1a313af235cb4af085390e676668016a2c04afc9eaa` |
+|  `latest`     | February 13th | `sha256:1239a15a31b37a9c6c1b81952993b0c2f58df49e795d8c1fd1e4c2f5798e240f` |
+|  `latest-dev` | February 13th | `sha256:ea9a654385f5890082ff79ecb07a8b51d32fc3cf1b46e4c04c81a59557e54de2` |
 

--- a/content/chainguard/chainguard-images/reference/node-problem-detector/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/node-problem-detector/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the node-problem-detector Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:e912ab62bdf33ac1316ea8a6da7e1aeb37a9be9cdfc8777eb19c910b2987642a` |
-|  `latest`     | February 8th  | `sha256:d2ac52ec89a4299986eb7799f4a92a00215f4988f74e8738ed6b50d470adc727` |
+|  `latest-dev` | February 13th | `sha256:c7366aa6b0e19b5e83b897b44a71b93cbf2e6a8b755154e1d51077a77f4a26e1` |
+|  `latest`     | February 13th | `sha256:17553b637e79485be8430b3833129887eb01be69a6e37ef01eccfedf45c3c633` |
 

--- a/content/chainguard/chainguard-images/reference/postgres-helm-compat/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/postgres-helm-compat/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the postgres-helm-compat Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:306aacb3f7b43b7ca5759164641d5927e19a142c01d68829a9b0227d377f3341` |
-|  `latest`     | February 9th  | `sha256:8fc7ece2863212fef547e01c97967dabbd27f01dd1a93b0a899258cb781c8e4a` |
+|  `latest`     | February 13th | `sha256:4a56d3ae0673f7645c9b7e49f401296146d822c3488f6d257c710cb7d1a53c7d` |
+|  `latest-dev` | February 13th | `sha256:b1c364085237e0278b9743bc9e1698ab380bbba25f44e01406197ea1f38207c3` |
 

--- a/content/chainguard/chainguard-images/reference/postgres/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/postgres/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the postgres Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:651bd41c687de5272d54111c10992d31c18677edcd3e8c08d1a49f905a8bddcc` |
-|  `latest`     | February 9th  | `sha256:c0c2f9d79107bcc9b0e0d2d32dede803b365d6ef0db59638330c5e693363747b` |
+|  `latest-dev` | February 13th | `sha256:e84bd7fecfc0c02be9e91c224f2b496f90980f1cf02ce65d35e8b1bec4b72feb` |
+|  `latest`     | February 13th | `sha256:61d7206d55e60ebc60e881f1cc8f05600c1e1ca89a3535595520d0739404d531` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public prometheus-alertmanager Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -31,12 +31,12 @@ The table has detailed information about each of these variants.
 
 |              | latest-dev                                                                      | latest                                                                          |
 |--------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| Default User | `nonroot`                                                                       | `nonroot`                                                                       |
+| Default User | `alertmanager`                                                                  | `alertmanager`                                                                  |
 | Entrypoint   | `/usr/bin/alertmanager`                                                         | `/usr/bin/alertmanager`                                                         |
 | CMD          | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` |
 | Workdir      | not specified                                                                   | not specified                                                                   |
-| Has apk?     | yes                                                                             | no                                                                              |
-| Has a shell? | yes                                                                             | no                                                                              |
+| Has apk?     | yes                                                                             | yes                                                                             |
+| Has a shell? | yes                                                                             | yes                                                                             |
 
 Check the [tags history page](/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history/) for the full list of available tags.
 
@@ -45,31 +45,33 @@ The table shows package distribution across variants.
 
 |                           | latest-dev | latest |
 |---------------------------|------------|--------|
-| `apk-tools`               | X          |        |
+| `apk-tools`               | X          | X      |
 | `bash`                    | X          |        |
-| `busybox`                 | X          |        |
+| `busybox`                 | X          | X      |
 | `ca-certificates-bundle`  | X          | X      |
 | `git`                     | X          |        |
-| `glibc`                   | X          |        |
-| `glibc-locale-posix`      | X          |        |
-| `ld-linux`                | X          |        |
+| `glibc`                   | X          | X      |
+| `glibc-locale-posix`      | X          | X      |
+| `ld-linux`                | X          | X      |
 | `libbrotlicommon1`        | X          |        |
 | `libbrotlidec1`           | X          |        |
-| `libcrypt1`               | X          |        |
-| `libcrypto3`              | X          |        |
+| `libcrypt1`               | X          | X      |
+| `libcrypto3`              | X          | X      |
 | `libcurl-openssl4`        | X          |        |
 | `libexpat1`               | X          |        |
 | `libidn2`                 | X          |        |
 | `libnghttp2-14`           | X          |        |
 | `libpcre2-8-0`            | X          |        |
 | `libpsl`                  | X          |        |
-| `libssl3`                 | X          |        |
+| `libssl3`                 | X          | X      |
 | `libunistring`            | X          |        |
 | `ncurses`                 | X          |        |
 | `ncurses-terminfo-base`   | X          |        |
-| `openssl-config`          | X          |        |
+| `openssl-config`          | X          | X      |
 | `prometheus-alertmanager` | X          | X      |
 | `wget`                    | X          |        |
+| `wolfi-base`              | X          | X      |
 | `wolfi-baselayout`        | X          | X      |
-| `zlib`                    | X          |        |
+| `wolfi-keys`              | X          | X      |
+| `zlib`                    | X          | X      |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-13 00:34:25
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` `0-dev` `0.26-dev` `0.26.0-dev` | February 12th | `sha256:4b20efb3fb96c0c96fafc551c8951f64e04510488d8095ab51d8b7db4891545f` |
-|  `latest` `0.26` `0` `0.26.0`                 | February 12th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
+|  `latest` `0.26` `0` `0.26.0`                 | February 13th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
+|  `latest-dev` `0-dev` `0.26-dev` `0.26.0-dev` | February 13th | `sha256:4b20efb3fb96c0c96fafc551c8951f64e04510488d8095ab51d8b7db4891545f` |
 

--- a/content/chainguard/chainguard-images/reference/proxysql/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/proxysql/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the proxysql Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:34c969071065bac0e2eece7b2005434a133df2a8fcc005e1db0a876cb21322dc` |
-|  `latest`     | February 7th  | `sha256:5d6d1de5bfe5466a7e238877da962db6d5c715032cdb620244e3ac826b43d65b` |
+|  `latest`     | February 13th | `sha256:4e06313ce3ddc430713ac68f36c3cd14863b001293b2c8c88e0af62ca89a3fae` |
+|  `latest-dev` | February 13th | `sha256:23c675b5af54882b648cfce1ca3bc5ff3b3744fe0cdc5232634e096a190fe90c` |
 

--- a/content/chainguard/chainguard-images/reference/r-base/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/r-base/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the r-base Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:4e8e5ec340dc7e2b36d9d73c28e68e8232789fd12db99ec66e7ba5548a927082` |
-|  `latest`     | February 8th  | `sha256:1cb4eea66bc997ae224121675400e350d7129027e8defedff39249d88c6560d3` |
+|  `latest-dev` | February 13th | `sha256:4c2bf3cece3266e5df1901688b93a7873ebd62a50b95623e4d6b71060cc8178f` |
+|  `latest`     | February 13th | `sha256:0e8ddb1d6a17420b264a522b536e24a3cc1fbee0c594388ef138cdbaef417858` |
 

--- a/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the rqlite Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:8e0c3353751b69113b70c535d3b56cdf80c1824300aae16f8c37d0b86f488f45` |
-|  `latest`     | February 8th  | `sha256:3ab9a24c6fed8cf7b92f6308abbbce60850936f30b0db83e760d9e3014ac4117` |
+|  `latest-dev` | February 13th | `sha256:e397bb7a8032be8317face0bb962440bf1bebf6620f1ad7ec7d92acd8886775b` |
+|  `latest`     | February 13th | `sha256:d03b98142a62ad461c9fc06bb17fd02e8cc7cda8e17ffb8cc695f6ce03c86635` |
 

--- a/content/chainguard/chainguard-images/reference/secrets-store-csi-driver/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/secrets-store-csi-driver/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the secrets-store-csi-driver Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:9f2c92ae16201a8809b5d085d0a0a3468b41d46ccefc423965e77c9f14def43a` |
-|  `latest`     | February 8th  | `sha256:4070b98422186a4bb6500d94d1babaf85edc66de04190fe28de74d26dfc63401` |
+|  `latest-dev` | February 13th | `sha256:48088e1471338f83c6a348a8761d6aac7ef2f3796a6fb43b27711d503460aea6` |
+|  `latest`     | February 13th | `sha256:81ea7bf1a4828103a1a2f9c4f06f3064fb6554e3c85df2162f87bf6cb021f16c` |
 

--- a/content/chainguard/chainguard-images/reference/temporal-server/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/temporal-server/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public temporal-server Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -79,6 +79,7 @@ The table shows package distribution across variants.
 | `temporal-server`                  | X          | X      |
 | `temporal-server-compat`           | X          | X      |
 | `temporal-server-oci-entrypoint`   | X          | X      |
+| `wget`                             | X          |        |
 | `wolfi-baselayout`                 | X          | X      |
 | `zlib`                             | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/temporal-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/temporal-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the temporal-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-05 00:18:41
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,8 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)       | Last Changed | Digest                                                                    |
-|---------------|--------------|---------------------------------------------------------------------------|
-|  `latest`     | February 2nd | `sha256:64367f816dab68ff49ecb1cf3de3eeccf50fd44086442444037c4a6ef0700415` |
-|  `latest-dev` | February 2nd | `sha256:505c8f4fedcd686fc3ac0f64929f521bd9b6619b851c18db916d20a8640a06c6` |
+| Tag (s)       | Last Changed  | Digest                                                                    |
+|---------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev` | February 13th | `sha256:540a7319a959608a6b59bb40434357524403302062c93e557e45c95df62b7728` |
+|  `latest`     | February 2nd  | `sha256:64367f816dab68ff49ecb1cf3de3eeccf50fd44086442444037c4a6ef0700415` |
 

--- a/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/zookeeper/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the zookeeper Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-12 00:21:23
+lastmod: 2024-02-14 00:20:21
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 10th | `sha256:7d8494825ef6a0dda1b0446958938d1b2ac419172aa9de25c2b8ffd276126016` |
-|  `latest`     | February 8th  | `sha256:40ce28d802d813e3bf5a52b0fa7f9aa18b87d38e215df97cf9029f02d365b442` |
+|  `latest`     | February 13th | `sha256:69a52a13e786c2cb54751fcfb836e44ade6c70b42cb01a3f84dcaeb15e96b83c` |
+|  `latest-dev` | February 13th | `sha256:1aa1fddbb6f6f76feb3fb0279fe1f7393037e7047d5e0aecc7ee5137d4afbe60` |
 


### PR DESCRIPTION
Updated Docs:

- aws-cli/tags_history.md
- aws-ebs-csi-driver/tags_history.md
- aws-efs-csi-driver/tags_history.md
- calico-node/tags_history.md
- guacamole-server/tags_history.md
- istio-proxy/tags_history.md
- k3s/tags_history.md
- k3s-allinone/tags_history.md
- kubeflow-jupyter-web-app/tags_history.md
- kubeflow-pipelines-metadata-writer/tags_history.md
- kubeflow-volumes-web-app/tags_history.md
- kubernetes-csi-external-snapshot-controller/tags_history.md
- kubernetes-csi-external-snapshot-validation-webhook/tags_history.md
- kubernetes-csi-external-snapshotter/tags_history.md
- management-api-for-apache-cassandra/tags_history.md
- mariadb/tags_history.md
- newrelic-infrastructure-bundle/tags_history.md
- nfs-subdir-external-provisioner/tags_history.md
- node-problem-detector/tags_history.md
- postgres/tags_history.md
- postgres-helm-compat/tags_history.md
- prometheus-alertmanager/image_specs.md
- prometheus-alertmanager/tags_history.md
- proxysql/tags_history.md
- r-base/tags_history.md
- rqlite/tags_history.md
- secrets-store-csi-driver/tags_history.md
- temporal-server/image_specs.md
- temporal-server/tags_history.md
- zookeeper/tags_history.md