### PR TITLE
Add a test for invalid contentDir cli argument

### DIFF
--- a/tools/chainlink/main_test.go
+++ b/tools/chainlink/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWalkDir(t *testing.T) {
+	validDir, err := os.MkdirTemp("", "validDir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(validDir)
+
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr bool
+	}{
+		{"Valid contentDir", validDir, false},
+		{"Nonexistent contentDir", "invalidDir", true},
+		{"Invalid contentDir", "really,an,invalidDir", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			contentDir = tc.dir // override the global runtime flag
+			err := processContentDir()
+			switch tc.wantErr {
+			case true:
+				if err == nil {
+					t.Errorf("expected an error for directory %s, but got none", tc.dir)
+				}
+			case false:
+				if err != nil {
+					t.Errorf("unexpected error for directory %s: %v", tc.dir, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of change
bug

### What should this PR do?
Add a check for a valid `contentDir` CLI argument to chainlink.

### Why are we making this change?
Without this, an invalid contentDir would panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x100b0eb10]

goroutine 1 [running]:
main.(*filepathWalker).walkDirFunc(...)
	/Users/jamon/chainguard/edu/tools/chainlink/files.go:17
path/filepath.WalkDir({0x16f5876e3, 0x17}, 0x140001b7f10)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/path/filepath/path.go:531 +0xa4
main.main()
	/Users/jamon/chainguard/edu/tools/chainlink/main.go:48 +0x58
exit status 2
```

### What are the acceptance criteria? 
`go run . -contentDir ../../content` should still work

### How should this PR be tested?
`go test -v ./...` should pass