### PR TITLE
fix redirect for migration guides

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -73,7 +73,7 @@ http {
         "~^/chainguard/chainguard-enforce/authentication/identity-examples/(.+)?$"  /chainguard/administration/iam-groups/identity-examples/;
         "~^/chainguard/chainguard-images/vulnerability-comparisons/(.+)?$"  /chainguard/chainguard-images/comparing-images/vulnerability-comparisons;
         "~^/chainguard/administration/iam-groups/(.+)?$"  /chainguard/administration/iam-organizations;
-        "~^/chainguard/chainguard-images/migration-guides/(.+)?$"  /chainguard/chainguard-images/migration/$1;
+        "~^/chainguard/migration-guides/(.+)?$"  /chainguard/migration/$1;
 
     }
 


### PR DESCRIPTION
This fixes the URLs in the redirect rule for migration guides since we moved it from /chainguard/migration-guides to /chainguard/migration.