### PR TITLE
301 redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM cgr.dev/chainguard/nginx:latest
 
 COPY public/ /usr/share/nginx/html/
+COPY redirects /etc/nginx/redirects
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM cgr.dev/chainguard/nginx:latest
 
 COPY public/ /usr/share/nginx/html/
-COPY redirects /etc/nginx/redirects
+COPY public/_aliases /etc/nginx/aliases
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -18,7 +18,7 @@ disableLanguages = ["de", "nl"]
 
 # add redirects/headers
 [outputs]
-home = ["HTML", "RSS", "REDIRECTS", "HEADERS"]
+home = ["HTML", "RSS", "ALIASES", "REDIRECTS", "HEADERS"]
 section = ["HTML", "RSS", "SITEMAP"]
 
 # remove .{ext} from text/netlify
@@ -30,6 +30,13 @@ delimiter = ""
 [outputFormats.REDIRECTS]
 mediaType = "text/netlify"
 baseName = "_redirects"
+isPlainText = true
+notAlternative = true
+
+# add output format for alias meta refresh to 301 # redirects
+[outputFormats.ALIASES]
+mediaType = "text/netlify"
+baseName = "_aliases"
 isPlainText = true
 notAlternative = true
 

--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,5 +1,7 @@
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
-rewrite {{ . }} {{ $p.RelPermalink -}};
-{{- end }}
+{{- if ne (strings.TrimSuffix "/" .) (strings.TrimSuffix "/" $p.RelPermalink) -}}
+rewrite {{ . }} {{ $p.RelPermalink }} permanent;
+{{ end }}
+{{- end -}}
 {{- end -}}

--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,0 +1,5 @@
+{{- range $p := .Site.Pages -}}
+{{- range .Aliases }}
+rewrite {{ . }} {{ $p.RelPermalink -}};
+{{- end }}
+{{- end -}}

--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,7 +1,7 @@
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
 {{- if ne (strings.TrimSuffix "/" .) (strings.TrimSuffix "/" $p.RelPermalink) -}}
-rewrite {{ . }} {{ $p.RelPermalink }} permanent;
+rewrite ~^{{ strings.TrimSuffix "/" . }}(.+)?$ {{ $p.RelPermalink }} permanent;
 {{ end }}
 {{- end -}}
 {{- end -}}

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,7 +105,8 @@ http {
         server_name  localhost;
         root   /usr/share/nginx/html/;
 
-        include redirects;
+        # Add Hugo aliases as 301 redirects
+        include aliases;
 
         # process $request_uri -> $redirect_url if url is absolute
         if ($redirect_url ~ ^https://) {

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,6 +105,8 @@ http {
         server_name  localhost;
         root   /usr/share/nginx/html/;
 
+        include redirects;
+
         # process $request_uri -> $redirect_url if url is absolute
         if ($redirect_url ~ ^https://) {
             rewrite ^(.*)$ $redirect_url permanent;

--- a/redirects
+++ b/redirects
@@ -1,7 +1,0 @@
-rewrite /funky /chainguard/migration/migrations-overview/;
-
-
-
-
-
-

--- a/redirects
+++ b/redirects
@@ -1,0 +1,7 @@
+rewrite /funky /chainguard/migration/migrations-overview/;
+
+
+
+
+
+


### PR DESCRIPTION
## Description

Adds 301 redirects for all aliases on edu.

## Details

We've been asked to change redirects implemented in meta refresh (HTML headers) with full 301 redirects for SEO purposes. All our Hugo aliases (redirects implemented in front matter) are meta refresh redirects.

After poking around in Cloud Run, the only functionality they have for this is the load balancer. That didn't seem like the most ideal solution for a number of reasons.

This PR adds application code that takes our Hugo aliases and adds them to our nginx.conf as an included file containing rewrite directives. An "_aliases" file gets built in the output folder and is copied to the image to be included in the nginx.conf. Some regex is included to handle situations related to trailing slashes, etc. In addition, many of the aliases redirect to their own pages, which would cause a redirect loop in nginx, and I've added application logic to check for these situations and exclude those aliases.

## Testing

The Netlify preview will not assist with testing. Redirects can be tested by building the edu image locally. You can check curl headers for 301 redirects. I tried to look for edge cases but I could have missed something.

## Notes

cc @ltagliaferri  @jamonation  (for interest)

Resolves https://github.com/chainguard-dev/internal/issues/4542