### PR TITLE
Fix duplicate menu item warning for nginx

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Getting Started with the nginx Chainguard Image"
 type: "article"
-linktitle: "nginx"
+linktitle: "nginx "
+aliases: 
+- /chainguard/chainguard-images/getting-started/nginx
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
 lastmod: 2024-06-17T18:39:59+00:00


### PR DESCRIPTION
## Type of change

Remove duplicate menu item to resolve warning (nginx / nginx)

### What should this PR do?

Adds a space to the menu entry for the nginx tutorial. Adds an alias to avoid any issues with the URL.

### Why are we making this change?

Resolve warning for menu name collision.

### Notes

Resolves #1670 