### PR TITLE
[AutoDocs] Update Images Reference Docs

### DIFF
--- a/autodocs/changelog.md
+++ b/autodocs/changelog.md
@@ -1,3 +1,44 @@
+# 2024-02-22
+New images added:
+
+- clickhouse
+
+Updated Docs:
+
+- dask-gateway-server/tags_history.md
+- datadog-agent/tags_history.md
+- envoy-ratelimit/tags_history.md
+- gitlab-exporter/tags_history.md
+- gitlab-pages/tags_history.md
+- gitlab-shell/tags_history.md
+- hugo/tags_history.md
+- kubeflow-katib-earlystopping-medianstop/tags_history.md
+- kubeflow-katib-suggestion-darts/tags_history.md
+- kubeflow-katib-suggestion-hyperband/tags_history.md
+- kubeflow-katib-suggestion-hyperopt/tags_history.md
+- kubeflow-katib-suggestion-optuna/tags_history.md
+- kubeflow-katib-suggestion-pbt/tags_history.md
+- kubeflow-katib-suggestion-skopt/tags_history.md
+- kubeflow-pipelines-visualization-server/tags_history.md
+- kyverno/tags_history.md
+- kyverno-background-controller/tags_history.md
+- kyverno-cleanup-controller/tags_history.md
+- kyverno-cli/tags_history.md
+- kyverno-policy-reporter/tags_history.md
+- kyverno-reports-controller/tags_history.md
+- openai/tags_history.md
+- opentelemetry-collector-contrib/tags_history.md
+- prometheus-alertmanager/_index.md
+- prometheus-alertmanager/image_specs.md
+- prometheus-alertmanager/tags_history.md
+- rqlite/tags_history.md
+- skaffold/tags_history.md
+- stakater-reloader/tags_history.md
+- thanos/tags_history.md
+- trino/tags_history.md
+- wasmtime/tags_history.md
+- zot/tags_history.md
+
 # 2024-02-21
 New images added:
 

--- a/content/chainguard/chainguard-images/reference/clickhouse/_index.md
+++ b/content/chainguard/chainguard-images/reference/clickhouse/_index.md
@@ -1,0 +1,113 @@
+---
+title: "Image Overview: clickhouse"
+linktitle: "clickhouse"
+type: "article"
+layout: "single"
+description: "Overview: clickhouse Chainguard Image"
+date: 2024-02-22 00:36:42
+lastmod: 2024-02-22 00:36:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+menu: 
+  docs: 
+    parent: "images-reference"
+weight: 500
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/clickhouse/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/clickhouse/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/clickhouse/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/clickhouse/provenance_info/" >}}
+{{</ tabs >}}
+
+
+
+<!--overview:start-->
+[Clickhouse](https://clickhouse.com) is the fastest and most resource efficient open-source database for real-time apps and analytics.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/clickhouse:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Using Clickhouse
+
+The default Clickhouse listen_host is `127.0.0.1` and port is `8123`.
+
+### start server instance
+
+To run with Docker and allow empty passwords:
+
+```
+docker run -d --ulimit nofile=262144:262144 cgr.dev/chainguard/clickhouse:latest
+```
+
+By default, ClickHouse will be accessible only via the Docker network. See the networking section below.
+
+By default, starting above server instance will be run as the default user without password.
+
+## Users and Directories
+
+By default, this image runs as a non-root user named `clickhouse` with a uid of `101` and a home directory of `/home/clickhouse`.
+
+### Volumes
+
+Typically you may want to mount the following folders inside your container to achieve persistency:
+
+* /var/lib/clickhouse/ - main folder where ClickHouse stores the data
+* /var/log/clickhouse-server/ - logs
+
+```
+docker run -d \
+    -v $(realpath ./ch_data):/var/lib/clickhouse/ \
+    -v $(realpath ./ch_logs):/var/log/clickhouse-server/ \
+    --ulimit nofile=262144:262144 cgr.dev/chainguard/clickhouse:latest
+```
+
+You may also want to mount:
+
+* /etc/clickhouse-server/config.d/*.xml - files with server configuration adjustmenets
+* /etc/clickhouse-server/users.d/*.xml - files with user settings adjustmenets
+* /docker-entrypoint-initdb.d/ - folder with database initialization scripts (see below).
+
+
+## Docker Compose Example
+
+This `docker-compose.yaml` sets up a Clickhouse database with a default database and user.
+
+```yaml
+version: "3.7"
+services:
+  clickhouse:
+    image: ttl.sh/steve/clickhouse@sha256:8717f81f80aa851d53dcf3355e1eb728e84932dd59d42333e6b42b0b9f354fc3
+    restart: unless-stopped
+    entrypoint: /usr/bin/clickhouse-server -- --listen_host 0.0.0.0
+    working_dir: /home/clickhouse
+    ports:
+      - 8123:8123
+    volumes:
+      - ./data/clickhouse:/var/lib/clickhouse
+      - ./logs/clickhouse:/var/log/clickhouse-server
+    networks:
+      - wolfi
+
+networks:
+  wolfi:
+    driver: bridge
+```
+
+## Advanced Configuration
+
+Please refer to [Clickhouse's documentation](https://clickhouse.com/docs/en/operations/configuration-files#configuration_files) for more advanced configuration.
+
+<!--body:end-->
+

--- a/content/chainguard/chainguard-images/reference/clickhouse/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/clickhouse/image_specs.md
@@ -1,0 +1,76 @@
+---
+title: "clickhouse Image Variants"
+type: "article"
+unlisted: true
+description: "Detailed information about the public clickhouse Chainguard Image variants"
+date: 2024-02-22 00:36:42
+lastmod: 2024-02-22 00:36:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 550
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/clickhouse/" >}}
+{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/clickhouse/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/clickhouse/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/clickhouse/provenance_info/" >}}
+{{</ tabs >}}
+
+This page shows detailed information about all public variants of the Chainguard **clickhouse** Image.
+
+## Variants Compared
+The **clickhouse** Chainguard Image currently has 2 public variants: 
+
+- `latest-dev`
+- `latest`
+
+The table has detailed information about each of these variants.
+
+|              | latest-dev            | latest                |
+|--------------|-----------------------|-----------------------|
+| Default User | `clickhouse`          | `clickhouse`          |
+| Entrypoint   | `/usr/bin/clickhouse` | `/usr/bin/clickhouse` |
+| CMD          | `help`                | `help`                |
+| Workdir      | `/home/clickhouse`    | `/home/clickhouse`    |
+| Has apk?     | yes                   | no                    |
+| Has a shell? | yes                   | no                    |
+
+Check the [tags history page](/chainguard/chainguard-images/reference/clickhouse/tags_history/) for the full list of available tags.
+
+## Packages Included
+The table shows package distribution across variants.
+
+|                          | latest-dev | latest |
+|--------------------------|------------|--------|
+| `apk-tools`              | X          |        |
+| `bash`                   | X          |        |
+| `busybox`                | X          |        |
+| `ca-certificates-bundle` | X          | X      |
+| `clickhouse`             | X          | X      |
+| `clickhouse-compat`      | X          | X      |
+| `git`                    | X          |        |
+| `glibc`                  | X          | X      |
+| `glibc-locale-posix`     | X          | X      |
+| `ld-linux`               | X          | X      |
+| `libbrotlicommon1`       | X          |        |
+| `libbrotlidec1`          | X          |        |
+| `libcrypt1`              | X          |        |
+| `libcrypto3`             | X          |        |
+| `libcurl-openssl4`       | X          |        |
+| `libexpat1`              | X          |        |
+| `libidn2`                | X          |        |
+| `libnghttp2-14`          | X          |        |
+| `libpcre2-8-0`           | X          |        |
+| `libpsl`                 | X          |        |
+| `libssl3`                | X          |        |
+| `libunistring`           | X          |        |
+| `ncurses`                | X          |        |
+| `ncurses-terminfo-base`  | X          |        |
+| `openssl-config`         | X          |        |
+| `wget`                   | X          |        |
+| `wolfi-baselayout`       | X          | X      |
+| `zlib`                   | X          |        |
+

--- a/content/chainguard/chainguard-images/reference/clickhouse/provenance_info.md
+++ b/content/chainguard/chainguard-images/reference/clickhouse/provenance_info.md
@@ -1,0 +1,88 @@
+---
+title: "Provenance Information for clickhouse Images"
+type: "article"
+unlisted: true
+description: "Provenance information for clickhouse Chainguard Image"
+date: 2024-02-22 00:36:42
+lastmod: 2024-02-22 00:36:42
+draft: false
+tags: ["Reference", "Chainguard Images", "Product"]
+images: []
+weight: 600
+toc: true
+---
+
+{{< tabs >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/clickhouse/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/clickhouse/image_specs/" >}}
+{{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/clickhouse/tags_history/" >}}
+{{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/clickhouse/provenance_info/" >}}
+{{</ tabs >}}
+
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+## Verifying clickhouse Image Signatures
+The **clickhouse** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
+
+The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/clickhouse | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading clickhouse Image Attestations
+
+The following [attestations](https://slsa.dev/attestation-model) for the clickhouse image can be obtained and verified via cosign:
+
+| Attestation Type | Description |
+|----------------|-------------|
+| `https://slsa.dev/provenance/v1` | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point. |
+| `https://spdx.dev/Document` | Contains the image SBOM (Software Bill of Materials) in SPDX format. |
+
+
+To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the clickhouse image on `linux/amd64`:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  cgr.dev/chainguard/clickhouse | jq -r .payload | base64 -d | jq .predicate
+```
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+## Verifying clickhouse Image Attestations
+You can use the `cosign verify-attestation` command to check the signatures of the clickhouse image attestations:
+
+```shell
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/clickhouse
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```
+Verification for cgr.dev/chainguard/clickhouse --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/reference/clickhouse/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/clickhouse/tags_history.md
@@ -1,9 +1,9 @@
 ---
-title: "zot Image Tags History"
+title: "clickhouse Image Tags History"
 type: "article"
 unlisted: true
-description: "Image Tags and History for the zot Chainguard Image"
-date: 2023-06-22T11:07:52+02:00
+description: "Image Tags and History for the clickhouse Chainguard Image"
+date: 2024-02-22 00:36:42
 lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
@@ -13,10 +13,10 @@ toc: true
 ---
 
 {{< tabs >}}
-{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/zot/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/zot/image_specs/" >}}
-{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/zot/tags_history/" >}}
-{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/zot/provenance_info/" >}}
+{{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/clickhouse/" >}}
+{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/clickhouse/image_specs/" >}}
+{{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/clickhouse/tags_history/" >}}
+{{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/clickhouse/provenance_info/" >}}
 {{</ tabs >}}
 
 The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 21st | `sha256:4c5911acdcb3d04d46e02163bfbcce8d8295dc4b58dae910599f11777f3b54d7` |
-|  `latest`     | February 21st | `sha256:ffa13d5c0ca5da8f05545a8dd8e807c328d2069540a944d511172d0ee5148b8d` |
+|  `latest-dev` | February 21st | `sha256:9048f9dec4121df0870691b08a32425219fd56ef37f2a93d7d45760dc5f66c7a` |
+|  `latest`     | February 21st | `sha256:358baeb3984f91f8d31f8127923c0fbf57ee55f2050682eba7f7c04e5fb12ff7` |
 

--- a/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/dask-gateway-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the dask-gateway-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 20th | `sha256:25b6ce935d6dbcec31b9eeba1baf8eb8312626d16faa14d5588426cecdf11f4f` |
-|  `latest`     | February 20th | `sha256:5e45cb129ef78a71ec31c189b98bfd2a7fc8fc417616b05b820e21d1da02173a` |
+|  `latest-dev` | February 21st | `sha256:4f4a534142d1dd8d15185c6ea82a020fe8db68042cea816ef117b0c2c3b88fde` |
+|  `latest`     | February 21st | `sha256:6b610db0dcf68c01f2d10b3f804fe239190906aca99fa7c3acb0050df2951c49` |
 

--- a/content/chainguard/chainguard-images/reference/datadog-agent/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/datadog-agent/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the datadog-agent Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 20th | `sha256:9ac20b3a71d9a948173d72a835e443be6f98f5fd323bee05acbbe4241a78088c` |
-|  `latest-dev` | February 20th | `sha256:f83bb9e7ee6b23d39756ad5f2762270a41cb96549296f93d1078956bdfa4b0f4` |
+|  `latest`     | February 21st | `sha256:364d6ec3c96725f9db294a188fbaea330c9f864165c1cf5100d9c1ce6ec470b2` |
+|  `latest-dev` | February 21st | `sha256:29c973030ba1e9d47f2abacbd912ff4dc01caedf0c964ff13ad2a83b1af0e33e` |
 

--- a/content/chainguard/chainguard-images/reference/envoy-ratelimit/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/envoy-ratelimit/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the envoy-ratelimit Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:806acd030a87512dc1fcd0be7ae1e90d95ed01da5d6dd7264aa24080eb429dc1` |
-|  `latest`     | January 31st  | `sha256:098971e0e17628a04f72a3c8edd1bd709badd7b3610f5cf483139997d1b41bc0` |
+|  `latest`     | February 21st | `sha256:3767ba0137d5e4322aa046f22dae00e3f13699824716691d37ffd219afff0fda` |
+|  `latest-dev` | February 21st | `sha256:8828e55e50f62776f34090ce68b8da00539004bae6b3bfb0f82ec80297cef41d` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-exporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-exporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 20th | `sha256:d20f3991a037e2cdc693b76623845a35abfc2b8d3804e8a8a7cc5b1d91404053` |
-|  `latest`     | February 20th | `sha256:3c94fa4c81d601e1fd905b5380d8dc92d24a53ba873ac3b81faec607f51f5794` |
+|  `latest`     | February 21st | `sha256:f10c20a11fc5204030835ff2987f771a52b28551d6db3e6c83cc62321dcccdec` |
+|  `latest-dev` | February 21st | `sha256:bd5dd6833ab9c4f71bb5e907da4a85484d78df66d8aa71dfc1bef079a920912f` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-pages/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-pages Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:b00c1dbdc47d9cb909750c2177a5f3357f070a40c77986110547005bb4b6060e` |
-|  `latest`     | February 14th | `sha256:153f78e5489b60b83cd513f72c77285b3e1b5d693ee582121fa701910b3fda9a` |
+|  `latest`     | February 21st | `sha256:9153ecbf2613c9c6b961b473e175442ec6362a7613a81a967e62b93c0f7770d0` |
+|  `latest-dev` | February 21st | `sha256:6642e6e11a424e514c892488d5905945b6e6b0928fd3ca26acae21b1d7bf589e` |
 

--- a/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/gitlab-shell/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the gitlab-shell Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:a465acacc43df9f581db0eed2ec57c37c12a5acdd15bdc37927797379172561e` |
-|  `latest`     | February 14th | `sha256:f78400eaba21413088ad59b05dcbfa3761ec895e44f3222d52c812811ffdd6c7` |
+|  `latest`     | February 21st | `sha256:0dfcdf2892f6d3f8e2d278700e2988856847215d550aeef94e9360bc47bee03c` |
+|  `latest-dev` | February 21st | `sha256:10681a044622f0dfdb49da5d53733740119b4ed0b0943cc623bd247de75e31d6` |
 

--- a/content/chainguard/chainguard-images/reference/hugo/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/hugo/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the hugo Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 20th | `sha256:af6f877ab6570743e704aeb8b37ff8aa616d56bee25fd337345359af7fed2882` |
-|  `latest-dev` | February 20th | `sha256:c76d13709132001212b5c1f45e1c7740de2fa56cec628794d85506a347429eb9` |
+|  `latest-dev` | February 21st | `sha256:af9dbe67f5d9bf4cd362f043322ddfbff7e1a11436ae49bef0896b0d58fbefe7` |
+|  `latest`     | February 21st | `sha256:2715ac6ab735d3826c5596d4776f9cf1895a90bdb248cad260866b8954a75099` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-earlystopping-medianstop/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-earlystopping-medianstop Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0` `latest` `0` `0.16`                 | February 20th | `sha256:25cb28a1595df88150f55f5f00cbffa36fbe19a78b82c57123928c658743a2df` |
-|  `0-dev` `latest-dev` `0.16-dev` `0.16.0-dev` | February 20th | `sha256:c18cf0b65b5e39d2f5b3b5d79358256b73520ce48e8f2b70523a3655145ee0d8` |
+|  `0.16.0` `0.16` `0` `latest`                 | February 21st | `sha256:547a76944af3f3ba5cc2d65c4a00a8f896fea732d8da31bcbb820efab9045595` |
+|  `0.16-dev` `0.16.0-dev` `0-dev` `latest-dev` | February 21st | `sha256:0f0b99d0232dd2fed1e17eeee2df7d8f61711bc7a94fb1a75c8492b254fb8482` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-darts/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-darts Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest` `0.16.0` `0` `0.16`                 | February 20th | `sha256:050b378793670e2af1ffcedd762ef70b81374ab960ac5c10f5661576587775a9` |
-|  `latest-dev` `0.16-dev` `0.16.0-dev` `0-dev` | February 20th | `sha256:323a0375e8fa6572f41af775c1d2cf708f404a8278cd15ac8e26ace2408f18b9` |
+|  `latest` `0` `0.16` `0.16.0`                 | February 21st | `sha256:02bd735e023af44f7afe92e2df56e72fc4bae9058a70befbcec4f95b94646157` |
+|  `0.16.0-dev` `0.16-dev` `latest-dev` `0-dev` | February 21st | `sha256:b8fb8749d623ad745ca881fe95d1e3ac46eaf213ffdfcf5ce48e3237af2e07b2` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperband/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperband Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0` `latest` `0.16` `0`                 | February 20th | `sha256:8f679631b1f6c1de2f629c497097b4d611dcbe60523f6648513dccf50004e039` |
-|  `0-dev` `latest-dev` `0.16.0-dev` `0.16-dev` | February 20th | `sha256:9fd6210b9c3afe804e66dec52323e3817c2ec43745f72a473f86e04fec2768aa` |
+|  `0.16` `0` `latest` `0.16.0`                 | February 21st | `sha256:16dfd0a8000f24c7536d7c388d0c02d6d639fdb2b16d73f9be4365983a0e223c` |
+|  `0.16-dev` `0-dev` `latest-dev` `0.16.0-dev` | February 21st | `sha256:88e4df8f29bbd9b365baafee535d98f7c39ae683e36291ba400cf426ac3c7e77` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-hyperopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-hyperopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 20th | `sha256:707fe61a5fc699c8bd37430636fb95acd568d5beaed0fb5ffbfddbfd70d751c9` |
-|  `0` `0.16` `0.16.0` `latest`                 | February 20th | `sha256:86a99bdf0d1bcda9af3d4869923eb5fa717850f0b70276c46f4ef1076a242f2e` |
+|  `0.16.0-dev` `0-dev` `0.16-dev` `latest-dev` | February 21st | `sha256:986b4b5f3fa77dc27e20e0ab29d44c7ca283aefa3ee37e47ea695e387b278d89` |
+|  `0.16` `latest` `0.16.0` `0`                 | February 21st | `sha256:f7bbcce1b0050c3093f471b2a13b265931a9ec1ee1f353d244c918ab3fe4dbf0` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-optuna/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-optuna Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0-dev` `0.16.0-dev` `0.16-dev` `latest-dev` | February 20th | `sha256:e8d268ac945990c872bde90db675859dc7076a56028bd62cebc3cb71ade46537` |
-|  `latest` `0.16.0` `0.16` `0`                 | February 20th | `sha256:099272334a34543cb1b1491f36799157c3d0979b37c582d051758ca20f237a33` |
+|  `0-dev` `0.16.0-dev` `0.16-dev` `latest-dev` | February 21st | `sha256:54dcf11e5f98081e03b0f714a2f50f5baf145f92a00a7c55fe94effb86372cfa` |
+|  `0` `latest` `0.16` `0.16.0`                 | February 21st | `sha256:3772b464fc258f34ef35c5b655f8f7b8093ccfcee6f70641201d80ce9943ed09` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-pbt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-pbt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0` `0` `0.16` `latest`                 | February 20th | `sha256:5c470733c528302893dbc44612de9627c92523210878d0a6e6d71e22d131e085` |
-|  `latest-dev` `0-dev` `0.16-dev` `0.16.0-dev` | February 20th | `sha256:2bab4460f0e7db21a0bca3bf80af42bfc3ff286c53b7689eb356e04abd36d376` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 21st | `sha256:dcb44ad7e770b9a8381abbf290407f5550f485d82772b120aa12ac5112aec56b` |
+|  `0.16.0` `0` `0.16` `latest`                 | February 21st | `sha256:72ce53a43edf7ca6fe7e8b5f0a3832abb5584257c246c28d19b1841df9dc1fce` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-katib-suggestion-skopt/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-katib-suggestion-skopt Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)                                       | Last Changed  | Digest                                                                    |
 |-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `0.16.0-dev` `0.16-dev` `0-dev` `latest-dev` | February 20th | `sha256:9a25ad0029c04ac42019d80c689f8cf5bbd30aa2e949e7b74aacce9a4dccca94` |
-|  `0.16.0` `0.16` `latest` `0`                 | February 20th | `sha256:21dd9ee151610fd2c87cc17adb9db999023c188686f328957290fcc60f7c7bf9` |
+|  `0.16` `0` `latest` `0.16.0`                 | February 21st | `sha256:9a6eb97cbd3638514a268c22d499dd26df23bae77ed94c738593e8a9cba47640` |
+|  `0.16-dev` `latest-dev` `0-dev` `0.16.0-dev` | February 21st | `sha256:15996a57dfa6542bfaf7b642a20e7f4f460124eecab55ede12304707b936b580` |
 

--- a/content/chainguard/chainguard-images/reference/kubeflow-pipelines-visualization-server/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kubeflow-pipelines-visualization-server/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kubeflow-pipelines-visualization-server Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 20th | `sha256:07c40d392dd62d5b2efe99e83b47577dc088d1ca65436f52504eef6cf85c9df1` |
-|  `latest-dev` | February 20th | `sha256:14f3d9530c8e5a44b317c771c324f136478dc180fd1193f767539dccae873b60` |
+|  `latest`     | February 21st | `sha256:4c5953156b18b52f13cfc19578fe7a60ba7c8c8c1f7d555644ada8e3041f541b` |
+|  `latest-dev` | February 21st | `sha256:8f29335d68d128603bfa5aa493f61e375a7dd5da1e9837c8d51f98ede9a92bd1` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-background-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-background-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 20th | `sha256:a479cad80c6289320ede235190254d9817396e942ac541e1b5f51528951d1399` |
+|  `latest` | February 21st | `sha256:ecc55b4164091c5d89bbb015b3d7258295ce6029e8ecd65e21b905df8eab29e8` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cleanup-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-cleanup-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 20th | `sha256:e142bf1e8916b8b895d68c4e24c77d875b1fb121521c29c57a8cc9583b90a960` |
+|  `latest` | February 21st | `sha256:fde71439e0280fc493149f0f9de8951df1a58ba832cb300486e6098e6480cae9` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-cli/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-cli Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 20th | `sha256:71274a692a2566e06b7e6caea546a3211accb867c23eacbc6fdb57fa8c966f37` |
+|  `latest` | February 21st | `sha256:76b26786cd60627bd9bdf37f2f7cc3e1b6d86c4807cbc5b7f2aac49afd9a77c0` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-policy-reporter/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-policy-reporter Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:fc0da86f5aa3f231663fb1a9d7347998fe5a5cd6ac8bbdcb66be875b073ac53d` |
-|  `latest`     | February 5th  | `sha256:8a4d38758384fa4d2b222e508f4f8b349643f7cf60e96966fb7fe97d7ff48d85` |
+|  `latest`     | February 21st | `sha256:8433031fcb10c464b81688bed8652a112986ad95a8c976bc3d7102a82ae15dc0` |
+|  `latest-dev` | February 21st | `sha256:64ea304be01144a934bc0dc065c7c332958631acc0072ac545e5a2508fcdd6d7` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno-reports-controller/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno-reports-controller Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 20th | `sha256:48f2f5ed704c4cf5ab4572a4e2ae85a536dced71bf15f08cdfaadc6f4e7ee447` |
+|  `latest` | February 21st | `sha256:ad2f219017cf3a4410617d782f6424b0c89901abc180080ed46f87307c5ca078` |
 

--- a/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/kyverno/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the kyverno Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,5 +25,5 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)   | Last Changed  | Digest                                                                    |
 |-----------|---------------|---------------------------------------------------------------------------|
-|  `latest` | February 20th | `sha256:44a075c4a2381327879927a585eafd667d864ab8a7e126f651a16a487ec4c0ca` |
+|  `latest` | February 21st | `sha256:854bd2639dd02f88f9662edc6c992412786645b73490b2d9df095e5fb213ad9c` |
 

--- a/content/chainguard/chainguard-images/reference/openai/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/openai/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the openai Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 20th | `sha256:365a9b83f69a2d2843f1a8d2fd820fd1590ce848423ae6a7ac36d7f7bf4acf0b` |
-|  `latest-dev` | February 20th | `sha256:0d2c723c31d3f323328e8b9d68ddcfd7131c46ac21a58dc3a08efdcafe1b9041` |
+|  `latest-dev` | February 21st | `sha256:e39a025467653f9d3ae1f1c782eb3fca5a86e20aa3dba40c39af29883bc6b71b` |
+|  `latest`     | February 21st | `sha256:a2f2aa3c3dad8aca54065255dc89db08b8c1e2d6f197887372ac63c0b5812bb6` |
 

--- a/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/opentelemetry-collector-contrib/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the opentelemetry-collector-contrib Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:622773167474952602824a4cd2974e0b56881f41ae88e3e17c61d4abb0fbad9a` |
-|  `latest`     | February 12th | `sha256:daf7507c260b1438cb4751f4f9da1252455ad8a8536087bd05e0508c208d465c` |
+|  `latest`     | February 21st | `sha256:3f43eb4dbc5554c129405389c2584cda4411c2125eafcceb449b70f67e2bb522` |
+|  `latest-dev` | February 21st | `sha256:bc148b4ffef7e6611bbea649429502508a4368e2cb88ce86f1f9e4b4264b3ea0` |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/_index.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/_index.md
@@ -5,7 +5,7 @@ type: "article"
 layout: "single"
 description: "Overview: prometheus-alertmanager Chainguard Image"
 date: 2022-11-01T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -26,7 +26,7 @@ toc: true
 
 
 <!--overview:start-->
-Minimal Prometheus Image
+Minimalist Wolfi-based image for Prometheus Alertmanager. Handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing to the correct receiver.
 <!--overview:end-->
 
 <!--getting:start-->
@@ -34,45 +34,94 @@ Minimal Prometheus Image
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/prometheus:latest
+docker pull cgr.dev/chainguard/prometheus-alertmanager:latest
 ```
 <!--getting:end-->
 
 <!--body:start-->
+
 ## Usage
+For full instructions on prometheus-alertmanager, refer to the
+[official documentation](https://prometheus.io/docs/alerting/latest/alertmanager).
+The GitHub repository can also be [found here](https://github.com/prometheus/alertmanager).
 
-This requires a prometheus configuration file to run.
-An example is provided at `/etc/prometheus/prometheus.yml`.
-The values from this example can be found in the [Prometheus source tree](https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus.yml).
+### Default config settings
+The upstream docker image, overrides some of the default values for
+alertmanager, for example, [see here](https://github.com/prometheus/alertmanager/blob/main/Dockerfile#L20).
+We replicate the same behaviour in the chainguard image to provide parity with
+the upstream image.
 
-THe default port that prometheus listens on is 9090.
-The web browser can be viewed locally over that port by mapping that in with `-p 9090:9090`.
+### Helm
+To deploy via helm, please refer to the upstream
+[helm charts documentation](https://github.com/prometheus-community/helm-charts)
+for comprehensive instructions, which includes
+[supported parameters](https://github.com/prometheus-community/helm-charts/blob/main/charts/alertmanager/values.yaml).
 
-To test:
+Below is an example of how to use the helm chart, overriding the image with the
+chainguard image:
 
-```shell
-% docker run -p 9090:9090 cgr.dev/chainguard/prometheus:latest --config.file=/etc/prometheus/prometheus.yml
-ts=2022-12-27T02:32:45.181Z caller=main.go:512 level=info msg="No time or size retention was set so using the default time retention" duration=15d
-ts=2022-12-27T02:32:45.181Z caller=main.go:556 level=info msg="Starting Prometheus Server" mode=server version="(version=2.41.0, branch=master, revision=WolfiLinux)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:561 level=info build_context="(go=go1.19.4, platform=linux/arm64, user=@dag-wfjfq, date=19700101-00:00:00)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:562 level=info host_details="(Linux 5.10.104-linuxkit #1 SMP PREEMPT Thu Mar 17 17:05:54 UTC 2022 aarch64 98fc282ede4c (none))"
-ts=2022-12-27T02:32:45.181Z caller=main.go:563 level=info fd_limits="(soft=1048576, hard=1048576)"
-ts=2022-12-27T02:32:45.181Z caller=main.go:564 level=info vm_limits="(soft=unlimited, hard=unlimited)"
-ts=2022-12-27T02:32:45.183Z caller=web.go:559 level=info component=web msg="Start listening for connections" address=0.0.0.0:9090
-ts=2022-12-27T02:32:45.184Z caller=main.go:993 level=info msg="Starting TSDB ..."
-ts=2022-12-27T02:32:45.185Z caller=tls_config.go:232 level=info component=web msg="Listening on" address=[::]:9090
-ts=2022-12-27T02:32:45.185Z caller=tls_config.go:235 level=info component=web msg="TLS is disabled." http2=false address=[::]:9090
-ts=2022-12-27T02:32:45.185Z caller=head.go:562 level=info component=tsdb msg="Replaying on-disk memory mappable chunks if any"
-ts=2022-12-27T02:32:45.186Z caller=head.go:606 level=info component=tsdb msg="On-disk memory mappable chunks replay completed" duration=1.417µs
-ts=2022-12-27T02:32:45.186Z caller=head.go:612 level=info component=tsdb msg="Replaying WAL, this may take a while"
-ts=2022-12-27T02:32:45.186Z caller=head.go:683 level=info component=tsdb msg="WAL segment loaded" segment=0 maxSegment=0
-ts=2022-12-27T02:32:45.186Z caller=head.go:720 level=info component=tsdb msg="WAL replay completed" checkpoint_replay_duration=21.5µs wal_replay_duration=473.791µs wbl_replay_duration=84ns total_replay_duration=509.416µs
-ts=2022-12-27T02:32:45.187Z caller=main.go:1014 level=info fs_type=794c7630
-ts=2022-12-27T02:32:45.187Z caller=main.go:1017 level=info msg="TSDB started"
-ts=2022-12-27T02:32:45.188Z caller=main.go:1197 level=info msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
-ts=2022-12-27T02:32:45.188Z caller=main.go:1234 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml totalDuration=434.958µs db_storage=875ns remote_storage=709ns web_handler=208ns query_engine=417ns scrape=123.25µs scrape_sd=15.084µs notify=17.208µs notify_sd=5.75µs rules=1.208µs tracing=2.875µs
-ts=2022-12-27T02:32:45.188Z caller=main.go:978 level=info msg="Server is ready to receive web requests."
-ts=2022-12-27T02:32:45.188Z caller=manager.go:953 level=info component="rule manager" msg="Starting rule manager..."
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+helm install prom-alertmanager prometheus-community/alertmanager \
+ --set image.repository=cgr.dev/chainguard/prometheus-alertmanager \
+ --set image.tag=latest
 ```
+
+The [upstream helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager)
+provides some default `config:` values, but if you intend to deploy with
+additional configuration, i.e defining routes and receivers, you'll need to
+create your own custom values.yaml and pass this into the chart at deployment.
+
+### Docker
+
+#### Create config file
+Before running the container, you'll need to create a configuration file. This
+contains all the necessary configurations for Alertmanager, such as alerting
+routes, receivers, and integrations.
+
+Refer to the [official documentation](https://prometheus.io/docs/alerting/latest/alertmanager)
+for more information. Below is a simple example:
+
+```yaml
+# Save this as 'alertmanager.yml')
+global:
+  resolve_timeout: 11m
+  pagerduty_url: https://example-pagerduty.com/v2/test
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10m
+  repeat_interval: 1h
+receivers:
+  - name: 'example-webhook'
+    webhook_configs:
+    - url: 'http://example.com/hook'
+```
+
+In order to ensure the 'nonroot' container user can access the file when
+volume mounted (below step), ensure you've set read-only permissions:
+
+```bash
+chmod 400 alertmanager.ym
+```
+
+#### Run container
+
+> **IMPORTANT**: Prometheus looks for a file mounted as 'alertmanager.yml' (i.e not .yaml).
+
+```bash
+# TODO: Update '$(pwd)/alertmanager.yml' accordingly to reference your locally
+# created config file.
+docker run -p 9093:9093 \
+  -v $(pwd)/alertmanager.yml:/etc/alertmanager/alertmanager.yml \
+  --name alertmanager \
+  cgr.dev/chainguard/prometheus-alertmanager:latest
+```
+
+Verify that Alertmanager is running correctly by accessing http://localhost:9093
+on your browser.
+
 <!--body:end-->
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/image_specs.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Detailed information about the public prometheus-alertmanager Chainguard Image variants"
 date: 2023-03-07T11:07:52+02:00
-lastmod: 2024-02-14 00:20:21
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -31,12 +31,12 @@ The table has detailed information about each of these variants.
 
 |              | latest-dev                                                                      | latest                                                                          |
 |--------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| Default User | `alertmanager`                                                                  | `alertmanager`                                                                  |
+| Default User | `nonroot`                                                                       | `nonroot`                                                                       |
 | Entrypoint   | `/usr/bin/alertmanager`                                                         | `/usr/bin/alertmanager`                                                         |
 | CMD          | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` | `--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager` |
 | Workdir      | not specified                                                                   | not specified                                                                   |
-| Has apk?     | yes                                                                             | yes                                                                             |
-| Has a shell? | yes                                                                             | yes                                                                             |
+| Has apk?     | yes                                                                             | no                                                                              |
+| Has a shell? | yes                                                                             | no                                                                              |
 
 Check the [tags history page](/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history/) for the full list of available tags.
 
@@ -45,33 +45,31 @@ The table shows package distribution across variants.
 
 |                           | latest-dev | latest |
 |---------------------------|------------|--------|
-| `apk-tools`               | X          | X      |
+| `apk-tools`               | X          |        |
 | `bash`                    | X          |        |
-| `busybox`                 | X          | X      |
+| `busybox`                 | X          |        |
 | `ca-certificates-bundle`  | X          | X      |
 | `git`                     | X          |        |
-| `glibc`                   | X          | X      |
-| `glibc-locale-posix`      | X          | X      |
-| `ld-linux`                | X          | X      |
+| `glibc`                   | X          |        |
+| `glibc-locale-posix`      | X          |        |
+| `ld-linux`                | X          |        |
 | `libbrotlicommon1`        | X          |        |
 | `libbrotlidec1`           | X          |        |
-| `libcrypt1`               | X          | X      |
-| `libcrypto3`              | X          | X      |
+| `libcrypt1`               | X          |        |
+| `libcrypto3`              | X          |        |
 | `libcurl-openssl4`        | X          |        |
 | `libexpat1`               | X          |        |
 | `libidn2`                 | X          |        |
 | `libnghttp2-14`           | X          |        |
 | `libpcre2-8-0`            | X          |        |
 | `libpsl`                  | X          |        |
-| `libssl3`                 | X          | X      |
+| `libssl3`                 | X          |        |
 | `libunistring`            | X          |        |
 | `ncurses`                 | X          |        |
 | `ncurses-terminfo-base`   | X          |        |
-| `openssl-config`          | X          | X      |
+| `openssl-config`          | X          |        |
 | `prometheus-alertmanager` | X          | X      |
 | `wget`                    | X          |        |
-| `wolfi-base`              | X          | X      |
 | `wolfi-baselayout`        | X          | X      |
-| `wolfi-keys`              | X          | X      |
-| `zlib`                    | X          | X      |
+| `zlib`                    | X          |        |
 

--- a/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/prometheus-alertmanager/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the prometheus-alertmanager Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -23,8 +23,10 @@ The following table contains the most recent tags and digests that can be used t
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-| Tag (s)                                       | Last Changed  | Digest                                                                    |
-|-----------------------------------------------|---------------|---------------------------------------------------------------------------|
-|  `latest` `0.26` `0` `0.26.0`                 | February 20th | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
-|  `latest-dev` `0-dev` `0.26-dev` `0.26.0-dev` | February 20th | `sha256:8e9240ffb864f06774c03a6148d64536a61694499ff9acbb359e16f74e7c1d9d` |
+| Tag (s)                          | Last Changed  | Digest                                                                    |
+|----------------------------------|---------------|---------------------------------------------------------------------------|
+|  `latest-dev`                    | February 21st | `sha256:bc020392b648637ef163a13798f510a63c2623ea8a2be17448598622ac4dde0e` |
+|  `latest`                        | February 21st | `sha256:727d8f53ac6607e6c525bfab114f1b84ea874eb4846df557b28738ecc614e3b3` |
+|  `0-dev` `0.26-dev` `0.26.0-dev` | February 18th | `sha256:8e9240ffb864f06774c03a6148d64536a61694499ff9acbb359e16f74e7c1d9d` |
+|  `0.26` `0` `0.26.0`             | February 8th  | `sha256:7193a40485dd6e9dba0dc8b4325723e26d735366c21caef3138a662abf72475d` |
 

--- a/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/rqlite/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the rqlite Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:0e56e14f3ad8b502e6cd74f582f2fb745b71ffec2b56d7a26ab7261f0dc938f3` |
-|  `latest`     | February 18th | `sha256:646450720375322aa12aa8602deae766752e4e2a6ec8e0ea81428f4ca20d5126` |
+|  `latest-dev` | February 21st | `sha256:2779a0ce8070ebe69777790ada40c56fcfa05cfee355aeffe185d63142e71fb6` |
+|  `latest`     | February 21st | `sha256:7a892953abe8ac6c73bcd8c3a15938d83714bf918daeb24b6b92a6a6ab8f1ccd` |
 

--- a/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/skaffold/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the skaffold Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 20th | `sha256:a8c6616df21af7695b9b2082cae72449a937193a71d331501001491d166ace65` |
-|  `latest`     | February 20th | `sha256:8488479f3acdf0787cf7427051cbe0592283c4ed6e85f3eb0107fff428627d2e` |
+|  `latest-dev` | February 21st | `sha256:475f46de8cbbb7268d7d4505b881b8fb00d9e1e215cf64edc98bdc7568e179e4` |
+|  `latest`     | February 21st | `sha256:41665d3bc5626c890563dc6c775883b2134bdcf275f997622327a17650492541` |
 

--- a/content/chainguard/chainguard-images/reference/stakater-reloader/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/stakater-reloader/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the stakater-reloader Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:c5fad41a2354df54214e045f0645432e1eb16aad36f54e479b61a9796f1472cb` |
-|  `latest`     | February 8th  | `sha256:793d09da8d830445a30df636aa68ddb59c7b2c4b73471536433ab85364644bdd` |
+|  `latest-dev` | February 21st | `sha256:909310e7a936ed79f53ea0637748091df97b5e24728746737ea057526719d74d` |
+|  `latest`     | February 21st | `sha256:168ca50545052cf39472d0c70c5aeef3614af493565c0ac1f985717c477e8616` |
 

--- a/content/chainguard/chainguard-images/reference/thanos/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/thanos/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the thanos Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-19 00:28:58
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 18th | `sha256:85d63800b18ed7676c7c16f0567e12c2b4dedded156f5c065f796aa5cc649867` |
-|  `latest`     | January 28th  | `sha256:82e048e36bc40deab289f2b32b2076d8036cfbb4eda33f8ae8ae1a93ca547574` |
+|  `latest-dev` | February 21st | `sha256:43680eeed536542c5dae524ff6fee784babecbd3da04ed16523b89c7774a1af9` |
+|  `latest`     | February 21st | `sha256:657d51f3ec33023689d9849a2365ce06bd935845095c729f5c59b7bbc0c53272` |
 

--- a/content/chainguard/chainguard-images/reference/trino/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/trino/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the trino Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest-dev` | February 20th | `sha256:956c0f137fc831a5a9ba736ec72e3bcc24b6803214f4532f5a030d00ebdab49e` |
-|  `latest`     | February 20th | `sha256:160b5e75669dc8202f4089afb37ecc2274a5662cfb8e242cbeecb77ea13ad29f` |
+|  `latest-dev` | February 21st | `sha256:d7719fef8a7bf61f07563f715d7a18361a2372e7765e5bf9ea3690053837d5f0` |
+|  `latest`     | February 21st | `sha256:d4f21e116032fd9c7806e1f033edae34872dfc330c3f7b0ae4d582eaa47793a8` |
 

--- a/content/chainguard/chainguard-images/reference/wasmtime/tags_history.md
+++ b/content/chainguard/chainguard-images/reference/wasmtime/tags_history.md
@@ -4,7 +4,7 @@ type: "article"
 unlisted: true
 description: "Image Tags and History for the wasmtime Chainguard Image"
 date: 2023-06-22T11:07:52+02:00
-lastmod: 2024-02-21 00:39:53
+lastmod: 2024-02-22 00:36:42
 draft: false
 tags: ["Reference", "Chainguard Images", "Product"]
 images: []
@@ -25,6 +25,6 @@ Please note that digests and timestamps only change when there is a change to th
 
 | Tag (s)       | Last Changed  | Digest                                                                    |
 |---------------|---------------|---------------------------------------------------------------------------|
-|  `latest`     | February 20th | `sha256:eacdf42f4d91f3aa65be4c98b7e891c583b6a222cf9b328a90c75632b7108b61` |
-|  `latest-dev` | February 20th | `sha256:0ad0cbdfac6985875f73f2b14a26ac0e99cc103b155bea2492a90660a00ae884` |
+|  `latest`     | February 21st | `sha256:271c095b59fd7ef1e779b089d899daf59678a64175b993e8ff21086d0a5d0ee3` |
+|  `latest-dev` | February 21st | `sha256:9f0d2e4aafa2bc1334e312d4bdcdb279785c3e17c8aa4482a6edd88497c917cc` |
 


### PR DESCRIPTION
New images added:

- clickhouse

Updated Docs:

- dask-gateway-server/tags_history.md
- datadog-agent/tags_history.md
- envoy-ratelimit/tags_history.md
- gitlab-exporter/tags_history.md
- gitlab-pages/tags_history.md
- gitlab-shell/tags_history.md
- hugo/tags_history.md
- kubeflow-katib-earlystopping-medianstop/tags_history.md
- kubeflow-katib-suggestion-darts/tags_history.md
- kubeflow-katib-suggestion-hyperband/tags_history.md
- kubeflow-katib-suggestion-hyperopt/tags_history.md
- kubeflow-katib-suggestion-optuna/tags_history.md
- kubeflow-katib-suggestion-pbt/tags_history.md
- kubeflow-katib-suggestion-skopt/tags_history.md
- kubeflow-pipelines-visualization-server/tags_history.md
- kyverno/tags_history.md
- kyverno-background-controller/tags_history.md
- kyverno-cleanup-controller/tags_history.md
- kyverno-cli/tags_history.md
- kyverno-policy-reporter/tags_history.md
- kyverno-reports-controller/tags_history.md
- openai/tags_history.md
- opentelemetry-collector-contrib/tags_history.md
- prometheus-alertmanager/_index.md
- prometheus-alertmanager/image_specs.md
- prometheus-alertmanager/tags_history.md
- rqlite/tags_history.md
- skaffold/tags_history.md
- stakater-reloader/tags_history.md
- thanos/tags_history.md
- trino/tags_history.md
- wasmtime/tags_history.md
- zot/tags_history.md