### PR TITLE
Revert "Add Harden Runner audit config to some edu jobs"

### DIFF
--- a/.github/workflows/autodocs-enforce.yaml
+++ b/.github/workflows/autodocs-enforce.yaml
@@ -18,11 +18,6 @@ jobs:
     outputs:
       status: ${{ steps.compare-releases.outputs.status }}
     steps:
-    - name: 'Github Actions Runner'
-      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 
@@ -62,11 +57,6 @@ jobs:
     if: needs.check-new-docs.outputs.status == 'outdated'
 
     steps:
-    - name: 'Github Actions Runner'
-      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 

--- a/.github/workflows/autodocs-images-variants.yaml
+++ b/.github/workflows/autodocs-images-variants.yaml
@@ -25,11 +25,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: 'Github Actions Runner'
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-          with:
-            egress-policy: audit
-
       - name: Check out Destination Repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -26,11 +26,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: 'Github Actions Runner'
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-          with:
-              egress-policy: audit
-
       - name: Check out Destination Repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:

--- a/.github/workflows/build-terminal-images.yaml
+++ b/.github/workflows/build-terminal-images.yaml
@@ -22,11 +22,6 @@ jobs:
           - vexctl
 
     steps:
-      - name: 'Github Actions Runner'
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-          with:
-            egress-policy: audit
-
       - uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
 
       - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -20,11 +20,6 @@ jobs:
       issues: write # opens issues when bad links are found
 
     steps:
-      - name: 'Github Actions Runner'
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-          with:
-            egress-policy: audit
-
       - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 

--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -13,11 +13,6 @@ jobs:
       id-token: write # federates with GCP
 
     steps:
-    - name: 'Github Actions Runner'
-      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-
     - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 

--- a/.github/workflows/rumble-vulnerability-data.yaml
+++ b/.github/workflows/rumble-vulnerability-data.yaml
@@ -26,11 +26,6 @@ jobs:
       id-token: write # federate with GCP
       
     steps:
-      - name: 'Github Actions Runner'
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-          with:
-            egress-policy: audit
-
       - name: 'Checkout default branch to $GITHUB_WORKSPACE dir'
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 


### PR DESCRIPTION
Reverts chainguard-dev/edu#1408

Need to redo formatting, Github isn't happy with the `uses: with` indenting.