### PR TITLE
Add Chainguard Libraries for Java documentation

### DIFF
--- a/content/chainguard/libraries/_index.md
+++ b/content/chainguard/libraries/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Chainguard Libraries"
+linkTitle: "Libraries"
+description: "Libraries for your application development"
+type: "article"
+draft: false
+weight: 001
+---

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -1,0 +1,117 @@
+---
+title: "Chainguard Libraries Access"
+linktitle: "Access"
+type: "article"
+description: "Getting access to Chainguard Libraries"
+draft: false
+tags: ["Chainguard Libraries", "Overview"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 002
+toc: true
+---
+
+Access to Chainguard Libraries is consistent across all permissions and accounts
+across the Chainguard platform.
+
+If you are not a Chainguard user yet, a new Chainguard account must be created
+and configured for access to Chainguard Libraries.
+
+If you are already a Chainguard user, the Chainguard account owner in your
+organization can grant access to Chainguard Libraries.
+
+In both cases confirm the name of the organization so you can use it with the
+`--parent` parameter to specify the organization.
+
+Once your user account is created and access is confirmed, [install the
+Chainguard Control `chainctl` command line
+tool](/chainguard/administration/how-to-install-chainctl/) and login to your
+account:
+
+```shell
+chainctl auth login
+```
+
+After authentication in a browser window, a successful login displays a message
+and a token:
+
+```shell
+Successfully exchanged token.
+Valid! Id: 8a4141a........7d9904d98c
+```
+
+Retrieve an authentication token for the Chainguard Libraries for Java:
+
+```shell
+chainctl auth pull-token --library-ecosystem=java --parent=example --ttl=8670h
+```
+
+* `--library-ecosystem=java`: retrieve the token for use with Chainguard
+  Libraries for Java
+* `--parent=example`: specify the parent organization for your account as
+  provided when requesting access to Chainguard Libraries for Java and the
+  replace `example`.
+* `--ttl=8670d`: set the duration for the validaty of the token, defaults to
+  `720h` (equivalent to 30 days), maximum valid value is `8760d` (equivalent to
+  365 days), valid unit strings range from nanoseconds to hours and are `ns`,
+  `us`, `ms`, `s`, `m`, and `h`.
+
+When omitting the parent parameter, potentially a list of organizations is
+displayed. Use the arrow keys to navigate the selection displayed after the
+question “With which location is the pull token associated?” and select the
+organization that has the entitlement to access Chainguard Libraries for Java.
+Press `/` to filter the list.
+
+`chainctl` returns a username and password suitable for basic authentication in
+the response:
+
+```shell
+Username: 45a.....424eb0
+
+Password: eyJhbGciO..........WF0IjoxN
+```
+
+To use this pull token in another environment supply the following for username
+and password valid for basic authentication. Note that the actual returned
+values are much longer.
+
+You can verify entitlements with the following command:
+
+```shell
+chainctl libraries entitlements list --parent=example
+```
+
+The output must include the Java ecosystem in the table:
+
+```shell
+Ecosystem Library Entitlements for chainguard.edu (45a0...764595)
+
+                             ID                             | ECOSYSTEM
+------------------------------------------------------------+------------
+  45a....................................................e1 | JAVA
+```
+
+Contact your Chainguard account owner for confirmation or adjustments if
+necessary. 
+
+<!-- Removed for now until we decide where this info should live. It is only accessible
+for administrators (so Chainguard internal), but they might also be an audience to 
+read the docs - so TBD
+
+As administrator you can create entitlements:
+
+```shell
+chainctl libraries entitlements create --ecosystems=java,python --parent=example
+```
+
+Use the` --parent` option to specify the organization or select the organization
+when running the command.
+
+With the ID from listing the entitlements detailed in the preceding section, you
+can also remove a Chainguard Libraries entitlement:
+
+```shell
+chainctl libraries entitlements rm ENTITLEMENT_ID
+```
+-->

--- a/content/chainguard/libraries/faq.md
+++ b/content/chainguard/libraries/faq.md
@@ -1,0 +1,39 @@
+---
+title: "Chainguard Libraries FAQ"
+linktitle: "FAQ"
+type: "article"
+description: "Frequently asked questions and answers for Chainguard Libraries users"
+draft: false
+tags: ["Chainguard Libraries", "Overview"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 003
+toc: true
+---
+
+## Does Chainguard Libraries for Java include CVE remediation fixes?
+
+Short answer: 
+
+No. Libraries are built from source code in the secured and hardened Chainguard
+infrastructure. This eliminates any build and distribution stage
+vulnerabilities.
+
+More details:
+
+Chainguard cannot patch Java libraries and create binaries with the same
+identifier because the complete behavior and API surface of every library
+affects the use. That use however is part of the application development of each
+customer. It varies widely and any change potentially creates incompatibilities,
+different behavior or even new security issues. 
+
+Chainguard collaborates with many upstream projects and can collaborate with
+customers to increase and accelerate the creation and adoption of fixes and the
+work towards new releases.
+
+Importantly [over 95% of all known vulnerable components have a fixed version
+available](https://www.sonatype.com/blog/are-unnecessary-vulnerabilities-polluting-your-software-supply-chain)
+and by adopting those newer versions in your application you can remediate most
+CVEs. Chainguard Libraries for Java includes those newest versions and adds the
+build and distribution channel security.

--- a/content/chainguard/libraries/java/_index.md
+++ b/content/chainguard/libraries/java/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Chainguard Libraries for Java"
+linkTitle: "Java"
+description: "Java libraries for your application development"
+type: "article"
+draft: false
+weight: 050
+---

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -1,0 +1,246 @@
+---
+title: "Build Configuration"
+linktitle: "Build Configuration"
+type: "article"
+description: "Configuring Chainguard Libraries for Java on your workstation"
+draft: false
+tags: ["Chainguard Libraries", "Java"]
+menu:
+  docs:
+    parent: "java"
+weight: 053
+toc: true
+---
+
+The configuration for the use of Chainguard Libraries depends on your build
+tools, continuous integration, and continuous deployment setups
+
+At a high level adopting the use of Chainguard Libraries consists of the
+following steps:
+
+* Remove local caches on workstations and CI/CD pipelines. This step ensures that
+  any libraries that were already sourced from other repositories are requested
+  again and the version from Chainguard Libraries is used instead of other
+  binaries.
+* Change configuration to access Chainguard Libraries via your repository
+  manager after the changes from the [global
+  configuration](/chainguard/libraries/java/global-configuration) are
+  implemented.
+
+These changes must be performed on all workstations of individual developers and
+other engineers running relevant application builds. They must also be performed
+on any build server such as Jenkins, TeamCity, GitHub or other infrastructure
+that builds the applications or otherwise downloads and uses relevant libraries.
+
+## Cloudsmith
+
+Build configuration to retrieve artifacts from Cloudsmith requires you to
+authenticate. Use your username and password for Cloudsmith in your build tool
+configuration.
+
+## JFrog Artifactory
+
+Build configuration to retrieve artifacts from Artifactory typically requires
+you to authenticate and use the identity token in the configuration of your
+build tool:
+
+1. Log in as user with access to the configured virtual repository.
+1. Select **Edit Profile** from the drop down in the top right corner from your
+   user name.
+1. Press **Generate Identity Token**.
+1. Provide a description such as *Chainguard Libraries* for the token as a
+   reminder for the use of the token.
+1. Copy the token value and use it as your password in your build tool
+   configuration.
+
+## Sonatype Nexus Repository
+
+Build configuration to retrieve artifacts from Nexus requires you to
+authenticate. Use your username and password for Nexus in your build tool
+configuration.
+
+## Apache Maven
+
+[Apache Maven](https://maven.apache.org/) is the most widely used build tool in
+the Java ecosystem. 
+
+### Remove Maven Caches
+
+Apache Maven uses a local cache of libraries. When adopting Chainguard Libraries
+for Java you must delete that local cache so that libraries are downloaded
+again. By default the cache, also known as the local repository, is located in a
+hidden `.m2/repository` directory in your user's home directory. Use the
+following command to delete it:
+
+```shell
+rm -rf ~/.m2/repository
+```
+
+### Change Maven Configuration
+
+Before running a new build you must configure access to the Chainguard Libraries
+for Java. If the administrator for your organization’s repository manager
+created a new repository or virtual repository or group repository, you must
+update your settings defined in `~/.m2/settings.xml`.
+
+A typical setup defines a global mirror (id `ecosystems`) for all artifacts and
+configures the URL of the repository group or virtual repository from your
+repository manager `https://repo.example.com/group/`. Since the group or virtual
+repository combines release and snapshot artifacts you must override the
+built-in `central` repository and its configuration in an automatically
+activated profile.
+
+
+```xml
+<settings>
+
+  <mirrors>
+    <mirror>
+      <!--Send all requests to the repository manager -->
+      <id>ecosystems</id>
+      <mirrorOf>*</mirrorOf>
+      <url>https://repo.example.com/group/</url>
+    </mirror>
+  </mirrors>
+
+  <activeProfiles>
+    <activeProfile>ecosystems</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>ecosystems</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>
+```
+
+If your repository manager requires authentication, you must specify credentials
+for the server. The id value in the server element must match the id value in
+the mirror configuration. The username and password values vary depending on the
+repository manager and the configured authentication.
+
+```xml
+<settings>
+...
+
+  <servers>
+    <server>
+      <id>ecosystems</id>
+      <username>YOUR_USERNAME_FOR_REPOSITORY_MANAGER</username>
+      <password>YOUR_PASSWORD</password>
+    </server>
+  </servers>
+
+....
+</settings>
+
+```
+
+Refer to the [official documentation for the Maven settings
+file](https://maven.apache.org/settings.html) for more details.
+
+If the administrator only re-configured the existing repository group or virtual
+repository, you can trigger a build to initiate use of Chainguard Libraries for
+Java.
+
+If you are not using a repository manager at your organization, you can
+configure access to the Chainguard Libraries for Java repository directly in
+your settings or pom files. Note that the order of the repositories in these
+files is significant and you must configure the chainguard repository to be
+located on the top of the list.
+
+## Gradle
+
+[Gradle](https://gradle.org/) is a commonly used build tool in the Java
+ecosystem.
+
+### Remove Gradle Caches
+
+Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
+Java you must delete that local cache so that libraries are downloaded again. By
+default the cache is located in a hidden `.gradle/.cache` directory in your
+users home directory. Use the following command to delete it:
+
+```shell
+rm -rf ~/.gradle/caches/
+```
+
+Gradle can also be configured to use a local Maven repository with a repository
+configuration in the global `init.gradle` or a project specific `build.gradle`
+file:
+
+```
+repositories {
+   ...
+    mavenLocal()    
+}
+```
+
+If this configuration is used, ensure to [delete the local Maven repository as
+well](#remove-maven-caches). 
+
+### Change Gradle Configuration
+
+Global configuration for artifact download is Gradle can be performed in an
+[init
+script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
+using the repositories definition. Each project can also [declare
+repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
+separately.
+
+Configure the Chainguard Libraries for Java repository with the credentials from
+[Chainguard Libraries access](/chainguard/libraries/access/). Ensure that the
+chainguard repository is located above the mavenCentral repository.
+
+```
+repositories {
+    maven {
+        url = uri("https://libraries.cgr.dev/maven/")
+        credentials {
+            username = "longhash"
+            password = "longerhash"
+        }
+    }
+    mavenCentral()
+}
+```
+
+## Other Build Tools
+
+Other build tools such as [Apache Ant](https://ant.apache.org/) with the [Maven
+Artifact Resolver Ant Tasks](https://maven.apache.org/resolver-ant-tasks/),
+[sbt](https://www.scala-sbt.org/), [Bazel](https://bazel.build/),
+[Leiningen](https://leiningen.org/) and others use Maven or Gradle caches or
+similar approaches. Refer to the documentation of your specific tool and the
+preceding sections to determine how to remove any used caches.
+
+These tools also include their own mechanisms to configure repositories for
+binary artifact retrieval. Consult the specific documentation and adjust your
+configuration to use your repository manager and newly created repository group
+or virtual repository.

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -1,0 +1,212 @@
+---
+title: "Global Configuration"
+linktitle: "Global Configuration"
+type: "article"
+description: "Configuring Chainguard Libraries for Java in your organization"
+lead: "lead tbd"
+draft: false
+tags: ["Chainguard Libraries", "Java"]
+images: []
+menu:
+  docs:
+    parent: "java"
+weight: 052
+toc: true
+---
+
+Java and JVM library consumption in a large organization is typically managed by
+a repository manager. Commonly used repository manager applications are
+[Cloudsmith](https://cloudsmith.com/), [JFrog
+Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus
+Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
+repository manager acts as a single point of access for developers and
+development tools to retrieve the required libraries.
+
+At a high level, adopting the use of Chainguard Libraries consists of the the
+following steps:
+
+* Add Chainguard Libraries as a remote repository for library retrieval.
+* Configure the Chainguard Libraries repository as the first choice for any
+  library access. This ensures that any future requests of new libraries access
+  the version supplied by Chainguard. Typically this is accomplished by creating a
+  group repository or virtual repository that combines the repository with other
+  external and internal repositories.
+
+Additional steps depend on the desired insights and can include the following
+optional measures:
+
+* Remove all cached artifacts in the proxy repository of Maven Central and other
+  repositories. This step allows you to validate which libraries are not
+  available from Chainguard Libraries and proceed with potential next steps with
+  Chainguard and your own development efforts. 
+* Remove any repositories that are no longer desired or necessary. Depending on
+  your library requirements this step can result in removal of some proxy
+  repositories or even removal of all proxy repositories. 
+
+Adopting the use of a repository manager is the recommended approach, however if
+your organization does not use a repository manager, you can still use
+Chainguard Libraries. All access to the Chainguard libraries repository is then
+distributed across all your build platforms and therefore more complex to
+configure and control. 
+
+## Cloudsmith
+
+[Cloudsmith](https://cloudsmith.com/) supports Maven repositories for proxying
+and hosting. Refer to the [Maven Repository
+documentation](https://help.cloudsmith.io/docs/maven-repository) and the [Maven
+Upstream
+documentation](https://help.cloudsmith.io/docs/upstream-proxying-caching#create-a-maven-upstream)
+for Cloudsmith for more information. Cloudsmith supports combining repositories
+by defining multiple upstream repositories.
+
+Use the following steps to add a repository with the Maven Central Repository
+and the Chainguard Libraries for Java repository as Maven upstream repositories. 
+
+1. Log in as a user with administrator privileges.
+1. Select the **Repositories** tab near the top of the screen.
+1. On the **Repositories** page, click the **+ New Repository** button.
+1. Enter the name *maven* for your new repository. The name should include
+   *maven* to identify the repository format. This convention helps avoiding
+   confusion since repositories in Cloudsmith are multi-format.
+1. Press **+ Create Repository**. 
+1. Click the name of the new repository on the repositories page to configure
+   it.
+1. Access the **Upstreams** tab and click **+ Add Upstream Proxy** and proceed
+   to configure two upstream proxies.
+1. Configure an upstream proxy with the following details:
+    * **Name** *chainguard* 
+    * **Priority** *1*
+    * **Upstream URL** *https://libraries.cgr.dev/maven/*
+    * **Mode** *Cache and Proxy*
+    * Add the **Username** and **Password** value from [Chainguard Libraries
+      access](/chainguard/libraries/access/) in **Authentication**
+1. Press **Create Maven Upstream**.
+1. Configure another upstream proxy with the following details
+    * **Name** *central* 
+    * **Priority** *2*
+    * **Upstream URL** *https://repo1.maven.org/maven2/*
+    * **Mode** *Cache and Proxy*
+1. Press **Create Maven Upstream**.
+
+Use this setup for initial testing with Chainguard Libraries for Java. For
+production usage add the `chainguard` upstream proxy to your production
+repository.
+
+Use the URL of the repository in the [build
+configuration](/chainguard/libraries/java/build-configuration) and build a
+first test project. In a working setup all libraries retrieved from Chainguard
+are tagged with the name of the upstream proxy.
+
+## JFrog Artifactory
+
+[JFrog Artifactory](https://jfrog.com/artifactory/) supports Maven repositories
+for proxying and hosting, and virtual repositories to combine them. Refer to the
+[Maven Repository documentation for
+Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/maven-repository)
+for more information.
+
+Use the following steps to add the Maven Central Repository and the Chainguard
+Libraries for Java repository as remote repositories and combine them as a
+virtual repository:
+
+1. Log in as a user with administrator privileges.
+1. Press **Administration** in the top navigation bar.
+1. Select **Repositories** in the left hand navigation.
+
+Configure a remote repository for the Maven Central Repository:
+
+1. Press **Create repository**.
+1. Select *Maven* as the Package type.
+1. Set the **Repository Key** to *maven-central*.
+1. Set the **URL** to *https://repo1.maven.org/maven2/*.
+1. Press Create Remote Repository.
+
+Configure a remote repository for the Chainguard Libraries for Java repository:
+
+1. Press **Create repository**.
+1. Select *Maven* as the **Package type**.
+1. Set the **Repository Key** to *chainguard*.
+1. Set the **URL** to *https://libraries.cgr.dev/maven/*.
+1. Set **User Name** and Password / Access Token to the [values as retrieved
+   with chainctl](/chainguard/libraries/access/).
+1. Press Test to validate the connection.
+1. Press Create Remote Repository.
+
+Combine the two repositories in a new virtual repository:
+
+1. Press **Create repository**.
+1. Select **Virtual**
+1. Set the **Repository Key** to *java*.
+1. In the **Repositories** input, add the *chainguard* and *maven-central*
+   repositories so that the chainguard repository is the first in the displayed
+   list.
+1. Press **Create Virtual Repository**.
+
+Use this setup for initial testing with Chainguard Libraries for Java. For
+production usage add the `chainguard` repository to your production virtual
+repository.
+
+Use the URL of the virtual repository in the [build
+configuration](/chainguard/libraries/java/build-configuration) and build a first
+test project. In a working setup the chainguard remote repository contains all
+libraries retrieved from Chainguard.
+
+## Sonatype Nexus Repository
+
+[Sonatype Nexus
+Repository](https://www.sonatype.com/products/sonatype-nexus-repository)
+includes a *maven-public* repository group out of the box. It groups access to
+the Maven Central Repository from the *maven-central* repository with the
+internal *maven-releases* and *maven-snapshot* repositories. Refer to the [Maven
+Repositories documentation for
+Nexus](https://help.sonatype.com/en/maven-repositories.html) for more
+information.
+
+If you are using this group, you can add a proxy repository for Chainguard
+Libraries for Java repository for production use.
+
+For initial testing and adoption it is advised to create a separate proxy
+repository for the Maven Central Repository, a separate proxy repository
+Chainguard Libraries for Java repository, and a separate repository group:
+
+1. Log in as a user with administrator privileges.
+1. Access the **Server administration** and configuration section with the gear
+   icon in the top navigation bar.
+
+Configure a remote repository for the Maven Central Repository:
+
+1. Select **Repository - Repositories** in the left hand navigation.
+1. Press **Create repository**.
+1. Select the **maven2 (proxy)** recipe.
+1. Provide a new name *central*.
+1. In the **Proxy - Remote storage** input add the URL *https://repo1.maven.org/maven2/*.
+1. Press **Create repository**.
+
+Configure a remote repository for the Chainguard Libraries for Java repository:
+
+1. Select **Repository - Repositories** in the left hand navigation.
+1. Press **Create repository**.
+1. Select the **maven2 (proxy)** recipe.
+1. Provide a new name *chainguard*.
+1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven*.
+1. In **HTTP - Authentication** with the **Authentication type** *username*,
+   provide the [username and password values as retrieved with
+   chainctl](/chainguard/libraries/access/).
+1. Press **Create repository**. 
+
+Combine a new repository group and add the two repositories:
+
+1. Select **Repository - Repositories** in the left hand navigation.
+1. Press **Create repository**.
+1. Select the **maven2 (group)** recipe.
+1. Provide a new name *chainguard-group*.
+1. In the section **Group - Member repositories**, move the new repositories
+   `central` and `chainguard` to the right and move the `chainguard` repository
+   to the top of the list with the arrow control.
+
+Use the URL of the repository group, such as
+*https://repo.example.com/repository/chainguard-group/* or
+*https://repo.example.com/repository/maven-public/* in the [build
+configuration](/chainguard/libraries/java/build-configuration) and build a first
+test project. In a working setup the `chainguard` proxy repository contains all
+libraries retrieved from Chainguard.

--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -1,0 +1,65 @@
+---
+title: "Management and Maintenance"
+linktitle: "Management"
+type: "article"
+description: "Working with your Chainguard Libraries for Java use"
+draft: false
+tags: ["Chainguard Libraries", "Java"]
+images: []
+menu:
+  docs:
+    parent: "java"
+weight: 053
+toc: true
+---
+
+After the initial [global
+configuration](/chainguard/libraries/java/global-configuration/) and [build
+configuration](/chainguard/libraries/java/build-configuration/) the use of
+Chainguard Libraries for Java is transparently in progress. Newly use artifacts
+from new projects or new artifact versions are automatically retrieved from the
+Chainguard repository as they are available and the Maven Central Repository and
+other configure repositories serve as backstop to provide any additionally
+needed artifacts.
+
+The following sections detail optional management, maintenance, and auditing
+steps on the repository manager and the build tool.
+
+## Source Verification
+
+You can verify what artifacts are retrieved from the Chainguard Libraries
+repository on a global level:
+
+* Browse the proxy repository on your Artifactory or Nexus server.
+* Browse the Maven repository on your Cloudsmith instance and locate the
+  artifacts with the tag from the Chainguard upstream proxy. The tag uses the
+  name of the upstream proxy.
+
+Use the browsing access to locate specific artifacts and identify their name,
+filesize, checksum values, timestamp and other identifiers. With these details
+you can verify your libraries use in the following locations:
+
+* Local cache repositories on developer workstation
+* Cache repositories in your CI pipeline
+* Libraries in your application bundles
+* Installed applications on your hosts or in your container images
+
+## Increase Chainguard Library Use
+
+The number of available artifacts in Chainguard Libraries for Java increases
+over time. If an artifact was already retrieved from the Maven Central
+Repository and is available in your repository manager or local repository it is
+not automatically replaced with the equivalent Chainguard Library version. 
+
+You can force a download of new libraries by erasing them from your local
+repositories on your workstations and the Maven Central proxy repository in your
+repository manager. Both these repositories are caches only and it is therefore
+safe to delete them.
+
+After the deletion any new build retrieves the artifact again and attempts to
+download from the Chainguard repository. As a result, newly available artifacts
+replace old artifacts that originated from Maven Central and your use of
+Chainguard Libraries increased.
+
+For a more fine-grained approach you can also delete subsections of local
+repositories and the proxy repositories.

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -1,0 +1,129 @@
+---
+title: "Chainguard Libraries for Java Overview"
+linktitle: "Java Overview"
+type: "article"
+description: "Java libraries for your application development"
+draft: false
+tags: ["Chainguard Libraries", "Java", "Overview"]
+menu:
+  docs:
+    parent: "java"
+weight: 051
+toc: true
+---
+
+## Introduction
+
+**Chainguard Libraries for Java** represents the first ecosystem support with
+[Chainguard Libraries](/chainguard/libraries/overview/). The Java and larger JVM
+ecosystem consists of hundreds of open source projects from large foundations
+such as the Apache Software Foundation, the Eclipse Foundation, and many smaller
+foundations and projects. 
+
+Chainguard Libraries for Java provides access to all open source libraries
+commonly used. New releases of common libraries or artifacts requested by
+customers are added to the growing index by an automated system. The number of
+included libraries continues to grow.
+
+The main public repository for binary artifacts is the [Maven Central
+Repository](https://central.sonatype.com/). It has been in operation for  nearly
+20 years and hosts artifacts of all releases of most open source projects in the
+Java community.  It is the default repository in all commonly used build tools
+from the Java community including [Apache Maven](https://maven.apache.org/),
+[Gradle](https://gradle.org/), and others and uses the Maven repository format.
+Chainguard Libraries for Java covers all open source artifacts from Maven
+Central.
+
+Chainguard Libraries for Java also builds binaries for many other open source
+projects available in other repositories or on code hosting platforms like
+GitHub. Examples include Google, Oracle, JetBrains, CERN, Apache, and many
+others. Any request for library or library version missing in the Chainguard
+Libraries, automatically triggers a process to provision the artifacts from
+relevant sources if available. 
+
+You can use Chainguard Libraries for Java alongside third-party software
+repositories to create a single source of truth with your repository manager
+application. 
+
+## Technical Details
+
+The [username and password retrieved with
+chainctl](/chainguard/libraries/access/) are required to access the Chainguard
+Libraries for Java repository. The URL for the repository is:
+
+```
+https://libraries.cgr.dev/maven/
+```
+
+The URL does not expose a browsable directory structure, however if you know the
+location of any particular artifact you can use the login credentials and a set
+path URL to access a file.
+
+This Chainguard Libraries for Java repository uses the Maven repository format
+and only includes release artifacts of the libraries built by Chainguard from
+source. Snapshot versions are not available.
+
+For example, you can locate a Maven POM file on the Maven Central Repository:
+
+```
+https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+And then use the path composed from the Maven coordinates
+
+```
+commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+And combine it with the URL for the Chainguard Libraries for Java repository to
+check for the presence of the same file:
+
+```
+https://libraries.cgr.dev/maven/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+Use the [Maven Central Repository search](https://central.sonatype.com/) or
+[browse functionality](https://repo1.maven.org/maven2/) to locate artifacts of
+interest.
+
+The Chainguard Libraries for Java repository does not include all artifacts from
+the Maven Central Repository and other repositories.
+
+Specifically the following components can be required by your application
+builds, yet are not included:
+
+* Binary versions of closed-source libraries. The Maven Central Repository and
+  other repositories often include such libraries. They enable interoperability
+  with open source applications and development of internal applications as a
+  combination of these libraries and other open source libraries. Examples include
+  JDBC drivers for proprietary databases such as Oracle
+* Other artifacts that are found in the Maven Central Repository with incomplete
+  information about the location of the source code or a pointer to a location
+  with access restrictions or an incomplete source, that prevents creation of a
+  binary by Chainguard.
+
+Some types of artifacts are included if the source build produces them, but are
+often not available:
+
+* Source JAR artifacts
+* Javadocs JAR artifacts
+* Distributable versions of artifacts such JARs with dependencies or tar.gz archives
+* Other package formats sometimes found such as RPMs, SO files, Android AARs,
+  and similar rarely used artifacts
+
+As a result you must configure the repository as the first point of contact and
+request for any retrieval of a library. This ensures that any library that is
+available from Chainguard is also used. In addition, any failed requests are
+flagged at Chainguard and backfill processes are run where possible.
+
+At the same time you must continue to use the Maven Central Repository, and any
+other repository that fills the needs for libraries that are not available from
+the Chainguard Libraries repository.
+
+Typically the access is [configured globally on a repository manager for your
+organization](/chainguard/libraries/java/global-configuration/). This approach
+is strongly recommended. 
+
+Alternatively, you can use the token for direct access from a build tool as
+discussed in [Build
+configuration](/chainguard/libraries/java/build-configuration/).

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -1,0 +1,81 @@
+---
+title: "Chainguard Libraries Overview"
+linktitle: "Libraries Overview"
+type: "article"
+description: "Software libraries for your application development"
+draft: false
+tags: ["Chainguard Libraries", "Overview"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 001
+toc: true
+---
+
+## Background
+
+Most application development rests on the shoulders of libraries and
+applications from the open source community. Most of the time organizations and
+application developers consume those libraries as binaries from a collection of
+sources. Binary versions are produced by individual project maintainers or
+through continuous integration server setups, and are publicly distributed
+through various channels. Open source libraries use different distribution
+services for their binary artifacts. Common examples are the [Maven Central
+Repository](https://central.sonatype.com/) for the Java and JVM ecosystem, the
+[npm registry](https://www.npmjs.com/) for the JavaScript community, or [Python
+Package Index (PyPI)](https://pypi.org/) for the Python community. All
+ecosystems also include numerous other repositories with lower usage rates, but
+also often reduced quality, oversight, or security.
+
+While convenient, these services remove the direct link from your application to
+the source code of a specific project, and create a potential risk for quality
+issues with the artifacts, man-in-middle attacks, removal or override of
+libraries with vulnerable or malicious versions, and other issues. The
+[Supply-chain Levels for Software Artifacts SLSA](https://slsa.dev/)
+specification describes these risks and how to protect your software against
+them.
+
+In this common use of open source via binary artifacts you put tremendous trust
+into the following aspects for the dozen or even hundreds of open source
+libraries you typically use for each application:
+
+* Maintainers and specifically release managers of the projects
+* Local workstation or CI setup used for the release build
+* Release process mechanisms to create the binaries
+* Transport of the binaries from the build system to the public repositories
+* Management of access to the repositories
+* Monitoring of repositories for attacks as well as harmful or malicious binaries
+* Traffic to public repositories and attacks on the transport to your infrastructure
+
+There are no real guarantees as to the actual provenance of the software code.
+Repositories also vary greatly in quality and there is no guarantee that the
+upstream source of a project is available in a repository. In addition, these
+repositories also hold non-open source binaries of libraries.
+
+All these factors create uncertainty. Using these public repositories can feel
+as opaque as picking up a USB drive off of the sidewalk and plugging its
+contents into our production environment.
+
+## Introduction 
+
+Chainguard Libraries builds all available libraries from source code in the
+secure Chainguard infrastructure and makes them available for you. It removes
+all the software supply chain problems for libraries:
+
+* Build stage protection - All binary libraries and library versions are built
+  within the trusted Chainguard infrastructure directly from the source code of
+  the official project. 
+* Distribution stage protection - Binaries are handled and managed only by
+  Chainguard and made exclusively available for your consumption.
+* Any supply chain attacks at build and distribution are eliminated, since all
+  steps from the source to your use are handled by Chainguard 
+* If there is no open source code available, no binaries are made available by
+  Chainguard. This eliminates any license-related risks from commercial
+  libraries. The policy and process to have no binaries without source also
+  removes the danger from malicious artifacts, since these artifacts do not
+  provide source code in public code repositories.
+
+Chainguard Libraries is available for the following library ecosystems:
+
+* Java and the larger Java Virtual Machine (JVM) with [Chainguard Libraries for
+  Jave](/chainguard/libraries/java/overview)


### PR DESCRIPTION
## Type of change

Addition of new documentation

### What should this PR do?

Add new section "Libraries" for the documentation of Chainguard Libraries for Java and future additions.

Implements https://github.com/chainguard-dev/internal/issues/4763

### Why are we making this change?

Need to provide info for users

### What are the acceptance criteria? 

* Review approval
* Wait for 25th of March, 5am PST at least before merge

### How should this PR be tested?

Read and review. All the chainctl and global config can be tested with a local Nexus or Artifactory instance and a Maven build. I can also demo.