### PR TITLE
removing quotas prereq from custom IDP docs

### DIFF
--- a/content/chainguard/administration/custom-idps/azure-ad/index.md
+++ b/content/chainguard/administration/custom-idps/azure-ad/index.md
@@ -5,7 +5,7 @@ lead: ""
 description: "Procedural tutorial on how to register an Azure Active Directory Application"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2024-04-03T15:22:20+01:00
+lastmod: 2024-06-26T15:22:20+01:00
 draft: false
 tags: ["Chainguard Images", "Procedural"]
 images: []
@@ -23,7 +23,6 @@ To complete this guide, you will need the following.
 
 * `chainctl` installed on your system. Follow our guide on [How To Install `chainctl`](/chainguard/chainguard-enforce/how-to-install-chainctl/) if you don't already have this installed.
 * An Azure account you can use to set up an Active Directory Application.
-* A Custom IDP quota of at least 1. You can reach out to [Chainguard's support team](https://support.chainguard.dev/) for help with this.
 
 
 ## Create an Azure Active Directory Application

--- a/content/chainguard/administration/custom-idps/okta/index.md
+++ b/content/chainguard/administration/custom-idps/okta/index.md
@@ -5,7 +5,7 @@ lead: ""
 description: "Procedural tutorial on how to create an Okta App Integration"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2024-04-03T15:22:20+01:00
+lastmod: 2024-06-26T15:22:20+01:00
 draft: false
 tags: ["Chainguard Images", "Procedural"]
 images: []
@@ -23,7 +23,6 @@ To complete this guide, you will need the following.
 
 * `chainctl` installed on your system. Follow our guide on [How To Install `chainctl`](/chainguard/chainguard-enforce/how-to-install-chainctl/) if you don't already have this installed.
 * An Okta account over which you have administrative access.
-* A Custom IDP quota of at least 1. You can reach out to [Chainguard's support team](https://support.chainguard.dev/) for help with this.
 
 
 ## Create an Okta App integration

--- a/content/chainguard/administration/custom-idps/ping-id/index.md
+++ b/content/chainguard/administration/custom-idps/ping-id/index.md
@@ -5,7 +5,7 @@ lead: ""
 description: "Procedural tutorial on how to create a Ping Identity Application"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2024-04-03T15:22:20+01:00
+lastmod: 2024-06-26T15:22:20+01:00
 draft: false
 tags: ["Chainguard Images", "Procedural"]
 images: []
@@ -23,7 +23,6 @@ To complete this guide, you will need the following.
 
 * `chainctl` installed on your system. Follow our guide on [How To Install `chainctl`](/chainguard/chainguard-enforce/how-to-install-chainctl/) if you don't already have this installed.
 * A Ping Identity account over which you have administrative access.
-* A Custom IDP quota of at least 1. You can reach out to [Chainguard's support team](https://support.chainguard.dev/) for help with this.
 
 
 ## Create a Ping Identity Application


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Minor change removes a prereq from our custom IDP examples. Each org now has a quota of 1 by default, so this is unnecessary.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/3931

### Why are we making this change?
<!-- What larger problem does this PR address? -->
https://chainguard-dev.slack.com/archives/C03H64P08UT/p1719438496333249

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Minor change, I think just a quick glance will do.