### PR TITLE
How to use images docker

### DIFF
--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -39,7 +39,7 @@ Chainguard Images are available through the [Chainguard Registry](/chainguard/ch
 
 ## Are Chainguard Images available on Docker Hub?
 
-Yes, Chainguard Developer Images are available on Docker Hub. As Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Images, you need to use the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
+Yes, Chainguard Developer Images are available on [Docker Hub](https://hub.docker.com/u/chainguard?utm_source=academy&utm_medium=referral&utm_campaign=FY25-DockerHub-Orgprofile). As Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Images, you need to use the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
 
 ## What options do I have to use Chainguard Images?
 

--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -37,6 +37,10 @@ To review Chainguard's Developer Images, you can check out either the [Chainguar
 
 Chainguard Images are available through the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
 
+## Are Chainguard Images available on Docker Hub?
+
+Yes, Chainguard Developer Images are available on Docker Hub. As Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Images, you need to use the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
+
 ## What options do I have to use Chainguard Images?
 
 You can get free Chainguard Images for your organization; you can also upgrade for more versions, SLAs, and dedicated support.

--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -39,7 +39,7 @@ Chainguard Images are available through the [Chainguard Registry](/chainguard/ch
 
 ## Are Chainguard Images available on Docker Hub?
 
-Yes, Chainguard Developer Images are available on [Docker Hub](https://hub.docker.com/u/chainguard?utm_source=academy&utm_medium=referral&utm_campaign=FY25-DockerHub-Orgprofile). As Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Images, you need to use the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
+Yes, Chainguard Developer Images are available on [Docker Hub](https://hub.docker.com/u/chainguard?utm_source=academy&utm_medium=referral&utm_campaign=FY25-DockerHub-Orgprofile). As a Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Images, you need to use the [Chainguard Registry](/chainguard/chainguard-images/registry/overview/).
 
 ## What options do I have to use Chainguard Images?
 

--- a/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
@@ -25,7 +25,7 @@ In this guide, you'll learn how to get started using Chainguard Images and how t
 
 ## Quickstart: Using Chainguard Images
 
-To get up and running with Chainguard Images, you can use `docker` commands to pull and run images. For each specific image, you'll find this guidance on its overview page (for example, see [Node](/chainguard/chainguard-images/reference/node/overview/), [Python](/chainguard/chainguard-images/reference/python/overview/), or [NGINX](/chainguard/chainguard-images/reference/nginx/overview/)). 
+To get up and running with Chainguard Images, you can use `docker` commands to pull and run images. For each specific image, you'll find this guidance on its overview page (for example, see [Node](/chainguard/chainguard-images/reference/node/overview/), [Python](/chainguard/chainguard-images/reference/python/overview/), or [NGINX](/chainguard/chainguard-images/reference/nginx/overview/)).
 
 ### Pulling a Chainguard Image
 
@@ -37,11 +37,13 @@ docker pull cgr.dev/chainguard/git
 
 Without passing a tag or a digest, the reference to the Git image will pull down the default tag, which is `:latest`.
 
-Note that if you have your own registry, you'll need to change the `cgr.dev/chainguard` path to your own registry path. 
+If you have your own registry, you'll need to change the `cgr.dev/chainguard` path to your own registry path.
+
+Chainguard Developer Images are also available on Docker Hub. See [Chainguard's organization page on Docker Hub](https://hub.docker.com/u/chainguard?utm_source=academy&utm_medium=referral&utm_campaign=FY25-DockerHub-Orgprofile) for a list of all images and instructions. Note that Production Images can only be accessed from cgr.dev.
 
 ### Pulling by Tag
 
-You can also add a relevant tag that you have access to. In the case of the Git image, you can pull the `:latest-glibc` tag for the Git image. [Note that not all tags are available for public images](/chainguard/chainguard-images/faq/#do-i-need-to-authenticate-into-chainguard-to-use-chainguard-images). 
+You can also add a relevant tag that you have access to. In the case of the Git image, you can pull the `:latest-glibc` tag for the Git image. [Note that not all tags are available for public images](/chainguard/chainguard-images/faq/#do-i-need-to-authenticate-into-chainguard-to-use-chainguard-images).
 
 ```sh
 docker pull cgr.dev/chainguard/git:latest-glibc
@@ -49,21 +51,21 @@ docker pull cgr.dev/chainguard/git:latest-glibc
 
 You may use tags to pull a specific version of a software like Git, or programming language version in a catalog you have access to. Chainguard Academy has tag history pages for each image, which you can find in our reference docs. For example, the [Git Image Tags History](/chainguard/chainguard-images/reference/git/tags_history/), [PHP Image Tags History](/chainguard/chainguard-images/reference/php/tags_history/), and [JDK Image Tags History](/chainguard/chainguard-images/reference/jdk/tags_history/).
 
-You can learn about the Chainguard Images tags history in our guide about [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/). 
+You can learn about the Chainguard Images tags history in our guide about [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/).
 
 ### Pulling by Digest
 
-Pulling a Chainguard Image by its digest guarantees reproducibility, as it will ensure that you are using the same image each time (versus the tag that may receive updates). 
+Pulling a Chainguard Image by its digest guarantees reproducibility, as it will ensure that you are using the same image each time (versus the tag that may receive updates).
 
 To pull an image by its digest, you can do so by appending the digest which begins with `sha256`. You can find these on our reference tags history pages.
 
-In our Git example, we can review the [Git Image Tags History](/chainguard/chainguard-images/reference/git/tags_history/) page and choose a relevant digest. We will choose the `:latest-dev` image that was last updated on September 2, 2023 at the time this document was being prepared. 
+In our Git example, we can review the [Git Image Tags History](/chainguard/chainguard-images/reference/git/tags_history/) page and choose a relevant digest. We will choose the `:latest-dev` image that was last updated on September 2, 2023 at the time this document was being prepared.
 
 ```sh
 docker pull cgr.dev/chainguard/git@sha256:f6658e10edde332c6f1dc804f0f664676dc40db78ba4009071fea6b9d97d592f
 ```
 
-When you pull this image, you'll receive output of the digest which should match the exact digest you have pulled. 
+When you pull this image, you'll receive output of the digest which should match the exact digest you have pulled.
 
 To learn more about image digests, you can review our video [How to Use Container Image Digests to Improve Reproducibility](/chainguard/chainguard-images/videos/container-image-digests/).
 
@@ -99,7 +101,7 @@ Let's run the [Cosign Chainguard Image](/chainguard/chainguard-images/reference/
 docker run --rm -t cgr.dev/chainguard/cosign:latest version
 ```
 
-You'll receive the version information that confirms the image is working as expected. 
+You'll receive the version information that confirms the image is working as expected.
 
 ```
   ______   ______        _______. __    _______ .__   __.
@@ -125,9 +127,9 @@ If you would like to review a filesystem, you can use the [wolfi-base image](/ch
 docker run -it cgr.dev/chainguard/wolfi-base
 ```
 
-This will start a Wolfi container where you can explore the file system and investigate which packages are available. 
+This will start a Wolfi container where you can explore the file system and investigate which packages are available.
 
-Continue reading the next section to learn more about building off of the Wolfi base image. 
+Continue reading the next section to learn more about building off of the Wolfi base image.
 
 ## Getting Started with Distroless Base Images
 


### PR DESCRIPTION
## Type of change
Added info about Docker hub to the How to use Images tutorial. 

### What should this PR do?
Add a few sentences to the tutorial. 

### Why are we making this change?
To inform users they can also access CG Developer Images on Docker. 

### What are the acceptance criteria? 
Is the added copy sufficient, clear, correct? 

### How should this PR be tested?
It should be read. 