### PR TITLE
Add documentation on verifying Images and other attestations

### DIFF
--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -141,6 +141,7 @@ GitHub Workflow Name: .github/workflows/release.yaml
 GitHub Workflow Trigger chainguard-images/images
 GitHub Workflow Ref: refs/heads/main
 ...
+
 ## Learn more
 
 To get up to speed with Sigstore, you can review the [Sigstore](/open-source/sigstore/) section of Chainguard Academy, visit the upstream [Sigstore Docs](https://docs.sigstore.dev/) site, and check out the [Sigstore organization on GitHub](https://github.com/sigstore). You can learn more about verifying software artifacts with Cosign by reading [How to Verify File Signatures with Cosign](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).  

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -25,7 +25,7 @@ The following commands requires [cosign](https://docs.sigstore.dev/cosign/overvi
 
 Attestations are provided per image build, so you'll need to specify the correct tag and registry when pulling attestations from an image with `cosign`.
 
-- `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `latest*` versions of an image.
+- `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `:latest` versions of an image.
 - `cgr.dev/your-registry-name` - A Private/Dedicated Registry contains our **Production Images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
 
 The commands listed on this page will default to the `latest` tag, but you can specify a different tag to fetch attestations for.

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -141,9 +141,10 @@ GitHub Workflow Name: .github/workflows/release.yaml
 GitHub Workflow Trigger chainguard-images/images
 GitHub Workflow Ref: refs/heads/main
 ...
+```
 
 ## Learn more
 
-To get up to speed with Sigstore, you can review the [Sigstore](/open-source/sigstore/) section of Chainguard Academy, visit the upstream [Sigstore Docs](https://docs.sigstore.dev/) site, and check out the [Sigstore organization on GitHub](https://github.com/sigstore). You can learn more about verifying software artifacts with Cosign by reading [How to Verify File Signatures with Cosign](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).  
+To get up to speed with Sigstore, you can review the [Sigstore](/open-source/sigstore/) section of Chainguard Academy, visit the upstream [Sigstore Docs](https://docs.sigstore.dev/) site, and check out the [Sigstore organization on GitHub](https://github.com/sigstore). You can learn more about verifying software artifacts with Cosign by reading [How to Verify File Signatures with Cosign](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).
 
-Navigate to our [Images](/chainguard/chainguard-images/) landing page or [Getting Started Guides](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/) to understand more about Chainguard Images and how they offer low-to-zero CVEs. 
+Navigate to our [Images](/chainguard/chainguard-images/) landing page or [Getting Started Guides](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/) to understand more about Chainguard Images and how they offer low-to-zero CVEs.

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -1,0 +1,144 @@
+---
+title: "Verifying Chainguard Images and Metadata Signatures with Cosign"
+linktitle: "Verifying with Cosign"
+aliases:
+  - /chainguard/chainguard-images/verifying-images-with-cosign
+type: "article"
+description: "A walkthrough of verifying Chainguard Images and metadata signatures with Cosign."
+date: 2024-03-18T08:59:52-07:00
+lastmod: 2024-03-18T08:59:52-07:00
+draft: false
+tags: ["Conceptual", "Chainguard Images", "Product"]
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 020
+toc: true
+---
+
+All Chainguard Images contain verifiable signatures and build-time SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+
+The following commands requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine in order to download and verify image attestations. It will pull detailed information about all signatures found for the provided image.
+
+## Registry and Tags for Chainguard Images
+
+Attestations are provided per image build, so you'll need to specify the correct tag and registry when pulling attestations from an image with `cosign`.
+
+- `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `latest*` versions of an image.
+- `cgr.dev/your-registry-name` - A Private/Dedicated Registry contains our **Production Images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
+
+The commands listed on this page will default to the `latest` tag, but you can specify a different tag to fetch attestations for.
+
+## Verifying Image Signatures
+
+Chainguard Images are signed using Sigstore and you can check the included signatures using `cosign`. The `cosign verify` command will pull detailed information about all signatures found for the provided image.
+
+### Public Registry
+
+```shell
+IMAGE=go
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/${IMAGE} | jq
+```
+
+### Private/Dedicated Registry
+
+```shell
+PARENT=your-registry-name
+IMAGE=go
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/${PARENT}/${IMAGE} | jq
+```
+
+By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+
+## Downloading Image Attestations
+
+Attestations are signed metadata about the artifact, which can include SBOMs (software bill of materials), vulnerability scans, or other custom predicates.
+
+The [attestations](https://slsa.dev/attestation-model) for an image can be obtained and verified via cosign. These are a few of the existing types:
+
+| Attestation Type                       | Description                                                                                                                          |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `https://slsa.dev/provenance/v1`       | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.       |
+| `https://spdx.dev/Document`            | Contains the image SBOM (software bill of materials) in SPDX format.                                                                 |
+
+To download an attestation, use the `cosign download attestation` command and provide both the `predicate-type` and the build `platform`.
+
+By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
+
+To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
+
+For example, the following command will obtain the SBOM for the requested image for the `linux/amd64` platform:
+
+### Public Registry
+
+```shell
+IMAGE=go
+cosign download attestation \
+  --predicate-type=https://spdx.dev/Document \
+  --platform=linux/amd64 \
+  cgr.dev/chainguard/${IMAGE} | jq -r .payload | base64 -d | jq .predicate
+```
+
+### Private/Dedicated Registry
+
+```shell
+PARENT=your-registry-name
+IMAGE=go
+cosign download attestation \
+  --predicate-type=https://spdx.dev/Document \
+  --platform=linux/amd64 \
+  cgr.dev/${PARENT}/${IMAGE} | jq -r .payload | base64 -d | jq .predicate
+```
+
+## Verifying Image Attestations
+
+You can use the `cosign verify-attestation` command to check the signatures of the desired image [attestations](https://slsa.dev/attestation-model):
+
+### Public Registry
+
+```shell
+IMAGE=go
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/chainguard/${IMAGE}
+```
+
+### Private/Dedicated Registry
+
+```shell
+PARENT=your-registry-name
+IMAGE=go
+cosign verify-attestation \
+  --type https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+  cgr.dev/${PARENT}/${IMAGE}
+```
+
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation for SBOMs (software bill of materials). You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```shell
+Verification for cgr.dev/chainguard/go --
+The following checks were performed on each of these signatures:
+- The cosign claims were validated
+- Existence of the claims in the transparency log was verified offline
+- The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject:  https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL:  https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: schedule
+GitHub Workflow SHA: da283c26829d46c2d2883de5ff98bee672428696
+GitHub Workflow Name: .github/workflows/release.yaml
+GitHub Workflow Trigger chainguard-images/images
+GitHub Workflow Ref: refs/heads/main
+...
+```

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -61,7 +61,7 @@ By default, this command will fetch signatures for the `:latest` tag. You can al
 
 Attestations are signed metadata about the artifact, which can include SBOMs, vulnerability scans, or other custom predicates.
 
-The [attestations](https://slsa.dev/attestation-model) for an image can be obtained and verified via cosign. These are a few of the existing types:
+The [attestations](https://slsa.dev/attestation-model) for an image can be obtained and verified via Cosign. These are a few of the existing types:
 
 | Attestation Type                       | Description                                                                                                                          |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -55,7 +55,7 @@ cosign verify \
   cgr.dev/${PARENT}/${IMAGE} | jq
 ```
 
-By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+By default, this command will fetch signatures for the `:latest` tag. You can also specify the tag you want to fetch signatures for.
 
 ## Downloading Image Attestations
 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -17,7 +17,7 @@ weight: 020
 toc: true
 ---
 
-All Chainguard Images contain verifiable signatures and build-time SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+All Chainguard Images contain verifiable signatures and build-time SBOMs (software bills of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
 
 The following commands requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine in order to download and verify image attestations. It will pull detailed information about all signatures found for the provided image.
 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -19,7 +19,7 @@ toc: true
 
 All Chainguard Images contain verifiable signatures and build-time SBOMs (software bills of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
 
-The following commands requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine in order to download and verify image attestations. It will pull detailed information about all signatures found for the provided image.
+The following commands requires [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine in order to download and verify image attestations. It will pull detailed information about all signatures found for the provided image.
 
 ## Registry and Tags for Chainguard Images
 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -59,7 +59,7 @@ By default, this command will fetch signatures for the `latest` tag. You can als
 
 ## Downloading Image Attestations
 
-Attestations are signed metadata about the artifact, which can include SBOMs (software bill of materials), vulnerability scans, or other custom predicates.
+Attestations are signed metadata about the artifact, which can include SBOMs, vulnerability scans, or other custom predicates.
 
 The [attestations](https://slsa.dev/attestation-model) for an image can be obtained and verified via cosign. These are a few of the existing types:
 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -1,6 +1,6 @@
 ---
 title: "Verifying Chainguard Images and Metadata Signatures with Cosign"
-linktitle: "Verifying with Cosign"
+linktitle: "Verifying Images"
 aliases:
   - /chainguard/chainguard-images/verifying-images-with-cosign
 type: "article"

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -141,4 +141,8 @@ GitHub Workflow Name: .github/workflows/release.yaml
 GitHub Workflow Trigger chainguard-images/images
 GitHub Workflow Ref: refs/heads/main
 ...
-```
+## Learn more
+
+To get up to speed with Sigstore, you can review the [Sigstore](/open-source/sigstore/) section of Chainguard Academy, visit the upstream [Sigstore Docs](https://docs.sigstore.dev/) site, and check out the [Sigstore organization on GitHub](https://github.com/sigstore). You can learn more about verifying software artifacts with Cosign by reading [How to Verify File Signatures with Cosign](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).  
+
+Navigate to our [Images](/chainguard/chainguard-images/) landing page or [Getting Started Guides](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/) to understand more about Chainguard Images and how they offer low-to-zero CVEs. 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -125,7 +125,7 @@ cosign verify-attestation \
   cgr.dev/${PARENT}/${IMAGE}
 ```
 
-This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation for SBOMs (software bill of materials). You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation for SBOMs. You should get output that verifies the SBOM attestation signature in Cosign's transparency log:
 
 ```shell
 Verification for cgr.dev/chainguard/go --

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -67,7 +67,7 @@ The [attestations](https://slsa.dev/attestation-model) for an image can be obtai
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `https://slsa.dev/provenance/v1`       | The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
 | `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.       |
-| `https://spdx.dev/Document`            | Contains the image SBOM (software bill of materials) in SPDX format.                                                                 |
+| `https://spdx.dev/Document`            | Contains the image SBOM in SPDX format.                                                                 |
 
 To download an attestation, use the `cosign download attestation` command and provide both the `predicate-type` and the build `platform`.
 

--- a/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
+++ b/content/chainguard/chainguard-images/verifying-chainguard-images-and-metadata-signatures-with-cosign.md
@@ -28,7 +28,7 @@ Attestations are provided per image build, so you'll need to specify the correct
 - `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `:latest` versions of an image.
 - `cgr.dev/your-registry-name` - A Private/Dedicated Registry contains our **Production Images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
 
-The commands listed on this page will default to the `latest` tag, but you can specify a different tag to fetch attestations for.
+The commands listed on this page will default to the `:latest` tag, but you can specify a different tag to fetch attestations for.
 
 ## Verifying Image Signatures
 


### PR DESCRIPTION
## Type of change
Documentation

### What should this PR do?
This PR adds generic information on verifying Images and their attestations via the `cosign` command.

### Why are we making this change?
This helps increase overall discoverability of validating image provenance and the Image's corresponding signatures.

### What are the acceptance criteria? 
n/a

### How should this PR be tested?
n/a