### PR TITLE
Fix terminal chainctl install page path

### DIFF
--- a/layouts/partials/terminal.html
+++ b/layouts/partials/terminal.html
@@ -7,7 +7,7 @@
         <div id="grab"></div>
       </div>
       <div class="button-container">
-        <a class="a--original" href="/chainguard/chainguard-enforce/how-to-install-chainctl/">
+        <a class="a--original" href="/chainguard/administration/how-to-install-chainctl/">
           <button class="tooltip-container">
             <svg width="12" height="13" viewBox="0 0 12 13" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M1.74999 12.583C1.37533 12.583 1.05933 12.4547 0.801992 12.198C0.545326 11.9407 0.416992 11.6247 0.416992 11.25V10H1.49999V11.25C1.49999 11.3053 1.52766 11.361 1.58299 11.417C1.63899 11.4723 1.69466 11.5 1.74999 11.5H10.25C10.3053 11.5 10.361 11.4723 10.417 11.417C10.4723 11.361 10.5 11.3053 10.5 11.25V10H11.583V11.25C11.583 11.6247 11.4547 11.9407 11.198 12.198C10.9407 12.4547 10.6247 12.583 10.25 12.583H1.74999ZM5.99999 9.688L2.60399 6.292L3.37499 5.521L5.45799 7.604V0.270996H6.54199V7.604L8.62499 5.521L9.39599 6.292L5.99999 9.688Z" fill="currentColor"/>


### PR DESCRIPTION
### What should this PR do?
The chainctl link in the terminal experience isn't redirecting properly. `/chainguard/chainguard-enforce/how-to-install-chainctl/` redirects to the homepage.