### PR TITLE
Removed self-referential high-level aliases

### DIFF
--- a/content/chainguard/chainguard-images/staying-secure/_index.md
+++ b/content/chainguard/chainguard-images/staying-secure/_index.md
@@ -3,7 +3,6 @@ title: "Staying Secure"
 linktitle: "Staying Secure"
 aliases:
 - /chainguard/chainguard-images/recommended-practices/
-- /chainguard/chainguard-images/staying-secure/
 description: "Conceptual articles outlining various best practices for keeping Chainguard Images secure."
 type: "article"
 date: 2024-12-19T08:49:15+00:00

--- a/content/chainguard/chainguard-images/troubleshooting/_index.md
+++ b/content/chainguard/chainguard-images/troubleshooting/_index.md
@@ -1,9 +1,6 @@
 ---
 title: "Troubleshooting Chainguard Images"
 linktitle: "Troubleshooting"
-aliases:
-- /chainguard/chainguard-images/recommended-practices/
-- /chainguard/chainguard-images/staying-secure/
 description: "Resources on how to troubleshoot issues that may come up when using Chainguard Images."
 type: "article"
 date: 2024-12-19T08:49:15+00:00


### PR DESCRIPTION
## Description

Some of the category-level aliases are causing issues with the new redirects. This PR removes some aliases that were referencing one another. 

