### PR TITLE
Force https in 301 redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -111,7 +111,7 @@ http {
         }
         # process $request_uri -> $redirect_url, preserving https, and ensure URLs don't have any ports in them
         if ($redirect_url != "") {
-            rewrite ^(.*)$ $scheme://$http_host$redirect_url permanent;
+            rewrite ^(.*)$ https://$http_host$redirect_url permanent;
         }
 
         location / {


### PR DESCRIPTION
## Description

In 301s, instead of replicating the input protocol, force https.