### PR TITLE
Include subpath in iam-groups -> iam-orgs redirect.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,7 +52,7 @@ http {
         "~^/chainguard/chainguard-enforce/iam-groups/identity-examples/(.+)?$"  /chainguard/chainguard-enforce/authentication/$1;
         "~^/chainguard/chainguard-enforce/authentication/identity-examples/(.+)?$"  /chainguard/administration/iam-groups/identity-examples/;
         "~^/chainguard/chainguard-images/vulnerability-comparisons/(.+)?$"  /chainguard/chainguard-images/comparing-images/vulnerability-comparisons;
-        "~^/chainguard/administration/iam-groups/(.+)?$"  /chainguard/administration/iam-organizations;
+        "~^/chainguard/administration/iam-groups/(.+)?$"  /chainguard/administration/iam-organizations/$1;
         "~^/chainguard/migration-guides/(.+)?$"  /chainguard/migration/$1;
 
         # reference docs redirects - removed images, etc


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

Bug

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

Links are currently not working as expected because we're redirecting to the parent.

Example: https://edu.chainguard.dev/chainguard/administration/iam-groups/identity-examples/github-identity/

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

Any link under https://edu.chainguard.dev/chainguard/administration/iam-groups should link to the corresponding iam-organizations page.

e.g. https://edu.chainguard.dev/chainguard/administration/iam-groups/identity-examples/github-identity/ -> Example: https://edu.chainguard.dev/chainguard/administration/iam-organizations/identity-examples/github-identity/



### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->

Check redirect (https://edu.chainguard.dev/chainguard/administration/iam-organizations/assumable-ids/ has a bunch of these broken links)