### PR TITLE
Adding new GraphQL proxy endpoint to Network Requirements allowlist

### DIFF
--- a/content/chainguard/administration/network-requirements.md
+++ b/content/chainguard/administration/network-requirements.md
@@ -25,6 +25,7 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | ----------------------- | ---- | -------- | ----------------------------------------------- |
 | cgr.dev                 | 443  | HTTPS    | Main image registry                             |
 | console.chainguard.dev  | 443  | HTTPS    | Chainguard dashboard                            |
+| data.chainguard.dev     | 443  | HTTPS    | Console API endpoint                            |
 | console-api.enforce.dev | 443  | HTTPS    | Registry API endpoint                           |
 | enforce.dev             | 443  | HTTPS    | Registry authentication                         |
 | dl.enforce.dev          | 443  | HTTPS    | `chainctl` downloads                            |
@@ -32,6 +33,7 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | apk.cgr.dev             | 443  | HTTPS    | Package repository                              |
 | packages.cgr.dev        | 443  | HTTPS    | Package repository (Extra packages)             |
 | packages.wolfi.dev      | 443  | HTTPS    | Package repository (Developer Images)           |
+
 
 
 > If you experience networking issues while trying to use Chainguard Images, please ensure that your firewall allows traffic to and from these hosts, and that it doesn't have any rules to block `.dev` domains.


### PR DESCRIPTION
[ X ] Check if this is a typo or other quick fix and ignore the rest :)

This is a quick update to the Network Requirements doc that was raised to me by @julienv3, adding another URL to the allowlist in the first section.

resolves https://github.com/chainguard-dev/internal/issues/4625

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->