### PR TITLE
Update docker build commands

### DIFF
--- a/content/chainguard/chainguard-images/getting-started/go.md
+++ b/content/chainguard/chainguard-images/getting-started/go.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-go
 description: "Tutorial on the distroless Go Chainguard Image"
 date: 2023-02-28T11:07:52+02:00
-lastmod: 2024-12-06T11:07:52+02:00
+lastmod: 2025-02-21T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -85,7 +85,7 @@ This Dockerfile will:
 Run the following command to build the image, tagging it `go-greeter`:
 
 ```shell
-docker build . -t go-greeter
+docker build . --pull -t go-greeter
 ```
 
 You can now run the image with:
@@ -149,7 +149,7 @@ ENTRYPOINT ["/usr/bin/greet-server"]
 Use the following command to build the image, tagging it `greet-server`:
 
 ```shell
-docker build . -t greet-server
+docker build . --pull -t greet-server
 ```
 
 Now you can run the image with the following command:

--- a/content/chainguard/chainguard-images/getting-started/nginx/index.md
+++ b/content/chainguard/chainguard-images/getting-started/nginx/index.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/nginx
 description: "Tutorial on how to get started with the nginx Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-08-13T13:25:40+00:00
+lastmod: 2025-02-21T13:25:40+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -254,7 +254,7 @@ Save the file when you're finished.
 You can now build the image with:
 
 ```shell
-docker build . -t nginx-demo
+docker build . --pull -t nginx-demo
 ```
 
 Once the build is complete, run the image with:

--- a/content/chainguard/chainguard-images/getting-started/node.md
+++ b/content/chainguard/chainguard-images/getting-started/node.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-node
 description: "Tutorial on how to get started with the Node Chainguard Image"
 date: 2023-02-01T11:07:52+02:00
-lastmod: 2023-09-22T11:07:52+02:00
+lastmod: 2025-02-21T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -153,7 +153,7 @@ Save the file when you're finished.
 You can now build the image with:
 
 ```shell
-docker build . -t wolfi-node-server
+docker build . --pull -t wolfi-node-server
 ```
 
 Once the build is finished, run the image with:

--- a/content/chainguard/chainguard-images/getting-started/php.md
+++ b/content/chainguard/chainguard-images/getting-started/php.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-php
 description: "Tutorial on how to get started with the PHP Chainguard Image"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2024-11-15T11:07:52+02:00
+lastmod: 2025-02-21T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -156,7 +156,7 @@ This Dockerfile will:
 You can now build the image with:
 
 ```shell
-docker build . -t php-namegen
+docker build . --pull -t php-namegen
 ```
 You'll get output similar to this:
 

--- a/content/chainguard/chainguard-images/getting-started/python.md
+++ b/content/chainguard/chainguard-images/getting-started/python.md
@@ -6,7 +6,7 @@ aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-python
 description: "Tutorial on the distroless Python Chainguard Image"
 date: 2023-02-28T11:07:52+02:00
-lastmod: 2025-02-18T13:46:53+00:00
+lastmod: 2025-02-21T13:46:53+00:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -173,7 +173,7 @@ nano requirements.txt
 We'll use version 68.2.2 of Python [setuptools](https://pypi.org/project/setuptools/) and also install [climage](https://pypi.org/project/climage/). We need to use a slightly older version of setuptools for compatability with climage. Add the following text to the file:
 
 ```shell
-setuptools==68.2.2
+setuptools==70.0.0
 climage==0.2.0
 ```
 

--- a/content/chainguard/chainguard-images/getting-started/ruby.md
+++ b/content/chainguard/chainguard-images/getting-started/ruby.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "Tutorial on how to get started with the Ruby Chainguard Image"
 date: 2023-05-10T11:07:52+02:00
-lastmod: 2023-05-10T11:07:52+02:00
+lastmod: 2025-02-21T11:07:52+02:00
 tags: ["Chainguard Images", "Products"]
 draft: false
 images: []
@@ -126,7 +126,7 @@ ENTRYPOINT [ "ruby", "octo.rb" ]
 Save and close the file when you're done. Next, build the image with:
 
 ```shell
-docker build . -t octo-ruby-demo
+docker build . --pull -t octo-ruby-demo
 ```
 
 Once the build is finished, you can execute the image with:
@@ -260,7 +260,7 @@ Save the file when you're finished.
 You can now build the image with:
 
 ```shell
-docker build . -t linky-says
+docker build . --pull -t linky-says
 ```
 
 Once the build is finished, run the image with:


### PR DESCRIPTION
In doing the Learning Lab this week, @amouat suggested updating the `docker build` commands to include the `--pull` flag, so I brought this through the Getting Started guides in this PR.