### PR TITLE
Fix: Link to considerations-for-images-updates

### DIFF
--- a/content/chainguard/chainguard-images/recommended-practices/cve-risk.md
+++ b/content/chainguard/chainguard-images/recommended-practices/cve-risk.md
@@ -67,7 +67,7 @@ One tool that's useful for automating updates for your dependencies is [**Depend
 
 If you'd like to automate updates outside of GitHub repositories, [**Snyk**](https://snyk.io/) is another tool that enables automatic updates. Synk can integrate into IDEs as well as repositories, allowing you to continously scan for vulnerabilities. Like Dependabot, Snyk will automatically submit a pull request when it encoutners a vulnerability and it can recommend a solution. 
 
-There are a number of important considerations one should make when keeping container images up to date. Please check out our [conceptual article on the subject](/chainguard/chainguard-images/considerations-for-image-updates/).
+There are a number of important considerations one should make when keeping container images up to date. Please check out our [conceptual article on the subject](/chainguard/chainguard-images/considerations-for-images-updates/).
 
 
 ### Minimal container images
@@ -88,4 +88,4 @@ As mentioned in the introduction, there's no way to guarantee that no CVEs will 
 If you'd like to learn more about CVEs, and strategies for remediating them, we encourage you to check out the following resources:
 * [What Are Software Vulnerabilities and CVEs?](/software-security/cves/cve-intro/#what-is-a-cve)
 * [False Positives and False Negatives with Images Scanners](/chainguard/chainguard-images/scanners/false-results/)
-* [Considerations for Keeping Images Up to Date](/chainguard/chainguard-images/considerations-for-image-updates/)
+* [Considerations for Keeping Images Up to Date](/chainguard/chainguard-images/considerations-for-images-updates/)


### PR DESCRIPTION
## Type of change
Fixes `considerations-for-images-updates` link in `/chainguard/chainguard-images/recommended-practices/cve-risk/`