### PR TITLE
GID is not set in bash so use id -g

### DIFF
--- a/content/chainguard/administration/how-to-install-chainctl.md
+++ b/content/chainguard/administration/how-to-install-chainctl.md
@@ -66,7 +66,7 @@ curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | t
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.
 
 ```sh
-sudo install -o $UID -g $(id -g) -m 0755 chainctl /usr/local/bin/
+sudo install -o $UID -g $(id -g) -m 0755 chainctl /usr/local/bin/ 
 ```
 
 At this point, you'll be able to use the `chainctl` command.

--- a/content/chainguard/administration/how-to-install-chainctl.md
+++ b/content/chainguard/administration/how-to-install-chainctl.md
@@ -66,7 +66,7 @@ curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | t
 Move `chainctl` into your `/usr/local/bin` directory and elevate its permissions so that it can execute as needed.
 
 ```sh
-sudo install -o $UID -g $GID -m 0755 chainctl /usr/local/bin/
+sudo install -o $UID -g $(id -g) -m 0755 chainctl /usr/local/bin/
 ```
 
 At this point, you'll be able to use the `chainctl` command.


### PR DESCRIPTION
The instructions for installing `chainctl` fail in bash due to GID not being a variable set by the shell. 

This resolves that and https://github.com/chainguard-dev/edu/issues/1797 .
