### PR TITLE
Updating PHP guide - maintenance sprint

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/php.md
+++ b/content/chainguard/chainguard-images/getting-started/php.md
@@ -76,7 +76,7 @@ Next, make sure permissions are set correctly on the generated files.
 On Linux systems run the following:
 
 ```shell
-sudo chown -R ${USER}.${USER} .
+sudo chown -R ${USER}:${USER} .
 ```
 
 On macOS systems, run this:
@@ -128,11 +128,6 @@ In the next step, you'll build the application in a multi-stage Dockerfile.
 
 We'll now build a distroless image for the application. To be able to install dependencies with Composer, our build will consist of **two** stages. First, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development. Then, we'll create a separate stage for the final image. The resulting image will be based on the distroless PHP Wolfi image, which means it doesn't come with Composer or even a shell.
 
-Open the `Dockerfile` included within the root of the application folder. You can use your code editor of choice, for example `nano`:
-
-```shell
-nano Dockerfile
-```
 For reference, here is the content of the included `Dockerfile`:
 
 ```Dockerfile
@@ -229,10 +224,10 @@ The `latest-fpm` image variant is suitable for running PHP applications over Fas
 
 The `namegen-api` demo is a variation of the previous demo, but it serves the random name generation over HTTP. The application responds with a JSON payload containing the animal and adjective combination, and accepts an optional `animal` parameter to specify the animal for the final suggested name.
 
-Start by accessing the `namegen-api` demo folder:
+Start by accessing the `namegen-api` demo folder. This should be at the same level as the previous `namegen` demo in the `edu-images-demos` repository. If your terminal is still open on the previous demo, you can navigate to the `namegen-api` folder with:
 
 ```shell
-cd edu-images-demos/php/namegen-api
+cd ../namegen-api
 ```
 
 The `index.php` file contains the following code:

--- a/content/chainguard/chainguard-images/getting-started/php.md
+++ b/content/chainguard/chainguard-images/getting-started/php.md
@@ -126,14 +126,14 @@ In the next step, you'll build the application in a multi-stage Dockerfile.
 
 ## 2. Building a Distroless Image for the Application
 
-We'll now build a distroless image for the application. To be able to install dependencies with Composer, our build will consist of **two** stages: first, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development. Then, we'll create a separate stage for the final image. The resulting image will be based on the distroless PHP Wolfi image, which means it doesn't come with Composer or even a shell.
+We'll now build a distroless image for the application. To be able to install dependencies with Composer, our build will consist of **two** stages. First, we'll build the application using the `dev` image variant, a Wolfi-based image that includes Composer and other useful tools for development. Then, we'll create a separate stage for the final image. The resulting image will be based on the distroless PHP Wolfi image, which means it doesn't come with Composer or even a shell.
 
 Open the `Dockerfile` included within the root of the application folder. You can use your code editor of choice, for example `nano`:
 
 ```shell
 nano Dockerfile
 ```
-For convenience, here is the content of the included `Dockerfile`:
+For reference, here is the content of the included `Dockerfile`:
 
 ```Dockerfile
 FROM cgr.dev/chainguard/php:latest-dev AS builder
@@ -225,7 +225,7 @@ It's worth highlighting that nothing is carried from one stage to the other unle
 
 ## 3. Working with the PHP-FPM Image Variant
 
-The `latest-fpm` image variant is suitable for running PHP applications over FastCGI, to be server via a web server such as Nginx. In this section, we'll run a Docker Compose setup using the `latest-fpm` image variant and the Chainguard Nginx image.
+The `latest-fpm` image variant is suitable for running PHP applications over FastCGI, to be served by a web server such as Nginx. In this section, we'll run a Docker Compose setup using the `latest-fpm` image variant and the Chainguard Nginx image.
 
 The `namegen-api` demo is a variation of the previous demo, but it serves the random name generation over HTTP. The application responds with a JSON payload containing the animal and adjective combination, and accepts an optional `animal` parameter to specify the animal for the final suggested name.
 

--- a/content/chainguard/chainguard-images/getting-started/php.md
+++ b/content/chainguard/chainguard-images/getting-started/php.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-php
 description: "Tutorial on how to get started with the PHP Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-01-24T11:07:52+02:00
+lastmod: 2024-11-15T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []


### PR DESCRIPTION
This PR updates our PHP getting started guide, as part of the maintenance sprint. Solves #1896 

It adds a new section that demonstrates our php-fpm image. The demo is currently under review on a PR to edu-images-demos: https://github.com/chainguard-dev/edu-images-demos/pull/28

Preview: https://deploy-preview-1914--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/getting-started/php/