### PR TITLE
updating IAM docs to reflect new nomenclature

### DIFF
--- a/content/chainguard/administration/iam-organizations/assumable-ids.md
+++ b/content/chainguard/administration/iam-organizations/assumable-ids.md
@@ -38,9 +38,9 @@ This enables you to create identities that can only be assumed by specific autom
 * [Buildkite](/chainguard/administration/iam-groups/identity-examples/buildkite-identity/)
 * [Bitbucket](/chainguard/administration/iam-groups/identity-examples/bitbucket-identity/)
 
-A notable difference between registered users and identities in Chainguard's IAM model is that identities are tied to a specific [IAM group](/chainguard/chainguard-enforce/iam-groups/overview-of-enforce-iam-model/). When you create an identity, you must specify a Chainguard group under which the identity will be created.
+A notable difference between registered users and identities in Chainguard's IAM model is that identities are tied to a specific [IAM organization](/chainguard/chainguard-enforce/iam-groups/overview-of-enforce-iam-model/). When you create an identity, you must specify a Chainguard organization under which the identity will be created.
 
-However, an identity won't automatically have access to the other resources associated with that group. In order for an identity to be able to interact with a group's resources — including the Images, repositories, and users associated with the group — it must be granted the permissions it needs to do so. To do this, you must also tie the identity to a role. Chainguard comes with a few built-in roles, including `viewer`, `editor`, and `owner`. You can also create custom role-bindings with `chainctl`. Check out the [`chainctl iam role-bindings` documentation](/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings/) for more details. 
+However, an identity won't automatically have access to the other resources associated with that organization. In order for an identity to be able to interact with a organization's resources — including the Images, repositories, and users associated with the organization — it must be granted the permissions it needs to do so. To do this, you must also tie the identity to a role. Chainguard comes with a few built-in roles, including `viewer`, `editor`, and `owner`. You can also create custom role-bindings with `chainctl`. Check out the [`chainctl iam role-bindings` documentation](/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings/) for more details. 
 
 Now that you have a better understanding of what assumable identities are, let's go over how you can set up an assumable identity. There are currently two main ways you can create an identity: with Terraform and with `chainctl`. Let's first go over how to set up an identity with Terraform.
 
@@ -51,7 +51,7 @@ To set up an assumable identity with Terraform, you will need to add a few speci
 
 ```
 resource "chainguard_identity" "<id-ref>" {
-  parent_id   = <chainguard group ID>
+  parent_id   = <chainguard organization ID>
   name   	 = "<identity name>"
   description = <<EOF
     This is an example description for an identity.
@@ -64,7 +64,7 @@ resource "chainguard_identity" "<id-ref>" {
 }
 ```
 
-Here, `parent_id` defines the Chainguard group that the identity will be tied to. This could be a literal value — like a Chainguard group identification number — or a [local value](https://developer.hashicorp.com/terraform/language/values/locals) that references an existing group. You can enter whatever you'd like for the `name`, though it helps to provide a descriptive name for your identities. The `description` field is optional, but it can be helpful to include to clarify the identity's purpose.
+Here, `parent_id` defines the Chainguard organization that the identity will be tied to. This could be a literal value — like a Chainguard organization identification number — or a [local value](https://developer.hashicorp.com/terraform/language/values/locals) that references an existing organization. You can enter whatever you'd like for the `name`, though it helps to provide a descriptive name for your identities. The `description` field is optional, but it can be helpful to include to clarify the identity's purpose.
 
 The `claim_match` block within this section is what specifies the users and workloads allowed to assume the identity. You must specify an issuer and subject in the claim match block, but you can optionally specify an `audience` here as well.
 
@@ -96,7 +96,7 @@ data "chainguard_roles" "viewer" {
 }
 ```
 
-Then you need to include another `resource` block to create the role-binding using the determined role. The identity will have the permissions of that role over the group specified within this block.
+Then you need to include another `resource` block to create the role-binding using the determined role. The identity will have the permissions of that role over the organization specified within this block.
 
 ```
 resource "chainguard_role-binding" "view-stuff" {
@@ -106,7 +106,7 @@ resource "chainguard_role-binding" "view-stuff" {
 }
 ```
 
-This means that the identity this Terraform configuration will create will only be able to view the resources tied to the same group the identity is tied to.
+This means that the identity this Terraform configuration will create will only be able to view the resources tied to the same organization the identity is tied to.
 
 Applying this configuration will create the assumable identity. You can follow any of our [identity examples](/chainguard/chainguard-enforce/iam-groups/identity-examples/) to create an assumable identity that can be used by a continuous integration workflow to interact with Chainguard. The Terraform files used in the linked tutorials are based closely on the template outlined here.
 
@@ -120,11 +120,11 @@ chainctl iam identities create <identity-name> \
     --identity-issuer=<issuer of the identity> \
     --issuer-keys=<keys for the issuer> \
     --subject=<subject of the identity> \
-    --group=<group name> \
+    --group=<organization name> \
     --role=<role>
 ```
 
-As with Terraform, you must provide `chainctl` with certain information about the identity you want to create, including the issuer and subject of the identity, the role-bindings associated with the identity (if any), and the group under which the identity should be created.
+As with Terraform, you must provide `chainctl` with certain information about the identity you want to create, including the issuer and subject of the identity, the role-bindings associated with the identity (if any), and the organization under which the identity should be created.
 
 You can change an existing identity with the `update` command. The following example would update the identity's issuer.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/aws-identity.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/aws-identity.md
@@ -124,13 +124,13 @@ Next, you can create the `chainguard.tf` file.
 resource "chainguard_group" "example-group" {
   name   	 = "example-group"
   description = <<EOF
-    This group simulates an end-user group, which the AWS role identity
+    This organization simulates an end-user organization, which the AWS role identity
     can interact with via the identity in aws.tf.
   EOF
 }
 ```
 
-This section creates a Chainguard IAM group named `example-group`, as well as a description of the group. This will serve as some data for the identity to access when we test it out later on.
+This section creates a Chainguard IAM organization named `example-group`, as well as a description of the organization. This will serve as some data for the identity to access when we test it out later on.
 
 Then we'll define a Chainguard identity that can be assumed by the AWS role created in `lambda.tf` above:
 
@@ -269,7 +269,7 @@ if err != nil {
 The resulting token, `cgtok`, can be used to authenticate requests to Chainguard API calls:
 
 ```go
-// Use the token to list repos in the group.
+// Use the token to list repos in the organization.
 clients, err := registry.NewClients(ctx, env.APIEndpoint, cgtok)
 if err != nil {
   return "", fmt.Errorf("creating clients: %w", err)
@@ -289,10 +289,10 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. However, you'll need to destroy the `example-group` group yourself with `chainctl`. It will also delete all the AWS resources defined earlier in `chainguard.tf` and `lambda.tf`.
+This will destroy the role-binding, and the identity created in this guide. However, you'll need to destroy the `example-group` organization yourself with `chainctl`. It will also delete all the AWS resources defined earlier in `chainguard.tf` and `lambda.tf`.
 
 ```sh
-chainctl iam groups rm example-group
+chainctl iam organizations rm example-group
 ```
 
 You can then remove the working directory to clean up your system.

--- a/content/chainguard/administration/iam-organizations/identity-examples/bitbucket-identity.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/bitbucket-identity.md
@@ -72,7 +72,7 @@ data "chainguard_group" "group" {
 }
 ```
 
-This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `bitbucket.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM organization named `my-customer.biz`. This will contain the identity — which will be created by the `bitbucket.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the rest of our Terraform configuration files, `bitbucket.tf`.
 
@@ -127,7 +127,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -231,12 +231,12 @@ Now you can add the commands for testing the identity like `chainctl images repo
           # Assume the bitbucket pipeline identity
           - ./chainctl auth login --identity-token $BITBUCKET_STEP_OIDC_TOKEN --identity %bitbucket-identity%
           - ./chainctl images repos list
-          - docker pull cgr.dev/<group>/<repo>:<tag>
+          - docker pull cgr.dev/<organization>/<repo>:<tag>
 ```
 
 Once you commit the `bitbucket-pipelines.yml` file the pipeline will run.
 
-Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, listing repos available to the group.
+Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, listing repos available to the organization.
 
 ```
 . . .
@@ -256,7 +256,7 @@ data "chainguard_roles" "editor" {
 }
 ```
 
-You can also edit the pipeline itself to change its behavior. For example, instead of listing the repos the identity has access to, you could have the workflow inspect the groups.
+You can also edit the pipeline itself to change its behavior. For example, instead of listing the repos the identity has access to, you could have the workflow inspect the organizations.
 
 ```
           - ./chainctl images repos list
@@ -273,7 +273,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
+This will destroy the role-binding, and the identity created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/buildkite-identity.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/buildkite-identity.md
@@ -73,7 +73,7 @@ data "chainguard_group" "group" {
 }
 ```
 
-This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `buildkite.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM organization named `my-customer.biz`. This will contain the identity — which will be created by the `buildkite.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `buildkite.tf`.
 
@@ -125,7 +125,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -214,10 +214,10 @@ From there, click the **Edit Steps** button to add the following commands to a s
 	./chainctl auth login --identity-token $token --identity <your buildkite identity>
   ./chainctl auth configure-docker --identity-token $token --identity <your buildkite identity>
   ./chainctl images repos list
-  docker pull cgr.dev/<group>/<repo>:<tag>
+  docker pull cgr.dev/<organization>/<repo>:<tag>
 ```
 
-These commands will cause your Buildkite pipeline to download `chainctl` and make it executable. It will then sign in to Chainguard using the Buildkite identity you generated previously. If this workflow can successfully assume the identity, then it will be able to execute the `chainctl images repos list` command and retrieve the list of repos available to the group.
+These commands will cause your Buildkite pipeline to download `chainctl` and make it executable. It will then sign in to Chainguard using the Buildkite identity you generated previously. If this workflow can successfully assume the identity, then it will be able to execute the `chainctl images repos list` command and retrieve the list of repos available to the organization.
 
 There are a couple ways you can add commands to an existing Buildkite pipeline, so follow whatever procedure works best for you.
 
@@ -246,7 +246,7 @@ steps:
 
 Click the **Save and Build** button. Ensure that your Buildkite agent is running, and then wait a few moments for the pipeline to finish building.
 
-Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, returning the images available to the group. Then it will pull an image from the group's repository.
+Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, returning the images available to the organization. Then it will pull an image from the organization's repository.
 
 ```
 ...
@@ -266,10 +266,10 @@ data "chainguard_roles" "editor" {
 }
 ```
 
-You can also edit the pipeline itself to change its behavior. For example, instead of listing repos, you could have the workflow inspect the groups.
+You can also edit the pipeline itself to change its behavior. For example, instead of listing repos, you could have the workflow inspect the organization.
 
 ```
-chainctl iam groups ls
+chainctl iam organizations ls
 ```
 
 Of course, the Buildkite pipeline will only be able to perform certain actions on certain resources, depending on what kind of access you grant it.
@@ -283,7 +283,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding and the identity created in this guide. It will not delete the group.
+This will destroy the role-binding and the identity created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/github-identity/index.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/github-identity/index.md
@@ -74,7 +74,7 @@ data "chainguard_group" "group" {
 }
 ```
 
-This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `actions.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM organization named `my-customer.biz`. This will contain the identity — which will be created by the `actions.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `actions.tf`.
 
@@ -100,7 +100,7 @@ resource "chainguard_identity" "actions" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `github-actions` and has a brief description.
+First, this section creates a Chainguard Identity tied to the Chainguard Organization looked up in the `sample.tf` file. The identity is named `github-actions` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the GitHub Actions workflow tries to assume this identity later on, it must present a token matching the `issuer` and `subject` specified here in order to do so. The `issuer` is the entity that creates the token, while the `subject` is the entity (here, the Actions workflow) that the token represents.
 
@@ -122,7 +122,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -226,7 +226,7 @@ jobs:
         identity: <your actions identity>
 
     - run: |
-      docker pull cgr.dev/<your group>/example-image:latest
+      docker pull cgr.dev/<your organization>/example-image:latest
 ```
 
 This workflow is named `actions assume example`. The `permissions` block grants `write` permissions to the workflow for the `id-token` scope. [Per the GitHub Actions documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings), you **must** grant this permission in order for the workflow to be able to fetch an OIDC token.
@@ -234,13 +234,13 @@ This workflow is named `actions assume example`. The `permissions` block grants 
 This workflow performs two actions:
 
 * First, it assumes the identity you just created with Terraform.
-* Second, the workflow runs the `docker pull` command to pull an image from the group's Chainguard registry.
+* Second, the workflow runs the `docker pull` command to pull an image from the organization's Chainguard registry.
 
 Commit the workflow to your repository, then navigate back to the **Actions** tab. The **Assume and Explore** workflow will appear in the left-hand sidebar menu. Click on this, and then click the **Run workflow** button on the resulting page to execute the workflow.
 
 ![Screenshot of the "Assume and Explore" workflow, with the "Run workflow" button showing.](actions-run-workflow.png)
 
-This indicates that the workflow can indeed assume the identity and interact with the group.
+This indicates that the workflow can indeed assume the identity and interact with the organization.
 
 ![Screenshot showing the output of the "Assume and Explore" workflow.](actions-workflow-output.png)
 
@@ -268,7 +268,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
+This will destroy the role-binding, and the identity created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/gitlab-identity.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/gitlab-identity.md
@@ -73,7 +73,7 @@ data "chainguard_group" "group" {
 }
 ```
 
-This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `gitlab.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM organization named `my-customer.biz`. This will contain the identity — which will be created by the `gitlab.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `gitlab.tf`.
 
@@ -124,7 +124,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -233,7 +233,7 @@ assume-and-explore:
     chainctl images repos list
 
     # Pull an image.
-    docker pull cgr.dev/<group>/<repo>:<tag>
+    docker pull cgr.dev/<organization>/<repo>:<tag>
 ```
 
 Let's go over what this configuration does.
@@ -244,11 +244,11 @@ Next, this configuration creates a JSON Web Token (JWT) with an [`id_tokens`](ht
 
 Following that, the job runs a few commands to download and install `chainctl`. It then uses `chainctl`, the JWT, and the Chainguard identity's `id` value to log in to Chainguard under the assumed identity. Be sure to replace `<your gitlab identity>` with the identity UIDP you noted down in the previous section.
 
-After logging in, the pipeline is able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repos associated associated with the group.
+After logging in, the pipeline is able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repos associated associated with the organization.
 
 After updating the configuration, commit the changes and the pipeline will run automatically. A status box in the dashboard will let you know whether the pipeline runs successfully.
 
-Click the **View Pipeline** button, and then click the **assume-and-explore** job button to open the job's output from the last run. There you should see a list of repos accessible to your group.
+Click the **View Pipeline** button, and then click the **assume-and-explore** job button to open the job's output from the last run. There you should see a list of repos accessible to your organization.
 
 This indicates that the GitLab CI/CD pipeline did indeed assume the identity and run the `chainctl images repos list` command.
 
@@ -266,10 +266,10 @@ To retrieve a list of all the available roles — including any custom roles —
 chainctl iam roles list
 ```
 
-You can also edit the pipeline itself to change its behavior. For example, instead of inspecting the image repos the identity has access to, you could have the workflow inspect the groups like in the following exmaple.
+You can also edit the pipeline itself to change its behavior. For example, instead of inspecting the image repos the identity has access to, you could have the workflow inspect the organization like in the following exmaple.
 
 ```
-chainctl iam groups ls
+chainctl iam orgs ls
 ```
 
 Of course, the GitLab pipeline will only be able to perform certain actions on certain resources, depending on what kind of access you grant it.
@@ -283,7 +283,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy identity and the role-binding created in this guide. It will not delete the group.
+This will destroy identity and the role-binding created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/jenkins-identity/index.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/jenkins-identity/index.md
@@ -88,7 +88,7 @@ data "chainguard_group" "group" {
 }
 ```
 
-This section looks up a Chainguard IAM group named `my-customer.biz`. This will contain the identity — which will be created by the `jenkins.tf` file — to access when we test it out later on.
+This section looks up a Chainguard IAM organization named `my-customer.biz`. This will contain the identity — which will be created by the `jenkins.tf` file — to access when we test it out later on.
 
 Now you can move on to creating the last of our Terraform configuration files, `jenkins.tf`.
 
@@ -115,7 +115,7 @@ resource "chainguard_identity" "jenkins" {
 }
 ```
 
-First, this section creates a Chainguard Identity tied to the `chainguard_group` looked up in the `sample.tf` file. The identity is named `jenkins` and has a brief description.
+First, this section creates a Chainguard Identity tied to the Chainguard organization looked up in the `sample.tf` file. The identity is named `jenkins` and has a brief description.
 
 The most important part of this section is the `claim_match`. When the Jenkins workflow tries to assume this identity later on, it must present a token matching the `audience`, `issuer` and `subject` specified here in order to do so. The `audience` is the intended recipient of the issued token, while the `issuer` is the entity that creates the token. Finally, the `subject` is the entity (here, the Jenkins pipeline build) that the token represents.
 
@@ -145,7 +145,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -255,13 +255,13 @@ sh '''
     ./chainctl auth login --identity-token $token --identity <your jenkins identity>
     ./chainctl auth configure-docker --identity-token $token --identity <your jenkins identity>
     ./chainctl images repos list
-    docker pull cgr.dev/<group>/<repo>:<tag>
+    docker pull cgr.dev/<organization>/<repo>:<tag>
 '''
 ```
 
 Save the job, and then build it using the `Build with Parameters` option.
 
-Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, listing repositories available to the group.
+Assuming everything works as expected, your pipeline will be able to assume the identity and run the `chainctl images repos list` command, listing repositories available to the organization.
 
 ```
 . . .
@@ -282,11 +282,11 @@ data "chainguard_role" "editor" {
 }
 ```
 
-You can also edit the pipeline itself to change its behavior. For example, instead of inspecting the policies the identity has access to, you could have the workflow inspect the groups.
+You can also edit the pipeline itself to change its behavior. For example, instead of inspecting the policies the identity has access to, you could have the workflow inspect the organizations.
 
 ```
 	. . .
-	- './chainctl iam groups ls'
+	- './chainctl iam organizations ls'
 ```
 
 Of course, the Jenkins pipeline will only be able to perform certain actions on certain resources, depending on what kind of access you grant it.
@@ -299,7 +299,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy the role-binding, and the identity created in this guide. It will not delete the group.
+This will destroy the role-binding, and the identity created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/identity-examples/keycloak-identity.md
+++ b/content/chainguard/administration/iam-organizations/identity-examples/keycloak-identity.md
@@ -134,7 +134,7 @@ data "chainguard_role" "viewer" {
 }
 ```
 
-The final section grants this role to the identity on the group.
+The final section grants this role to the identity.
 
 ```
 resource "chainguard_rolebinding" "view-stuff" {
@@ -233,7 +233,7 @@ chainctl auth configure-docker \
   --identity $ID
 ```
 
-After logging in, the pipeline will be able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repositories associated associated with the group.
+After logging in, the pipeline will be able to run any `chainctl` command under the assumed identity. To test out this ability, this configuration runs the `chainctl images repos list` command to list all available image repositories associated associated with the organization.
 
 ```sh
 chainctl images repos list
@@ -276,7 +276,7 @@ To remove the resources Terraform created, you can run the `terraform destroy` c
 terraform destroy
 ```
 
-This will destroy identity and the role-binding created in this guide. It will not delete the group.
+This will destroy identity and the role-binding created in this guide. It will not delete the organization.
 
 You can then remove the working directory to clean up your system.
 

--- a/content/chainguard/administration/iam-organizations/rolebinding-terraform-gh/index.md
+++ b/content/chainguard/administration/iam-organizations/rolebinding-terraform-gh/index.md
@@ -11,11 +11,11 @@ images: []
 weight: 050
 ---
 
-There may be cases where an organization will want multiple users to have access to the same Chainguard organization. Chainguard allows you to grant other users access to Chainguard by [generating an invite link or code](/chainguard/chainguard-enforce/iam-groups/how-to-manage-iam-groups-in-chainguard-enforce/#inviting-others-to-a-group).
+There may be cases where an organization will want multiple users to have access to the same Chainguard organization. Chainguard allows you to grant other users access to Chainguard by [generating an invite link or code](/chainguard/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/#inviting-others-to-an-organization).
 
 In addition, you can now grant access to users using Terraform and identity providers like GitHub, GitLab, and Google. You can also manage access through these providers' existing group structures, like GitHub Teams or GitLab Groups. Granting access through Terraform helps to reduce the risk of unwanted users gaining access to Chainguard.
 
-This guide outlines one method of using Terraform to grant members of a GitHub team access to the resources managed by a Chainguard group. It also highlights a few other Terraform configurations you can use to manage role-bindings in the Chainguard platform. Although this guide is specific to GitHub, the same approach can be used for other systems.
+This guide outlines one method of using Terraform to grant members of a GitHub team access to the resources managed by a Chainguard organization. It also highlights a few other Terraform configurations you can use to manage role-bindings in the Chainguard platform. Although this guide is specific to GitHub, the same approach can be used for other systems.
 
 
 ## Prerequisites
@@ -83,10 +83,10 @@ Following that, you will need to provide Terraform with your GitHub personal acc
 export GITHUB_TOKEN=<your GitHub token>
 ```
 
-Lastly, the Chainguard role-bindings that this guide's Terraform configuration will create must all be tied to a group. Create another variable named `CHAINGUARD_GROUP` with the following command, replacing `<UIDP of target Chainguard IAM group>` with the UIDP of the Chainguard IAM group you want to tie the role-bindings to. You can find the UIDPs for all your Chainguard IAM groups by running `chainctl iam groups ls -o table`.
+Lastly, the Chainguard role-bindings that this guide's Terraform configuration will create must all be tied to an organization. Create another variable named `CHAINGUARD_ORG` with the following command, replacing `<UIDP of target Chainguard IAM organization>` with the UIDP of the Chainguard IAM organization you want to tie the role-bindings to. You can find the UIDP for your Chainguard IAM organization by running `chainctl iam organizations ls -o table`.
 
 ```sh
-export CHAINGUARD_GROUP="<UIDP of target Chainguard IAM group>"
+export CHAINGUARD_ORG="<UIDP of target Chainguard IAM organization>"
 ```
 
 Following that, you will have everything you need in place to set up the Terraform configuration.
@@ -94,7 +94,7 @@ Following that, you will have everything you need in place to set up the Terrafo
 
 ## Creating your Terraform Configuration
 
-As mentioned previously, we will be using Terraform to create role-bindings for each user in a GitHub team, giving them access to resources associated with a given Chainguard group. This guide outlines how to create two Terraform configuration files that, together, will produce a set of such role-bindings.
+As mentioned previously, we will be using Terraform to create role-bindings for each user in a GitHub team, giving them access to resources associated with a given Chainguard organization. This guide outlines how to create two Terraform configuration files that, together, will produce a set of such role-bindings.
 
 To help explain both files' purposes, we will go over what they do and how to create each one individually.
 
@@ -206,12 +206,12 @@ The final block puts all this information together to create the role-bindings f
 resource "chainguard_rolebinding" "cg-binding" {
   for_each = data.chainguard_identity.team_ids
   identity = each.value.id
-  group    = "$CHAINGUARD_GROUP"
+  group    = "$CHAINGUARD_ORG"
   role     = data.chainguard_role.viewer.items[0].id
 }
 ```
 
-This `resource` block iterates through the list of Chainguard identities, assigns each one to the IAM group specified by the `group` argument, and binds each identity to the `viewer` role. Here, the `group` argument is set to the `CHAINGUARD_GROUP` variable you created at the start of this guide.
+This `resource` block iterates through the list of Chainguard identities, assigns each one to the IAM organization specified by the `group` argument, and binds each identity to the `viewer` role. Here, the `group` argument is set to the `CHAINGUARD_ORG` variable you created at the start of this guide.
 
 Create the `rolebindings.tf` file with the following command.
 
@@ -240,7 +240,7 @@ data "chainguard_role" "viewer" {
 resource "chainguard_rolebinding" "cg-binding" {
   for_each = data.chainguard_identity.team_ids
   identity = each.value.id
-  group    = "$CHAINGUARD_GROUP"
+  group    = "$CHAINGUARD_ORG"
   role     = data.chainguard_role.viewer.items[0].id
 }
 EOF
@@ -299,7 +299,7 @@ After pressing `ENTER`, the command will complete.
 Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
 ```
 
-Following this, any members of your GitHub team for whom you've created role-bindings will be able to view the resources associated with the Chainguard group you specified. To do so, they need to log in to the Chainguard platform, either by logging into the [Chainguard Console](https://console.enforce.dev/) or with the following command.
+Following this, any members of your GitHub team for whom you've created role-bindings will be able to view the resources associated with the Chainguard organization you specified. To do so, they need to log in to the Chainguard platform, either by logging into the [Chainguard Console](https://console.enforce.dev/) or with the following command.
 
 ```sh
 chainctl auth login
@@ -309,7 +309,7 @@ After navigating to the Console or running the login command, they will be prese
 
 ![Screenshot of the default Chainguard login flow. It includes the Inky logo above the words "Welcome. Log in to Chainguard to continue to Chainguard." Below this are three buttons, one reading "Continue with Google", one reading "Continue with GitHUb", and a third reading "Continue with GitLab".](login-flow.png)
 
-There, they must click the **Continue with GitHub** button to continue logging in under their GitHub account. Chainguard will immediately recognize their GitHub account because it is tied to the role-binding you created in the previous step, and they will be able to view the resources associated with the Chainguard group specified in your Terraform configuration.
+There, they must click the **Continue with GitHub** button to continue logging in under their GitHub account. Chainguard will immediately recognize their GitHub account because it is tied to the role-binding you created in the previous step, and they will be able to view the resources associated with the Chainguard organization specified in your Terraform configuration.
 
 
 ## Optional Configurations
@@ -326,7 +326,7 @@ data "chainguard_roles" "editor" {
 resource "chainguard_rolebinding" "cg-binding" {
   for_each = toset(data.chainguard_identity.team_ids)
   identity = each.value.id
-  group	= "$CHAINGUARD_GROUP"
+  group	= "$CHAINGUARD_ORG"
   role     = data.chainguard_roles.editor.items[0].id
 }
 ```

--- a/content/chainguard/administration/terraform-provider/index.md
+++ b/content/chainguard/administration/terraform-provider/index.md
@@ -74,13 +74,13 @@ You can find more information about authenticating with the Chainguard Terraform
 
 Terraform was designed to allow users to manage various resources declaratively. In practice, this means that you define the state you want your resources to be in and then you let Terraform and the provider handle the details of bringing that state to reality. 
 
-Resources on the Chainguard platform are organized in a hierarchical structure of folder-like groups, with an organization's group at the root, though most users will only need to work at the organization level.
+Resources on the Chainguard platform are organized in a hierarchical structure consisting of [**Organizations** and **Folders**](/chainguard/administration/iam-organizations/overview-of-chainguard-iam-model/#organizations-and-folders). An organization is a customer or group of customers working with the same Chainguard resources, while a folder is a collection of resources within a Chainguard organization. Most users will only need to work at the organization level.
 
 ![Diagram outlining hierarchical structure of Chainguard resources. The diagram has two halves: one labeled "Organization" and another labeled "Chainguard". Under Organization is a box labeled "Tags" with an arrow pointing toward another box labeled "Repos." Under both halves is a box labeled "Role Bindings" which has four arrows pointing from it. Two arrows point to boxes (labeled "Identities" and "Custom Roles") under Organization and the other two point to boxes (labeled "User Identities" and "roles) under Chainguard.](tf-diagram.png)
 
-All user-managed resources are defined in relation to some parent group. This means developers need to be able to reference their organization's group throughout their configuration. We'll outline two ways to define this kind of reference: using local values and data sources.
+All user-managed resources are defined in relation to the organization to which they belong. This means developers need to be able to reference their organization throughout their configuration. We'll outline two ways to define this kind of reference: using local values and data sources. For more details on referencing an organization, please refer to the [`chainguard_group` resource documentation](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/resources/group) for more information.
 
-> **Note:** This section specifically outlines how to define organization group references. There may be times when you need to reference a group other than your organization in your Terraform code. Refer to the [`chainguard_group` resource documentation](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/resources/group) for more information.
+> **Note:** Chainguard organizations were previously called "groups," with a "root group" representing what is now referred to as an organization and "subgroups" referring to folders. As of this writing, the Chainguard Terraform provider still refers to "groups" instead of organizations. To align with our other [IAM resources](/chainguard/administration/iam-organizations/), this document uses the new nomenclature wherever possible.
 
 ### Defining local values
 
@@ -89,10 +89,10 @@ The Terraform configuration language allows you to define *local values* which a
 If you are familiar with `chainctl`, you can find your organization's ID with the following command:
 
 ```shell
-chainctl iam groups list -o table
+chainctl iam organizations list -o table
 ```
 
-Once you've copied the UIDP of your root or organization group (the 40-digit long hex string listed in the `ID` column of the previous command's output), you can use it to create a local variable in Terraform:
+Once you've copied the UIDP of your organization (the 40-digit long hex string listed in the `ID` column of the previous command's output), you can use it to create a local variable in Terraform:
 
 ```
 locals {
@@ -104,15 +104,15 @@ Throughout your Terraform code, you can refer to this value as `local.org_id`. I
 
 ### Using data sources
 
-*Data sources* allow Terraform to access and use information that was defined outside ofWe'll outline two ways to define this kind of reference: using local values and data sources. a Terraform configuration. The available data sources for Chainguard resources are [groups](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/group), [identities](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/identity), and [roles](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/role).
+*Data sources* allow Terraform to access and use information that was defined outside ofWe'll outline two ways to define this kind of reference: using local values and data sources. The available data sources for Chainguard resources are [groups](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/group), [identities](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/identity), and [roles](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/data-sources/role).
 
-If you know the exact name of your organization's group, you can use a data resource to query the API for it:
+If you know the exact name of your organization, you can use a data resource to query the API for it:
 
 ```
 data "chainguard_group" "org" {
   # This indicates the group is an organization.
   parent_id = "/"
-  name  	= "[organization group name]"
+  name  	= "[organization name]"
 }
 ```
 
@@ -210,5 +210,5 @@ After applying this Terraform configuration, any user whose GitHub ID was includ
 
 The [Chainguard Terraform provider documentation](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs) includes examples of how you can use it to manage your Chainguard resources.
 
-For more information on setting up custom identity providers, we encourage you to check out our documentation on setting up [custom IDPs](/chainguard/administration/custom-idps/custom-idps/), as well as our examples for [Okta](/chainguard/administration/custom-idps/okta/), [Ping Identity](/chainguard/administration/custom-idps/ping-id/), and [Azure Active Directory](/chainguard/administration/custom-idps/azure-ad/). Additionally, [our tutorial](/chainguard/administration/iam-groups/rolebinding-terraform-gh/) on using the Terraform provider to grant members of a GitHub team access to the resources managed by a Chainguard group provides more context and information to the method outlined in this guide.
+For more information on setting up custom identity providers, we encourage you to check out our documentation on setting up [custom IDPs](/chainguard/administration/custom-idps/custom-idps/), as well as our examples for [Okta](/chainguard/administration/custom-idps/okta/), [Ping Identity](/chainguard/administration/custom-idps/ping-id/), and [Azure Active Directory](/chainguard/administration/custom-idps/azure-ad/). Additionally, [our tutorial](/chainguard/administration/iam-groups/rolebinding-terraform-gh/) on using the Terraform provider to grant members of a GitHub team access to the resources managed by a Chainguard organization provides more context and information to the method outlined in this guide.
 


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This PR updates several more of our IAM-related docs to use the new nomenclature around our IAM structures ("groups" ==> "organizations").

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/3801

### Why are we making this change?
<!-- What larger problem does this PR address? -->
I had been holding off from updating these docs until the Terraform provider itself was updated, but that work has been moved to the backlog for now. I'm updating these docs in an attempt to minimize confusion between them and the rest of our IAM-related docs.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Review these changes to make sure that they all sound okay. Tech test not necessary for these.

Related: I added this note to the Terraform provider overview:

```
> **Note:** Chainguard organizations were previously called "groups," with a "root group" representing what is now referred to as an organization and "subgroups" referring to folders. As of this writing, the Chainguard Terraform provider still refers to "groups" instead of organizations. To align with our other [IAM resources](/chainguard/administration/iam-organizations/), this document uses the new nomenclature wherever possible.
```

Would this be helpful in the other docs? or would it be overkill to add it to each one?