### PR TITLE
chainlink: check URLs concurrently

### DIFF
--- a/tools/chainlink/go.mod
+++ b/tools/chainlink/go.mod
@@ -5,4 +5,5 @@ go 1.19
 require (
 	github.com/yuin/goldmark v1.5.4
 	golang.org/x/net v0.23.0
+	golang.org/x/sync v0.8.0
 )

--- a/tools/chainlink/go.sum
+++ b/tools/chainlink/go.sum
@@ -2,3 +2,5 @@ github.com/yuin/goldmark v1.5.4 h1:2uY/xC0roWy8IBEGLgB1ywIoEJFGmRrX21YQcvGZzjU=
 github.com/yuin/goldmark v1.5.4/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/tools/chainlink/links.go
+++ b/tools/chainlink/links.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"sync"
 )
 
 func (l *link) processLink(path *string) {
@@ -77,9 +76,7 @@ func (l *link) parseURL() (*url.URL, error) {
 	return u, nil
 }
 
-func (l *link) check(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (l *link) check() {
 	if !checkAll {
 		// this check is the default and ensures only fetching URLs
 		// with the `-hostname` in them e.g. to only check

--- a/tools/chainlink/types.go
+++ b/tools/chainlink/types.go
@@ -24,6 +24,7 @@ var (
 	extractMode = false
 	contentDir  = ""
 	fileType    = ""
+	jobs        = 10
 
 	// url rules
 	correctURLregex = &regexp.Regexp{}


### PR DESCRIPTION
Using `errgroup.Group` helps us do things concurrently with a concurrency limit of 10 (by default)