### PR TITLE
Make monospace links in dark mode distinguishable as links

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1084,11 +1084,11 @@
     }
 
     [data-dark-mode] body a code:not(.hljs) {
-        color: var(--primary-2)
+        color: var(--article-link-color)
     }
 
     [data-dark-mode] body code:not(.hljs) a {
-        color: var(--primary-2)
+        color: var(--article-link-color)
     }
 
     .pagination {

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1083,6 +1083,10 @@
         letter-spacing: 0.0025em;
     }
 
+    [data-dark-mode] body code:not(.hljs) {
+        color: var(--primary-1)
+    }
+
     .pagination {
         justify-content: center;
         margin-top: 48px;

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1083,7 +1083,11 @@
         letter-spacing: 0.0025em;
     }
 
-    [data-dark-mode] body code:not(.hljs) {
+    [data-dark-mode] body a code:not(.hljs) {
+        color: var(--primary-1)
+    }
+
+    [data-dark-mode] body code:not(.hljs) a {
         color: var(--primary-1)
     }
 

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1084,11 +1084,11 @@
     }
 
     [data-dark-mode] body a code:not(.hljs) {
-        color: var(--primary-1)
+        color: var(--primary-2)
     }
 
     [data-dark-mode] body code:not(.hljs) a {
-        color: var(--primary-1)
+        color: var(--primary-2)
     }
 
     .pagination {


### PR DESCRIPTION
## Problem

In dark mode, monospace + links just look like monospace.

## Description

This adds link color to monospace, keeping the dark background and monospace font.

## Notes

Resolves #1707

cc @mcaveety 