### PR TITLE
Removing redirect rule in favor of Hugo aliases

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/comparing-images.md
+++ b/content/chainguard/chainguard-images/how-to-use/comparing-images.md
@@ -6,6 +6,7 @@ aliases:
 - /chainguard/chainguard-images/comparing-images/comparing-images/
 - /chainguard/chainguard-images/using-the-image-diff-api
 - /chainguard/chainguard-images/comparing-images/using-the-image-diff-api/
+- /chainguard/chainguard-images/working-with-images/comparing-images/
 - /chainguard/chainguard-images/how-to-use/comparing-images/
 type: "article"
 description: "An overview of how to use the chainctl images diff command to compare two Chainguard Images."

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,16 +19,11 @@ http {
 
         # individual URL redirects here
         "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl$1;
-        # "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-discovery-onboarding(.+)?$" /chainguard/chainguard-enforce/chainguard-enforce-discovery-onboarding$1;
-        # "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chaingaurd-enforce-user-onboarding(.+)?$" /chainguard/chainguard-enforce/chainguard-enforce-user-onboarding$1;
         "~^/chainguard/chainguard-enforce/chainctl-docs(.+)?$" /chainguard/chainctl$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events(.+)?$" /chainguard/administration/cloudevents/events-reference$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-events(.+)?$" /chainguard/administration/cloudevents/events-reference$1;
-        # "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/changelog(.+)?$" /chainguard/chainguard-enforce/changelog$1;
-        # "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/how-to-disable-policy-enforcement(.+)?$" /chainguard/chainguard-enforce/policies/how-to-disable-policy-enforcement$1;
         "~^/open-source/apko/apk-package-manager(.+)?$" /open-source/wolfi/apk-package-manager$1;
         "~^/chainguard/chainctl/chainctl-docs/(index.html|index.xml)?$" /chainguard/chainctl/;
-        # "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/(index.html|index.xml)?$" /chainguard/chainguard-enforce/enforce-overview/;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-policy-examples(.+)?$" /open-source/sigstore/policy-controller/policies$1;
         "~^/open-source/melange/getting-started-with-melange(.+)?$" /open-source/build-tools/melange/getting-started-with-melange/;
         "~^/open-source/melange/tutorials/getting-started-with-melange/(.+)?$" /open-source/build-tools/melange/getting-started-with-melange/;
@@ -40,10 +35,6 @@ http {
         "~^/chainguard/chainguard-enforce/authentication/custom-idps/(.+)?$" /chainguard/administration/custom-idps/custom-idps/;
         "~^/chainguard/network-requirements/(.+)?$" /chainguard/administration/network-requirements/;
         "~^/chainguard/chainguard-enforce/reference/events/(.+)?$" /chainguard/administration/cloudevents/events-reference/;
-        # "~^/chainguard/chainguard-enforce/administration/connecting-to-private-registries/(.+)?$" /chainguard/chainguard-registry/authenticating/;
-        # "~^/chainguard/chainguard-enforce/administration/annotation-based-caching/(.+)?$" /chainguard/chainguard-enforce/annotation-based-caching/;
-        #"~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
-        #"~^/chainguard/chainguard-images/comparing-images/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
         "~^/chainguard/administration/cloudevents/create-github-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-jira-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-slack-alerts/(.+)?$" /chainguard/administration/cloudevents/;

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,8 +42,8 @@ http {
         "~^/chainguard/chainguard-enforce/reference/events/(.+)?$" /chainguard/administration/cloudevents/events-reference/;
         # "~^/chainguard/chainguard-enforce/administration/connecting-to-private-registries/(.+)?$" /chainguard/chainguard-registry/authenticating/;
         # "~^/chainguard/chainguard-enforce/administration/annotation-based-caching/(.+)?$" /chainguard/chainguard-enforce/annotation-based-caching/;
-        "~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
-        "~^/chainguard/chainguard-images/comparing-images/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
+        #"~^/chainguard/chainguard-images/comparing-images/using-the-image-diff-api/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
+        #"~^/chainguard/chainguard-images/comparing-images/(.+)?$" /chainguard/chainguard-images/working-with-images/comparing-images/;
         "~^/chainguard/administration/cloudevents/create-github-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-jira-issues/(.+)?$" /chainguard/administration/cloudevents/;
         "~^/chainguard/administration/cloudevents/create-slack-alerts/(.+)?$" /chainguard/administration/cloudevents/;


### PR DESCRIPTION
This is a quick PR that I'm hoping will fix some failing redirects on Academy.

The [How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/) doc has been plagued by bad redirects since the recent reorg and I think it's because the Hugo aliases are conflicting with a redirect listed in nginx.conf. This PR comments out the relevant line from nginx.conf and adds another alias for the comparing images doc.

I tested locally and it seems like all the bad links listed in [this issue](https://github.com/chainguard-dev/internal/issues/4541) are redirecting as expected.

resolves https://github.com/chainguard-dev/internal/issues/4541

First PR was a bust, this one should be good