### PR TITLE
Adding section on -r tags to Product Release Lifecycle doc

### DIFF
--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -78,11 +78,13 @@ Actively maintained Chainguard Images are rebuilt on a daily cadence, so you can
 
 ### A note about `-r` tags
 
-In some cases, Chainguard will fix vulnerabilities in tools without waiting for the external project to release patches. As an example, say there's a CVE in Go `1.21.3` and the Go team is uncharacteristically slow releasing a fix. In this case, Chainguard could patch a fix into `1.21.3`, and release it as `1.21.3-r2`. Chainguard would continue to make the original package available as `-r1`, and future fixes would be available in -r3, -r4, etc. We call this the *epoch number*. We may take steps like this in order to patch vulnerabilities, remove unnecessary bloat, rebuild the same source with newer tools, or to address bugs in our build configs and build tooling.
+In some cases, Chainguard will fix vulnerabilities in tools without waiting for the external project to release patches. As an example, say there's a CVE in Go `1.21.3` and the Go team is uncharacteristically slow releasing a fix. In this case, Chainguard could patch a fix into `1.21.3`, and release it as `1.21.3-r2`. Chainguard would continue to make the original package available in an image tagged as `1.21.3-r1`. If Chainguard had to apply further patches to Go `1.21.3`, it would tag these later patched images with `-r3`, `-r4`, and so on. We call this the *epoch number*. We may take steps like this in order to patch vulnerabilities, remove unnecessary bloat, rebuild the same source with newer tools, or to address bugs in our build configs and build tooling.
 
-Bear in mind that Chainguard's images, although minimal, will almost always contain more than one package. At the time of writing this, the Go image has more than 60 distinct packages in it, such as bash, busybox, git, glibc, make, and zlib. When we fix a vulnerability in bash for example, we likewise ensure that fix gets rolled out to every image that includes bash, including the `go:1.21.3` image. The image tagged `1.21.3-r2` will get that bash fix, and fixes for any of the other packages in the image.‍
+Bear in mind that Chainguard's images, although minimal, will almost always contain more than one package. At the time of writing this, the Go image has more than 60 distinct packages in it, such as bash, busybox, git, glibc, make, and zlib. When we fix a vulnerability in bash for example, we likewise ensure that fix gets rolled out to every image that includes bash, including the `go:1.21.3` image. The image tagged `1.21.3-r2` will pull in that bash fix, and fixes for any of the other packages in the image.‍
 
 Put simply, when you opt in to pulling `go:1.21.3-r2`, you're opting in to a consistent version of Go, and potentially floating versions of all the other packages. This means you get CVE fixes as well as patch, and minor, and even major version releases of bash, and every other package the image contains.
+
+You can learn more about our approach by reviewing our [blog on image tagging philosophy](https://www.chainguard.dev/unchained/chainguards-image-tagging-philosophy-enabling-high-velocity-updates-pt-1-of-3?utm=docs).
 
 
 ## Wolfi Packages in Chainguard Images

--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -76,6 +76,15 @@ For single release track software projects, Chainguard will maintain only the `:
 
 Actively maintained Chainguard Images are rebuilt on a daily cadence, so you can be sure the Image you are using is up to date.
 
+### A note about `-r` tags
+
+In some cases, Chainguard will fix vulnerabilities in tools without waiting for the external project to release patches. As an example, say there's a CVE in Go `1.21.3` and the Go team is uncharacteristically slow releasing a fix. In this case, Chainguard could patch a fix into `1.21.3`, and release it as `1.21.3-r2`. Chainguard would continue to make the original package available as `-r1`, and future fixes would be available in -r3, -r4, etc. We call this the *epoch number*. We may take steps like this in order to patch vulnerabilities, remove unnecessary bloat, rebuild the same source with newer tools, or to address bugs in our build configs and build tooling.
+
+Bear in mind that Chainguard's images, although minimal, will almost always contain more than one package. At the time of writing this, the Go image has more than 60 distinct packages in it, such as bash, busybox, git, glibc, make, and zlib. When we fix a vulnerability in bash for example, we likewise ensure that fix gets rolled out to every image that includes bash, including the `go:1.21.3` image. The image tagged `1.21.3-r2` will get that bash fix, and fixes for any of the other packages in the image.‍
+
+Put simply, when you opt in to pulling `go:1.21.3-r2`, you're opting in to a consistent version of Go, and potentially floating versions of all the other packages. This means you get CVE fixes as well as patch, and minor, and even major version releases of bash, and every other package the image contains.
+
+
 ## Wolfi Packages in Chainguard Images
 
 Chainguard Images only contain packages that are either built and maintained internally by Chainguard or packages from the [Wolfi Project](https://github.com/wolfi-dev). These packages follow the same conventions of minimalism and rapid updates as Chainguard Images. 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
This PR adds a new section to the product release lifecycle doc (versions.md) that outlines what images tagged with `-r` mean. The content is based off of [this blog post](https://www.chainguard.dev/unchained/chainguards-image-tagging-philosophy-enabling-high-velocity-updates-pt-1-of-3)

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/4553

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
Content should be clear and free of errors.

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Close read of the new section.

Deploy preview: https://deploy-preview-2005--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/about/versions/#a-note-about--r-tags