### PR TITLE
Update how-to-install-chainctl.md

### DIFF
--- a/content/chainguard/administration/how-to-install-chainctl.md
+++ b/content/chainguard/administration/how-to-install-chainctl.md
@@ -66,7 +66,7 @@ curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | t
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.
 
 ```sh
-sudo install -o $UID -g $GID -m 0755 chainctl /usr/local/bin/chainctl
+sudo install -o $UID -g $GID -m 0755 chainctl /usr/local/bin/
 ```
 
 At this point, you'll be able to use the `chainctl` command.


### PR DESCRIPTION
```install``` expects a path rather than a filename and path combination

## Type of change
Documentation

### What should this PR do?
Clarify installation process on linux systems. 
https://manpages.debian.org/bookworm/coreutils/install.1.en.html

### Why are we making this change?
Current instructions cause the following error. 
```install: target '/usr/local/bin/chainctl': No such file or directory```

### What are the acceptance criteria? 
Success with the command.

### How should this PR be tested?
set $GID, set $UID run command with sudo.