### PR TITLE
Fix nav buttons

### DIFF
--- a/layouts/partials/footer/main/docs-navigation.html
+++ b/layouts/partials/footer/main/docs-navigation.html
@@ -1,9 +1,17 @@
-{{ if or .Prev .Next -}}
+<h1>Prev</h1>
+<p>
+{{ .PrevInSection }}
+</p>
+  <h1>Next</h1>
+<p>
+{{ .NextInSection }}
+  </p>
+
+{{ if or .PrevInSection .NextInSection -}}
 <div class="docs-navigation">
-	<!-- https://www.feliciano.tech/blog/custom-sort-hugo-single-pages/ -->
-	{{ $pages := where site.RegularPages "Section" .Section -}}
-	{{ with $pages.Next . -}}
-		<a class="docs-navigation-button docs-navigation-button-previous" href="{{ .RelPermalink }}">
+
+  {{ with .NextInSection }}
+  <a class="docs-navigation-button docs-navigation-button-previous" href="{{ .RelPermalink }}">
 			<div class="chevron-rotator">
 				<svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
 					<path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
@@ -13,7 +21,9 @@
 			<span class="next-in-line">Prev&nbsp;&nbsp;</span>
 		</a>
 	{{ end -}}
-	{{ with $pages.Prev . -}}
+<!-- end previous -->
+
+  {{ with .PrevInSection }}
 		<a class="docs-navigation-button docs-navigation-button-next" href="{{ .RelPermalink }}">
 			<span class="next-in-line">{{ .Title }}</span>
 			<span class="next-in-line">&nbsp;&nbsp;Next</span>
@@ -23,6 +33,8 @@
 				</svg>
 			</div>
 		</a>
-	{{ end -}}
+	{{ end -}}                
+
+
 </div>
-{{ end -}}
+  {{ end }}

--- a/layouts/partials/footer/main/docs-navigation.html
+++ b/layouts/partials/footer/main/docs-navigation.html
@@ -1,61 +1,76 @@
-{{ $currentPage := . -}}
-{{ $active := in $currentPage.RelPermalink .RelPermalink }}
-
-{{ $section := .Section -}}
-
 {{ $allsections := slice }}
-
-
-
-<h1>Prev in section</h1>
-<p>
-  {{ .PrevInSection }}
-</p>
-<h1>Next in section</h1>
-<p>
-  {{ .NextInSection }}
-</p>
-
-<h1>Prev</h1>
-<p>
-  {{ .Prev }}
-</p>
-<h1>Next</h1>
-<p>
-  {{ .Next }}
-</p>
+{{ $walkpages := slice }}
 
 {{ range $index, $section := sort .Site.Sections "Weight" }}
+{{ if not (eq .Title "Uis") }}
 {{ $allsections = $allsections | append . }}
 
-<!-- Second level -->
-{{ range .Sections }}
-{{ $allsections = $allsections | append . }}
-
-<!-- Third level -->
-{{ range .Sections }}
-{{ $allsections = $allsections | append . }}
+{{ end }}
 
 {{ range .Sections }}
 {{ $allsections = $allsections | append . }}
 
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
 
 {{ range .Sections }}
 {{ $allsections = $allsections | append . }}
 
 
-<!-- End section finding loop -->
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
+
 {{ end }}
 {{ end }}
 {{ end }}
 {{ end }}
 {{ end }}
 
+{{ range $allsections }}
 
-{{ if or .PrevInSection .NextInSection -}}
+{{ range .RegularPages }}
+
+{{ $walkpages = $walkpages | append . }}
+
+{{ end }}
+
+{{ end }}
+
+{{ $walkpages = where $walkpages ".Params.unlisted" "!=" "true"}}
+
+
+
+{{ $prevpage := false }}
+{{ $thispage := false }}
+{{ $nextpage := false }}
+{{ $pageindex := false }}
+
+{{ range $index, $page := $walkpages }}
+
+
+{{ if eq .RelPermalink $.RelPermalink }}
+{{ $pageindex = $index }}
+{{ end }}
+
+{{ end }}
+
+{{ with $pageindex }}
+{{ $thispage = index $walkpages $pageindex }}
+{{ $prevpage = index $walkpages (math.Sub $pageindex 1) }}
+{{ $nextpage = index $walkpages (math.Add $pageindex 1) }}
+{{ end }}
+
+{{ if eq $pageindex 0 }}
+{{ $thispage = (index $walkpages 0) }}
+{{ $prevpage = index $walkpages (math.Sub $pageindex 1) }}
+{{ $nextpage = index $walkpages (math.Add $pageindex 1) }}
+{{ end }}
+
+
+{{ if or $prevpage $nextpage }}
 <div class="docs-navigation">
 
-  {{ with .NextInSection }}
+  {{ with $prevpage }}
   <a class="docs-navigation-button docs-navigation-button-previous" href="{{ .RelPermalink }}">
     <div class="chevron-rotator">
       <svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
@@ -68,7 +83,7 @@
   {{ end -}}
   <!-- end previous -->
 
-  {{ with .PrevInSection }}
+  {{ with $nextpage }}
   <a class="docs-navigation-button docs-navigation-button-next" href="{{ .RelPermalink }}">
     <span class="next-in-line">{{ .Title }}</span>
     <span class="next-in-line">&nbsp;&nbsp;Next</span>
@@ -78,17 +93,8 @@
       </svg>
     </div>
   </a>
-  {{ end -}}                
+  {{ end -}} 
 
 
 </div>
 {{ end }}
-
-
-{{ $allsections }}
-
-<!-- {{ range $allsections }}
-     <p>
-     {{ .Title }}
-     </p>
-     {{ end }} -->

--- a/layouts/partials/footer/main/docs-navigation.html
+++ b/layouts/partials/footer/main/docs-navigation.html
@@ -1,40 +1,94 @@
+{{ $currentPage := . -}}
+{{ $active := in $currentPage.RelPermalink .RelPermalink }}
+
+{{ $section := .Section -}}
+
+{{ $allsections := slice }}
+
+
+
+<h1>Prev in section</h1>
+<p>
+  {{ .PrevInSection }}
+</p>
+<h1>Next in section</h1>
+<p>
+  {{ .NextInSection }}
+</p>
+
 <h1>Prev</h1>
 <p>
-{{ .PrevInSection }}
+  {{ .Prev }}
 </p>
-  <h1>Next</h1>
+<h1>Next</h1>
 <p>
-{{ .NextInSection }}
-  </p>
+  {{ .Next }}
+</p>
+
+{{ range $index, $section := sort .Site.Sections "Weight" }}
+{{ $allsections = $allsections | append . }}
+
+<!-- Second level -->
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
+
+<!-- Third level -->
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
+
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
+
+
+{{ range .Sections }}
+{{ $allsections = $allsections | append . }}
+
+
+<!-- End section finding loop -->
+{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}
+
 
 {{ if or .PrevInSection .NextInSection -}}
 <div class="docs-navigation">
 
   {{ with .NextInSection }}
   <a class="docs-navigation-button docs-navigation-button-previous" href="{{ .RelPermalink }}">
-			<div class="chevron-rotator">
-				<svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
-					<path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
-				</svg>
-			</div>
-			<span class="next-in-line">{{ .Title }}</span>
-			<span class="next-in-line">Prev&nbsp;&nbsp;</span>
-		</a>
-	{{ end -}}
-<!-- end previous -->
+    <div class="chevron-rotator">
+      <svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
+	<path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
+      </svg>
+    </div>
+    <span class="next-in-line">{{ .Title }}</span>
+    <span class="next-in-line">Prev&nbsp;&nbsp;</span>
+  </a>
+  {{ end -}}
+  <!-- end previous -->
 
   {{ with .PrevInSection }}
-		<a class="docs-navigation-button docs-navigation-button-next" href="{{ .RelPermalink }}">
-			<span class="next-in-line">{{ .Title }}</span>
-			<span class="next-in-line">&nbsp;&nbsp;Next</span>
-			<div class="chevron-rotator">
-				<svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
-					<path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
-				</svg>
-			</div>
-		</a>
-	{{ end -}}                
+  <a class="docs-navigation-button docs-navigation-button-next" href="{{ .RelPermalink }}">
+    <span class="next-in-line">{{ .Title }}</span>
+    <span class="next-in-line">&nbsp;&nbsp;Next</span>
+    <div class="chevron-rotator">
+      <svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 0 10 6" fill="none">
+	<path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
+      </svg>
+    </div>
+  </a>
+  {{ end -}}                
 
 
 </div>
-  {{ end }}
+{{ end }}
+
+
+{{ $allsections }}
+
+<!-- {{ range $allsections }}
+     <p>
+     {{ .Title }}
+     </p>
+     {{ end }} -->


### PR DESCRIPTION
## Type of change

Bug fix

### What should this PR do?

This PR rewrites the site navigation Instead of going to random pages, it creates a depth-first run of the site (up to five levels) to collate all sections in order, extracts relevant pages from each section, creates a master listed page collection in order of weight, then moves the user along site using that flattened collection.

One detail here is that the implementation will go through all "regular" pages on a level, then go down or forward (in the tree) to the next  section. This does make a difference, as in a few places we have a section nested in the middle of another section, but I think it works fine as a previous/next implementation.

### Why are we making this change?

The previous and next buttons have a functionally random behavior on the current version of the site.

### What are the acceptance criteria? 

We should check that this solution doesn't break anything. In terms of behavior, it can only be an improvement to the previous and next buttons, but we also don't want anything else to get affected on the site.


### How should this PR be tested?

Try out the behavior of the previous and next buttons. They should (mostly) line up with the left sidebar, and I used a similar approach to the sidebar code (depth-first to five levels). The overview page is the first page and should only have a next button. I think the video on sigstore is the last page. Unlisted pages should not appear.

### Notes

I just want to complain about how Hugo handles stuff. The previous and next logic is reversed (why?) and their previous and next method implementation is incredibly naive.

Resolves #860 