### PR TITLE
Minor improvements - adding video embed and switching Node --> Go

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -21,7 +21,9 @@ The nginx images maintained by Chainguard include development and production dis
 
 In this tutorial, we will create a local demo website using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
 
-You will need to have [nginx](https://nginx.org/en/download.html) and [Docker Engine](https://docs.docker.com/engine/install/) installed on your machine to follow along.
+You will need to have [nginx](https://nginx.org/en/download.html) and [Docker Engine](https://docs.docker.com/engine/install/) installed on your machine to follow along. Additionally, you can watch our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial.
+
+{{< youtube KirTeDMzzxk >}}
 
 {{< details "What is distroless" >}}
 {{< blurb/distroless >}}
@@ -39,7 +41,7 @@ You will need to have [nginx](https://nginx.org/en/download.html) and [Docker En
 
 We'll start by serving static content to a local web server with nginx.
 
-For this tutorial, you will be copying code to files you create locally. You can find the demo code throughout this tutorial, or you can find the complete demo at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx). Additionally, you can follow along with our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial.
+For this tutorial, you will be copying code to files you create locally. You can find the demo code throughout this tutorial, or you can find the complete demo at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
 
 With nginx installed, create a directory for your demo. In this guide we'll call the directory `nginxdemo`:
 

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/nginx
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-07-22T14:03:47+00:00
+lastmod: 2024-08-13T13:25:40+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -21,7 +21,7 @@ The nginx images maintained by Chainguard include development and production dis
 
 In this tutorial, we will create a local demo website using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
 
-If you'd like, you can watch our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial.
+If you'd like, you can watch our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial, which will walk through the same steps that are detailed here.
 
 {{< youtube KirTeDMzzxk >}}
 
@@ -37,11 +37,15 @@ If you'd like, you can watch our [Getting Started with the nginx Chainguard Imag
 {{< blurb/images >}}
 {{< /details >}}
 
+## Prerequisites
+
+You will need to have [nginx](https://nginx.org/en/download.html) and [Docker Engine](https://docs.docker.com/engine/install/) installed on your machine to follow along with this demonstration.
+
+For this tutorial, you will be copying code to files you create locally. You can find the demo code throughout this tutorial, or you can find the complete demo at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
+
 ## Step 1: Setting up a Demo Website 
 
 We'll start by serving static content to a local web server with nginx.
-
-For this tutorial, you will be copying code to files you create locally. You can find the demo code throughout this tutorial, or you can find the complete demo at the [demo GitHub repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/nginx).
 
 With nginx installed, create a directory for your demo. In this guide we'll call the directory `nginxdemo`:
 

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -21,7 +21,7 @@ The nginx images maintained by Chainguard include development and production dis
 
 In this tutorial, we will create a local demo website using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Image to build and execute the demo in a lightweight containerized environment.
 
-You will need to have [nginx](https://nginx.org/en/download.html) and [Docker Engine](https://docs.docker.com/engine/install/) installed on your machine to follow along. Additionally, you can watch our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial.
+If you'd like, you can watch our [Getting Started with the nginx Chainguard Image video](https://youtu.be/KirTeDMzzxk) as you work through this tutorial.
 
 {{< youtube KirTeDMzzxk >}}
 

--- a/content/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/index.md
+++ b/content/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/index.md
@@ -135,7 +135,7 @@ docker scout cves cgr.dev/chainguard-private/go:1.21.5
   No vulnerable packages detected
 ```
 
-> Note: Version `1.21.5` was the current version of the Node Image at the time of this writing. It may have accumulated CVEs since this guide was published.
+> Note: Version `1.21.5` was the current version of the Go Image at the time of this writing. It may have accumulated CVEs since this guide was published.
 
 You can go a step further by comparing these two images directly with the `chainctl images diff` command, as in this example.
 


### PR DESCRIPTION
This PR achieves two things:
1. Embeds the Getting Started with the nginx Chainguard Image video into its associated guide for more visibility. (note: no transcript provided at this time since it walks through the written tutorial content, though I could write something up if it's desired) https://deploy-preview-1764--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/getting-started/nginx/

2. Fixes a reference to Node that should say Go. See the diff in the file for more context. It seems like the wrong image was referenced (likely because Node showed up earlier in advisories database) but it appears that the Go image is what is used for the hands-on portion. https://deploy-preview-1764--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/#comparing-images

To test this PR, it would be great if someone can double check that these two changes look correct (especially the video) on the deploy preview.
