### PR TITLE
Adding new dedicated guide to distroless, updating other pages

### DIFF
--- a/content/chainguard/chainguard-images/getting-started-distroless.md
+++ b/content/chainguard/chainguard-images/getting-started-distroless.md
@@ -24,17 +24,17 @@ This minimal approach offers several benefits, including:
 - **Simplified Dependency Management:** Traditional container images can introduce dependency bloat, making it difficult to track and manage exactly what's included. Distroless images keep things clear by only containing what's directly required for the application to function.
 - **Potentially Smaller Image Sizes:** By eliminating extraneous OS components, distroless images can be significantly smaller than their full-blown counterparts.
 
-Chainguard offers a mix of distroless and development (or builder) images that are minimalist and contain provenance attestations for increased security. Since distroless images have fewer tools and don't come with a package manager, some adaptation might be necessary when migrating from traditional base images. A typical approach is using Docker multi-stage builds to compose a final distroless image containing the additional artifacts required by the application in order to run successfully.
+Chainguard offers a mix of distroless and development (or builder) images that are minimalist and contain provenance attestations for increased security. Since distroless images have fewer tools and don't come with a package manager, some adaptation might be necessary when migrating from traditional base images. A typical approach is using multi stage builds to compose a final distroless image containing the additional artifacts required by the application in order to run successfully.
 
-## Multi-Stage Builds
-A Docker multi-stage build is a technique for creating slimmer and more efficient Docker images. It allows you to define multiple stages within a single Dockerfile. Each stage acts like a separate build environment with its own base image and instructions.
+## Multi Stage Builds
+A multi stage build is a technique for creating slimmer and more efficient container images. It allows you to define multiple stages within a single Dockerfile. Each stage acts like a separate build environment with its own base image and instructions.
 
-The key benefit of multi-stage builds is that they enable you to separate the build process from the final runtime environment. This separation helps in reducing the final image size by:
+The key benefit of multi stage builds is that they enable you to separate the build process from the final runtime environment. This separation helps in reducing the final image size by:
 
 - **Using different base images**: You can leverage a larger image containing all the build tools in the initial stage and then switch to a smaller, leaner base image for the final stage that only includes the necessary runtime dependencies for your application.
 - **Excluding unnecessary layers**: By separating the build and runtime stages, you can exclude all the temporary files, build tools, and intermediate artifacts from the final image. These elements are only required during the build process and not needed when running the application.
 
-Overall, multi-stage builds promote efficient Docker images by minimizing their size and optimizing their contents for execution.
+Overall, multi stage builds promote efficient container images by minimizing their size and optimizing their contents for execution.
 
 ### Example 1: Distroless images as runtime for static binaries
 Distroless images are typically designed to work as platforms for running workloads in as minimal an environment as possible. In the case of languages that can compile completely static binaries (such as C and Rust), the **static** base image can be used as a runtime. You'll still need to get your application compiled in a separate build stage that has the tooling necessary to build it.
@@ -112,7 +112,7 @@ If you look into the image layers with `docker inspect c-distroless`, you'll als
 
 ### Example 2: Incorporating Application-Level Dependencies in Distroless Images
 
-When working with language ecosystems that have their own dependency management tools such as PHP (Composer) and Node (npm), a multi-stage build is necessary to include application dependencies within the final distroless runtime.
+When working with language ecosystems that have their own dependency management tools such as PHP (Composer) and Node (npm), a multi stage build is necessary to include application dependencies within the final distroless runtime.
 
 The next example creates a Dockerfile to run a demo PHP application that has third-party dependencies managed by [Composer](https://getcomposer.org/). The application is a single executable that queries the [cat facts API](https://catfact.ninja/) and returns a random fact.
 
@@ -215,7 +215,6 @@ php          cli-alpine   7879e816aba0   6 days ago   104MB
 
 ## Final Considerations
 
-Distroless images offer a compelling approach to creating minimal and secure container images by stripping away system components that are unnecessary at execution time, such as package managers and shells. While such images offer many advantages, they might require some adjustments in your existing development and deployment workflows. In this guide we demonstrated how to use Docker multi-stage builds to create final distroless images that include additional components, such as static binaries and application-level dependencies.
-
+Distroless images offer a compelling approach to creating minimal and secure container images by stripping away system components that are unnecessary at execution time, such as package managers and shells. While such images offer many advantages, they might require some adjustments in your existing development and deployment workflows. In this guide we demonstrated how to use multi stage builds to create final distroless images that include additional components, such as static binaries and application-level dependencies.
 
 You can find more examples in our [Getting Started Guides](/chainguard/chainguard-images/getting-started/) page. Check also our article on [Debugging Distroless Images](/chainguard/chainguard-images/debugging-distroless-images/) for important tips when you run into issues and need to debug containers running distroless images.

--- a/content/chainguard/chainguard-images/getting-started-distroless.md
+++ b/content/chainguard/chainguard-images/getting-started-distroless.md
@@ -1,0 +1,221 @@
+---
+title: "Getting Started with Distroless Images"
+linktitle: "Going Distroless"
+type: "article"
+description: "How to leverage distroless images for improved container security"
+date: 2024-03-21T08:49:31+00:00
+lastmod: 2024-03-21T08:49:31+00:00
+draft: false
+tags: ["Chainguard Images", "Product", "Overview"]
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 030
+toc: true
+---
+
+## About Distroless Images
+[Distroless](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) container images are a type of container image designed to be minimal. Unlike traditional images based on Debian or Ubuntu, which include package managers, utilities, and shells, distroless images typically contain only essential software required to run an application or service.
+
+This minimal approach offers several benefits, including:
+
+- **Enhanced Security:** By stripping out unnecessary components, distroless images reduce the potential attack surface for vulnerabilities. With fewer extraneous programs, there are fewer opportunities for malicious actors to exploit.
+- **Simplified Dependency Management:** Traditional container images can introduce dependency bloat, making it difficult to track and manage exactly what's included. Distroless images keep things clear by only containing what's directly required for the application to function.
+- **Potentially Smaller Image Sizes:** By eliminating extraneous OS components, distroless images can be significantly smaller than their full-blown counterparts.
+
+Chainguard offers a mix of distroless and development (or builder) images that are minimalist and contain provenance attestations for increased security. Since distroless images have fewer tools and don't come with a package manager, some adaptation might be necessary when migrating from traditional base images. A typical approach is using Docker muilti stage builds to compose a final distroless image containing the additional artifacts required by the application in order to run successfully.
+
+## Multi-Stage Builds
+A Docker multi-stage build is a technique for creating slimmer and more efficient Docker images. It allows you to define multiple stages within a single Dockerfile. Each stage acts like a separate build environment with its own base image and instructions.
+
+The key benefit of multi-stage builds is that they enable you to separate the build process from the final runtime environment. This separation helps in reducing the final image size by:
+
+- **Using different base images**: You can leverage a larger image containing all the build tools in the initial stage and then switch to a smaller, leaner base image for the final stage that only includes the necessary runtime dependencies for your application.
+- **Excluding unnecessary layers**: By separating the build and runtime stages, you can exclude all the temporary files, build tools, and intermediate artifacts from the final image. These elements are only required during the build process and not needed when running the application.
+
+Overall, multi-stage builds promote efficient Docker images by minimizing their size and optimizing their contents for execution.
+
+### Example 1: Distroless images as runtime for static binaries
+Distroless images are typically designed to work as platforms for running workloads in as minimal an environment as possible. In the case of languages that can compile completely static binaries (such as C and Rust), the **static** base image can be used as a runtime. You'll still need to get your application compiled in a separate build stage that has the tooling necessary to build it.
+
+In this example, we'll build a distroless image to run a "Hello World" program in C. Start by creating a diretctory for the demo. We'll call it **distroless-demo**.
+
+```sh
+mkdir ~/distroless-demo && cd $_
+```
+
+Create a new Dockerfile within this directory. You can use `nano` or other command line editor of your choice.
+
+```sh
+nano Dockerfile
+```
+
+The following Dockerfile will build a final distroless image using two distinct build stages. The first stage, named `build`, builds a C program using the `cgr.dev/chainguard/gcc-glibc:latest` image. The final image, which is then based on the `cgr.dev/chainguard/static:latest` distroless image, will copy the compiled binary from the `build` environment and define it as the entry point command for the final image.
+
+```dockerfile
+# syntax=docker/dockerfile:1.4
+FROM cgr.dev/chainguard/gcc-glibc:latest as build
+
+COPY <<EOF /hello.c
+#include <stdio.h>
+int main() { printf("Hello Distroless!%c",0x0A); }
+EOF
+RUN cc -static /hello.c -o /hello
+
+FROM cgr.dev/chainguard/static:latest
+
+COPY --from=build /hello /hello
+CMD ["/hello"]
+```
+
+Run the following command to build the demo image and tag it as `c-distroless`:
+
+```shell
+DOCKER_BUILDKIT=1 docker build -t c-distroless  .
+```
+
+If you receive an error, you may try removing the top line of the Dockerfile. Now you can run the image with:
+
+```shell
+docker run c-distroless
+```
+
+You should get output like this:
+
+```
+Hello Distroless!
+```
+
+You can note the size of the resulting image.
+
+```shell
+docker images c-distroless
+```
+
+```
+REPOSITORY     TAG       IMAGE ID       CREATED          SIZE
+c-distroless   latest    cd3bb76a84f5   45 seconds ago   2.04MB
+```
+
+If you look into the image layers with `docker inspect c-distroless`, you'll also notice that it has only two layers: a single layer from the `static` image that serves as base for the final image, and one layer with the COPY command that brings in the compiled binary from the **build** stage.
+
+```shell
+        "RootFS": {
+            "Type": "layers",
+            "Layers": [
+                "sha256:cfc10a76380242be256af62b8782e536770dee83dcc823fce6c196c1ef5638e5",
+                "sha256:bc7690d8bd810d969e6601d8468b4ae42fa411dfe460440e96092db454d80080"
+            ]
+        },
+```
+
+### Example 2: Incorporating Application-Level Dependencies in Distroless Images
+
+When working with language ecosystems that have their own dependency management tools such as PHP (Composer) and Node (npm), a multi-stage build is necessary to include application dependencies within the final distroless runtime.
+
+The next example creates a Dockerfile to run a demo PHP application that has third-party dependencies managed by [Composer](https://getcomposer.org/). The application is a single executable that queries the [cat facts api](https://catfact.ninja/) and returns a random quote.
+
+Start by creating a directory for the demo. We'll call it **distroless-php**.
+
+```sh
+mkdir ~/distroless-php && cd $_
+```
+
+The following command will create a new `composer.json` file with a single dependency, a small curl library called `minicli/curly`. We are using a shared volume so that the `vendor` folder is shared with our local directory.
+
+```shell
+docker run --rm --entrypoint composer --user=root -v ${PWD}:/app cgr.dev/chainguard/php:latest-dev require minicli/curly
+```
+In this case, we had to use the **root** image user in order to be able to write files in the current host directory. The following command will fix file permissions for our current system user:
+
+```shell
+sudo chown -R ${USER}:${USER} .
+```
+Now create the PHP executable. You can call it `catfact.php`:
+
+```shell
+nano catfact.php
+```
+
+The following code makes a query to the cat facts api, returning the quote as output. Copy the contents to your own `catfact.php` script:
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$curly = new Minicli\Curly\Client();
+$response = $curly->get("https://catfact.ninja/fact");
+if ($response['code'] === 200) {
+    echo "\n" . json_decode($response['body'], true)['fact'] . "\n";
+    return 0;
+}
+
+echo "query error.";
+return 1;
+```
+
+Save the file when you're done. Now you can create your Dockerfile.
+
+```sh
+nano Dockerfile
+```
+
+The following Dockerfile will create a `run.php` script that makes a curl query using the library we just added as a dependency.
+
+```Dockerfile
+FROM cgr.dev/chainguard/php:latest-dev AS builder
+USER root
+COPY . /app
+RUN chown -R php /app
+USER php
+RUN cd /app && \
+    composer install --no-progress --no-dev --prefer-dist
+
+FROM cgr.dev/chainguard/php:latest
+COPY --from=builder /app /app
+
+ENTRYPOINT [ "php", "/app/catfact.php" ]
+```
+
+Now you can build the image with:
+
+```shell
+docker build . -t distroless-demo-php
+```
+
+Finally, you can run the new app with:
+
+```shell
+docker run --rm distroless-demo-php
+```
+
+And you should get a cat fact as output, such as:
+
+```shell
+A domestic cat can run at speeds of 30 mph.
+```
+
+Upon inspection with `docker images`, you can check the image size around 38MB:
+
+```shell
+❯ docker images distroless-demo-php
+REPOSITORY            TAG       IMAGE ID       CREATED         SIZE
+distroless-demo-php   latest    8691d09f56ca   2 minutes ago   37.9MB
+```
+
+For comparison, the `php:cli-alpine` image is almost 3 times bigger:
+
+```shell
+❯ docker images php:cli-alpine
+REPOSITORY   TAG          IMAGE ID       CREATED      SIZE
+php          cli-alpine   7879e816aba0   6 days ago   104MB
+```
+
+## Final Considerations
+
+Distroless images offer a compelling approach to creating minimal and secure container images by stripping away system components that are unnecessary at execution time, such as package managers and shells. While such images offer many advantages, they might require some adjustments in your existing development and deployment workflows. In this guide we demonstrated how to use Docker multi-stage builds to create final distroless images that include additional components, such as static binaries and application-level dependencies.
+
+
+You can find more examples in our [Getting Started Guides](/chainguard/chainguard-images/getting-started/) page. Check also our article on [Debugging Distroless Images](/chainguard/chainguard-images/debugging-distroless-images/) for important tips when you run into issues and need to debug containers running distroless images.

--- a/content/chainguard/chainguard-images/getting-started-distroless.md
+++ b/content/chainguard/chainguard-images/getting-started-distroless.md
@@ -16,7 +16,7 @@ toc: true
 ---
 
 ## About Distroless Images
-[Distroless](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) container images are a type of container image designed to be minimal. Unlike traditional images based on Debian or Ubuntu, which include package managers, utilities, and shells, distroless images typically contain only essential software required to run an application or service.
+[Distroless](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) container images are a type of container image  that is designed to be minimal. Unlike traditional images based on Debian or Ubuntu — which include package managers, utilities, and shells — distroless images typically contain only essential software required to run an application or service.
 
 This minimal approach offers several benefits, including:
 
@@ -24,7 +24,7 @@ This minimal approach offers several benefits, including:
 - **Simplified Dependency Management:** Traditional container images can introduce dependency bloat, making it difficult to track and manage exactly what's included. Distroless images keep things clear by only containing what's directly required for the application to function.
 - **Potentially Smaller Image Sizes:** By eliminating extraneous OS components, distroless images can be significantly smaller than their full-blown counterparts.
 
-Chainguard offers a mix of distroless and development (or builder) images that are minimalist and contain provenance attestations for increased security. Since distroless images have fewer tools and don't come with a package manager, some adaptation might be necessary when migrating from traditional base images. A typical approach is using Docker muilti stage builds to compose a final distroless image containing the additional artifacts required by the application in order to run successfully.
+Chainguard offers a mix of distroless and development (or builder) images that are minimalist and contain provenance attestations for increased security. Since distroless images have fewer tools and don't come with a package manager, some adaptation might be necessary when migrating from traditional base images. A typical approach is using Docker multi-stage builds to compose a final distroless image containing the additional artifacts required by the application in order to run successfully.
 
 ## Multi-Stage Builds
 A Docker multi-stage build is a technique for creating slimmer and more efficient Docker images. It allows you to define multiple stages within a single Dockerfile. Each stage acts like a separate build environment with its own base image and instructions.
@@ -39,7 +39,7 @@ Overall, multi-stage builds promote efficient Docker images by minimizing their 
 ### Example 1: Distroless images as runtime for static binaries
 Distroless images are typically designed to work as platforms for running workloads in as minimal an environment as possible. In the case of languages that can compile completely static binaries (such as C and Rust), the **static** base image can be used as a runtime. You'll still need to get your application compiled in a separate build stage that has the tooling necessary to build it.
 
-In this example, we'll build a distroless image to run a "Hello World" program in C. Start by creating a diretctory for the demo. We'll call it **distroless-demo**.
+In this example, we'll build a distroless image to run a "Hello World" program in C. Start by creating a directory for the demo. We'll call it **distroless-demo**.
 
 ```sh
 mkdir ~/distroless-demo && cd $_
@@ -98,7 +98,7 @@ REPOSITORY     TAG       IMAGE ID       CREATED          SIZE
 c-distroless   latest    cd3bb76a84f5   45 seconds ago   2.04MB
 ```
 
-If you look into the image layers with `docker inspect c-distroless`, you'll also notice that it has only two layers: a single layer from the `static` image that serves as base for the final image, and one layer with the COPY command that brings in the compiled binary from the **build** stage.
+If you look into the image layers with `docker inspect c-distroless`, you'll also notice that it has only two layers: a single layer from the `static` image that serves as base for the final image, and one layer with the `COPY` command that brings in the compiled binary from the **build** stage.
 
 ```shell
         "RootFS": {
@@ -114,7 +114,7 @@ If you look into the image layers with `docker inspect c-distroless`, you'll als
 
 When working with language ecosystems that have their own dependency management tools such as PHP (Composer) and Node (npm), a multi-stage build is necessary to include application dependencies within the final distroless runtime.
 
-The next example creates a Dockerfile to run a demo PHP application that has third-party dependencies managed by [Composer](https://getcomposer.org/). The application is a single executable that queries the [cat facts api](https://catfact.ninja/) and returns a random quote.
+The next example creates a Dockerfile to run a demo PHP application that has third-party dependencies managed by [Composer](https://getcomposer.org/). The application is a single executable that queries the [cat facts API](https://catfact.ninja/) and returns a random fact.
 
 Start by creating a directory for the demo. We'll call it **distroless-php**.
 
@@ -138,7 +138,7 @@ Now create the PHP executable. You can call it `catfact.php`:
 nano catfact.php
 ```
 
-The following code makes a query to the cat facts api, returning the quote as output. Copy the contents to your own `catfact.php` script:
+The following code makes a query to the cat facts API, returning the quote as output. Copy the contents to your own `catfact.php` script:
 
 ```php
 <?php

--- a/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
@@ -17,11 +17,9 @@ terminalImage: academy/chainguard-images:latest
 toc: true
 ---
 
-[Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs) are distroless images based on [Wolfi](/open-source/wolfi/overview/), our Linux _undistro_. You can have a look at [Chainguard Image's GitHub org](https://github.com/chainguard-images) in order to find out which images are already available for general usage.
+[Chainguard Images](https://www.chainguard.dev/chainguard-images?utm_source=docs) are based on [Wolfi](/open-source/wolfi/overview/), our Linux _undistro_ designed specifically for containers. Wolfi uses the [Alpine apk](https://wiki.alpinelinux.org/wiki/Package_management) package format, which contributes in making packages smaller and more accountable, resulting in smaller images with traceable provenance information based on cryptographic signatures.
 
-Each image has its own usage instructions, which is detailed in their READMEs. All images are hosted on the `cgr.dev` registry.
-
-In this guide, you'll learn how to get started using Chainguard Images and how to migrate existing container-based workflows to use our images.
+In this guide, you'll find general instructions on how to get started using Chainguard Images and how to migrate existing container-based workflows to use our images. For specific image usage instructions, please refer to our [Images Reference Docs](https://edu.chainguard.dev/chainguard/chainguard-images/reference/), which contains the full list of all images available to the public and their respective documentation.
 
 ## Quickstart: Using Chainguard Images
 
@@ -131,82 +129,9 @@ This will start a Wolfi container where you can explore the file system and inve
 
 Continue reading the next section to learn more about building off of the Wolfi base image.
 
-## Getting Started with Distroless Base Images
+## Extending Chainguard Base Images
 
-Chainguard Images are fully OCI compatible, which means they work seamlessly with any system that supports that standard, including Docker.
-
-Most Chainguard Images do not include a package manager such as `apt` or `apk`. This is by design to keep images minimal, following the distroless approach.
-
-There are a few different ways to include additional software on distroless images, depending on your use case. If you are using Chainguard Images with  Dockerfile pipelines, you can add artifacts from a multi-stage Docker build. Alternatively, you can use Chainguard’s [apko](/open-source/apko/getting-started-with-apko/) and [melange](/open-source/melange/tutorials/getting-started-with-melange/) tooling to add extra software (this will also give you some extra features like build-time SBOM support).
-
-### Using the Distroless Base Images
-
-Many of the images are intended as platforms for running compiled binaries in as minimal an environment as possible. In the case of languages that can compile completely static binaries (such as C and Rust), the static base image can be used.
-
-Let's work on an example. Navigate to a test directory. For example:
-
-```sh
-mkdir ~/distroless-example && cd $_
-```
-
-In this directory, we'll create an example Dockerfile that builds a "Hello, World!" program in C.
-
-You can create the Dockerfile with nano, for instance.
-
-```sh
-nano Dockerfile
-```
-
-We will create the program on top of the `cgr.dev/chainguard/static:latest` base image.
-
-```dockerfile
-# syntax=docker/dockerfile:1.4
-FROM cgr.dev/chainguard/gcc-glibc:latest as build
-
-COPY <<EOF /hello.c
-#include <stdio.h>
-int main() { printf("Hello Distroless!%c",0x0A); }
-EOF
-RUN cc -static /hello.c -o /hello
-
-FROM cgr.dev/chainguard/static:latest
-
-COPY --from=build /hello /hello
-CMD ["/hello"]
-```
-
-Run the following command to build the demo image and tag it as `c-distroless`:
-
-```shell
-DOCKER_BUILDKIT=1 docker build -t c-distroless  .
-```
-
-If you receive an error, you may try removing the top line of the Dockerfile. Now you can run the image with:
-
-```shell
-docker run c-distroless
-```
-
-You should get output like this:
-
-```
-Hello Distroless!
-```
-
-You can note the size of the resulting image.
-
-```shell
-docker images c-distroless
-```
-
-```
-REPOSITORY     TAG       IMAGE ID       CREATED              SIZE
-c-distroless   latest    d3b1c78f4ed2   8 seconds ago   3.31MB
-```
-
-### Extending Chainguard Base Images
-
-It often happens that you want a distroless image with one or two extra packages, for example you may have a binary with a dependency on `curl` or `git`. Ideally you’d like a base image with this dependency already installed. There are a few options here:
+It often happens that you want a [distroless](/chainguard/chainguard-images/getting-started-distroless/) image with one or two extra packages, for example you may have a binary with a dependency on `curl` or `git`. Ideally you’d like a base image with this dependency already installed. There are a few options here:
 
 1. Compile the dependency from source and use a multi-stage Dockerfile to create a new base image. This works, but may require considerable effort to get the dependency compiling and to keep it up to date. This process quickly becomes untenable if you require several dependencies.
 2. Use the `wolfi-base` image that includes apk tools to install the package in the traditional Dockerfile manner. This works but sacrifices a lot of the advantages of the “distroless” philosophy.
@@ -267,3 +192,4 @@ You should get output like this, with a random piece of advice:
 "Big things have small beginnings."
 ```
 
+Check also the [Wolfi Images with Dockerfiles](/open-source/wolfi/wolfi-with-dockerfiles/) guide for more examples using Wolfi-based images with Dockerfiles, and the [Getting Started with Distroless](/chainguard/chainguard-images/getting-started-distroless/) guide for more details about distroless images and how to use them in Docker multi-stage builds.

--- a/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use-chainguard-images.md
@@ -5,7 +5,7 @@ type: "article"
 description: "A primer on how to migrate to Chainguard Images"
 lead: "A primer on how to migrate to Chainguard Images"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2023-01-23T19:42:31+00:00
+lastmod: 2024-03-22T19:42:31+00:00
 draft: false
 tags: ["Chainguard Images", "Procedural", "Product"]
 images: []

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -34,7 +34,7 @@ Chainguard Images are available from the [Chainguard Registry](/chainguard/chain
 
 ## Why Distroless
 
-[Distroless images](https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/) are the result of pushing minimalism in containers to the next level. When compared to traditional base images such as [Alpine](https://hub.docker.com/_/alpine) or [Debian](https://hub.docker.com/_/debian), they are more stripped back, lacking even a shell or package managers. However, compared to the empty “scratch” image, they do contain structure essential for the majority of Linux applications such as root certificates for TLS and core files like `/etc/passwd`.
+[Distroless images](/chainguard/chainguard-images/getting-started-distroless/) are the result of pushing minimalism in containers to the next level. When compared to traditional base images such as [Alpine](https://hub.docker.com/_/alpine) or [Debian](https://hub.docker.com/_/debian), they are more stripped back, lacking even a shell or package managers. However, compared to the empty “scratch” image, they do contain structure essential for the majority of Linux applications such as root certificates for TLS and core files like `/etc/passwd`.
 
 ## Comparing Images
 
@@ -46,11 +46,11 @@ The major advantage of distroless images is the reduced size and complexity, whi
 
 You can review more comparisons of Chainguard Images and external images by checking out our [Vulnerability Comparisons](/chainguard/chainguard-images/vuln-comparison/) dashboard.
 
-## Architecture 
+## Architecture
 
 By default, all Wolfi-based images are built for x86_64 (also known as AMD64) and AArch64 (also known as ARM64) architectures. Being able to provide multi-platform Chainguard Images enables the support of more than one runtime environment, like those available on all three major clouds, AWS, GCP, and Azure. The macOS M1 and M2 chips are also based on ARM architecture. Chainguard Images allow you to take advantage of ARM's power consumption and cost benefits.
 
-You can confirm the available architecture of a given Chainguard Image with Crane. In this example, we'll use the latest Ruby image, but you can opt to use an alternate image. 
+You can confirm the available architecture of a given Chainguard Image with Crane. In this example, we'll use the latest Ruby image, but you can opt to use an alternate image.
 
 ```sh
 crane manifest cgr.dev/chainguard/ruby:latest |jq -r '.manifests []| .platform'
@@ -69,6 +69,6 @@ Once you run this command, you'll receive output similar to the following.
 }
 ```
 
-This verifies that the Ruby Chainguard Image is built for both AMD64 and ARM64 architectures. 
+This verifies that the Ruby Chainguard Image is built for both AMD64 and ARM64 architectures.
 
 You can read more about our support of ARM64 in our blog on [Building Wolfi from the ground up](https://www.chainguard.dev/unchained/building-wolfi-from-the-ground-up-and-announcing-arm64-support).

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -5,7 +5,7 @@ type: "article"
 description: "Chainguard Images Overview"
 lead: "A primer on Chainguard Images and the distroless approach"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2022-09-01T08:49:31+00:00
+lastmod: 2023-03-22T08:49:31+00:00
 draft: false
 tags: ["Chainguard Images", "Product", "Overview"]
 images: []

--- a/content/open-source/wolfi/overview.md
+++ b/content/open-source/wolfi/overview.md
@@ -4,7 +4,7 @@ type: "article"
 description: "Getting started with Wolfi, the Linux undistro for secure container images"
 lead: "Introducing Wolfi, the Linux undistro for secure container images"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2022-09-01T08:49:31+00:00
+lastmod: 2023-03-22T08:49:31+00:00
 draft: false
 tags: ["Wolfi", "Overview"]
 images: []

--- a/content/open-source/wolfi/overview.md
+++ b/content/open-source/wolfi/overview.md
@@ -14,7 +14,7 @@ menu:
 weight: 100
 toc: true
 ---
-[Wolfi](https://github.com/wolfi-dev) is a community Linux [undistro](#why-undistro) designed for the container and cloud-native era. Chainguard started the Wolfi project to enable building  [Chainguard Images](/chainguard/chainguard-images/overview), our collection of curated [distroless]( https://blog.chainguard.dev/minimal-container-images-towards-a-more-secure-future/)  images that meet the requirements of a secure software supply chain. This required a Linux distribution with components at the appropriate granularity and with support for [glibc](https://www.gnu.org/software/libc/).
+[Wolfi](https://github.com/wolfi-dev) is a community Linux [undistro](#why-undistro) designed for the container and cloud-native era. Chainguard started the Wolfi project to enable building  [Chainguard Images](/chainguard/chainguard-images/overview), our collection of curated [distroless](/chainguard/chainguard-images/getting-started-distroless/)  images that meet the requirements of a secure software supply chain. This required a Linux distribution with components at the appropriate granularity and with support for [glibc](https://www.gnu.org/software/libc/).
 
 Building our own undistro also allows us to ensure packages have full provenance and metadata for supporting modern supply-chain security needs.
 


### PR DESCRIPTION
This PR brings a few updates to Images high level docs, introducing a new page dedicated to the distroless topic showing two examples on how to work with such images. This makes it easier for linking from external articles.

Other pages were updated to link back to the new distroless resource.

I made these changes in preparation for upcoming migration guides. Open to feedback and suggestions for menu title name and location.

Preview new guide: https://deploy-preview-1469--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/getting-started-distroless/
