### PR TITLE
Add docs pages related to chainctl <noun> <verb> forms

### DIFF
--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -21,7 +21,13 @@ To install `chainctl`, follow our <ins>[installation guide](/chainguard/administ
 
 Once installed, these will help you on your path to success:
 
-* <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
 * <ins>[Getting Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl/)</ins>
+* <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
 * <ins>[How to Manage chainctl Configuration](/chainguard/administration/manage-chainctl-config/)</ins>
-* <ins>[How To Compare Chainguard Images with chainctl](/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>
+* <ins>[How To Compare Chainguard Images with chainctl diff](/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>
+* <ins>[chainctl events](/chainguard/chainctl-usage/chainctl-events/)</ins>
+* <ins>[chainctl iam](/chainguard/chainctl-usage/chainctl-iam/)</ins>
+* <ins>[chainctl images](/chainguard/chainctl-usage/chainctl-images/)</ins>
+* <ins>[chainctl packages](/chainguard/chainctl-usage/chainctl-packages/)</ins>
+* <ins>[chainctl update](/chainguard/chainctl-usage/chainctl-update/)</ins>
+* <ins>[chainctl version](/chainguard/chainctl-usage/chainctl-version/)</ins>

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -15,7 +15,7 @@ This page presents some of the more commonly used `chainctl events` commands. Fo
 
 There are three commands available: create, delete, and list. We'll start with list to see what subscriptions exist.
 
-## chainctl list 
+## `chainctl list`
 
 Get a list of all your Chainguard account's subscriptions with:
 
@@ -26,7 +26,7 @@ chainctl events subscriptions list
 This will return a list of IDs and SINKs for all of your subscriptions. You know what an ID is. A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
 
 
-## chainctl events subscriptions create
+## `chainctl events subscriptions create`
 
 To create a new event and subscribe to events in that organization or folder, use:
 
@@ -37,7 +37,7 @@ chainctl events subscriptions create $SINK_URL
 Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
 
 
-## chainctl events subscriptions delete
+## `chainctl events subscriptions delete`
 
 To delete an existing event, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -26,7 +26,7 @@ chainctl events subscriptions list
 This will return a list of IDs and SINKs for all of your subscriptions. You know what an ID is. A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
 
 
-## `chainctl events subscriptions create`
+## chainctl events subscriptions create
 
 To create a new event and subscribe to events in that organization or folder, use:
 
@@ -37,7 +37,7 @@ chainctl events subscriptions create $SINK_URL
 Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
 
 
-## `chainctl events subscriptions delete`
+## chainctl events subscriptions delete
 
 To delete an existing event, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -15,7 +15,7 @@ This page presents some of the more commonly used `chainctl events` commands. Fo
 
 There are three commands available: create, delete, and list. We'll start with list to see what subscriptions exist.
 
-## `chainctl list`
+## chainctl events subscriptions list
 
 Get a list of all your Chainguard account's subscriptions with:
 

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -1,0 +1,48 @@
+---
+title: "chainctl events"
+lead: ""
+description: "chainctl events basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "events", "Product"]
+images: []
+weight: 50
+---
+
+This page presents some of the more commonly used `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+There are three commands available: create, delete, and list. We'll start with list to see what subscriptions exist.
+
+## chainctl list 
+
+Get a list of all your Chainguard account's subscriptions with:
+
+```shell
+chainctl events subscriptions list
+```
+
+This will return a list of IDs and SINKs for all of your subscriptions. You know what an ID is. A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
+
+
+## chainctl events subscriptions create
+
+To create a new event and subscribe to events in that organization or folder, use:
+
+```shell
+chainctl events subscriptions create $SINK_URL
+```
+
+Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
+
+
+## chainctl events subscriptions delete
+
+To delete an existing event, use:
+
+```shell
+chainctl events subscriptions delete $SUBSCRIPTION_ID
+```
+
+Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.

--- a/content/chainguard/chainctl-usage/chainctl-iam.md
+++ b/content/chainguard/chainctl-usage/chainctl-iam.md
@@ -18,7 +18,7 @@ For a full reference of all commands with details and switches, see [chainctl Re
 For the following, assume that returned information only includes that which your account has permissions to view. Also, actions such as `create` and `delete` are similarly limited.
 
 
-## `chainguard iam folders`
+## chainctl iam folders
 
 Find out what folders are available to your organization with:
 
@@ -36,7 +36,7 @@ $ chainctl iam folders list chainguard.edu
 This command can also delete, describe, and update folders by replacing `list` with `delete`, `describe`, or `update`. See the reference guide for more details.
 
 
-## `chainguard iam identities`
+## chainctl iam identities
 
 To list all of the existing identities along with roles, types, and more, use:
 
@@ -47,7 +47,7 @@ chainctl iam identities list
 This command can also create, delete, describe, and update identities by replacing `list` with `create`, `delete`, `describe`, or `update`. See the reference guide for more details.
 
 
-## `chainguard iam identity-providers`
+## chainctl iam identity-providers
 
 This command enables you to manage your own identity management provider, such as a custom OIDC provider. To list all currently configured identity management providers, use:
 
@@ -58,7 +58,7 @@ chainctl iam identity-providers list
 This command can also create, delete, and update identity providers by replacing `list` with `create`, `delete`, or `update`. See the reference guide for more details.
 
 
-## `chainguard iam invites`
+## chainctl iam invites
 
 This command lets you manage invite codes that register identities with Chainguard. To list current invites, use:
 
@@ -72,7 +72,7 @@ This will return a list of invites by ID with information about the invite's exp
 This command can also create and delete invites by replacing `list` with `create` or `delete`. See the reference guide for more details.
 
 
-## `chainctl iam organizations`
+## chainctl iam organizations
 
 To list all of the organizations your account is associated with, use:
 
@@ -83,7 +83,7 @@ chainctl iam organizations list
 This command can also delete and describe organizations by replacing `list` with `delete` or `describe`. See the reference guide for more details.
 
 
-## `chainctl iam roles`
+## chainctl iam roles
 
 To list all of the roles your account is associated with, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-iam.md
+++ b/content/chainguard/chainctl-usage/chainctl-iam.md
@@ -18,7 +18,7 @@ For a full reference of all commands with details and switches, see [chainctl Re
 For the following, assume that returned information only includes that which your account has permissions to view. Also, actions such as `create` and `delete` are similarly limited.
 
 
-## chainguard iam folders
+## `chainguard iam folders`
 
 Find out what folders are available to your organization with:
 
@@ -36,7 +36,7 @@ $ chainctl iam folders list chainguard.edu
 This command can also delete, describe, and update folders by replacing `list` with `delete`, `describe`, or `update`. See the reference guide for more details.
 
 
-## chainguard iam identities
+## `chainguard iam identities`
 
 To list all of the existing identities along with roles, types, and more, use:
 
@@ -47,7 +47,7 @@ chainctl iam identities list
 This command can also create, delete, describe, and update identities by replacing `list` with `create`, `delete`, `describe`, or `update`. See the reference guide for more details.
 
 
-## chainguard iam identity-providers
+## `chainguard iam identity-providers`
 
 This command enables you to manage your own identity management provider, such as a custom OIDC provider. To list all currently configured identity management providers, use:
 
@@ -58,7 +58,7 @@ chainctl iam identity-providers list
 This command can also create, delete, and update identity providers by replacing `list` with `create`, `delete`, or `update`. See the reference guide for more details.
 
 
-## chainguard iam invites
+## `chainguard iam invites`
 
 This command lets you manage invite codes that register identities with Chainguard. To list current invites, use:
 
@@ -72,7 +72,7 @@ This will return a list of invites by ID with information about the invite's exp
 This command can also create and delete invites by replacing `list` with `create` or `delete`. See the reference guide for more details.
 
 
-## chainctl iam organizations
+## `chainctl iam organizations`
 
 To list all of the organizations your account is associated with, use:
 
@@ -83,7 +83,7 @@ chainctl iam organizations list
 This command can also delete and describe organizations by replacing `list` with `delete` or `describe`. See the reference guide for more details.
 
 
-## chainctl iam roles
+## `chainctl iam roles`
 
 To list all of the roles your account is associated with, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-iam.md
+++ b/content/chainguard/chainctl-usage/chainctl-iam.md
@@ -1,0 +1,110 @@
+---
+title: "chainctl iam"
+lead: ""
+description: "chainctl iam basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "iam", "Product", "authentication", "access", "identity", "management"]
+images: []
+weight: 60
+---
+
+This page presents some of the more commonly used `chainctl iam` commands. These commands all relate to identity and access management (IAM), enabling your organization to control access to various resources and actions.
+
+For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+For the following, assume that returned information only includes that which your account has permissions to view. Also, actions such as `create` and `delete` are similarly limited.
+
+
+## chainguard iam folders
+
+Find out what folders are available to your organization with:
+
+```shell
+chainctl iam folders list $ORGANIZATION_NAME
+```
+
+For example, for our Developer Enablement team, which uses the `chainguard.edu` organization, the interaction looks like this:
+
+```shell
+$ chainctl iam folders list chainguard.edu
+[chainguard.edu] Developer Enablement images catalog
+```
+
+This command can also delete, describe, and update folders by replacing `list` with `delete`, `describe`, or `update`. See the reference guide for more details.
+
+
+## chainguard iam identities
+
+To list all of the existing identities along with roles, types, and more, use:
+
+```shell
+chainctl iam identities list
+```
+
+This command can also create, delete, describe, and update identities by replacing `list` with `create`, `delete`, `describe`, or `update`. See the reference guide for more details.
+
+
+## chainguard iam identity-providers
+
+This command enables you to manage your own identity management provider, such as a custom OIDC provider. To list all currently configured identity management providers, use:
+
+```shell
+chainctl iam identity-providers list
+```
+
+This command can also create, delete, and update identity providers by replacing `list` with `create`, `delete`, or `update`. See the reference guide for more details.
+
+
+## chainguard iam invites
+
+This command lets you manage invite codes that register identities with Chainguard. To list current invites, use:
+
+```shell
+chainctl iam invites list
+```
+
+This will return a list of invites by ID with information about the invite's expiration date, associated roles, and keyID.
+
+
+This command can also create and delete invites by replacing `list` with `create` or `delete`. See the reference guide for more details.
+
+
+## chainctl iam organizations
+
+To list all of the organizations your account is associated with, use:
+
+```shell
+chainctl iam organizations list
+```
+
+This command can also delete and describe organizations by replacing `list` with `delete` or `describe`. See the reference guide for more details.
+
+
+## chainctl iam roles
+
+To list all of the roles your account is associated with, use:
+
+```shell
+chainctl iam roles list
+```
+
+This command can also create, delete, and update identities by replacing `list` with `create`, `delete` or `update`.
+
+To find out what actions can be done by each role, use:
+
+```shell
+chainctl iam roles capabilities list
+```
+
+To find out about role bindings, use:
+
+```shell
+chainctl iam role-bindings list
+```
+
+This command can also create, delete, and update identities by replacing `list` with `create`, `delete` or `update`.
+
+See the reference guide for more details on each of these commands.

--- a/content/chainguard/chainctl-usage/chainctl-images.md
+++ b/content/chainguard/chainctl-usage/chainctl-images.md
@@ -14,7 +14,7 @@ weight: 70
 This page presents some of the more commonly used `chainctl images` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## chainctl images list
+## `chainctl images list`
 
 To see which Chainguard Images are available to your account, use:
 
@@ -25,7 +25,7 @@ chainctl images list
 Be warned, that list may take a while to generate and is likely to scroll past quickly in your command line terminal. You may prefer to direct the output into a file.
 
 
-## chainctl images repos list
+## `chainctl images repos list`
 
 For a list of image repositories available to your account, use:
 
@@ -34,7 +34,7 @@ chainctl images repos list
 ```
 
 
-## chainctl images diff
+## `chainctl images diff`
 
 This useful command enables you to compare two Chainguard images. To use it, enter:
 

--- a/content/chainguard/chainctl-usage/chainctl-images.md
+++ b/content/chainguard/chainctl-usage/chainctl-images.md
@@ -14,7 +14,7 @@ weight: 70
 This page presents some of the more commonly used `chainctl images` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## `chainctl images list`
+## chainctl images list
 
 To see which Chainguard Images are available to your account, use:
 
@@ -25,7 +25,7 @@ chainctl images list
 Be warned, that list may take a while to generate and is likely to scroll past quickly in your command line terminal. You may prefer to direct the output into a file.
 
 
-## `chainctl images repos list`
+## chainctl images repos list
 
 For a list of image repositories available to your account, use:
 
@@ -34,7 +34,7 @@ chainctl images repos list
 ```
 
 
-## `chainctl images diff`
+## chainctl images diff
 
 This useful command enables you to compare two Chainguard images. To use it, enter:
 

--- a/content/chainguard/chainctl-usage/chainctl-images.md
+++ b/content/chainguard/chainctl-usage/chainctl-images.md
@@ -1,0 +1,45 @@
+---
+title: "chainctl images"
+lead: ""
+description: "chainctl images basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "images", "Product"]
+images: []
+weight: 70
+---
+
+This page presents some of the more commonly used `chainctl images` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+
+## chainctl images list
+
+To see which Chainguard Images are available to your account, use:
+
+```shell
+chainctl images list
+```
+
+Be warned, that list may take a while to generate and is likely to scroll past quickly in your command line terminal. You may prefer to direct the output into a file.
+
+
+## chainctl images repos list
+
+For a list of image repositories available to your account, use:
+
+```shell
+chainctl images repos list
+```
+
+
+## chainctl images diff
+
+This useful command enables you to compare two Chainguard images. To use it, enter:
+
+```shell
+chainctl images diff $FROM_IMAGE $TO_IMAGE
+```
+
+There is a full docs page on this command. See <ins>[How To Compare Chainguard Images with chainctl](/chainguard/chainguard-images/how-to-use/comparing-images/)</ins> to learn more.

--- a/content/chainguard/chainctl-usage/chainctl-packages.md
+++ b/content/chainguard/chainctl-usage/chainctl-packages.md
@@ -13,7 +13,7 @@ weight: 80
 
 This page presents the most commonly used `chainctl packages` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
-## List Available Package Versions
+## `chainctl packages versions list`
 
 If you want to get details about the various package versions available that can be used in images, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-packages.md
+++ b/content/chainguard/chainctl-usage/chainctl-packages.md
@@ -1,0 +1,24 @@
+---
+title: "chainctl packages"
+lead: ""
+description: "chainctl packages basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "packages", "Product"]
+images: []
+weight: 80
+---
+
+This page presents the most commonly used `chainctl packages` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+## List Available Package Versions
+
+If you want to get details about the various package versions available that can be used in images, use:
+
+```shell
+chainctl packages versions list $PACKAGENAME
+```
+
+This will list all the versions that Chainguard has built and the end-of-life date for each version that has one assigned. It will also list older package versions that are no longer available.

--- a/content/chainguard/chainctl-usage/chainctl-packages.md
+++ b/content/chainguard/chainctl-usage/chainctl-packages.md
@@ -13,7 +13,7 @@ weight: 80
 
 This page presents the most commonly used `chainctl packages` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
-## `chainctl packages versions list`
+## chainctl packages versions list
 
 If you want to get details about the various package versions available that can be used in images, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-update.md
+++ b/content/chainguard/chainctl-usage/chainctl-update.md
@@ -1,0 +1,25 @@
+---
+title: "chainctl update"
+lead: ""
+description: "chainctl update basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "update", "Product"]
+images: []
+weight: 90
+---
+
+This page presents the most commonly used `chainctl update` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+
+## chainctl update
+
+To update your `chainctl` installation, use:
+
+```shell
+chainctl update
+```
+
+Updating requires administrative privileges, so be prepared to enter your machine's admin password.

--- a/content/chainguard/chainctl-usage/chainctl-update.md
+++ b/content/chainguard/chainctl-usage/chainctl-update.md
@@ -14,7 +14,7 @@ weight: 90
 This page presents the most commonly used `chainctl update` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## chainctl update
+## `chainctl update`
 
 To update your `chainctl` installation, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-update.md
+++ b/content/chainguard/chainctl-usage/chainctl-update.md
@@ -14,7 +14,7 @@ weight: 90
 This page presents the most commonly used `chainctl update` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## `chainctl update`
+## chainctl update
 
 To update your `chainctl` installation, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-version.md
+++ b/content/chainguard/chainctl-usage/chainctl-version.md
@@ -14,7 +14,7 @@ weight: 100
 This page presents the most commonly used `chainctl version` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## chainctl update
+## `chainctl version`
 
 To see which `chainctl` version you have installed, use:
 

--- a/content/chainguard/chainctl-usage/chainctl-version.md
+++ b/content/chainguard/chainctl-usage/chainctl-version.md
@@ -1,0 +1,61 @@
+---
+title: "chainctl version"
+lead: ""
+description: "chainctl version basics"
+type: "article"
+date: 2025-03-0620T08:49:15+00:00
+lastmod: 2025-03-0620T08:49:15+00:00
+draft: false
+tags: ["chainctl", "version", "Product"]
+images: []
+weight: 100
+---
+
+This page presents the most commonly used `chainctl version` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+
+## chainctl update
+
+To see which `chainctl` version you have installed, use:
+
+```shell
+chainctl version
+```
+
+This command tells you more than just a release number.
+
+```shell
+$ chainctl version
+
+               ▄▄▄▄▄▄▄▄▄▄▄              
+             ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄            
+           ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄          
+          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄         
+         ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄        
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄        
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄       
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄       
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄       
+        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄       
+     ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄    
+  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄ 
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄   ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄ 
+           ▄▄▄▄▄▄▄     ▄▄▄▄▄▄▄▄         
+
+   ____   _   _      _      ___   _   _    ____   _____   _
+  / ___| | | | |    / \    |_ _| | \ | |  / ___| |_   _| | |
+ | |     | |_| |   / _ \    | |  |  \| | | |       | |   | |
+ | |___  |  _  |  / ___ \   | |  | |\  | | |___    | |   | |___
+  \____| |_| |_| /_/   \_\ |___| |_| \_|  \____|   |_|   |_____|
+chainctl: Chainguard Control
+
+GitVersion:    v0.2.54
+GitCommit:     9a492e7ad02e4ac7bcb68060a004757ef6b74fee
+GitTreeState:  clean
+BuildDate:     2025-03-04T19:53:11Z
+GoVersion:     go1.24.0
+Compiler:      gc
+Platform:      linux/amd64
+```

--- a/content/chainguard/chainctl-usage/chainctl-version.md
+++ b/content/chainguard/chainctl-usage/chainctl-version.md
@@ -14,7 +14,7 @@ weight: 100
 This page presents the most commonly used `chainctl version` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
 
 
-## `chainctl version`
+## chainctl version
 
 To see which `chainctl` version you have installed, use:
 

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -45,7 +45,7 @@ chainctl auth configure-docker
 ```
 
 
-## Update chainctl to the Latest Release
+## Update `chainctl` to the Latest Release
 
 To see which `chainctl` version you have installed, use:
 
@@ -62,7 +62,7 @@ chainctl update
 Updating requires administrative privileges, so be prepared to enter your machine's admin password.
 
 
-## Configure chainctl
+## Configure `chainctl`
 
 `chainctl` comes with a default configuration, but there are aspects of it that can be adjusted. Examples include setting the registry location that will be used when one is not mentioned in an issued command. To edit the current configuration, use:
 

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -45,7 +45,7 @@ chainctl auth configure-docker
 ```
 
 
-## Update `chainctl` to the Latest Release
+## Update chainctl to the Latest Release
 
 To see which `chainctl` version you have installed, use:
 
@@ -62,7 +62,7 @@ chainctl update
 Updating requires administrative privileges, so be prepared to enter your machine's admin password.
 
 
-## Configure `chainctl`
+## Configure chainctl
 
 `chainctl` comes with a default configuration, but there are aspects of it that can be adjusted. Examples include setting the registry location that will be used when one is not mentioned in an issued command. To edit the current configuration, use:
 

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-0320T08:49:15+00:00
 draft: false
 tags: ["chainctl", "Getting Started", "Product", "Basics"]
 images: []
-weight: 100
+weight: 10
 ---
 
 This page presents some of the more commonly used basic `chainctl` commands to help you get started. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
@@ -26,7 +26,7 @@ This will present a list of identity providers for you to select from. Use the o
 
 To check your authentication status at any time, enter:
 
-```
+```shell
 chainctl auth status
 ```
 
@@ -34,13 +34,13 @@ This will list your identity and other attributes tied to your account, includin
 
 To create a pull token, use:
 
-```
+```shell
 chainctl auth pull-token
 ```
 
 To configure a Docker credential helper, which will use a token to pull images when using Docker, use:
 
-```
+```shell
 chainctl auth configure-docker
 ```
 
@@ -49,13 +49,13 @@ chainctl auth configure-docker
 
 To see which `chainctl` version you have installed, use:
 
-```
+```shell
 chainctl version
 ```
 
 To update your `chainctl` installation, use:
 
-```
+```shell
 chainctl update
 ```
 
@@ -66,13 +66,13 @@ Updating requires administrative privileges, so be prepared to enter your machin
 
 `chainctl` comes with a default configuration, but there are aspects of it that can be adjusted. Examples include setting the registry location that will be used when one is not mentioned in an issued command. To edit the current configuration, use:
 
-```
+```shell
 chainctl config edit
 ```
 
 If you make a mistake and can't recall the original settings, reset the configuration to default settings with:
 
-```
+```shell
 chainctl config reset
 ```
 
@@ -83,7 +83,7 @@ Learn more at [How to Manage chainctl Configuration](/chainguard/administration/
 
 To see which Chainguard Images are available to your account, use:
 
-```
+```shell
 chainctl images list
 ```
 
@@ -96,7 +96,7 @@ Let's say you want to compare two versions of an image for the same package. You
 
 Use this, where we show the repo used by our Chainguard Developer Education team and where both instances of `<image_name>` are the same:
 
-```
+```shell
 chainctl images diff cgr.dev/chainguard.edu/$IMAGENAME>:latest cgr.dev/chainguard.edu/$IMAGENAME:latest-dev
 ```
 
@@ -109,7 +109,7 @@ Learn more at [How To Compare Chainguard Images with chainctl](/chainguard/chain
 
 If you want to get details about the various package versions available that can be used in images, use:
 
-```
+```shell
 chainctl packages versions list $PACKAGENAME
 ```
 
@@ -120,7 +120,7 @@ This will list all the versions that Chainguard has built and the end-of-life da
 
 Commands may have a default format for output, but that doesn't mean you have to stick with it. There is an option available to tell `chainctl` the output format to use, like this:
 
-```
+```shell
 chainctl $COMMAND -o $FORMAT
 ```
 


### PR DESCRIPTION
## Type of change
Docs addition

The new chainctl Usage section in the docs looks empty. I pushed myself a bit to get these pages done enough to push live. There is more that can be done in the future, but this is a solid foundation to get the new section going.