### PR TITLE
Capitalize 'AS' in Dockerfile examples

### DIFF
--- a/content/chainguard/chainguard-images/about/getting-started-distroless.md
+++ b/content/chainguard/chainguard-images/about/getting-started-distroless.md
@@ -58,7 +58,7 @@ The following Dockerfile will build a final distroless image using two distinct 
 
 ```dockerfile
 # syntax=docker/dockerfile:1.4
-FROM cgr.dev/chainguard/gcc-glibc:latest as build
+FROM cgr.dev/chainguard/gcc-glibc:latest AS build
 
 COPY <<EOF /hello.c
 #include <stdio.h>

--- a/content/chainguard/chainguard-images/getting-started/python.md
+++ b/content/chainguard/chainguard-images/getting-started/python.md
@@ -243,7 +243,7 @@ The following Dockerfile will:
 Copy this configuration to your own Dockerfile:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/python:latest-dev as builder
+FROM cgr.dev/chainguard/python:latest-dev AS builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/content/chainguard/chainguard-images/getting-started/ruby.md
+++ b/content/chainguard/chainguard-images/getting-started/ruby.md
@@ -237,7 +237,7 @@ The following Dockerfile will:
 Copy this content to your own `Dockerfile`:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/ruby:latest-dev as builder
+FROM cgr.dev/chainguard/ruby:latest-dev AS builder
 
 ENV GEM_HOME=/work/vendor
 ENV GEM_PATH=${GEM_PATH}:/work/vendor

--- a/content/chainguard/chainguard-images/getting-started/wordpress.md
+++ b/content/chainguard/chainguard-images/getting-started/wordpress.md
@@ -231,7 +231,7 @@ This demo includes a theme ([Cue](https://wordpress.org/themes/cue/), a simple b
 Navigate to the `03-distroless` directory to follow along. This is what the Dockerfile included in this directory looks like:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/wordpress:latest-dev as builder
+FROM cgr.dev/chainguard/wordpress:latest-dev AS builder
 #trigger wp-config.php creation
 ENV WORDPRESS_DB_HOST=foo
 

--- a/content/chainguard/chainguard-images/how-to-use/static-base-image.md
+++ b/content/chainguard/chainguard-images/how-to-use/static-base-image.md
@@ -28,7 +28,7 @@ toc: true
 ## Dockerfile
 
 ```Dockerfile
-FROM cgr.dev/chainguard/go as build
+FROM cgr.dev/chainguard/go AS build
 
 
 COPY main.go /main.go

--- a/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
@@ -112,7 +112,7 @@ Renovate also supports updating image references that are pinned to digests. Thi
 As an example, for the following Dockerfile Renovate opened two similar pull requests:
 
 ```
-FROM cgr.dev/chainguard/go:latest-dev@sha256:ff187ecd4bb5b45b65d680550eed302545e69ec4ed45f276f385e1b4ff0c6231 as builder
+FROM cgr.dev/chainguard/go:latest-dev@sha256:ff187ecd4bb5b45b65d680550eed302545e69ec4ed45f276f385e1b4ff0c6231 AS builder
 
 WORKDIR /work
 

--- a/content/chainguard/migration/migration-guides/migrating-node.md
+++ b/content/chainguard/migration/migration-guides/migrating-node.md
@@ -178,7 +178,7 @@ We can still do better in terms of size and security. A multi-stage Dockerfile w
 
 
 ```Docker
-FROM cgr.dev/chainguard/node:latest-dev as builder
+FROM cgr.dev/chainguard/node:latest-dev AS builder
 
 ENV NODE_ENV production
 

--- a/content/chainguard/migration/migration-guides/migrating-python.md
+++ b/content/chainguard/migration/migration-guides/migrating-python.md
@@ -54,7 +54,7 @@ The below Dockerfile provides an example of such a multi-stage build for a simpl
 ```Dockerfile
 # syntax=docker/dockerfile:1
 
-FROM cgr.dev/chainguard/python:latest-dev as dev
+FROM cgr.dev/chainguard/python:latest-dev AS dev
 
 WORKDIR /flask-app
 

--- a/content/chainguard/migration/porting-apps-to-chainguard/index.md
+++ b/content/chainguard/migration/porting-apps-to-chainguard/index.md
@@ -250,7 +250,7 @@ Ideally, we would use the `cgr.dev/chainguard/node:latest` image for this, but w
 To do this, replace the Dockerfile with the following:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/node:latest-dev as build
+FROM cgr.dev/chainguard/node:latest-dev AS build
 
 USER root
 RUN apk update && apk add \
@@ -322,7 +322,7 @@ We're most of the way now, but there are still a couple of finishing touches to 
 The `tini` binary will run as PID 1, launch npm as a subprocess and take care of PID 1 responsibilities. Now, the final Dockerfile looks like this:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/node:latest-dev as build
+FROM cgr.dev/chainguard/node:latest-dev AS build
 
 USER root
 
@@ -477,7 +477,7 @@ Let’s skip to the final Dockerfile for our image and walk through the changes 
 Replace the Dockerfile with this one (this is also available on the ["main" branch](https://github.com/chainguard-dev/identidock-cg/blob/main/identidock/Dockerfile)):
 
 ```Dockerfile
-FROM cgr.dev/chainguard/python:latest-dev as dev
+FROM cgr.dev/chainguard/python:latest-dev AS dev
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/content/open-source/wolfi/wolfi-with-dockerfiles.md
+++ b/content/open-source/wolfi/wolfi-with-dockerfiles.md
@@ -148,7 +148,7 @@ nano DockerfileDistroless
 Copy the following code into your new file:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/wolfi-base as builder
+FROM cgr.dev/chainguard/wolfi-base AS builder
 
 ARG version=3.12
 


### PR DESCRIPTION
[x] Check if this is a typo or other quick fix and ignore the rest :)

Align with [Dockerfile conventions](https://docs.docker.com/reference/dockerfile/#format), and closes #2127 