### PR TITLE
Minify resources

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -67,9 +67,6 @@ rel  = "sitemap"
   blog = "/blog/:title/"
 # docs = "/docs/1.0/:sections[1:]/:title/"
 
-[minify.tdewolff.html]
-  keepWhitespace = false
-
 [module]
   [module.hugoVersion]
     extended = true
@@ -121,3 +118,11 @@ rel  = "sitemap"
     source = "data"
     target = "data"
 
+
+
+# Minification options
+[minify]
+    [minify.tdewolff]
+        [minify.tdewolff.html]
+            keepComments = false
+            keepWhitespace = false

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -119,10 +119,39 @@ rel  = "sitemap"
     target = "data"
 
 
-
-# Minification options
 [minify]
-    [minify.tdewolff]
-        [minify.tdewolff.html]
-            keepComments = false
-            keepWhitespace = false
+  disableCSS = false
+  disableHTML = false
+  disableJS = false
+  disableJSON = false
+  disableSVG = false
+  disableXML = false
+  minifyOutput = true
+  [minify.tdewolff]
+    [minify.tdewolff.css]
+      inline = false
+      keepCSS2 = true
+      precision = 0
+    [minify.tdewolff.html]
+      keepComments = false
+      keepConditionalComments = false
+      keepDefaultAttrVals = true
+      keepDocumentTags = true
+      keepEndTags = true
+      keepQuotes = false
+      keepSpecialComments = true
+      keepWhitespace = false
+      templateDelims = ['', '']
+    [minify.tdewolff.js]
+      keepVarNames = false
+      precision = 0
+      version = 2022
+    [minify.tdewolff.json]
+      keepNumbers = false
+      precision = 0
+    [minify.tdewolff.svg]
+      inline = false
+      keepComments = false
+      precision = 0
+    [minify.tdewolff.xml]
+      keepWhitespace = false

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -113,10 +113,10 @@
       {{ partial "footer/main/docs-navigation.html" . }}
 
     </main>
-    {{ $snippetsStyle := resources.Get "scss/snippets.scss" | resources.ToCSS }}
+    {{ $snippetsStyle := resources.Get "scss/snippets.scss" | resources.ToCSS | minify | fingerprint "sha256" }}
     <link rel="stylesheet" href="{{ $snippetsStyle.Permalink }}" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-    {{- $snippets := resources.Get "js/snippets.js" -}}
+    {{- $snippets := resources.Get "js/snippets.js" | minify | fingerprint "sha256" -}}
     <script src="{{ $snippets.Permalink }}" integrity="{{ $snippets.Data.Integrity }}"></script>
     {{- $titles := resources.Get "js/titles.js" -}}
     <script src="{{ $titles.Permalink }}" integrity="{{ $titles.Data.Integrity }}"></script>

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,7 +1,7 @@
 {{ $indexTemplate := resources.Get "js/index.js" -}}
 {{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . | minify | fingerprint "sha512" -}}
 
-{{ $bs := resources.Get "js/bootstrap.js"  -}}
+{{ $bs := resources.Get "js/bootstrap.js" -}}
 {{ $bs := $bs | js.Build -}}
 
 {{ $highlight := resources.Get "js/highlight.js" | minify | fingerprint "sha256" -}}

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,63 +1,63 @@
-{{ $indexTemplate := resources.Get "js/index.js" -}}
+{{ $indexTemplate := resources.Get "js/index.js" | minify | fingerprint "sha512" -}}
 {{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . -}}
 
-{{ $bs := resources.Get "js/bootstrap.js" -}}
+{{ $bs := resources.Get "js/bootstrap.js" | minify | fingerprint "sha512" -}}
 {{ $bs := $bs | js.Build -}}
 
-{{ $highlight := resources.Get "js/highlight.js" -}}
+{{ $highlight := resources.Get "js/highlight.js" | minify | fingerprint "sha512" -}}
 {{ $highlight := $highlight | js.Build -}}
 
-{{ $katex := resources.Get "js/vendor/katex/dist/katex.js" -}}
-{{ $katexAutoRender := resources.Get "js/vendor/katex/dist/contrib/auto-render.js" -}}
+{{ $katex := resources.Get "js/vendor/katex/dist/katex.js" | minify | fingerprint "sha512" -}}
+{{ $katexAutoRender := resources.Get "js/vendor/katex/dist/contrib/auto-render.js" | minify | fingerprint "sha512" -}}
 
-{{ $mermaid := resources.Get "js/mermaid.js" | js.Build -}}
+{{ $mermaid := resources.Get "js/mermaid.js" | minify | fingerprint "sha512" | js.Build -}}
 
-{{ $app := resources.Get "js/app.js" -}}
+{{ $app := resources.Get "js/app.js" | minify | fingerprint "sha512" -}}
 
 {{ $slice := slice $app -}}
 
 {{ if .Site.Params.options.lazySizes -}}
-  {{ $lazySizes := resources.Get "js/lazysizes.js" -}}
+  {{ $lazySizes := resources.Get "js/lazysizes.js" | minify | fingerprint "sha512" -}}
   {{ $lazySizes := $lazySizes | js.Build -}}
   {{ $slice = $slice | append $lazySizes -}}
 {{ end -}}
 
 {{ if .Site.Params.options.clipBoard -}}
-  {{ $clipBoard := resources.Get "js/clipboard.js" -}}
+  {{ $clipBoard := resources.Get "js/clipboard.js" | minify | fingerprint "sha512" -}}
   {{ $clipBoard := $clipBoard | js.Build -}}
   {{ $slice = $slice | append $clipBoard -}}
 {{ end -}}
 
 {{ if .Site.Params.options.instantPage -}}
-  {{ $instantPage := resources.Get "js/instant.page.js" -}}
+  {{ $instantPage := resources.Get "js/instant.page.js" | minify | fingerprint "sha512" -}}
   {{ $instantPage := $instantPage | js.Build -}}
   {{ $slice = $slice | append $instantPage -}}
 {{ end -}}
 
 {{ if .Site.Params.options.flexSearch -}}
-  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.js" -}}
+  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.js" | minify | fingerprint "sha512" -}}
   {{ $slice = $slice | append $flexSearch -}}
 {{ end -}}
 
 {{ if .Site.Params.options.darkMode -}}
-  {{ $darkMode := resources.Get "js/darkmode.js" -}}
+  {{ $darkMode := resources.Get "js/darkmode.js" | minify | fingerprint "sha512" -}}
   {{ $darkMode := $darkMode | js.Build -}}
   {{ $slice = $slice | append $darkMode -}}
 {{ end -}}
 
 {{ if and (.Site.Params.alert) (.Site.Params.alertDismissable) -}}
-  {{ $alert := resources.Get "js/alert.js" -}}
+  {{ $alert := resources.Get "js/alert.js" | minify | fingerprint "sha512" -}}
   {{ $alert := $alert | js.Build -}}
   {{ $slice = $slice | append $alert -}}
 {{ end -}}
 
 {{ if .Site.Params.options.kaTex -}}
-  {{ $katexConfig := resources.Get "js/katex.js" -}}
+  {{ $katexConfig := resources.Get "js/katex.js" | minify | fingerprint "sha512" -}}
   {{ $katexConfig := $katexConfig | js.Build -}}
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
-{{ $js := $slice | resources.Concat "main.js" -}}
+{{ $js := $slice | resources.Concat "main.js" | minify | fingerprint "sha512" -}}
 
 {{ if eq (hugo.Environment) "development" -}}
   {{ if .Site.Params.options.bootStrapJs -}}

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,63 +1,63 @@
-{{ $indexTemplate := resources.Get "js/index.js" | minify | fingerprint "sha512" -}}
+{{ $indexTemplate := resources.Get "js/index.js" -}}
 {{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . -}}
 
-{{ $bs := resources.Get "js/bootstrap.js" | minify | fingerprint "sha512" -}}
+{{ $bs := resources.Get "js/bootstrap.js"  -}}
 {{ $bs := $bs | js.Build -}}
 
-{{ $highlight := resources.Get "js/highlight.js" | minify | fingerprint "sha512" -}}
+{{ $highlight := resources.Get "js/highlight.js" | minify | fingerprint "sha256" -}}
 {{ $highlight := $highlight | js.Build -}}
 
-{{ $katex := resources.Get "js/vendor/katex/dist/katex.js" | minify | fingerprint "sha512" -}}
-{{ $katexAutoRender := resources.Get "js/vendor/katex/dist/contrib/auto-render.js" | minify | fingerprint "sha512" -}}
+{{ $katex := resources.Get "js/vendor/katex/dist/katex.js" | minify | fingerprint "sha256" -}}
+{{ $katexAutoRender := resources.Get "js/vendor/katex/dist/contrib/auto-render.js" | minify | fingerprint "sha256" -}}
 
-{{ $mermaid := resources.Get "js/mermaid.js" | minify | fingerprint "sha512" | js.Build -}}
+{{ $mermaid := resources.Get "js/mermaid.js" | minify | fingerprint "sha256" | js.Build -}}
 
-{{ $app := resources.Get "js/app.js" | minify | fingerprint "sha512" -}}
+{{ $app := resources.Get "js/app.js" | minify | fingerprint "sha256" -}}
 
 {{ $slice := slice $app -}}
 
 {{ if .Site.Params.options.lazySizes -}}
-  {{ $lazySizes := resources.Get "js/lazysizes.js" | minify | fingerprint "sha512" -}}
+  {{ $lazySizes := resources.Get "js/lazysizes.js" | minify | fingerprint "sha256" -}}
   {{ $lazySizes := $lazySizes | js.Build -}}
   {{ $slice = $slice | append $lazySizes -}}
 {{ end -}}
 
 {{ if .Site.Params.options.clipBoard -}}
-  {{ $clipBoard := resources.Get "js/clipboard.js" | minify | fingerprint "sha512" -}}
+  {{ $clipBoard := resources.Get "js/clipboard.js" | minify | fingerprint "sha256" -}}
   {{ $clipBoard := $clipBoard | js.Build -}}
   {{ $slice = $slice | append $clipBoard -}}
 {{ end -}}
 
 {{ if .Site.Params.options.instantPage -}}
-  {{ $instantPage := resources.Get "js/instant.page.js" | minify | fingerprint "sha512" -}}
+  {{ $instantPage := resources.Get "js/instant.page.js" | minify | fingerprint "sha256" -}}
   {{ $instantPage := $instantPage | js.Build -}}
   {{ $slice = $slice | append $instantPage -}}
 {{ end -}}
 
 {{ if .Site.Params.options.flexSearch -}}
-  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.js" | minify | fingerprint "sha512" -}}
+  {{ $flexSearch := resources.Get "js/vendor/flexsearch/dist/flexsearch.bundle.js" | minify | fingerprint "sha256" -}}
   {{ $slice = $slice | append $flexSearch -}}
 {{ end -}}
 
 {{ if .Site.Params.options.darkMode -}}
-  {{ $darkMode := resources.Get "js/darkmode.js" | minify | fingerprint "sha512" -}}
+  {{ $darkMode := resources.Get "js/darkmode.js" | minify | fingerprint "sha256" -}}
   {{ $darkMode := $darkMode | js.Build -}}
   {{ $slice = $slice | append $darkMode -}}
 {{ end -}}
 
 {{ if and (.Site.Params.alert) (.Site.Params.alertDismissable) -}}
-  {{ $alert := resources.Get "js/alert.js" | minify | fingerprint "sha512" -}}
+  {{ $alert := resources.Get "js/alert.js" | minify | fingerprint "sha256" -}}
   {{ $alert := $alert | js.Build -}}
   {{ $slice = $slice | append $alert -}}
 {{ end -}}
 
 {{ if .Site.Params.options.kaTex -}}
-  {{ $katexConfig := resources.Get "js/katex.js" | minify | fingerprint "sha512" -}}
+  {{ $katexConfig := resources.Get "js/katex.js" | minify | fingerprint "sha256" -}}
   {{ $katexConfig := $katexConfig | js.Build -}}
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
-{{ $js := $slice | resources.Concat "main.js" | minify | fingerprint "sha512" -}}
+{{ $js := $slice | resources.Concat "main.js" | minify | fingerprint "sha256" -}}
 
 {{ if eq (hugo.Environment) "development" -}}
   {{ if .Site.Params.options.bootStrapJs -}}
@@ -78,13 +78,13 @@
     <script src="{{ $index.RelPermalink }}" defer></script>
   {{ end -}}
 {{ else -}}
-  {{ $js := $js | minify | fingerprint "sha512" -}}
-  {{ $index := $index | minify | fingerprint "sha512" -}}
-  {{ $bs := $bs | minify | fingerprint "sha512" -}}
-  {{ $highlight := $highlight | minify | fingerprint "sha512" -}}
-  {{ $katex := $katex | minify | fingerprint "sha512" -}}
-  {{ $katexAutoRender := $katexAutoRender | minify | fingerprint "sha512" -}}
-  {{ $mermaid := $mermaid | minify | fingerprint "sha512" -}}
+  {{ $js := $js | minify | fingerprint "sha256" -}}
+  {{ $index := $index | minify | fingerprint "sha256" -}}
+  {{ $bs := $bs | minify | fingerprint "sha256" -}}
+  {{ $highlight := $highlight | minify | fingerprint "sha256" -}}
+  {{ $katex := $katex | minify | fingerprint "sha256" -}}
+  {{ $katexAutoRender := $katexAutoRender | minify | fingerprint "sha256" -}}
+  {{ $mermaid := $mermaid | minify | fingerprint "sha256" -}}
   {{ if .Site.Params.options.bootStrapJs -}}
     <script src="{{ $bs.RelPermalink }}" integrity="{{ $bs.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,5 +1,5 @@
 {{ $indexTemplate := resources.Get "js/index.js" -}}
-{{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . -}}
+{{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . | minify | fingerprint "sha512" -}}
 
 {{ $bs := resources.Get "js/bootstrap.js"  -}}
 {{ $bs := $bs | js.Build -}}

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -13,11 +13,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <script id="6senseWebTag" src="https://j.6sc.co/j/edd32455-d420-405e-a9ba-ca4b02be04d3.js"></script>
 {{ if .Site.Params.options.darkMode -}}
-  {{ $darkModeInit := resources.Get "js/darkmode-init.js" | js.Build | minify | fingerprint "sha512" -}}
+  {{ $darkModeInit := resources.Get "js/darkmode-init.js" | js.Build | minify | fingerprint "sha256" -}}
   <script src="{{ $darkModeInit.RelPermalink }}" integrity="{{ $darkModeInit.Data.Integrity }}" crossorigin="anonymous" defer></script>
 {{ end -}}
 {{- if and (.Site.Params.alert) (.Site.Params.alertDismissable) -}}
-  {{ $alertInit := resources.Get "js/alert-init.js" | js.Build | minify | fingerprint "sha512" -}}
+  {{ $alertInit := resources.Get "js/alert-init.js" | js.Build | minify | fingerprint "sha256" -}}
   <script src="{{ $alertInit.RelPermalink }}" integrity="{{ $alertInit.Data.Integrity }}" crossorigin="anonymous" defer></script>
 {{- end -}}
 

--- a/layouts/partials/head/stylesheet.html
+++ b/layouts/partials/head/stylesheet.html
@@ -1,0 +1,10 @@
+{{ if eq (hugo.Environment) "development" -}}
+  {{ $options := (dict "targetPath" "main.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
+  {{ $css := resources.Get "scss/app.scss" | toCSS $options -}}
+  <link rel="stylesheet" href="{{ $css.Permalink | relURL }}">
+{{ else -}}
+  {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
+  {{ $css := resources.Get "scss/app.scss" | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | minify | fingerprint "sha512" -}}
+  <link rel="stylesheet" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+{{ end -}}
+<noscript><style>img.lazyload { display: none; }</style></noscript>

--- a/layouts/partials/head/stylesheet.html
+++ b/layouts/partials/head/stylesheet.html
@@ -1,10 +1,10 @@
 {{ if eq (hugo.Environment) "development" -}}
   {{ $options := (dict "targetPath" "main.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get "scss/app.scss" | toCSS $options -}}
+  {{ $css := resources.Get "scss/app.scss" | toCSS $options | minify | fingerprint "sha256" -}}
   <link rel="stylesheet" href="{{ $css.Permalink | relURL }}">
 {{ else -}}
   {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get "scss/app.scss" | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | minify | fingerprint "sha512" -}}
+  {{ $css := resources.Get "scss/app.scss" | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | minify | fingerprint "sha256" -}}
   <link rel="stylesheet" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
 {{ end -}}
 <noscript><style>img.lazyload { display: none; }</style></noscript>

--- a/layouts/partials/replacer.html
+++ b/layouts/partials/replacer.html
@@ -1,6 +1,6 @@
-{{- $replacer := resources.Get "js/replacer.js" | minify | fingerprint "sha512" -}}
+{{- $replacer := resources.Get "js/replacer.js" | minify | fingerprint "sha256" -}}
 {{ $scss := resources.Get "scss/replacer.scss" }}
-{{ $replacer_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
+{{ $replacer_style := $scss | resources.ToCSS | minify | fingerprint "sha256" }}
 
 
 {{/* Add replacer.css styling */}}

--- a/layouts/partials/replacer.html
+++ b/layouts/partials/replacer.html
@@ -1,6 +1,6 @@
-{{- $replacer := resources.Get "js/replacer.js" -}}
+{{- $replacer := resources.Get "js/replacer.js" | minify | fingerprint "sha512" -}}
 {{ $scss := resources.Get "scss/replacer.scss" }}
-{{ $replacer_style := $scss | resources.ToCSS }}
+{{ $replacer_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
 
 
 {{/* Add replacer.css styling */}}

--- a/layouts/partials/rumble-comparison.html
+++ b/layouts/partials/rumble-comparison.html
@@ -66,13 +66,13 @@
 
 </div>
 
-{{ $rumbleBase := resources.Get "js/rumble/base.js" }}
-{{ $rumbleComparison := resources.Get "js/rumble/comparison.js" }}
+{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha512" }}
+{{ $rumbleComparison := resources.Get "js/rumble/comparison.js" | minify | fingerprint "sha512" }}
 {{ $rumble := slice $rumbleBase $rumbleComparison | resources.Concat "js/rumble-comparison.js" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "scss/rumble.scss" }}
-{{ $rumble_style := $scss | resources.ToCSS }}
+{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $rumble_style.Permalink }}" />
 
 {{ end }}

--- a/layouts/partials/rumble-comparison.html
+++ b/layouts/partials/rumble-comparison.html
@@ -66,13 +66,13 @@
 
 </div>
 
-{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha512" }}
-{{ $rumbleComparison := resources.Get "js/rumble/comparison.js" | minify | fingerprint "sha512" }}
+{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha256" }}
+{{ $rumbleComparison := resources.Get "js/rumble/comparison.js" | minify | fingerprint "sha256" }}
 {{ $rumble := slice $rumbleBase $rumbleComparison | resources.Concat "js/rumble-comparison.js" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "scss/rumble.scss" }}
-{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
+{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha256" }}
 <link rel="stylesheet" href="{{ $rumble_style.Permalink }}" />
 
 {{ end }}

--- a/layouts/partials/rumble-comparison.html
+++ b/layouts/partials/rumble-comparison.html
@@ -69,6 +69,7 @@
 {{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha256" }}
 {{ $rumbleComparison := resources.Get "js/rumble/comparison.js" | minify | fingerprint "sha256" }}
 {{ $rumble := slice $rumbleBase $rumbleComparison | resources.Concat "js/rumble-comparison.js" }}
+{{ $rumble := $rumble | minify | fingerprint "sha512" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "scss/rumble.scss" }}

--- a/layouts/partials/rumble-vuln.html
+++ b/layouts/partials/rumble-vuln.html
@@ -27,6 +27,7 @@
 {{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha256" }}
 {{ $rumbleVulnerability := resources.Get "/js/rumble/vulnerability.js" | minify | fingerprint "sha256" }}
 {{ $rumble := slice $rumbleBase $rumbleVulnerability | resources.Concat "js/rumble-vulnerability.js" }}
+{{ $rumble := $rumble | minify | fingerprint "sha256" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "/scss/rumble.scss" }}

--- a/layouts/partials/rumble-vuln.html
+++ b/layouts/partials/rumble-vuln.html
@@ -24,13 +24,13 @@
 
 </div>
 
-{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha512" }}
-{{ $rumbleVulnerability := resources.Get "/js/rumble/vulnerability.js" | minify | fingerprint "sha512" }}
+{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha256" }}
+{{ $rumbleVulnerability := resources.Get "/js/rumble/vulnerability.js" | minify | fingerprint "sha256" }}
 {{ $rumble := slice $rumbleBase $rumbleVulnerability | resources.Concat "js/rumble-vulnerability.js" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "/scss/rumble.scss" }}
-{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
+{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha256" }}
 <link rel="stylesheet" href="{{ $rumble_style.Permalink }}" />
 
 {{ end }}

--- a/layouts/partials/rumble-vuln.html
+++ b/layouts/partials/rumble-vuln.html
@@ -24,13 +24,13 @@
 
 </div>
 
-{{ $rumbleBase := resources.Get "js/rumble/base.js" }}
-{{ $rumbleVulnerability := resources.Get "/js/rumble/vulnerability.js" }}
+{{ $rumbleBase := resources.Get "js/rumble/base.js" | minify | fingerprint "sha512" }}
+{{ $rumbleVulnerability := resources.Get "/js/rumble/vulnerability.js" | minify | fingerprint "sha512" }}
 {{ $rumble := slice $rumbleBase $rumbleVulnerability | resources.Concat "js/rumble-vulnerability.js" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ $scss := resources.Get "/scss/rumble.scss" }}
-{{ $rumble_style := $scss | resources.ToCSS }}
+{{ $rumble_style := $scss | resources.ToCSS | minify | fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $rumble_style.Permalink }}" />
 
 {{ end }}

--- a/layouts/partials/rumble.html
+++ b/layouts/partials/rumble.html
@@ -10,7 +10,7 @@
   </iframe>
 </div>
 
-{{- $rumble := resources.Get "js/rumble.js" -}}
+{{- $rumble := resources.Get "js/rumble.js" | minify | fingerprint "sha512" -}}
 <script src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ end }}

--- a/layouts/partials/rumble.html
+++ b/layouts/partials/rumble.html
@@ -10,7 +10,7 @@
   </iframe>
 </div>
 
-{{- $rumble := resources.Get "js/rumble.js" | minify | fingerprint "sha512" -}}
+{{- $rumble := resources.Get "js/rumble.js" | minify | fingerprint "sha256" -}}
 <script src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>
 
 {{ end }}

--- a/layouts/partials/sidebar/docs-toc.html
+++ b/layouts/partials/sidebar/docs-toc.html
@@ -7,10 +7,10 @@
   </div>
 {{ end -}}
 
-{{- $righthand := resources.Get "js/righthand.js" -}}
-{{ $scrollRighthand := resources.Get "js/scrollRighthand.js" }}
+{{- $righthand := resources.Get "js/righthand.js" | minify | fingerprint "sha512" -}}
+{{ $scrollRighthand := resources.Get "js/scrollRighthand.js" | minify | fingerprint "sha512" }}
 {{ $scss := resources.Get "scss/righthand.scss" }}
-{{ $righthand_style := $scss | resources.ToCSS }}
+{{ $righthand_style := $scss | resources.ToCSS | minify | fingerprint "sha512"}}
 
 
 {{/* Add righthand.css styling */}}

--- a/layouts/partials/sidebar/docs-toc.html
+++ b/layouts/partials/sidebar/docs-toc.html
@@ -7,10 +7,10 @@
   </div>
 {{ end -}}
 
-{{- $righthand := resources.Get "js/righthand.js" | minify | fingerprint "sha512" -}}
-{{ $scrollRighthand := resources.Get "js/scrollRighthand.js" | minify | fingerprint "sha512" }}
+{{- $righthand := resources.Get "js/righthand.js" | minify | fingerprint "sha256" -}}
+{{ $scrollRighthand := resources.Get "js/scrollRighthand.js" | minify | fingerprint "sha256" }}
 {{ $scss := resources.Get "scss/righthand.scss" }}
-{{ $righthand_style := $scss | resources.ToCSS | minify | fingerprint "sha512"}}
+{{ $righthand_style := $scss | resources.ToCSS | minify | fingerprint "sha256"}}
 
 
 {{/* Add righthand.css styling */}}

--- a/layouts/shortcodes/rumble.html
+++ b/layouts/shortcodes/rumble.html
@@ -4,5 +4,5 @@
         src="/rumble/bar/?left={{ .Get "left" }}&right={{ .Get "right" }}">
 </iframe>
 
-{{ $rumble := resources.Get "js/rumble/base.js" }}
+{{ $rumble := resources.Get "js/rumble/base.js" | minify | fingerprint "sha256" }}
 <script type="module" src="{{ $rumble.Permalink }}" integrity="{{ $rumble.Data.Integrity }}"></script>


### PR DESCRIPTION
## Description

We're working with an SEO consultant and one of the action items is to minify our CSS, JS files.

We're working from this spreadsheet: https://docs.google.com/spreadsheets/d/1nrti84sfUC-ZzB-I0MBpBSUR6OtOgCKP/edit?gid=501769198#gid=501769198

My rading of that document suggests it's these files we're primarily concerned with on edu:

```
/js/replacer.js
/js/righthand.js
/js/rumble-comparison.js
/js/rumble-vulnerability.js
/js/rumble/base.js
/js/scrollRighthand.js
/js/snippets.js
/scss/righthand.css
/scss/rumble.css
/scss/snippets.css
```

The spradhseet has more information on what pages these particular files appear on.

I've added pipelines to minify and fingerprint these resource files

## Testing

Maybe check some reprentative number of these resources to check that they're minified. The fingerprinting adds a sha to the filename so some of these files will no longer load in the form they appear above, you'll need to navigate to a page where the resource is listed as appearing, find the resource, and load it to check that it's minifed.

## Notes

I've added some explicit config settings related to minification.

In CSS, comments don't get minified/removed in this system. I think that's because they frequently contain licenses. I don't think this will be a problem.

I tried sha512 but it generates overlong filenames, my filesystem didn't like it.

Resolves https://github.com/chainguard-dev/internal/issues/4544
