### PR TITLE
Updated nginx config to compress css, js, etc

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,25 @@ http {
     sendfile        on;
     keepalive_timeout  65;
     gzip  on;
+    gzip_disable "msie6"; # Disable comnpression on really old Internet Explorer
+
+    gzip_comp_level 6; # Moderate compression level
+    gzip_min_length 256; # Don't zip really small files
+
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        application/rss+xml
+        image/svg+xml;
+
 
     # add URLs after the `default` line that are moved and aren't redirecting via Hugo aliases
     map $request_uri $redirect_url {


### PR DESCRIPTION
# Description

As part of an SEO update, we've been asked to compress JS and CSS files. This PR updates the nginx.conf to serve these and similar file types with gzip compression.

# Testing

You can test by building the edu image and then using curl to fetch headers of resources served.

```
cd ~/src/edu # or whereever
npm run build
docker build . -t edu
docker run -p 8080:8080 edu
```

Find the site at localhost:8080. Look at source and grab one of the resources mentioned in the [big ol' spreadsheet](https://docs.google.com/spreadsheets/d/1miswYeiaewu_VgwLpHLyoVLh8CWH6EtW/edit?gid=334556164#gid=334556164). It will be a 404 because the URL is set to the live site and fingerprinting is a thing. Replace the domain of the resource you found with localhost:8080.

Make sure that URL loads in the browser, it should be a resource like a js or css file. Check the headers with the following:

```
curl -H "Accept-Encoding: gzip" -I <url>
```

You should get output like

```
HTTP/1.1 200 OK
Server: nginx/1.27.3
Date: Mon, 13 Jan 2025 18:45:06 GMT
Content-Type: application/javascript
Last-Modified: Mon, 13 Jan 2025 18:38:13 GMT
Connection: keep-alive
ETag: W/"67855d95-17c"
Content-Encoding: gzip
```

The last line shows that it's been served as gzip.  So easy! :0

# Notes

Note that our preview site is useless for this as it doesn't use our nginx.conf.

Resolves https://github.com/chainguard-dev/internal/issues/4543