### PR TITLE
Removing redirect rule in favor of Hugo alias

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -74,7 +74,7 @@ The following example shows the **SBOM** tab for the `postgres` Image.
 
 You can use the drop-down menu above the table to select which version and architecture of the image you want to view. You can also use the search box to find specific packages in the SBOM or use the button to the right of the search box to download the SBOM to your machine.
 
-Check out our guide on [using the Chainguard Images Directory](/chainguard/chainguard-images/images-directory/) for more details.
+Check out our guide on [using the Chainguard Images Directory](/chainguard/chainguard-images/how-to-use/images-directory/) for more details.
 
 ## License Information and Source Code references
 

--- a/content/open-source/sigstore/rekor/an-introduction-to-rekor.md
+++ b/content/open-source/sigstore/rekor/an-introduction-to-rekor.md
@@ -35,7 +35,7 @@ The latest Signed Tree hashes of Rekor are published on Google Cloud Storage. Th
 
 ## Rekor usage
 
-Rekor provides a restful API based server for validation and a transparency log for storage, accessible via a command-line interface (CLI) application: `rekor-cli`. You can install `rekor-cli` with Go, which we will discuss in the lab section below. Alternatively, you can navigate to the [Rekor release page](https://github.com/sigstore/rekor/releases) to grab the most recent release, or you can build the [Rekor CLI manually](https://docs.sigstore.dev/rekor/installation#build-rekor-cli-manually).
+Rekor provides a restful API based server for validation and a transparency log for storage, accessible via a command-line interface (CLI) application: `rekor-cli`. You can install `rekor-cli` with Go, which we will discuss in the lab section below. Alternatively, you can navigate to the [Rekor release page](https://github.com/sigstore/rekor/releases) to grab the most recent release, or you can build the [Rekor CLI manually](https://docs.sigstore.dev/logging/installation/#build-rekor-cli-manually).
 
 Through the CLI, you can make and verify entries, query the transparency log to prove the inclusion of an artifact, verify the integrity of the transparency log, or retrieve entries by either public key or artifact.
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,8 +42,8 @@ http {
         "~^/chainguard/chainguard-enforce/reference/events/(.+)?$" /chainguard/administration/cloudevents/events-reference/;
         # "~^/chainguard/chainguard-enforce/administration/connecting-to-private-registries/(.+)?$" /chainguard/chainguard-registry/authenticating/;
         # "~^/chainguard/chainguard-enforce/administration/annotation-based-caching/(.+)?$" /chainguard/chainguard-enforce/annotation-based-caching/;
-        "~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
-        "~^/chainguard/chainguard-images/comparing-images/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
+        "~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/how-to-use/comparing-images/;
+        #"~^/chainguard/chainguard-images/comparing-images/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
         "~^/chainguard/administration/cloudevents/create-github-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-jira-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-slack-alerts/(.+)?$" /chainguard/administration/cloudevents/;

--- a/tools/chainlink/ignore.json
+++ b/tools/chainlink/ignore.json
@@ -1,5 +1,8 @@
 {
-  "urls": [],
+  "urls": [
+    "http://0.0.0.0:8080/Chainguard%20Customer",
+    "http://0.0.0.0:8080/version"
+  ],
   "regexps": [
     "^#",
     "^/$",


### PR DESCRIPTION
This is a quick PR that I'm hoping will fix some failing redirects on Academy.

The [How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/) doc has been plagued by bad redirects since the recent reorg and I think it's because the Hugo aliases are conflicting with a redirect listed in nginx.conf. This PR comments out the relevant line from nginx.conf and adds another alias for the comparing images doc.

I tested locally and it seems like all the bad links listed in [this issue](https://github.com/chainguard-dev/internal/issues/4541) are redirecting as expected.

resolves https://github.com/chainguard-dev/internal/issues/4541