### PR TITLE
Update edu.sts.yaml

### DIFF
--- a/.github/chainguard/edu.sts.yaml
+++ b/.github/chainguard/edu.sts.yaml
@@ -1,7 +1,7 @@
 issuer: https://token.actions.githubusercontent.com
-subject: repo:chainguard-dev/edu:ref:refs/heads/platform-docs
+subject: repo:chainguard-dev/edu:ref:refs/heads/main
 claim_pattern:
-  job_workflow_ref: chainguard-dev/edu/.github/workflows/autodocs-platform.yaml@refs/heads/platform-docs
+  job_workflow_ref: chainguard-dev/edu/.github/workflows/autodocs-platform.yaml@refs/heads/main
 
 permissions:
   contents: write


### PR DESCRIPTION
Fixes #1475 with the right octo-sts branch ref (was `platform-docs`, should be `main`) to work with workload identity permissions
