### PR TITLE
Getting Started with the nginx Chainguard Image Tutorial

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -1,0 +1,311 @@
+---
+title: "Getting Started with the NGINX Chainguard Image"
+type: "article"
+description: "Tutorial on how to get started with the NGINX Chainguard Image"
+date: 2023-01-09T11:07:52+02:00
+lastmod: 2023-01-19T11:07:52+02:00
+tags: ["Chainguard Images", "Products"]
+draft: false
+images: []
+menu:
+  docs:
+	parent: "getting-started"
+weight: 610
+toc: true
+---
+ <!-- This is outdated -->
+The nginx images maintained by Chainguard are a mix of development and production distroless images that are suitable for building and running nginx workloads.
+
+Because nginx applications typically require the installation of third-party dependencies via Composer, using a pure distroless image for building your application would not work. In cases like this, you'll need to implement a [multi-stage Docker build](https://docs.docker.com/build/building/multi-stage/) that uses one of the `-dev` images to set up the application.
+
+In this guide, we'll set up a distroless container image based on Wolfi as a runtime to execute a command-line nginx application.
+<!-- Update the above -->
+
+{{< details "What is distroless" >}}
+{{< blurb/distroless >}}
+{{< /details >}}
+
+{{< details "What is Wolfi" >}}
+{{< blurb/wolfi >}}
+{{< /details >}}
+
+{{< details "Chainguard Images" >}}
+{{< blurb/images >}}
+{{< /details >}}
+
+## Step 1: Setting up a Demo Application
+
+We'll start by creating a basic nginx application to serve as a demo. This app will instantiate a local webserver to display HTML in your browser. You will need to have nginx installed on your machine to follow along. If you do not already have nginx installed, you can do so using Homebrew:
+
+```shell
+brew install nginx
+```
+
+Alternatively, you can install nginx using another method [found here](https://nginx.org/en/docs/install.html).
+
+For this tutorial, you will be copying code to files you create locally. You can find this code throughout the demo or you can find a complete collection of files at the associated [GitHub repository here](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
+
+With nginx installed, create a directory for your app. In this guide we'll call the directory `nginxdemo`:
+
+```shell
+mkdir ~/nginxdemo/ && cd $_
+```
+
+Within this directory, we will create a `data` directory to contain our content hosted by the webserver.
+
+```shell
+mkdir data && cd $_
+```
+
+Using a text editor of your choice, create a new file `index.html` for the HTML content that will be served. In our case, we will use `nano`.
+
+```shell
+nano index.html
+```
+
+The following HTML file displays an image of Inky, our mascot, alongside a fun octopus fact.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<title>Chainguard NGINX Demo Application</title>
+<link rel="stylesheet" href="stylesheet.css">
+</head>
+
+<body>
+
+<h1>NGINX Demo Application</h1>
+
+<i><h2>from the <a href="https://edu.chainguard.dev/" target="_blank">Chainguard Academy</a></h2></i>
+
+<img src="inky.png" class="corners" width="250px">
+
+<i><h3>Did you know?</h3></i>
+<p>The Wolfi octopus is the world's smallest octopus, weighing in on average at less than a gram! They are found near the coastlines of the west Pacific Ocean.</p>
+
+</body>
+
+</html>
+```
+
+Copy this code to your `index.html` file, save, and close it.
+
+Next, create a CSS file named `stylesheet.css` using the text editor of your choice, and copy in the following code.
+
+```css
+/*
+Chainguard Academy NGINX demo application
+*/
+
+body {
+    text-align: center;
+    background-color: #fcebfc;
+    font-family: Arial, sans-serif;
+}
+
+h1 {
+    color: #df45e6;
+}
+
+h2, h3 {
+    color: #9745e6;
+}
+
+p {
+    color: #583ce8
+}
+
+.corners {
+    border-radius: 10px;
+}
+
+```
+
+After copying the code into the `stylesheet.css` file, save and close it.
+
+Next, you will pull down the `inky.png` file using `curl`. Always [inspect the URL](https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png) before downloading it to ensure it is from a safe and trustworthy location.
+
+```shell
+curl -O https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png
+```
+
+Now, return to the `nginxdemo` directory you created. Here we will create the `nginx.conf` configuration file used by NGINX to run the local webserver. We will demonstrate this using `nano`.
+
+```shell
+nano nginx.conf
+```
+
+Copy the following code into the configuration file. Be sure to update line 30 in the configuration to reference the path to the `data` directory you created in a previous step.
+
+```
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  logs/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    server {
+
+        listen 8080;
+        server_name localhost;
+        charset koi8-r;
+        access_log  logs/host.access.log  main;
+
+        location / {
+            root /Users/username/nginxdemo/data; # Update file path accordingly
+        }
+
+    }
+
+    include servers/*;
+
+}
+
+```
+
+Once you are finished editing the configuration file, save and close it.
+
+Create a new file named `mime.types` using a text editor of your choice. We will use `nano` to demonstrate.
+
+```shell
+nano mime.types
+```
+
+Copy and paste the following code into your `mime.types` file. This file will allow NGINX to handle our `inky.png` file when rendering the webserver. 
+
+```
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    image/png                                        png;
+}
+
+```
+
+Save and close the file when you are finished editing it.
+
+Navigate back to the `nginxdemo` directory you created earlier. Create a new subdirectory titled `logs`. This directory is where NGINX will output any error logs it generates.
+
+```shell
+mkdir logs && cd $_
+```
+Within this new `logs` directory, create the `access.log` file. NGINX will populate this file later if need be.
+
+```shell
+mkfile b access.log
+```
+
+Copy the filepath to your `nginx.conf` file you created earlier. Replacing `<filepath>` with this copied path, execute the following command to initialize the NGINX server:
+```shell
+nginx -c <filepath>
+```
+
+To view the local webserver, navigate to `localhost:8080` in your web browser of choice. You should see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
+
+If you make any changes to the files NGINX is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow NGINX to safely exit.
+
+
+## Step 2: Creating the Dockerfile
+
+To make sure our final image is _distroless_ while still being able to install dependencies with Composer, our build will consist of **two** stages: first, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development.
+Then, we'll create a separate stage for the final image. The resulting image will be based on the distroless PHP Wolfi image, which means it doesn't come with Composer or even a shell.
+
+Create a Dockerfile with:
+
+```shell
+touch Dockerfile
+```
+
+Then open this file in your code editor of choice, for example `nano`:
+
+```shell
+nano Dockerfile
+```
+The following Dockerfile will:
+
+1. Start a new build stage based on the `php:latest-dev` image and call it `builder`;
+2. Copy files from the current directory to the `/app` location in the container;
+3. Enter the `/app` directory and run `composer install` to install any dependencies;
+4. Start a new build stage based on the `php:latest` image;
+5. Copy the application from the `builder` stage;
+6. Set up the application as entry point for this image.
+
+Copy this content to your own `Dockerfile`:
+
+```Dockerfile
+FROM cgr.dev/chainguard/php:latest-dev AS builder
+COPY . /app
+RUN cd /app && \
+	composer install --no-progress --no-dev --prefer-dist
+
+FROM cgr.dev/chainguard/php:latest
+COPY --from=builder /app /app
+
+ENTRYPOINT [ "php", "/app/namegen" ]
+```
+Save the file when you're finished.
+
+You can now build the image with:
+
+```shell
+docker build . -t php-namegen
+```
+
+Once the build is finished, run the image with:
+
+```shell
+docker run --rm php-namegen get
+```
+
+And you should get output similar to what you got before, with a random name combination.
+
+```
+fortuitous-octopus
+```
+
+If you inspect the image with a `docker image inspect php-namegen`, you'll notice that it has only **two** layers, thanks to the use of a multi-staging Docker build.
+
+```shell
+docker image inspect php-namegen
+```
+```shell
+...
+    	"RootFS": {
+        	"Type": "layers",
+        	"Layers": [
+            	"sha256:23a50695d43b8aea7720c05bff1bdbfbcb45d0b0c7e7387f55d82110084002eb",
+            	"sha256:9b900cbd280a3d510588c3b14bc937718ccee43a10b8b7b1756438b030bc3e15"
+        	]
+    	},
+    	"Metadata": {
+        	"LastTagTime": "2023-01-10T19:02:13.062958609+01:00"
+    	}
+	}
+]
+
+```
+In such cases, the last `FROM` section from the Dockerfile is the one that composes the final image. That's why in our case it only adds one layer on top of the base `php:latest` image, containing the `COPY` command we use to copy the application from the build stage to the final image.
+
+It's worth highlighting that nothing is carried from one stage to the other unless you copy it. That facilitates creating a slim final image with only what's necessary to execute the application.
+
+## Advanced Usage
+
+{{< blurb/images-advanced image="PHP" >}}
+
+

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "nginx"
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-05-24T17:32:25+00:00
+lastmod: 2024-06-17T18:32:10+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -143,7 +143,7 @@ Here we will create the `nginx.conf` configuration file used by nginx to run the
 nano nginx.conf
 ```
 
-Copy the following code into the configuration file you created. In the `location` directive, be sure to update the configuration to reference the path from root to the `data` directory you created in a previous step.
+Copy the following code into the configuration file you created. In the `location` directive, be sure to update the configuration to reference the path from root to the `data` directory you created in a previous step. The file path which you are not using should be commented out using the `#` symbol to prevent syntax errors.
 
 ```nginx
 worker_processes  1;
@@ -168,7 +168,7 @@ http {
 
         location / {
             root /Users/username/nginxdemo/data; # Update the file path for your system
-            #root /home/username/nginxdemo/data # Linux file path example
+            #root /home/username/nginxdemo/data; # Linux file path example
 
         }
 
@@ -205,7 +205,15 @@ Next, copy the absolute filepath to the `nginx.conf` file you created earlier. R
 nginx -c /Users/username/nginxdemo/nginx.conf
 ```
 
-To view the HTML content, navigate to `localhost:8080` in your web browser of choice. You should see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
+Please note that you may encounter some permissions errors when executing this command. You will need to update the permissions of the default nginx logging directory on some systems to proceed. For example, nginx installed with Homebrew stores its log files at `/opt/homebrew/var/log/nginx/`, while on a Linux machine, the logs are stored in `/var/log/nginx/`. To update the permissions of these directories, execute the following command, replacing `username` with your local username and updating the log file path if need be.
+
+```shell
+chmod +wx /opt/homebrew/var/log/nginx/
+```
+
+With the directory permissions updated, you should now be able to initialize the nginx server.
+
+To view the HTML content, navigate to `localhost:8080` in your web browser of choice. You will see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
 
 If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your website, run `nginx -s quit` to allow nginx to safely shut down.
 

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "nginx"
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2023-01-19T11:07:52+02:00
+lastmod: 2024-05-20T14:49:27+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -17,9 +17,9 @@ toc: true
 
 The nginx images maintained by Chainguard are a mix of development and production distroless images that are suitable for building and running nginx workloads.
 
-In this guide, we'll create a demo application using nginx to serve static content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo.
+In this guide, we'll create a demo application using nginx to serve static content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a containerized environment.
 
-You will need to have nginx installed on your machine to follow along. If you do not already have nginx installed, you can do so using Homebrew or by using another method [found here](https://nginx.org/en/docs/install.html).
+You will need to have nginx installed on your machine to follow along.
 
 {{< details "What is distroless" >}}
 {{< blurb/distroless >}}
@@ -45,13 +45,13 @@ With nginx installed, create a directory for your app. In this guide we'll call 
 mkdir ~/nginxdemo/ && cd $_
 ```
 
-Within this directory, we will create a `data` directory to contain our content hosted by the webserver.
+Within this directory, we will create a `data` directory to contain our content to be hosted by the web server.
 
 ```shell
 mkdir data && cd $_
 ```
 
-Using a text editor of your choice, create a new file `index.html` for the HTML content that will be served. In our case, we will use `nano` as our editor.
+Using a text editor of your choice, create a new file `index.html` for the HTML content that will be served. We will use `nano` as an example.
 
 ```shell
 nano index.html
@@ -59,7 +59,7 @@ nano index.html
 
 The following HTML file displays an image of Inky, our mascot, alongside a fun octopus fact.
 
-```html
+```HTML
 <!DOCTYPE html>
 <html>
 <head>
@@ -86,7 +86,7 @@ The following HTML file displays an image of Inky, our mascot, alongside a fun o
 
 Copy this code to your `index.html` file, save, and close it.
 
-Next, create a CSS file named `stylesheet.css` using the text editor of your choice, for instance `nano`.
+Next, create a CSS file named `stylesheet.css` using the text editor of your choice. We'll use `nano` to demonstrate.
 
 ```shell
 nano stylesheet.css
@@ -94,7 +94,7 @@ nano stylesheet.css
 
 Copy the following code to your `stylesheet.css` file. 
 
-```css
+```CSS
 /*
 Chainguard Academy nginx demo application
 */
@@ -137,7 +137,7 @@ Now, return to the `nginxdemo` directory you created. Here we will create the `n
 nano nginx.conf
 ```
 
-Copy the following code into the configuration file. Be sure to update the file path in the `location` directive in the configuration to reference the path from root to the `data` directory you created in a previous step.
+Copy the following code into the configuration file you created. In the `location` directive, be sure to update the configuration to reference the path from root to the `data` directory you created in a previous step.
 
 ```nginx
 worker_processes  1;

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "nginx"
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-05-20T14:49:27+00:00
+lastmod: 2024-05-24T17:32:25+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -17,9 +17,9 @@ toc: true
 
 The nginx images maintained by Chainguard are a mix of development and production distroless images that are suitable for building and running nginx workloads.
 
-In this guide, we'll create a demo application using nginx to serve static content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a containerized environment.
+In this tutorial, we will create a demo application using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
 
-You will need to have nginx installed on your machine to follow along.
+You will need to have nginx and Docker Engine installed on your machine to follow along.
 
 {{< details "What is distroless" >}}
 {{< blurb/distroless >}}
@@ -57,19 +57,19 @@ Using a text editor of your choice, create a new file `index.html` for the HTML 
 nano index.html
 ```
 
-The following HTML file displays an image of Inky, our mascot, alongside a fun octopus fact.
+The following HTML file displays an image of Inky alongside a fun octopus fact.
 
 ```HTML
 <!DOCTYPE html>
 <html>
 <head>
-<title>Chainguard NGINX Demo Application</title>
+<title>Chainguard nginx Demo Application</title>
 <link rel="stylesheet" href="stylesheet.css">
 </head>
 
 <body>
 
-<h1>NGINX Demo Application</h1>
+<h1>nginx Demo Application</h1>
 
 <h2>from the <a href="https://edu.chainguard.dev/" target="_blank">Chainguard Academy</a></h2>
 
@@ -96,7 +96,7 @@ Copy the following code to your `stylesheet.css` file.
 
 ```CSS
 /*
-Chainguard Academy nginx demo application
+Chainguard Academy nginx Demo Application
 */
 
 body {
@@ -125,13 +125,13 @@ p {
 
 After copying the code into the `stylesheet.css` file, save and close it.
 
-Next, you will pull down the `inky.png` file using `curl`. Always [inspect the URL](https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png) before downloading it to ensure it is from a safe and trustworthy location.
+Next, you will pull down the `inky.png` file using `curl`. Always [inspect the URL](https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png) before downloading it to ensure it comes from a safe and trustworthy location.
 
 ```shell
 curl -O https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png
 ```
 
-Now, return to the `nginxdemo` directory you created. Here we will create the `nginx.conf` configuration file used by nginx to run the local webserver. We will demonstrate this using `nano`.
+Now, return to the `nginxdemo` directory you made earlier. Here we will create the `nginx.conf` configuration file used by nginx to run the local web server. We will demonstrate this using `nano`.
 
 ```shell
 nano nginx.conf
@@ -146,7 +146,6 @@ events {
     worker_connections  1024;
 }
 
-
 http {
     include       mime.types;
     default_type  application/octet-stream;
@@ -157,12 +156,13 @@ http {
 
     server {
 
-        listen 8080;
+        listen 1313;
         server_name localhost;
         charset koi8-r;
 
         location / {
-            root /Users/username/nginxdemo/data; # Update file path accordingly
+            root /Users/username/nginxdemo/data; # Update the file path for your system
+
         }
 
     }
@@ -170,7 +170,6 @@ http {
     include servers/*;
 
 }
-
 ```
 
 Once you are finished editing the configuration file, save and close it.
@@ -189,109 +188,69 @@ types {
     text/css                                         css;
     image/png                                        png;
 }
-
 ```
 
 Save and close the `mime.types` file when you are finished editing it.
 
-Copy the filepath to your `nginx.conf` file you created earlier. Replacing `<filepath>` with this copied path, execute the following command to initialize the nginx server:
+Next, copy the filepath to the `nginx.conf` file you created earlier. Replacing the example path with this copied path, execute the following command to initialize the nginx server:
 
 ```shell
-nginx -c <filepath>
+nginx -c /Users/username/nginxdemo/nginx.conf
 ```
 
 To view the HTML content, navigate to `localhost:8080` in your web browser of choice. You should see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
 
-If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow nginx to safely exit.
+If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow nginx to safely shut down.
 
-
-
-<!-- New content -->
 ## Step 2: Creating the Dockerfile
 
-To make sure our final image is _distroless_ while still being able to install dependencies with Composer, our build will consist of **two** stages: first, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development.
-Then, we'll create a separate stage for the final image. The resulting image will be based on the distroless PHP Wolfi image, which means it doesn't come with Composer or even a shell.
+We will now use a Dockerfile to build an image containing the demo application. 
 
-Create a Dockerfile with:
-
-```shell
-touch Dockerfile
-```
-
-Then open this file in your code editor of choice, for example `nano`:
+In the `nginxdemo` directory, create the `Dockerfile` with the text editor of your choice. We will use `nano`:
 
 ```shell
 nano Dockerfile
 ```
 The following Dockerfile will:
 
-1. Start a new build stage based on the `nginx:latest` image and call it `builder`;
-2. Copy files from the current directory to the `/app` location in the container;
-3. Enter the `/app` directory and run `composer install` to install any dependencies;
-4. Start a new build stage based on the `php:latest` image;
-5. Copy the application from the `builder` stage;
-6. Set up the application as entry point for this image.
+1. Start a new build based on the `cgr.dev/chainguard/nginx:latest` image;
+2. Expose port 8080 in the container for nginx to listen on;
+3. Copy the HTML content from the data directory into the image.
 
 Copy this content to your own `Dockerfile`:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/php:latest-dev AS builder
-COPY . /app
-RUN cd /app && \
-	composer install --no-progress --no-dev --prefer-dist
+FROM cgr.dev/chainguard/nginx:latest
 
-FROM cgr.dev/chainguard/php:latest
-COPY --from=builder /app /app
+EXPOSE 8080
 
-ENTRYPOINT [ "php", "/app/namegen" ]
+COPY data /usr/share/nginx/html/
 ```
 Save the file when you're finished.
 
 You can now build the image with:
 
 ```shell
-docker build . -t php-namegen
+docker build . -t nginx-demo
 ```
 
-Once the build is finished, run the image with:
+Once the build is complete, run the image with:
 
 ```shell
-docker run --rm php-namegen get
+docker run -d -p 8080:8080 nginx-demo
 ```
 
-And you should get output similar to what you got before, with a random name combination.
+The `-d` flag configures our container to run as a background process. The `-p` flag publishes the port that the container listens on to a port on your local machine. This allows us to navigate to `localhost:8080` in a web browser of our choice to view the HTML content served by the container. You should see the same HTML page as before, with Inky and an octopus fun fact.
 
-```
-fortuitous-octopus
-```
-
-If you inspect the image with a `docker image inspect php-namegen`, you'll notice that it has only **two** layers, thanks to the use of a multi-staging Docker build.
+If you wish to publish to a different port on your machine, such as `1313`, you can do so by altering the command-line argument as shown:
 
 ```shell
-docker image inspect php-namegen
+docker run -d -p 1313:8080 nginx-demo
 ```
-```shell
-...
-    	"RootFS": {
-        	"Type": "layers",
-        	"Layers": [
-            	"sha256:23a50695d43b8aea7720c05bff1bdbfbcb45d0b0c7e7387f55d82110084002eb",
-            	"sha256:9b900cbd280a3d510588c3b14bc937718ccee43a10b8b7b1756438b030bc3e15"
-        	]
-    	},
-    	"Metadata": {
-        	"LastTagTime": "2023-01-10T19:02:13.062958609+01:00"
-    	}
-	}
-]
-
-```
-In such cases, the last `FROM` section from the Dockerfile is the one that composes the final image. That's why in our case it only adds one layer on top of the base `php:latest` image, containing the `COPY` command we use to copy the application from the build stage to the final image.
-
-It's worth highlighting that nothing is carried from one stage to the other unless you copy it. That facilitates creating a slim final image with only what's necessary to execute the application.
 
 ## Advanced Usage
 
-{{< blurb/images-advanced image="PHP" >}}
+In this demo application, we did not copy the configuration file into the image built from the Dockerfile. This is because the default configuration file in the image was sufficient for the scope of this demo. If you wish to use a custom configuration file, you must ensure that file paths, ports, and other system-specific settings are configured to match the container environment. You can find more information about making these changes at the [Chainguard nginx Image Overview](/chainguard/chainguard-images/reference/nginx/image_specs/).
 
+{{< blurb/images-advanced image="nginx" >}}
 

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "nginx"
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-06-17T18:32:10+00:00
+lastmod: 2024-06-17T18:39:59+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -205,7 +205,7 @@ Next, copy the absolute filepath to the `nginx.conf` file you created earlier. R
 nginx -c /Users/username/nginxdemo/nginx.conf
 ```
 
-Please note that you may encounter some permissions errors when executing this command. You will need to update the permissions of the default nginx logging directory on some systems to proceed. For example, nginx installed with Homebrew stores its log files at `/opt/homebrew/var/log/nginx/`, while on a Linux machine, the logs are stored in `/var/log/nginx/`. To update the permissions of these directories, execute the following command, replacing `username` with your local username and updating the log file path if need be.
+Please note that you may encounter some permissions errors when executing this command. You will need to update the permissions of the default nginx logging directory on some systems to proceed. For example, nginx installed with Homebrew stores its log files at `/opt/homebrew/var/log/nginx/`, while on a Linux machine, the logs are stored in `/var/log/nginx/`. To update the permissions of these directories, execute the following command, updating the log file path if need be.
 
 ```shell
 chmod +wx /opt/homebrew/var/log/nginx/

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Getting Started with the NGINX Chainguard Image"
+title: "Getting Started with the nginx Chainguard Image"
 type: "article"
-description: "Tutorial on how to get started with the NGINX Chainguard Image"
+description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
 lastmod: 2023-01-19T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
@@ -43,7 +43,7 @@ brew install nginx
 
 Alternatively, you can install nginx using another method [found here](https://nginx.org/en/docs/install.html).
 
-For this tutorial, you will be copying code to files you create locally. You can find this code throughout the demo or you can find a complete collection of files at the associated [GitHub repository here](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
+For this tutorial, you will be copying code to files you create locally. You can find this code throughout the demo here, or you can find a complete collection of files at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
 
 With nginx installed, create a directory for your app. In this guide we'll call the directory `nginxdemo`:
 
@@ -91,7 +91,7 @@ The following HTML file displays an image of Inky, our mascot, alongside a fun o
 
 Copy this code to your `index.html` file, save, and close it.
 
-Next, create a CSS file named `stylesheet.css` using the text editor of your choice, and copy in the following code.
+Next, create a CSS file named `stylesheet.css` using the text editor of your choice, and copy in the following code. This will give our page a bit of color.
 
 ```css
 /*
@@ -138,7 +138,7 @@ nano nginx.conf
 
 Copy the following code into the configuration file. Be sure to update line 30 in the configuration to reference the path to the `data` directory you created in a previous step.
 
-```
+```nginx
 worker_processes  1;
 
 events {
@@ -187,7 +187,7 @@ Create a new file named `mime.types` using a text editor of your choice. We will
 nano mime.types
 ```
 
-Copy and paste the following code into your `mime.types` file. This file will allow NGINX to handle our `inky.png` file when rendering the webserver. 
+Copy and paste the following code into your `mime.types` file. This file will allow nginx to handle our `inky.png` file when rendering the webserver. 
 
 ```
 types {
@@ -200,27 +200,16 @@ types {
 
 Save and close the file when you are finished editing it.
 
-Navigate back to the `nginxdemo` directory you created earlier. Create a new subdirectory titled `logs`. This directory is where NGINX will output any error logs it generates.
-
-```shell
-mkdir logs && cd $_
-```
-Within this new `logs` directory, create the `access.log` file. NGINX will populate this file later if need be.
-
-```shell
-mkfile b access.log
-```
-
-Copy the filepath to your `nginx.conf` file you created earlier. Replacing `<filepath>` with this copied path, execute the following command to initialize the NGINX server:
+Copy the filepath to your `nginx.conf` file you created earlier. Replacing `<filepath>` with this copied path, execute the following command to initialize the nginx server:
 ```shell
 nginx -c <filepath>
 ```
 
 To view the local webserver, navigate to `localhost:8080` in your web browser of choice. You should see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
 
-If you make any changes to the files NGINX is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow NGINX to safely exit.
+If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow nginx to safely exit.
 
-
+<!-- New content -->
 ## Step 2: Creating the Dockerfile
 
 To make sure our final image is _distroless_ while still being able to install dependencies with Composer, our build will consist of **two** stages: first, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development.

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -237,15 +237,21 @@ docker build . -t nginx-demo
 Once the build is complete, run the image with:
 
 ```shell
-docker run -d -p 8080:8080 nginx-demo
+docker run -d --name nginxcontainer -p 8080:8080 nginx-demo
 ```
 
-The `-d` flag configures our container to run as a background process. The `-p` flag publishes the port that the container listens on to a port on your local machine. This allows us to navigate to `localhost:8080` in a web browser of our choice to view the HTML content served by the container. You should see the same HTML page as before, with Inky and an octopus fun fact.
+The `-d` flag configures our container to run as a background process. The `--name` flag will name our container `nginxcontainer`, making it easy to identify from other containers. The `-p` flag publishes the port that the container listens on to a port on your local machine. This allows us to navigate to `localhost:8080` in a web browser of our choice to view the HTML content served by the container. You should see the same HTML page as before, with Inky and an octopus fun fact.
 
 If you wish to publish to a different port on your machine, such as `1313`, you can do so by altering the command-line argument as shown:
 
 ```shell
-docker run -d -p 1313:8080 nginx-demo
+docker run -d --name nginxcontainer -p 1313:8080 nginx-demo
+```
+
+When you are done with your container, you can stop it with the following command:
+
+```shell
+docker container stop nginxcontainer
 ```
 
 ## Advanced Usage

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -15,11 +15,11 @@ weight: 610
 toc: true
 ---
 
-The nginx images maintained by Chainguard are a mix of development and production distroless images that are suitable for building and running nginx workloads.
+The nginx images maintained by Chainguard include development and production distroless images that are suitable for building and running nginx workloads. Images tagged with `:latest-dev` include additional packages to facilitate project development and testing. Images tagged with `:latest` strip back these extra packages to provide a secure, production-ready container image.
 
-In this tutorial, we will create a demo application using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
+In this tutorial, we will create a local demo website using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
 
-You will need to have nginx and Docker Engine installed on your machine to follow along.
+You will need to have [nginx](https://nginx.org/en/download.html) and [Docker Engine](https://docs.docker.com/engine/install/) installed on your machine to follow along.
 
 {{< details "What is distroless" >}}
 {{< blurb/distroless >}}
@@ -33,13 +33,13 @@ You will need to have nginx and Docker Engine installed on your machine to follo
 {{< blurb/images >}}
 {{< /details >}}
 
-## Step 1: Setting up a Demo Application
+## Step 1: Setting up a Demo Website 
 
-We'll start by creating a basic nginx application to serve as a demo. This app will serve static content to a local web server. 
+We'll start by serving static content to a local web server with nginx.
 
 For this tutorial, you will be copying code to files you create locally. You can find the demo code throughout this tutorial, or you can find the complete demo at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
 
-With nginx installed, create a directory for your app. In this guide we'll call the directory `nginxdemo`:
+With nginx installed, create a directory for your demo. In this guide we'll call the directory `nginxdemo`:
 
 ```shell
 mkdir ~/nginxdemo/ && cd $_
@@ -63,13 +63,13 @@ The following HTML file displays an image of Inky alongside a fun octopus fact.
 <!DOCTYPE html>
 <html>
 <head>
-<title>Chainguard nginx Demo Application</title>
+<title>Chainguard nginx Demo Website</title>
 <link rel="stylesheet" href="stylesheet.css">
 </head>
 
 <body>
 
-<h1>nginx Demo Application</h1>
+<h1>nginx Demo Website</h1>
 
 <h2>from the <a href="https://edu.chainguard.dev/" target="_blank">Chainguard Academy</a></h2>
 
@@ -96,7 +96,7 @@ Copy the following code to your `stylesheet.css` file.
 
 ```CSS
 /*
-Chainguard Academy nginx Demo Application
+Chainguard Academy nginx Demo Website
 */
 
 body {
@@ -131,7 +131,13 @@ Next, you will pull down the `inky.png` file using `curl`. Always [inspect the U
 curl -O https://raw.githubusercontent.com/chainguard-dev/edu-images-demos/734e6171ee69f0e0dbac95e6ebc1759ac18bf00a/nginx/data/inky.png
 ```
 
-Now, return to the `nginxdemo` directory you made earlier. Here we will create the `nginx.conf` configuration file used by nginx to run the local web server. We will demonstrate this using `nano`.
+Now, return to the `nginxdemo` directory you made earlier. 
+
+```shell
+cd ../
+```
+
+Here we will create the `nginx.conf` configuration file used by nginx to run the local web server. We will demonstrate this using `nano`.
 
 ```shell
 nano nginx.conf
@@ -156,12 +162,13 @@ http {
 
     server {
 
-        listen 1313;
+        listen 8080;
         server_name localhost;
         charset koi8-r;
 
         location / {
             root /Users/username/nginxdemo/data; # Update the file path for your system
+            #root /home/username/nginxdemo/data # Linux file path example
 
         }
 
@@ -192,7 +199,7 @@ types {
 
 Save and close the `mime.types` file when you are finished editing it.
 
-Next, copy the filepath to the `nginx.conf` file you created earlier. Replacing the example path with this copied path, execute the following command to initialize the nginx server:
+Next, copy the absolute filepath to the `nginx.conf` file you created earlier. Replacing the example path with this copied path, execute the following command to initialize the nginx server:
 
 ```shell
 nginx -c /Users/username/nginxdemo/nginx.conf
@@ -200,11 +207,11 @@ nginx -c /Users/username/nginxdemo/nginx.conf
 
 To view the HTML content, navigate to `localhost:8080` in your web browser of choice. You should see a simple landing page with a picture of Inky and a fun fact about the Wolfi octopus.
 
-If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your application, run `nginx -s quit` to allow nginx to safely shut down.
+If you make any changes to the files nginx is serving, run `nginx -s reload` in your terminal to allow the changes to render. When you are finished with your website, run `nginx -s quit` to allow nginx to safely shut down.
 
 ## Step 2: Creating the Dockerfile
 
-We will now use a Dockerfile to build an image containing the demo application. 
+We will now use a Dockerfile to build an image containing the demo. 
 
 In the `nginxdemo` directory, create the `Dockerfile` with the text editor of your choice. We will use `nano`:
 
@@ -214,7 +221,7 @@ nano Dockerfile
 The following Dockerfile will:
 
 1. Start a new build based on the `cgr.dev/chainguard/nginx:latest` image;
-2. Expose port 8080 in the container for nginx to listen on;
+2. Note which container port we need to expose for nginx to listen on;
 3. Copy the HTML content from the data directory into the image.
 
 Copy this content to your own `Dockerfile`:
@@ -256,7 +263,7 @@ docker container stop nginxcontainer
 
 ## Advanced Usage
 
-In this demo application, we did not copy the configuration file into the image built from the Dockerfile. This is because the default configuration file in the image was sufficient for the scope of this demo. If you wish to use a custom configuration file, you must ensure that file paths, ports, and other system-specific settings are configured to match the container environment. You can find more information about making these changes at the [Chainguard nginx Image Overview](/chainguard/chainguard-images/reference/nginx/image_specs/).
+In this demo, we did not copy the configuration file into the image built from the Dockerfile. This is because the default configuration file in the image was sufficient for the scope of this demo. If you wish to use a custom configuration file, you must ensure that file paths, ports, and other system-specific settings are configured to match the container environment. You can find more information about making these changes at the [Chainguard nginx Image Overview](/chainguard/chainguard-images/reference/nginx/image_specs/).
 
 {{< blurb/images-advanced image="nginx" >}}
 


### PR DESCRIPTION
## Type of change
Addition to documentation - adding new getting started tutorial

### What should this PR do?
Adds a new getting started tutorial to the Academy for the nginx Chainguard Image
https://github.com/chainguard-dev/internal/issues/3904

### Why are we making this change?
Expands Academy content that is helpful for new users, especially if a user may be interested in using an image for their nginx application(s)

### What are the acceptance criteria? // How should this PR be tested?
1. Please try to run this demonstration locally. I have had success with it multiple times on my MacOS laptop but I have not had an external test yet
2. Please read through the tutorial for any mistakes or for any suggestions for wording changes. I aimed to follow the style of the other "getting started" guides, but there has not been a formal review yet here

> Note: I did not create a demo with a multi-stage build. If we want to add something more complex, I am happy to try and figure that out. I wasn't sure how long we wanted this to be. It already seemed lengthy to me.

3. There is a pull request here https://github.com/chainguard-dev/edu-images-demos/pull/17 for the demo tutorial components which should be approved & merged before this article goes live since there is a reference to the repo link in the guide
4. Once the demo is tested, the other request merged, and any suggestions applied, it should be ready to go live