### PR TITLE
Added redirects.yaml file to create new redirects

### DIFF
--- a/data/redirects.yaml
+++ b/data/redirects.yaml
@@ -1,0 +1,2 @@
+- redirected: /chainguard/chainguard-images/getting-started/istio
+  outbound: https://images.chainguard.dev/directory/image/istio-pilot/overview

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -3,3 +3,6 @@
 {{ . }} {{ $p.RelPermalink -}}
 {{- end }}
 {{- end -}}
+{{- range $p := .Site.Data.redirects }}
+{{ .redirected }} {{ .outbound }}
+{{ end }}


### PR DESCRIPTION
## Description

We need a redirect to depricate an istio guide. It seems we've been adding redirects to nginx.conf . Unless I'm missing somethin, we could do this a bit more cleanly when generating the redirects file rather than doing it on the proxy level. Added a data file to add manual redirects and will check if it works.

## Notes

References https://github.com/chainguard-dev/internal/issues/4498
