### PR TITLE
Fix some inconsistencies in the IAM examples.

### DIFF
--- a/content/chainguard/administration/iam-groups/identity-examples/aws-identity.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/aws-identity.md
@@ -136,7 +136,7 @@ Then we'll define a Chainguard identity that can be assumed by the AWS role crea
 
 ```hcl
 resource "chainguard_identity" "aws" {
-  parent_id   = chainguard_group.example-group.id
+  parent_id   = data.chainguard_group.example-group.id
   name        = "aws-auth-identity"
   description = "Identity for AWS Lambda"
 
@@ -157,7 +157,7 @@ The `aws_user_id_pattern` field configures the identity to be assumable only by 
 The section after that looks up the `viewer` role.
 
 ```
-data "chainguard_roles" "viewer" {
+data "chainguard_role" "viewer" {
   name = "viewer"
 }
 ```
@@ -167,8 +167,8 @@ The final section grants this role to the identity on the `example-group`.
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.aws.id
-  group	= chainguard_group.example-group.id
-  role 	= data.chainguard_roles.viewer.items[0].id
+  group	= data.chainguard_group.example-group.id
+  role 	= data.chainguard_role.viewer.items[0].id
 }
 ```
 

--- a/content/chainguard/administration/iam-groups/identity-examples/bitbucket-identity.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/bitbucket-identity.md
@@ -84,7 +84,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "bitbucket" {
-  parent_id   = chainguard_group.group.id
+  parent_id   = data.chainguard_group.group.id
   name        = "bitbucket"
   description = <<EOF
     This is an identity that authorizes Bitbucket workflows
@@ -132,8 +132,8 @@ The final section grants this role to the identity on the group.
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.bitbucket.id
-  group    = chainguard_group.group.id
-  role     = data.chainguard_roles.viewer.items[0].id
+  group    = data.chainguard_group.group.id
+  role     = data.chainguard_role.viewer.items[0].id
 }
 ```
 

--- a/content/chainguard/administration/iam-groups/identity-examples/buildkite-identity.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/buildkite-identity.md
@@ -135,42 +135,7 @@ resource "chainguard_rolebinding" "view-stuff" {
 }
 ```
 
-Run the following command to create this file with each of these sections. Be sure to change the `subject_pattern` value to align with your own Buildkite pipeline. For example, if your organization name were `example-org-123` and the pipeline name was `sample-pipeline`, you would set the `subject_pattern` value to `"organization:example-org-123:pipeline:sample-pipeline:ref:refs/heads/main:commit:[0-9a-f]+:step:`.
-
-```sh
-cat > buildkite.tf <<EOF
-resource "chainguard_identity" "buildkite" {
-  parent_id   = chainguard_group.group.id
-  name    	= "buildkite"
-  description = <<EOF
-	This is an identity that authorizes Buildkite workflows
-	for this repository to assume to interact with chainctl.
-  EOF
-
-  claim_match {
-	issuer      	= "https://agent.buildkite.com"
-	subject_pattern = "organization:<organization-name>:pipeline:<pipeline-name>:ref:refs/heads/main:commit:[0-9a-f]+:step:"
-  }
-}
-
-output "buildkite-identity" {
-  value = chainguard_identity.buildkite.id
-}
-
-data "chainguard_roles" "viewer" {
-  name = "viewer"
-}
-
-resource "chainguard_rolebinding" "view-stuff" {
-  identity = chainguard_identity.buildkite.id
-  group	= chainguard_group.group.id
-  role 	= data.chainguard_roles.viewer.items[0].id
-}
-EOF
-```
-
 Following that, your Terraform configuration will be ready. Now you can run a few `terraform` commands to create the resources defined in your `.tf` files.
-
 
 ## Creating Your Resources
 

--- a/content/chainguard/administration/iam-groups/identity-examples/buildkite-identity.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/buildkite-identity.md
@@ -68,7 +68,7 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-data "chainguard_dev" "root_group" {
+data "chainguard_group" "group" {
   name = "my-customer.biz"
 }
 ```
@@ -85,7 +85,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "buildkite" {
-  parent_id   = chainguard_group.group.id
+  parent_id   = data.chainguard_group.group.id
   name   	 = "buildkite"
   description = <<EOF
     This is an identity that authorizes Buildkite workflows
@@ -130,8 +130,8 @@ The final section grants this role to the identity on the group.
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.buildkite.id
-  group	= chainguard_group.group.id
-  role 	= data.chainguard_roles.viewer.items[0].id
+  group	= data.chainguard_group.group.id
+  role 	= data.chainguard_role.viewer.items[0].id
 }
 ```
 

--- a/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
@@ -125,7 +125,7 @@ data "chainguard_role" "viewer" {
 The final section grants this role to the identity on the group.
 
 ```
-resource "chainguard_role-binding" "view-stuff" {
+resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.actions.id
   group	= data.chainguard_group.group.id
   role 	= data.chainguard_role.viewer.items[0].id

--- a/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/github-identity/index.md
@@ -69,7 +69,7 @@ Next, you can create the `sample.tf` file.
 This Terraform configuration consists of two main parts. The first part of the file will contain the following lines.
 
 ```
-data "chainguard_dev" "root_group" {
+data "chainguard_group" "group" {
   name = "my-customer.biz"
 }
 ```
@@ -86,7 +86,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "actions" {
-  parent_id   = chainguard_group.group.id
+  parent_id   = data.chainguard_group.group.id
   name    	= "github-actions"
   description = <<EOF
     This is an identity that authorizes the actions in this
@@ -127,7 +127,7 @@ The final section grants this role to the identity on the group.
 ```
 resource "chainguard_role-binding" "view-stuff" {
   identity = chainguard_identity.actions.id
-  group	= chainguard_group.group.id
+  group	= data.chainguard_group.group.id
   role 	= data.chainguard_role.viewer.items[0].id
 }
 ```

--- a/content/chainguard/administration/iam-groups/identity-examples/gitlab-identity.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/gitlab-identity.md
@@ -85,7 +85,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "gitlab" {
-  parent_id   = chainguard_group.group.id
+  parent_id   = data.chainguard_group.group.id
   name    	= "gitlab-ci"
   description = <<EOF
 	This is an identity that authorizes Gitlab CI in this
@@ -119,7 +119,7 @@ output "gitlab-identity" {
 The section after that looks up the `viewer` role.
 
 ```
-data "chainguard_roles" "viewer" {
+data "chainguard_role" "viewer" {
   name = "viewer"
 }
 ```
@@ -129,8 +129,8 @@ The final section grants this role to the identity on the group.
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.gitlab.id
-  group	= chainguard_group.group.id
-  role 	= data.chainguard_roles.viewer.items[0].id
+  group	= data.chainguard_group.group.id
+  role 	= data.chainguard_role.viewer.items[0].id
 }
 ```
 

--- a/content/chainguard/administration/iam-groups/identity-examples/jenkins-identity/index.md
+++ b/content/chainguard/administration/iam-groups/identity-examples/jenkins-identity/index.md
@@ -100,7 +100,7 @@ The first section creates the identity itself.
 
 ```
 resource "chainguard_identity" "jenkins" {
-  parent_id   = chainguard_group.group.id
+  parent_id   = data.chainguard_group.group.id
   name        = "jenkins"
   description = <<EOF
     This is an identity that authorizes Jenkins workflows
@@ -150,7 +150,7 @@ The final section grants this role to the identity on the group.
 ```
 resource "chainguard_rolebinding" "view-stuff" {
   identity = chainguard_identity.jenkins.id
-  group    = chainguard_group.group.id
+  group    = data.chainguard_group.group.id
   role     = data.chainguard_role.viewer.items[0].id
 }
 ```


### PR DESCRIPTION
Signed-off-by: Max Allan <max.allan@chainguard.dev>


### What should this PR do?
- Fix some inconsistencies between the different IAM examples. Some use `chainguard_roles`, some use `chainguard_role`. Some use `data.object` some just use `object`. etc.
- Make the IAM examples work!

When running terraform, the example code for GitLab was throwing the following errors:
```
│ Error: Reference to undeclared resource
│ 
│   on gitlab.tf line 2, in resource "chainguard_identity" "gitlab":
│    2:   parent_id   = chainguard_group.group.id
│ 
│ A managed resource "chainguard_group" "group" has not been declared in the root module.
│ 
│ Did you mean the data resource data.chainguard_group.group?
╵
╷
│ Error: Invalid data source
│ 
│   on gitlab.tf line 20, in data "chainguard_roles" "viewer":
│   20: data "chainguard_roles" "viewer" {
│ 
│ The provider chainguard-dev/chainguard does not support data source "chainguard_roles". Did you mean "chainguard_role"?
```

### What are the acceptance criteria? 
Should be reviewed by someone with a wider understanding of IAM and the commands used.
eg, should some actually use `root_group` rather than `group`. I'm not sure myself.

### How should this PR be tested?
Ideally run through each of these sets of instructions with the build systems suggested. I don't have access to any of them myself so can't easily.

Maybe run the `terraform plan` command once with the suggested changes and double check all the other examples are looking the same.