### PR TITLE
Added LinkedIn insight tag to script footer

### DIFF
--- a/layouts/partials/footer/linkedin-insight.html
+++ b/layouts/partials/footer/linkedin-insight.html
@@ -1,0 +1,17 @@
+<script type="text/javascript">
+ _linkedin_partner_id = "6142089";
+ window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+ window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+</script><script type="text/javascript">
+          (function(l) {
+              if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+                  window.lintrk.q=[]}
+              var s = document.getElementsByTagName("script")[0];
+              var b = document.createElement("script");
+              b.type = "text/javascript";b.async = true;
+              b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+              s.parentNode.insertBefore(b, s);})(window.lintrk);
+</script>
+<noscript>
+  <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=6142089&fmt=gif" />
+</noscript>

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -103,3 +103,5 @@
     <script src="{{ $index.Permalink }}" integrity="{{ $index.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}
 {{ end -}}
+
+{{ partial "footer/linkedin-insight.html" . }}


### PR DESCRIPTION
## Type of change

Adds tracking via LinkedIn insight tag. The code is added in a linkedin_insight partial that is called in the script footer partial so that the linkedin elements appear just before the closing body tag.

## Why are we making this change?

Tracking requested by marketing.

## What are the acceptance criteria? 

We'll need to test this works, but likely after merging. 

## How should this PR be tested?

Check the linkedin tag at the very end of each page on the site. If it passes a sanity check, we should likely just merge and check in with marketing.

## Notes

Resolves https://github.com/chainguard-dev/internal/issues/3901
