### PR TITLE
Updated how to use securitiy advisories

### DIFF
--- a/content/chainguard/chainguard-images/videos/security_advisories.md
+++ b/content/chainguard/chainguard-images/videos/security_advisories.md
@@ -6,7 +6,7 @@ description: "How to use security advisories and the diff API to investigate vul
 affecting Chainguard images"
 type: "article"
 date: 2024-01-18T01:21:01+00:00
-lastmod: 2024-01-18T15:21:01+00:00
+lastmod: 2024-12-06T15:16:50+01:00
 draft: false
 images: []
 menu:
@@ -18,17 +18,20 @@ toc: true
 
 {{< youtube ExZxIWmnm1s >}}
 
+## Updated Written Article
+
+You may wish to refer to the up-to-date written article covering the same material as this video:
+
+ [How to Use Chainguard Security Advisories](/chainguard/chainguard-images/security-advisories/)
+
+
+
 ## Tools used in this video
 
 * [Chainguard Security Advisories](https://images.chainguard.dev/security)
 * [chainctl](/chainguard/administration/how-to-install-chainctl/)
 * [Docker](https://docker.com)
 * [Docker Scout](https://docs.docker.com/scout/)
-
-## Related Article
-
-See [How to Use Chainguard Security Advisories](/chainguard/chainguard-images/security-advisories/) for a written article covering similar
-content to this video.
 
 ## Transcript
 

--- a/content/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/index.md
+++ b/content/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/index.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Image Directory."
 date: 2023-12-27T11:07:52+02:00
-lastmod: 2024-08-19T15:56:52-07:00
+lastmod: 2024-12-06T15:16:50+01:00
 draft: false
 tags: ["OVERVIEW", "PRODUCT", "CHAINGUARD IMAGES", "CVE"]
 images: []
@@ -19,34 +19,33 @@ weight: 010
 toc: true
 ---
 
-When you're checking to determine what vulnerabilities, if any, are present in a Chainguard Image, you may be using an image scanning tool like Grype or Docker Scout. Chainguard Images typically report few or zero CVEs, but when older versions of software are included in a given Image, a scanner may report more. Not all vulnerabilities are equal, and it may not be immediately clear whether a CVE found within a given Chainguard Image is likely to cause security issues in your software. Scanners can also misreport vulnerabilities found in Chainguard Images; they may return false positives that have, in reality, been fixed. 
+When using scanners such as [Grype](https://github.com/anchore/grype) or [Docker Scout](https://docs.docker.com/scout/) to scan for vulnerabilities in Chainguard Images, you'll often find that there are few or no CVEs present. However, CVEs can sometimes be found in Chainguard Images, and you may also encounter CVEs if you're using older tags. In these cases, you will likely wish to check Chainguard's security advisories for information on which CVEs will cause security issues in your deployment.
 
 To help demystify the nature of CVEs within Chainguard Images, we've created a self-service [Security Advisories page](https://images.chainguard.dev/security) that lists every security advisory published for Chainguard Images. Having this information available allows you to view whether Chainguard is aware of a specific vulnerability reported to exist within a Chainguard Image and whether we've mitigated or are planning to mitigate the CVE.
 
 This guide outlines how you can use Chainguard's Security Advisories to learn more about the status of a CVE within a given package. It will walk through a practical example of discovering a vulnerability in a Chainguard Image, searching for Security Advisories associated with this vulnerability, and then comparing the original Image with a later version.
 
-
 ## Prerequisites
 
-You don't need any special access or software to explore Chainguard's Security Advisories. However, this guide includes a few examples that use specific software tools in order to outline a practical example of how one might navigate and use the Security Advisories.
+You don't need any special access or software to explore Chainguard's Security Advisories. However, this guide includes a few examples that use specific software tools in order to outline a practical example of how one might navigate and use these Security Advisories.
 
 To follow along with these examples, you'll need the following tools installed.
 
-* A security scanner like [Trivy](https://aquasecurity.github.io/trivy/v0.18.3/installation/), [Grype](https://github.com/anchore/grype#installation), or [Docker Scout](https://docs.docker.com/get-docker/) — This guide's examples use Docker Scout, a component of the Docker container platform, to scan container images and identify vulnerabilities. However, you should be able to follow along with any container vulnerability scanning tool.
+* A security scanner like [Trivy](https://aquasecurity.github.io/trivy/v0.18.3/installation/), [Grype](https://github.com/anchore/grype#installation), or [Docker Scout](https://docs.docker.com/get-docker/) — This guide's examples use Grype to scan container images and identify vulnerabilities. However, you should be able to follow along with any container vulnerability scanning tool.
 * [`chainctl`](/chainguard/chainctl/) — Chainguard's command-line interface tool. To install `chainctl`, follow our [installation guide](/chainguard/administration/how-to-install-chainctl/). 
 * [`jq`](https://jqlang.github.io/jq/) — `jq` is a command-line JSON processor that allows you to filter and manipulate streaming JSON data. Although it isn’t strictly necessary for the purposes of this guide, this tutorial includes commands that use `jq` to filter command output that would otherwise be difficult to read. You can install `jq` by following the instructions on [the project’s Download jq page](https://jqlang.github.io/jq/download/).
 
-Lastly, note that this guide includes examples involving an example organization with a private Chainguard Registry named `example.com`. If you would like to follow along with your own private Chainguard Images, be sure to change this where relevant to reflect your own setup. If you don't have access to a private Chainguard Registry, you can also follow along using Chainguard's public Developer Images but be aware that these are limited to only the `latest` or `latest-dev` tags. You can download public Developer Images from the `cgr.dev/chainguard` registry, as in `cgr.dev/chainguard/go:latest`.
+Lastly, note that this guide includes examples involving a sample organization with a private Chainguard Registry named `example.com`. If you would like to follow along with your own private Chainguard Images, be sure to change this where relevant to reflect your own setup. If you don't have access to a private Chainguard Registry, you can also follow along using Chainguard's public Developer Images, but be aware that these are limited to only the `latest` or `latest-dev` tags. You can download public Developer Images from the `cgr.dev/chainguard` registry, as in `cgr.dev/chainguard/go:latest`.
 
 
 ## So you've encountered a CVE in a Chainguard Image
 
-Say you use a vulnerability scanner like Grype or Docker Scout to inspect a certain Chainguard Image. This example uses Docker Scout to scan a Chainguard Production Image, specifically one tagged with `1.21.2`.
+Say you use a vulnerability scanner like Grype or Docker Scout to inspect a certain Chainguard Image. This example uses Grype to scan a Chainguard Production Image, specifically one tagged with `1.21.2`.
 
 As of this writing, the `go:1.21.2` image points to the image digest `sha256:04ab6905552b54a6977bed40a4105e9c95f78033e1cde67806259efc4beb959d`. Be aware that this tag will be withdrawn in the future, but the digest will remain available.
 
 ```sh
-docker scout cves cgr.dev/example.com/go:1.21.2
+grype cgr.dev/example.com/go:1.21.2
 ```
 
 Because this is the digest for an older version of Chainguard's Go Image, this command's output will show a number of vulnerabilities that have been found to exist within this specific version of the Image. 
@@ -54,37 +53,28 @@ Because this is the digest for an older version of Chainguard's Go Image, this c
 ```
 . . .
 
-20 vulnerabilities found in 6 packages
-  UNSPECIFIED  8  
-  LOW      	1  
-  MEDIUM   	3  
-  HIGH     	6  
-  CRITICAL 	2  
+   ├── by severity: 28 critical, 230 high, 185 medium, 4 low, 0
+...
 ```
 
-This output shows that this particular image has 20 vulnerabilities. The Docker Scout output also lists each of the packages affected by CVEs as well as the specific vulnerabilities it found for each.
+This output shows that this particular image has many critical and high vulnerabilities. The Grype output also lists each of the packages affected by CVEs as well as the specific vulnerabilities it found for each.
 
 > Note: All of these vulnerabilities have been addressed in newer versions of the Chainguard Go Image.
 
-Scrolling to the listing immediately before the final vulnerability count, we'll find that in the case of this example, the package `nghttp2` is referenced. 
+Within this output,, we find that the package `nghttp2` is referenced. 
 
-```
-   0C 	1H 	0M 	0L 	1?  nghttp2 1.56.0-r0
-pkg:apk/chainguard/nghttp2@1.56.0-r0?os_name=chainguard&os_version=rolling
-
-	✗ HIGH CVE-2023-44487
-  	https://scout.docker.com/v/CVE-2023-44487
-  	Affected range : <1.57.0-r0  
-  	Fixed version  : 1.57.0-r0   
-    
-	✗ UNSPECIFIED GHSA-qppj-fm5r-hxr3
-  	https://scout.docker.com/v/GHSA-qppj-fm5r-hxr3
-  	Affected range : <1.57.0-r0  
-  	Fixed version  : 1.57.0-r0   
-    
+```sh
+grype cgr.dev/example.com/go:1.21.2| grep nghttp2
 ```
 
-As of this writing, this lists one vulnerability associated with version `1.56.0` of `nghttp2` as being `HIGH` severity and one as `UNSPECIFIED`. We'll use the `HIGH` severity vulnerability listed here as an example when we explore Chainguard's Security Advisories in the next section.
+```
+...
+libnghttp2-14        1.56.0-r0  1.57.0-r0        apk        CVE-2023-44487       High      
+libnghttp2-14        1.56.0-r0  1.61.0-r0        apk        CVE-2024-28182       Medium    
+libnghttp2-14        1.56.0-r0  1.57.0-r0        apk        GHSA-qppj-fm5r-hxr3  Unknown   
+```
+
+We'll use the `HIGH` severity vulnerability listed here as an example when we explore Chainguard's Security Advisories in the next section.
 
 Copy or note down the CVE identifier (`2023-44487` in this case). Additionally, note down the name of the affected package (`nghttp2`). You'll use these details to retrieve more information about the CVE shortly. 
 
@@ -95,7 +85,7 @@ After finding a vulnerability in a Chainguard Image, you can navigate to [Chaing
 
 The Security Advisories page is self-service, allowing you to check whether Chainguard is aware of a specific vulnerability and whether it has been mitigated in a certain package version. You can search the Security Advisories page by entering any CVE identifier to find what packages are affected by that CVE. You can also enter the names of individual packages to find what CVEs have been reported within them.
 
-Enter the CVE identifier you copied previously into the search box at the top of the page. This will immediately filter the list of security advisories to only show packages where that CVE has been reported. It will also show the **Status** of each.
+Enter the CVE identifier you copied previously (`2023-44487`) into the search box at the top of the page. This will immediately filter the list of security advisories to only show packages where that CVE has been reported. It will also show the **Status** of each.
 
 ![Screenshot showing the Chainguard Security Advisories page. The list of advisories has been filtered to only include those with a CVE ID of "CVE-2023-44487".](sec-adv-A.png)
 
@@ -114,30 +104,13 @@ As the previous screenshot highlights, for CVE-2023-44487, the `nghttp2` package
 
 Chainguard's Security Advisories have told us that the CVE-2023-44487 was fixed and removed from `nghttp2` with a more recent version than the one available in Chainguard's `go:1.21.2` Image. However, we don't have to take that report at face value; we can inspect a later version of the same Image and compare it with version `1.21.2` to determine whether the vulnerability is still present in the later version.
 
-If you inspect a later version of the Image with Docker Scout, you'll find that this time it reports no CVEs. This example inspects version `1.21.5` of the Image.
+If you inspect a later version of the Image with Grype, you'll find that this time it does not report the high CVE we noted earlier. This example inspects version `1.21.5` of the Image.
 
 ```shell
-docker scout cves cgr.dev/example.com/go:1.21.5
-```
-```
-## Overview
-
-                	│         	Analyzed Image         	 
-────────────────────┼─────────────────────────────────────────
-  Target        	│  cgr.dev/example.com/go:1.21.5   
-	digest      	│  65008b35ef40                      	 
-	platform    	│ linux/amd64                        	 
-	vulnerabilities │	0C 	0H 	0M 	0L         	 
-	size        	│ 232 MB                             	 
-	packages    	│ 132                                	 
-
-
-## Packages and Vulnerabilities
-
-  No vulnerable packages detected
+grype cgr.dev/example.com/go:1.21.5 | grep nghttp2
 ```
 
-> Note: Version `1.21.5` was the current version of the Go Image at the time of this writing. It may have accumulated CVEs since this guide was published.
+You should find that the high CVE fixed in this specific version no longer appears in the output. (You may still see other CVEs fixed in later versions.)
 
 You can go a step further by comparing these two images directly with the `chainctl images diff` command, as in this example.
 
@@ -164,7 +137,6 @@ This example will return a lot of output, as there are significant differences f
 ```
 
 As this output indicates, `CVE0223-44487` is no longer present in later versions of the Go Chainguard Image. If you were using version `1.21.2`, you should seriously consider upgrading to a later version.
-
 
 ## Learn More
 


### PR DESCRIPTION
## Description 

Updates [How to use Chainguard Security Advisories and the Diff API](https://edu.chainguard.dev/chainguard/chainguard-images/videos/security_advisories/) (video page) and [How to Use Chainguard Security Advisories](https://edu.chainguard.dev/chainguard/chainguard-images/working-with-images/security-advisories/how-to-use/) as part of the maintenance sprint.

## Details

Since the assigned page was a video page, I updated the linked article and then added a note to the video page, moving up the note and link to the top.

On the article page, I simplified the intro and switched the examples to use Grype, in my testing Docker Scout was acting a bit hinky on the old tags.

## Notes

Resolves https://github.com/chainguard-dev/edu/issues/1901
