### PR TITLE
fix apko and melange redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,8 +30,6 @@ http {
         "~^/chainguard/chainctl/chainctl-docs/(index.html|index.xml)?$" /chainguard/chainctl/;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/(index.html|index.xml)?$" /chainguard/chainguard-enforce/enforce-overview/;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-policy-examples(.+)?$" /chainguard/chainguard-enforce/policies/chainguard-enforce-policy-examples$1;
-        "~^/open-source/build-tools/apko"  https://github.com/chainguard-dev/apko;
-        "~^/open-source/build-tools/melange"  https://github.com/chainguard-dev/melange;
         "~^/chainguard/chainguard-enforce/sboms/sboms-and-attestations/(.+)?$" /open-source/sbom/sboms-and-attestations/;
         "~^/chainguard/chainguard-images/images-compared/(.+)?$" /chainguard/chainguard-images/vuln-comparison/;
         "~^/software-security/secure-software-development/considerations-for-image-updates/(.+)?$" /chainguard/chainguard-images/considerations-for-image-updates/;
@@ -119,6 +117,14 @@ http {
 
         location ~* /(\index.html)?$ {
             add_header Cache-Control "public, max-age=300, stale-while-revalidate=300";
+        }
+
+        location ~ ^/open-source/build-tools/apko/ {
+            rewrite ^ https://github.com/chainguard-dev/apko redirect;
+        }
+
+        location ~ ^/open-source/build-tools/melange/ {
+            rewrite ^ https://github.com/chainguard-dev/melange redirect;
         }
 
 	# use hugo's built in 404 page for now


### PR DESCRIPTION
this PR is an attempt to fix the redirects for apko and melange docs, since they are no longer in Academy, and will be maintained in-repo.
