### PR TITLE
retrieve-image-sboms: ensure two bullet texts are not rendered as code

### DIFF
--- a/content/chainguard/chainguard-images/working-with-images/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/working-with-images/retrieve-image-sboms/index.md
@@ -95,7 +95,7 @@ pkg:github/openssl/openssl.git@openssl-3.3.1
 pkg:github/openssl/openssl.git@db2ac4f6ebd8f3d7b2a60882992fbea1269114e2
 ```
 
-    * Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash:
+* Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash:
 
 ```
 pkg:github/wolfi-dev/os@f18ff825f94b9177cf603c6e3d72936683a504d2#glibc.yaml
@@ -109,7 +109,7 @@ checksum=sha256%3A8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af3150
 download_url=https%3A%2F%2Fftp.gnu.org%2Fgnu%2Fgcc%2Fgcc-13.2.0%2Fgcc-13.2.0.tar.gz
 ```
 
-    * Also note that `pkg:generic` is used to reference upstream git repositories, outside of GitHub:
+* Also note that `pkg:generic` is used to reference upstream git repositories, outside of GitHub:
 
 ```
 pkg:generic/ca-certificates@20240315?


### PR DESCRIPTION
The difference is this

    * Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash:

vs

* Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash: