### PR TITLE
Sanitize 301 redirects

### DIFF
--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,7 +1,7 @@
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
 {{- if ne (strings.TrimSuffix "/" .) (strings.TrimSuffix "/" $p.RelPermalink) -}}
-rewrite ~^{{ strings.TrimSuffix "/" . }}(.+)?$ {{ $p.RelPermalink }} permanent;
+"~^{{ strings.TrimSuffix "/" . }}(.+)?$" {{ strings.TrimSuffix "/" $p.RelPermalink }}$1;
 {{ end }}
 {{- end -}}
 {{- end -}}

--- a/nginx.conf
+++ b/nginx.conf
@@ -36,6 +36,9 @@ http {
     map $request_uri $redirect_url {
         default "";
 
+        # Add Hugo aliases as 301 redirects
+        include aliases;
+
         # individual URL redirects here
         "~^/chainguard/chainguard-enforce/chainctl-docs/how-to-install-chainctl(.+)?$" /chainguard/chainguard-enforce/how-to-install-chainctl$1;
         "~^/chainguard/chainguard-enforce/chainctl-docs(.+)?$" /chainguard/chainctl$1;
@@ -101,9 +104,6 @@ http {
         listen       8080;
         server_name  localhost;
         root   /usr/share/nginx/html/;
-
-        # Add Hugo aliases as 301 redirects
-        include aliases;
 
         # process $request_uri -> $redirect_url if url is absolute
         if ($redirect_url ~ ^https://) {


### PR DESCRIPTION
## Description

The new 301 redirects created from Hugo aliases will now be run through the same sanitization process we've used for redirects created directly in nginx.conf.

## Notes

I now have access to our Academy staging area on GCP and tested this in that environment.

References https://github.com/chainguard-dev/internal/issues/4542
