### PR TITLE
Adding canonicalUrl frontmatter option

### DIFF
--- a/content/chainguard/chainguard-images/recommended-practices/strategies-tools-updating-images/index.md
+++ b/content/chainguard/chainguard-images/recommended-practices/strategies-tools-updating-images/index.md
@@ -3,6 +3,7 @@ title: "Strategies and Tooling for Updating Container Images"
 linktitle: "Update Strategies and Tools"
 aliases: 
 - /chainguard/chainguard-images/recommended-practices/strategies-tools-updating-images
+canonicalUrl: "https://www.chainguard.dev/unchained/stay-secure-strategies-and-tooling-for-updating-container-images"
 type: "article"
 description: "A conceptual article outlining different strategies and tools for keeping images up to date and avoiding the use of end-of-life software."
 date: 2024-12-02T11:07:52+02:00

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -24,3 +24,9 @@
 {{ if hugo.IsProduction }}
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}
+
+{{ if .Params.canonicalUrl }}
+<link rel="canonical" href="{{ .Params.canonicalUrl }}">
+{{ else }}
+<link rel="canonical" href="{{ .RelPermalink }}">
+{{ end }}


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
I'm reworking a pair of Chainguard blog posts to publish them on Academy. There was some concern about SEO cannibalization and it was suggested that we use canonical URLs.

I found [this tutorial](https://blog.concannon.tech/tech-talk/hugo-canonical-url/) on how to add that functionality to Hugo and this PR implements it, and adds a canonical URL to the doc I published yesterday.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves #1942

### Why are we making this change?
<!-- What larger problem does this PR address? -->
We should be able to use canonical URLs if we want!

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
I'm honestly not sure exactly how this sort of thing is supposed to work. In my testing all seemed well but I'm very open to any suggestions.