### PR TITLE
rumble: refactor to use vuln scan results from `prod-enforce`

### DIFF
--- a/.github/workflows/rumble-vulnerability-data.yaml
+++ b/.github/workflows/rumble-vulnerability-data.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           check-latest: true
 
       - name: Authenticate to Google Cloud
@@ -49,8 +49,8 @@ jobs:
       - name: Generate vulnerability JSON files
         run: |
           go run main.go vulns \
-            --project prod-images-c6e5 \
-            --db insights_ds \
+            --project prod-enforce-fabc \
+            --db cloudevents_grype_scan_results \
             --gcs-project chainguard-academy \
             --bucket chainguard-academy \
             --upload
@@ -58,8 +58,8 @@ jobs:
       - name: Generate image comparison CSVs
         run: |
           go run main.go image-csv \
-            --project prod-images-c6e5 \
-            --db insights_ds \
+            --project prod-enforce-fabc \
+            --db cloudevents_grype_scan_results \
             --gcs-project chainguard-academy \
             --bucket chainguard-academy \
             --rumble-json-path ../../data/rumble.json \
@@ -68,8 +68,8 @@ jobs:
       - name: Generate legacy comparison CSV
         run: |
           go run main.go legacy-csv \
-            --project prod-images-c6e5 \
-            --db insights_ds \
+            --project prod-enforce-fabc \
+            --db cloudevents_grype_scan_results \
             --gcs-project chainguard-academy \
             --bucket chainguard-academy \
             --upload

--- a/data/rumble.json
+++ b/data/rumble.json
@@ -3,7 +3,7 @@
   {"image":"busybox","left":"busybox:latest","right":"cgr.dev/chainguard/busybox:latest"},
   {"image":"cassandra","left":"cassandra:latest","right":"cgr.dev/chainguard/cassandra:latest"},
   {"image":"curl","left":"curlimages/curl:latest","right":"cgr.dev/chainguard/curl:latest"},
-  {"image":"deno","left":"deno:latest","right":"cgr.dev/chainguard/deno:latest"},
+  {"image":"deno","left":"denoland/deno:latest","right":"cgr.dev/chainguard/deno:latest"},
   {"image":"dotnet-runtime","left":"mcr.microsoft.com/dotnet/runtime:latest","right":"cgr.dev/chainguard/dotnet-runtime:latest"},
   {"image":"dotnet-sdk","left":"mcr.microsoft.com/dotnet/sdk:latest","right":"cgr.dev/chainguard/dotnet-sdk:latest"},
   {"image":"dex","left":"dexidp/dex:latest","right":"cgr.dev/chainguard/dex:latest"},

--- a/tools/rumble/cmd/options.go
+++ b/tools/rumble/cmd/options.go
@@ -1,4 +1,24 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package cmd
+
+import (
+	"context"
+	"log"
+
+	cgbigquery "github.com/chainguard-dev/edu/tools/rumble/pkg/bigquery"
+	cloudstorage "github.com/chainguard-dev/edu/tools/rumble/pkg/cloudstorage"
+)
+
+type rumbleBase struct {
+	ctx           context.Context
+	bqClient      cgbigquery.BqClient
+	storageClient cloudstorage.GcsClient
+	opts          *options
+}
 
 type options struct {
 	dbProject      string
@@ -6,4 +26,32 @@ type options struct {
 	db             string
 	storageBucket  string
 	upload         bool
+}
+
+func (c *rumbleBase) setupClients() (func(), error) {
+	var err error
+
+	c.bqClient, err = cgbigquery.NewBqClient(c.opts.dbProject, c.opts.db)
+	if err != nil {
+		log.Fatalf("error initializing bq client: %v", err)
+	}
+
+	// Only instantiate gcs client if we're uploading
+	if c.opts.upload {
+		c.storageClient, err = cloudstorage.NewGcsClient(c.ctx, c.opts.storageBucket)
+		if err != nil {
+			log.Fatalf("error initializing gcs client: %v", err)
+		}
+	}
+
+	return func() {
+		if err := c.bqClient.Client.Close(); err != nil {
+			log.Println(err)
+		}
+		if c.storageClient.Client != nil {
+			if err := c.storageClient.Client.Close(); err != nil {
+				log.Println(err)
+			}
+		}
+	}, nil
 }

--- a/tools/rumble/go.mod
+++ b/tools/rumble/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/edu/tools/rumble
 
-go 1.22
+go 1.23.1
 
 require (
 	cloud.google.com/go/bigquery v1.62.0

--- a/tools/rumble/pkg/bigquery/bigquery.go
+++ b/tools/rumble/pkg/bigquery/bigquery.go
@@ -72,7 +72,7 @@ func (b *BqClient) Query(q *bigquery.Query, queryType string) ([]interface{}, er
 	q.DefaultProjectID = b.Client.Project()
 	it, err := q.Read(b.Ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, err
 	}
 
 	var records []interface{}
@@ -91,7 +91,7 @@ func (b *BqClient) Query(q *bigquery.Query, queryType string) ([]interface{}, er
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("%v", err)
+			return nil, fmt.Errorf("querying %s type: %w", queryType, err)
 		}
 		records = append(records, values)
 	}

--- a/tools/rumble/pkg/cloudstorage/cloudstorage.go
+++ b/tools/rumble/pkg/cloudstorage/cloudstorage.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/edu/tools/rumble/pkg/grype"
@@ -35,7 +36,7 @@ func NewGcsClient(ctx context.Context, bucket string) (g GcsClient, err error) {
 // this should live over in vulns.go and be a vulnsJson method
 func (g *GcsClient) SaveVulnJSON(vulns []grype.Vuln) error {
 	eg := new(errgroup.Group)
-	fmt.Printf("Found %d vulnerabilities\n", len(vulns))
+	log.Printf("Found %d vulnerabilities", len(vulns))
 	eg.SetLimit(50)
 	for _, v := range vulns {
 		vulnerability := v
@@ -66,13 +67,13 @@ func (g *GcsClient) SaveVulnJSON(vulns []grype.Vuln) error {
 				return err
 			}
 
-			fmt.Printf("Wrote %s\n", fName)
+			log.Printf("Wrote %s", fName)
 			return nil
 		})
 	}
 
 	if err := eg.Wait(); err == nil {
-		fmt.Println("Successfully saved all vulnerabilities.")
+		log.Println("Successfully saved all vulnerabilities.")
 	}
 	return nil
 }


### PR DESCRIPTION
## Type of change
Late breaking 24i issue. 

### What should this PR do?
Vuln scanning has moved from `prod-images` to `prod-enforce`. The CVE comparison pages on edu.chainguard.dev have been broken for a while since the scanners have been turned down from `prod-images`. This PR updates the location of the datasets used, as well as refactors to take into consideration some of the changes to the data.

### Why are we making this change?
Fix CVE comparisons between external and Chainguard equivalent images.

### What are the acceptance criteria? 
* CVE data is pulled from the correct bigquery source (`prod-enforce`), and we have data for both external and Chainguard images for each requested.

### How should this PR be tested?
This change chan be run locally without uploading the results to test the datasources are being queried and correlated properly:

```
go run main.go vulns --project=prod-enforce-fabc --db=cloudevents_grype_scan_results

go run main.go image-csv --project=prod-enforce-fabc --db=cloudevents_grype_scan_results --rumble-json-path=../../data/rumble.json

go run main.go legacy-csv --project=prod-enforce-fabc --db=cloudevents_grype_scan_results
```