### PR TITLE
Add cache-control header to nginx for html files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,6 +99,10 @@ http {
             rewrite ^ /vulnerabilities/index.html break;
         }
 
+        location ~* /(\index.html)?$ {
+            add_header Cache-Control "public, max-age=300, stale-while-revalidate=300";
+        }
+
 	# use hugo's built in 404 page for now
 	error_page 404 /404.html;
 


### PR DESCRIPTION
## Type of change
feature

### What should this PR do?
refs #1369 

### Why are we making this change?
This adds cache-control headers to html pages that should help with sidebar loads. The initial value is 300s, so a page will be refreshed after 5 minutes.

### What are the acceptance criteria? 
Shouldn't be anything visible to a user.

### How should this PR be tested?
Won't work on netlify, staging looks like this:
```
curl -sI --user ... https://<staging_url>/chainguard/chainguard-images/fips-images/ |grep cache-control
cache-control: public, max-age=300, stale-while-revalidate=300
```