### PR TITLE
rumble: fix legacy csv query and csv output to match what the chart js expects

### DIFF
--- a/tools/rumble/cmd/legacy_csv.go
+++ b/tools/rumble/cmd/legacy_csv.go
@@ -79,10 +79,8 @@ func (c *rumbleBase) generateCsv() error {
 		if !strings.Contains(image, "cgr.dev") || strings.Contains(image, "cgr.dev/chainguard/") {
 			csvRow := []string{
 				strconv.Itoa(i + 1),
-				r.(*cgbigquery.LegacyScan).Image,
+				fmt.Sprintf("%s:%s", r.(*cgbigquery.LegacyScan).Image, r.(*cgbigquery.LegacyScan).Tags),
 				r.(*cgbigquery.LegacyScan).Scanner,
-				r.(*cgbigquery.LegacyScan).Scanner_version,
-				r.(*cgbigquery.LegacyScan).Scanner_db_version,
 				r.(*cgbigquery.LegacyScan).Time,
 				strconv.FormatInt(r.(*cgbigquery.LegacyScan).Low_cve_cnt, 10),
 				strconv.FormatInt(r.(*cgbigquery.LegacyScan).Med_cve_cnt, 10),

--- a/tools/rumble/pkg/bigquery/bigquery.go
+++ b/tools/rumble/pkg/bigquery/bigquery.go
@@ -26,19 +26,18 @@ type BqClient struct {
 }
 
 type LegacyScan struct {
-	Row                int64
-	Image              string
-	Scanner            string
-	Scanner_version    string
-	Scanner_db_version string
-	Time               string
-	Low_cve_cnt        int64
-	Med_cve_cnt        int64
-	High_cve_cnt       int64
-	Crit_cve_cnt       int64
-	Unknown_cve_cnt    int64
-	Tot_cve_cnt        int64
-	Digest             string
+	Row             int64
+	Image           string
+	Tags            string
+	Scanner         string
+	Time            string
+	Low_cve_cnt     int64
+	Med_cve_cnt     int64
+	High_cve_cnt    int64
+	Crit_cve_cnt    int64
+	Unknown_cve_cnt int64
+	Tot_cve_cnt     int64
+	Digest          string
 }
 
 type ImageScan struct {


### PR DESCRIPTION
Drop unused fields `scanner_version` and `scanner_db_version`, append the tag to the end of the `image` name as expected by the javascript generating the chart, and exclude images with `latest-dev` tags since those are never used in image comparisons (cuts `data.csv` down from ~8MB to 4MB 📉 )