### PR TITLE
Fix chainlink ignoreFile flag being ignored

### DIFF
--- a/tools/chainlink/main.go
+++ b/tools/chainlink/main.go
@@ -33,6 +33,10 @@ func init() {
 	// won't match anything like `../` or `./` or non-leading `/` URLs
 	// unmatched urls will go into the unchecked result accumulator
 	correctURLregex = regexp.MustCompile(`^(http|https|\/).+`)
+}
+
+func main() {
+	flag.Parse()
 
 	if err := ignores.read(); err != nil {
 		log.Fatalf("error loading ignores json: %v\n", err)
@@ -40,10 +44,6 @@ func init() {
 	if err := ignores.compile(); err != nil {
 		log.Fatalf("error compiling ignores json: %v\n", err)
 	}
-}
-
-func main() {
-	flag.Parse()
 
 	err := processContentDir()
 	if err != nil {


### PR DESCRIPTION
## Type of change
Fix a bug in chainlink

### What should this PR do?
Chainlink's ignoreFile flag value is currently used before being parsed, ignoring whatever flag value was passed in and always using default.
This PR moves ignoreFile parsing after flag parsing so parsing comes before usage.

### Why are we making this change?
Discovered a bunch of "localhost" urls being flagged in an images-private run
https://github.com/chainguard-images/images-private/actions/runs/12058742634/job/33626025490?pr=6270
although it is in the specified ignoreFile
https://github.com/chainguard-images/images-private/blob/main/chainlink-ignore.json
investigated and landed here

### What are the acceptance criteria? 
This fixes a bug.

### How should this PR be tested?
```
cd /tools/chainlink
go run . -method GET -checkAll -hostname edu.chainguard.dev -ignoreFile /<code_location>/images-private/chainlink-ignore.json -contentDir /<code_location>/images-private/images/harbor/ -resultsFile ./res.json
```