### PR TITLE
use new setup-chainctl location

### DIFF
--- a/.github/workflows/autodocs-images-variants.yaml
+++ b/.github/workflows/autodocs-images-variants.yaml
@@ -44,7 +44,7 @@ jobs:
           chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: Set up Chainctl
-        uses: chainguard-dev/actions/setup-chainctl@main
+        uses: chainguard-dev/setup-chainctl@main
         with:
           identity: "${{ secrets.CHAINCTL_IDENTITY }}"
 

--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -51,7 +51,7 @@ jobs:
           chmod 777 "${{ github.workspace }}/${{ env.WORKDIR }}"
 
       - name: Set up Chainctl
-        uses: chainguard-dev/actions/setup-chainctl@main
+        uses: chainguard-dev/setup-chainctl@main
         with:
           identity: "${{ secrets.CHAINCTL_IDENTITY }}"
 

--- a/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
@@ -221,7 +221,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: chainguard-dev/actions/setup-chainctl@main
+    - uses: chainguard-dev/setup-chainctl@main
       with:
         identity: <your actions identity>
 

--- a/content/chainguard/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-registry/authenticating/index.md
@@ -130,8 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: chainguard-dev/actions/setup-chainctl@main
-        with:
+tup-        with:
           identity: [[ The Chainguard Identity ID you created above ]]
       - run: docker pull cgr.dev/chainguard/node
 ```

--- a/content/chainguard/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-registry/authenticating/index.md
@@ -130,7 +130,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-tup-        with:
+      - uses: chainguard-dev/setup-chainctl@main
+        with:
           identity: [[ The Chainguard Identity ID you created above ]]
       - run: docker pull cgr.dev/chainguard/node
 ```


### PR DESCRIPTION
## Type of change
cleanup

### What should this PR do?
point folks to the new action location

### Why are we making this change?
we're going to deprecate the old location (https://github.com/chainguard-dev/actions/pull/399)

### What are the acceptance criteria? 
the documented workflows still work

### How should this PR be tested?
