### PR TITLE
Nginx rewrite directive for alias redirects fix

### DIFF
--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,7 +1,7 @@
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
 {{- if ne (strings.TrimSuffix "/" .) (strings.TrimSuffix "/" $p.RelPermalink) -}}
-rewrite ~^{{ strings.TrimSuffix "/" . }}(.+)?$ {{ $p.RelPermalink }} permanent;
+rewrite ^{{ strings.TrimSuffix "/" . }}(.+)?$ {{ $p.RelPermalink }} permanent;
 {{ end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Description

This updates the new rewrite directive template for 301 redirects for Hugo aliases. In short, a `~` was breaking my beautiful redirects!

## Notes

Apparently rewrite directives use regex by default unlike in server blocks, so adding a ~ breaks the matching.

References https://github.com/chainguard-dev/internal/issues/4542
