### PR TITLE
Fixing typo in redirect for Retrieve Images SBOMs guide

### DIFF
--- a/content/chainguard/chainguard-images/images-features/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/images-features/retrieve-image-sboms/index.md
@@ -2,7 +2,7 @@
 title: "How to Retrieve SBOMs for Chainguard Images"
 linktitle: "Retrieve an Image's SBOM"
 aliases: 
-- /chainguard/chainguard-images/retrieve-image-boms
+- /chainguard/chainguard-images/retrieve-image-sboms
 type: "article"
 description: "A brief tutorial on how to use Cosign to retrieve Chainguard Image SBOMs."
 date: 2023-11-17T11:07:52+02:00


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This PR fixes a small typo in the `alias` front matter for our doc on Retrieving Images SBOMs. This fix will fix allow for the correct redirects to happen.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
n/a

### Why are we making this change?
<!-- What larger problem does this PR address? -->
n/a

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
The redirect should correctly reflect the old URL: https://edu.chainguard.dev/chainguard/chainguard-images/retrieve-image-sboms/ 

and also redirect to the new one: https://edu.chainguard.dev/chainguard/chainguard-images/images-features/retrieve-image-sboms/

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Not sure this will be easy to test, but I'm sure this is the correct redirect.