### PR TITLE
rumble: update bq queries to use dedicated views for rumble

### DIFF
--- a/tools/rumble/pkg/bigquery/queries.go
+++ b/tools/rumble/pkg/bigquery/queries.go
@@ -6,29 +6,27 @@ SPDX-License-Identifier: Apache-2.0
 package cgbigquery
 
 const (
-    vulnsTable   = "`cloudevents_grype_scan_results.dev_chainguard_image_scan_grype_vulns`"
-    summaryTable = "`cloudevents_grype_scan_results.dev_chainguard_image_scan_grype_summary`"
+	vulnsTable   = "`cloudevents_grype_scan_results.rumble_vulns`"
+	summaryTable = "`cloudevents_grype_scan_results.rumble_summary`"
 
-    LegacyCsvHeader    = `f0_,image,scanner,scanner_version,scanner_db_version,time,low_cve_cnt,med_cve_cnt,high_cve_cnt,crit_cve_cnt,unknown_cve_cnt,tot_cve_cnt,digest`
-    ImageScanCsvHeader = `image,package,vulnerability,version,type,s`
+	LegacyCsvHeader    = `f0_,image,scanner,scanner_version,scanner_db_version,time,low_cve_cnt,med_cve_cnt,high_cve_cnt,crit_cve_cnt,unknown_cve_cnt,tot_cve_cnt,digest`
+	ImageScanCsvHeader = `image,package,vulnerability,version,type,s`
 
-    AllVulnsQuery = `
+	AllVulnsQuery = `
 SELECT DISTINCT vulnerability
 FROM ` + vulnsTable
 
-    AffectedImagesQuery = `
+	AffectedImagesQuery = `
 SELECT summ.image, summ.time as time,
 FROM ` + vulnsTable + ` AS vulns
 INNER JOIN ` + summaryTable + ` AS scan
 ON scan.id = vulns.scan_id
 WHERE vulns.vulnerability = @vulnerability
-AND scan.image NOT LIKE "cgr.dev/chainguard-private/%"
-AND scan.image NOT LIKE "cgr.dev/custom%"
 GROUP BY scan.time, scan.image
 ORDER BY scan.image, scan.time
 `
 
-    LegacyCsvQuery = `
+	LegacyCsvQuery = `
 SELECT
 	ROW_NUMBER() OVER (ORDER BY time),
 	image,
@@ -43,14 +41,9 @@ SELECT
 	unknown_cve_count as unknown_cve_cnt,
 	low_cve_count + med_cve_count + high_cve_count + crit_cve_count + unknown_cve_count AS tot_cve_cnt,
 	digest
-FROM ` + summaryTable + `
-WHERE DATE(time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()
-AND scanner = "grype"
-AND image NOT LIKE "cgr.dev/chainguard-private/%"
-AND image NOT LIKE "cgr.dev/custom%"
-`
-    
-    ImageComparisonCsvQuery = `
+FROM ` + summaryTable
+
+	ImageComparisonCsvQuery = `
 WITH ruuuumble AS (
 	SELECT scan.image,
 		scan.time as t,
@@ -65,7 +58,6 @@ WITH ruuuumble AS (
 	OR (scan.image = @ours AND scan.tags = @our_tag)
 	)
 	SELECT image, package, vulnerability, version, type, severity FROM ruuuumble
-	WHERE DATE(t) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()
 	GROUP BY vulnerability, image, package, version, type, severity
 	ORDER BY (
 	CASE WHEN severity = "Critical" THEN 1


### PR DESCRIPTION
Update the bigquery queries to use views specifically created for rumble. These views already have the image and date filtering, so they have been removed from these queries for readability.