### PR TITLE
Create some new chainctl docs pages

### DIFF
--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -1,0 +1,27 @@
+---
+title: "chainctl Usage"
+lead: ""
+description: "chainctl Usage Documentation"
+type: "article"
+date: 2025-03-0320T08:49:15+00:00
+lastmod: 2025-03-0320T08:49:15+00:00
+draft: false
+tags: ["chainctl", "Usage", "Product", "Overview"]
+images: []
+weight: 100
+---
+
+`chainctl` (Chainguard Control) is a CLI tool that helps you control aspects of your Chainguard account and resources. You can use it to manage users, roles, images, tokens, and more. In many ways, `chainctl` parallels the abilities of the <ins>[Chainguard Console](https://console.chainguard.dev)</ins>, but with a different user interface that is both more complex and more powerful.
+
+Like most control commands that end with `ctl`, such as `systemctl` or `loginctl`, `chainctl` uses the familiar `<context> <noun> <verb>` syntax.
+
+This page lists a curated set of `chainctl` resources to help you get started.
+
+To install `chainctl`, follow our <ins>[installation guide](/chainguard/administration/how-to-install-chainctl/)</ins>.
+
+Once installed, these will help you on your path to success:
+
+* <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
+* <ins>[Getting Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl)</ins>
+* <ins>[How to Manage chainctl Configuration](https://edu.chainguard.dev/chainguard/administration/manage-chainctl-config/)</ins>
+* <ins>[How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>

--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -22,6 +22,6 @@ To install `chainctl`, follow our <ins>[installation guide](/chainguard/administ
 Once installed, these will help you on your path to success:
 
 * <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
-* <ins>[Getting Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl)</ins>
+* <ins>[Getting Started with chainctl](getting-started-with-chainctl.md)</ins>
 * <ins>[How to Manage chainctl Configuration](https://edu.chainguard.dev/chainguard/administration/manage-chainctl-config/)</ins>
 * <ins>[How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>

--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-0320T08:49:15+00:00
 draft: false
 tags: ["chainctl", "Usage", "Product", "Overview"]
 images: []
-weight: 100
+weight: 50
 ---
 
 `chainctl` (Chainguard Control) is a CLI tool that helps you control aspects of your Chainguard account and resources. You can use it to manage users, roles, images, tokens, and more. In many ways, `chainctl` parallels the abilities of the <ins>[Chainguard Console](https://console.chainguard.dev)</ins>, but with a different user interface that is both more complex and more powerful.
@@ -22,6 +22,6 @@ To install `chainctl`, follow our <ins>[installation guide](/chainguard/administ
 Once installed, these will help you on your path to success:
 
 * <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
-* <ins>[Getting Started with chainctl](getting-started-with-chainctl.md)</ins>
-* <ins>[How to Manage chainctl Configuration](https://edu.chainguard.dev/chainguard/administration/manage-chainctl-config/)</ins>
-* <ins>[How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>
+* <ins>[Getting Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl/)</ins>
+* <ins>[How to Manage chainctl Configuration](/chainguard/administration/manage-chainctl-config/)</ins>
+* <ins>[How To Compare Chainguard Images with chainctl](/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -11,14 +11,14 @@ images: []
 weight: 100
 ---
 
-This page presents some of the more commonly used basic `chainctl` commands to help you get started. For a full reference of all commands with details and switches, see [chainctl Reference](../chainctl/_index.md).
+This page presents some of the more commonly used basic `chainctl` commands to help you get started. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
 ## Authenticate and Check Auth Status
 
 To use `chainctl`, the first thing you must do is [authenticate with the Chainguard platform](/chainguard/chainguard-registry/authenticating/). Do so with:
 
-```
+```shell
 chainctl auth login
 ```
 
@@ -76,7 +76,7 @@ If you make a mistake and can't recall the original settings, reset the configur
 chainctl config reset
 ```
 
-Learn more at [How to Manage chainctl Configuration](https://edu.chainguard.dev/chainguard/administration/manage-chainctl-config/).
+Learn more at [How to Manage chainctl Configuration](/chainguard/administration/manage-chainctl-config/).
 
 
 ## List Available Images
@@ -104,7 +104,7 @@ The output returned will be in JSON format.
 
 If a requested image or release being requested is not available in the repo you are using, this will return a `Forbidden` error, just like if you tried to pull an image you did not have access to or from a repository your account is not authorized to use.
 
-Learn more at [How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/).
+Learn more at [How To Compare Chainguard Images with chainctl](/chainguard/chainguard-images/how-to-use/comparing-images/).
 
 
 ## List Available Package Versions

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -97,10 +97,8 @@ Let's say you want to compare two versions of an image for the same package. You
 Use this, where we show the repo used by our Chainguard Developer Education team and where both instances of `<image_name>` are the same:
 
 ```
-chainctl images diff cgr.dev/chainguard.edu/<image_name>:latest cgr.dev/chainguard.edu/<image_name>:latest-dev
+chainctl images diff cgr.dev/chainguard.edu/$IMAGENAME>:latest cgr.dev/chainguard.edu/$IMAGENAME:latest-dev
 ```
-
-The output returned will be in JSON format.
 
 If a requested image or release being requested is not available in the repo you are using, this will return a `Forbidden` error, just like if you tried to pull an image you did not have access to or from a repository your account is not authorized to use.
 
@@ -112,7 +110,20 @@ Learn more at [How To Compare Chainguard Images with chainctl](/chainguard/chain
 If you want to get details about the various package versions available that can be used in images, use:
 
 ```
-chainctl packages versions list <package_name>
+chainctl packages versions list $PACKAGENAME
 ```
 
 This will list all the versions that Chainguard has built and the end-of-life date for each version that has one assigned. It will also list older package versions that are no longer available.
+
+
+## Output Formats
+
+Commands may have a default format for output, but that doesn't mean you have to stick with it. There is an option available to tell `chainctl` the output format to use, like this:
+
+```
+chainctl $COMMAND -o $FORMAT
+```
+
+The `-o` is followed by one of the following strings: `csv`, `id`, `json`, `none`, `table`, `terse`, `tree`, or `wide`.
+
+Not all output formats make sense for all commands, so test thoroughly before you use any specific format in automation.

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -16,7 +16,7 @@ This page presents some of the more commonly used basic `chainctl` commands to h
 
 ## Authenticate and Check Auth Status
 
-To use `chainctl`, the first thing you must do is authenticate with the Chainguard platform. Do so with:
+To use `chainctl`, the first thing you must do is [authenticate with the Chainguard platform](/chainguard/chainguard-registry/authenticating/). Do so with:
 
 ```
 chainctl auth login
@@ -76,6 +76,8 @@ If you make a mistake and can't recall the original settings, reset the configur
 chainctl config reset
 ```
 
+Learn more at [How to Manage chainctl Configuration](https://edu.chainguard.dev/chainguard/administration/manage-chainctl-config/).
+
 
 ## List Available Images
 
@@ -101,6 +103,8 @@ chainctl images diff cgr.dev/chainguard.edu/<image_name>:latest cgr.dev/chaingua
 The output returned will be in JSON format.
 
 If a requested image or release being requested is not available in the repo you are using, this will return a `Forbidden` error, just like if you tried to pull an image you did not have access to or from a repository your account is not authorized to use.
+
+Learn more at [How To Compare Chainguard Images with chainctl](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/comparing-images/).
 
 
 ## List Available Package Versions

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -1,0 +1,114 @@
+---
+title: "Getting Started with chainctl"
+lead: ""
+description: "chainctl basics for beginners"
+type: "article"
+date: 2025-03-0320T08:49:15+00:00
+lastmod: 2025-03-0320T08:49:15+00:00
+draft: false
+tags: ["chainctl", "Getting Started", "Product", "Basics"]
+images: []
+weight: 100
+---
+
+This page presents some of the more commonly used basic `chainctl` commands to help you get started. For a full reference of all commands with details and switches, see [chainctl Reference](../chainctl/_index.md).
+
+
+## Authenticate and Check Auth Status
+
+To use `chainctl`, the first thing you must do is authenticate with the Chainguard platform. Do so with:
+
+```
+chainctl auth login
+```
+
+This will present a list of identity providers for you to select from. Use the one that is tied to your Chainguard Account. Once you select the one you wish to use, such as Google, `chainctl` will open a browser window for you to log in with your credentials. Upon successful login, you will have the option to save this identity provider as your default for future logins. Then a token will be exchanged and you will be able to use `chainctl`.
+
+To check your authentication status at any time, enter:
+
+```
+chainctl auth status
+```
+
+This will list your identity and other attributes tied to your account, including your account's assigned roles and capabilities.
+
+To create a pull token, use:
+
+```
+chainctl auth pull-token
+```
+
+To configure a Docker credential helper, which will use a token to pull images when using Docker, use:
+
+```
+chainctl auth configure-docker
+```
+
+
+## Update chainctl to the Latest Release
+
+To see which `chainctl` version you have installed, use:
+
+```
+chainctl version
+```
+
+To update your `chainctl` installation, use:
+
+```
+chainctl update
+```
+
+Updating requires administrative privileges, so be prepared to enter your machine's admin password.
+
+
+## Configure chainctl
+
+`chainctl` comes with a default configuration, but there are aspects of it that can be adjusted. Examples include setting the registry location that will be used when one is not mentioned in an issued command. To edit the current configuration, use:
+
+```
+chainctl config edit
+```
+
+If you make a mistake and can't recall the original settings, reset the configuration to default settings with:
+
+```
+chainctl config reset
+```
+
+
+## List Available Images
+
+To see which Chainguard Images are available to your account, use:
+
+```
+chainctl images list
+```
+
+Be warned, that list may take a while to generate and is likely to scroll past quickly in your command line terminal.
+
+
+## Compare Two Image Versions
+
+Let's say you want to compare two versions of an image for the same package. You need to know the URL for your repo, the image name, and the two versions you want to compare. For versions, you can use release numbers like `8.12.0` or you can use `latest` or `latest-dev`.
+
+Use this, where we show the repo used by our Chainguard Developer Education team and where both instances of `<image_name>` are the same:
+
+```
+chainctl images diff cgr.dev/chainguard.edu/<image_name>:latest cgr.dev/chainguard.edu/<image_name>:latest-dev
+```
+
+The output returned will be in JSON format.
+
+If a requested image or release being requested is not available in the repo you are using, this will return a `Forbidden` error, just like if you tried to pull an image you did not have access to or from a repository your account is not authorized to use.
+
+
+## List Available Package Versions
+
+If you want to get details about the various package versions available that can be used in images, use:
+
+```
+chainctl packages versions list <package_name>
+```
+
+This will list all the versions that Chainguard has built and the end-of-life date for each version that has one assigned. It will also list older package versions that are no longer available.


### PR DESCRIPTION
## Type of change
New documentation pages are being added for higher-level, more basic chainctl details to help users learn the basics. Related to [Internal #4684](https://github.com/chainguard-dev/internal/issues/4684)

### What should this PR do?
Make getting started with chainctl less daunting than pouring over reference pages.

### Why are we making this change?
To encourage chainctl use and enable it more quickly.

### What are the acceptance criteria? 
Accuracy, clarity, and a good feel for just the right amount of coverage for chainctl n00bs
