### PR TITLE
Change example from nginx to caddy.

### DIFF
--- a/content/chainguard/chainguard-images/debugging-distroless-images.md
+++ b/content/chainguard/chainguard-images/debugging-distroless-images.md
@@ -73,69 +73,62 @@ Another method to debug distroless images running in production is to use epheme
 
 Suppose you have a Kubernetes cluster and one of the containers is having issues. Perhaps it doesn't seem to be able to connect to other services in the cluster, or expected processes aren't running. If the container has a shell, you'd be able to use `kubectl exec` to run debugging commands from inside the container to help diagnose the issue. With a minimal image, this isn't possible, but we can achieve something very similar using `kubectl debug` to launch an ephemeral container.
 
-Let's review an example. We'll start by running a Chainguard NGINX image on a Kubernetes cluster:
+Let's review an example. We'll start by running a [Chainguard Caddy image](https://images.chainguard.dev/directory/image/caddy/overview) on a Kubernetes cluster:
 
 ```
-kubectl run nginx --image=cgr.dev/chainguard/nginx:latest
+kubectl run caddy --image=cgr.dev/chainguard/caddy:latest
 ```
 
 Which should result in:
 
 ```
-pod/nginx created
+pod/caddy created
 ```
 
 We can try to start a shell in this pod:
 
 ```
-kubectl exec -it nginx -- sh
+kubectl exec -it caddy -- sh
 ```
 
 But the following error occurs:
 
 ```
-error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "67bd5164394b1170ac1846bd77ea0b826332365970fbde3b3201bb9abec9b72c": OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown
+error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "28fc8d438c243d68923f81955b770ba305f9bd57ff9c38d6d2e635aad123b674": OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown
 ```
 
 Which is a long way of telling us there is no shell in the image. What we can do instead is use an ephemeral container. An ephemeral container will connect to the namespaces of an existing container, effectively allowing you to sideload debugging tools. Let's try that now:
 
 ```
-kubectl debug -it nginx --image=cgr.dev/chainguard/wolfi-base --target=nginx
+kubectl debug -it caddy --image=cgr.dev/chainguard/wolfi-base --target=caddy
 ```
 
 You should get output similar to:
 
 ```
-Targeting container "nginx". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
-Defaulting debug container name to debugger-87792.
+Targeting container "caddy". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
+Defaulting debug container name to debugger-7nt9j.
 If you don't see a command prompt, try pressing enter.
-nginx:/#
+caddy:/#
 ```
 
 Now we can try running some debugging commands. Let's start by seeing what's running:
 
 ```
-nginx:/# ps aux
+caddy:/# ps aux
 PID   USER     TIME  COMMAND
-    1 65532     0:00 nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf -e /dev/stderr
-   10 65532     0:00 nginx: worker process
-   11 65532     0:00 nginx: worker process
-   12 65532     0:00 nginx: worker process
-   13 65532     0:00 nginx: worker process
-   14 65532     0:00 nginx: worker process
-   15 65532     0:00 nginx: worker process
-   16 65532     0:00 nginx: worker process
-   23 root      0:00 /bin/sh -l
-   32 root      0:00 ps aux
+    1 nonroot   0:00 /usr/bin/caddy run
+   28 root      0:00 /bin/sh -l
+   38 root      0:00 ps aux
 ```
 
 And the open ports:
 
 ```
-nginx:/# netstat -lntu
+caddy:/# netstat -lntu
 Active Internet connections (only servers)
 Proto Recv-Q Send-Q Local Address           Foreign Address         State
-tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN
+tcp        0      0 127.0.0.1:2019          0.0.0.0:*               LISTEN
 ```
 
 To facilitate accessing processes running in other containers without having to specify a target, you may enable [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) within your Pod setup. It's also worth noting that the filesystem may not be accessible due to default user permissions.


### PR DESCRIPTION
## Type of change
Updated example code to use caddy instead of nginx.

(This was done as there is currently a shell in the nginx image).