### PR TITLE
Adding section about package search in Wolfi FAQ

### DIFF
--- a/content/open-source/wolfi/faq.md
+++ b/content/open-source/wolfi/faq.md
@@ -3,7 +3,7 @@ title: "Wolfi FAQs"
 type: "article"
 description: "Frequently asked questions about Wolfi, a Linux undistro"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2022-10-15T08:49:31+00:00
+lastmod: 2025-01-08T08:49:31+00:00
 draft: false
 tags: ["Wolfi", "FAQ"]
 images: []
@@ -30,6 +30,9 @@ Yes, Wolfi is free and will always be.
 
 ## Can I mix packages from Alpine repositories into a Wolfi-based image?
 No, it's not possible to mix Alpine apks with Wolfi apks. If your image requires dependencies that are currently only available for Alpine, you might consider opening a new issue in the [wolfi-os](https://github.com/chainguard-dev/wolfi-os/) repository to suggest the new package addition, or use [melange](https://github.com/chainguard-dev/melange) to build a custom apk for your image.
+
+## How can I find which packages are available in Wolfi?
+You can search for available packages using the `apk search` command from within a Wolfi container, as explained in the [Searching for Packages](https://edu.chainguard.dev/chainguard/migration/migrating-to-chainguard-images/#searching-for-packages) section of our Migrating to Chainguard Images guide. You can also use our [APK Explorer](https://apk.dag.dev/) tool for a web-based search on the Wolfi repositories.
 
 ## Can I use Wolfi on the Desktop?
 No. Wolfi is an un-distro, or distroless base to be used within the container / OCI ecosystem. Desktop distributions require additional software that is out of scope for Wolfi's roadmap.


### PR DESCRIPTION
This PR adds a section on how to search for packages in the Wolfi FAQ, addressing [this issue](https://github.com/chainguard-dev/edu/issues/1958).