### PR TITLE
fixes Internal #4401

### DIFF
--- a/content/chainguard/chainguard-images/working-with-images/images-directory/index.md
+++ b/content/chainguard/chainguard-images/working-with-images/images-directory/index.md
@@ -25,6 +25,12 @@ There are hundreds of Chainguard Images available for use. To help users explore
 
 This guide is primarily framed around the Public Images Directory found in the Chainguard Console. The Console is accessible to anyone, including users who aren't Chainguard customers. To access the Console, you'll first need to [create an account and sign in](https://console.chainguard.dev/auth/login).
 
+If you would like to open the console with your Organization already selected, you can use (and bookmark) a link like this, replacing ORGANIZATION with your organization's name:
+
+```html
+https://console.chainguard.dev/auth/login?org=ORGANIZATION
+```
+
 If you're not ready to create a Chainguard account, you can also follow along with the public [Chainguard Images Directory](https://images.chainguard.dev/?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-images-directory). As of this writing, there are some differences between the two directories, but both should provide a similar experience for users.
 
 

--- a/content/chainguard/chainguard-images/working-with-images/images-directory/index.md
+++ b/content/chainguard/chainguard-images/working-with-images/images-directory/index.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "A walkthrough of the Chainguard Images directory."
 date: 2024-02-23T11:07:52+02:00
-lastmod: 2024-08-05T11:07:52+02:00
+lastmod: 2024-12-18T11:07:52+02:00
 draft: false
 tags: ["CONCEPTUAL", "CHAINGUARD IMAGES", "PRODUCT"]
 images: []


### PR DESCRIPTION
## Type of change
This adds an instruction for pre-populating the Organization name on the Chainguard Console login screen via the request URL.

### What should this PR do?
Resolves [Internal #4401](https://github.com/chainguard-dev/internal/issues/4401)

### Why are we making this change?
Requested by a customer

### What are the acceptance criteria? 
Is it clear? Does it work?

### How should this PR be tested?
Check for typos, check the URL
