### PR TITLE
adding redirects for Enforce events docs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,9 @@ http {
         "~^/chainguard/chainguard-enforce/administration/connecting-to-private-registries/(.+)?$" /chainguard/chainguard-enforce/authentication/connecting-to-private-registries/;
         "~^/chainguard/chainguard-enforce/administration/annotation-based-caching/(.+)?$" /chainguard/chainguard-enforce/annotation-based-caching/;
         "~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/comparing-images/;
+        "~^/chainguard/administration/cloudevents/create-github-issues/(.+)?$" /chainguard/administration/cloudevents/;
+        "~^/chainguard/administration/cloudevents/create-jira-issues/(.+)?$" /chainguard/administration/cloudevents/;
+        "~^/chainguard/administration/cloudevents/create-slack-alerts/(.+)?$" /chainguard/administration/cloudevents/;
 
         # complete content directory redirects here
         "~^/chainguard/chainguard-enforce/events/(.+)$" /chainguard/chainguard-enforce/cloudevents/$1;


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
quick PR to add some redirects for the old Enforce-related Events docs. This PR will redirect those URLs to the cloud events bucket.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->
[slack context](https://chainguard-dev.slack.com/archives/C03H64P08UT/p1718398508911179)

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
I tested this locally and it all works just fine. Not sure how to easily test out the redirects but I might be helpful in talking one through it if desired.