### PR TITLE
Update autodocs-enforce.yaml

### DIFF
--- a/.github/chainguard/edu.sts.yaml
+++ b/.github/chainguard/edu.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/edu:ref:refs/heads/platform-docs
+claim_pattern:
+  job_workflow_ref: chainguard-dev/edu/.github/workflows/autodocs-platform.yaml@refs/heads/platform-docs
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/autodocs-platform.yaml
+++ b/.github/workflows/autodocs-platform.yaml
@@ -1,12 +1,12 @@
-name: Build Enforce Docs
+name: Build Platform Docs
 
 on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
   push:
-    branches:
-      - "update-enforce-workflow"
+    branches: 
+      - platform-docs
 
 jobs:
   check-new-docs:
@@ -51,7 +51,7 @@ jobs:
           echo "latest=$latest" >> $GITHUB_OUTPUT
         fi
 
-  integrate-enforce-docs:
+  integrate-platform-docs:
     runs-on: ubuntu-latest
 
     permissions:
@@ -83,7 +83,7 @@ jobs:
         workload_identity_provider: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
         service_account: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
 
-    - uses: ./.github/workflows/integrate-enforce-docs
+    - uses: ./.github/workflows/integrate-platform-docs
       with:
         project_id: "${{ secrets.PROJECT_ID }}"
         workload_identity_provider: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
@@ -103,6 +103,13 @@ jobs:
     - name: npm run build
       run: npm run build
 
+    - name: Set up Octo-STS
+      uses: chainguard-dev/octo-sts-action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo-sts
+      with:
+        scope: chainguard-dev/edu
+        identity: edu
+
     - name: Commit to autodocs branch
       env:
         GH_TOKEN: ${{ github.token }}
@@ -121,11 +128,10 @@ jobs:
           PR=$(gh pr list --json title,headRefName,url |jq '.[] | select(.headRefName=="autodocs")')
           if [ -z "${PR}" ]; then
             gh pr create \
-              --assignee jamonation \
               --base main --head autodocs \
-              --title "Enforce docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
-              --body "Enforce docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
-              --no-maintainer-edit --label automated,documentation,enforce
+              --title "Platform docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
+              --body "Platform docs ${{needs.check-new-docs.outputs.latest}} autocommit" \
+              --no-maintainer-edit --label automated,documentation,platform
           else
             echo "PR exists, see ${PR}"
           fi

--- a/.github/workflows/integrate-enforce-docs/action.yaml
+++ b/.github/workflows/integrate-enforce-docs/action.yaml
@@ -20,19 +20,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: download enforce changelog.md from cloud storage
+    - name: download changelog.md from cloud storage
       shell: bash
       run: |
         gcloud --quiet storage cp --project="${{ inputs.project_id }}" \
           "${{ inputs.storage_bucket }}/enforce-changelog/changelog.md" content/chainguard/chainguard-enforce/
 
-    - name: download enforce openapi api.json spec from cloud storage
+    - name: download openapi api.json spec from cloud storage
       shell: bash
       run: |
         gcloud --quiet storage cp --project="${{ inputs.project_id }}" \
           "${{ inputs.storage_bucket }}/enforce-openapi/api.json" static/
 
-    - name: download enforce events.md from cloud storage
+    - name: download events.md from cloud storage
       shell: bash
       run: |
         gcloud --quiet storage cp --project="${{ inputs.project_id }}" \
@@ -59,13 +59,13 @@ runs:
     - name: add tags to changelog by inserting line with sed
       shell: bash
       run: |
-        sed '/draft: false/a tags: ["Enforce", "Reference", "Product"]' \
+        sed '/draft: false/a tags: ["Platform", "Reference", "Product"]' \
           -i content/chainguard/chainguard-enforce/changelog.md
 
     - name: add tags to cloudevents by inserting line with sed
       shell: bash
       run: |
-        sed '/draft: false/a tags: ["Enforce", "Reference", "Product"]' \
+        sed '/draft: false/a tags: ["Platform", "Reference", "Product"]' \
           -i content/chainguard/administration/cloudevents/events-reference.md
 
     - name: download domains.md from cloud storage


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
This adds the octo-sts provider to academy so that the workflow action can create a PR with docs changes. I don't know if I'm using it correctly though.

### Why are we making this change?
The autodocs-enforce.yaml workflow is failing because it doesn't have permissions to create a PR.

