### PR TITLE
pin github actions to full-length commit SHA

### DIFF
--- a/autodocs/.github/workflows/php.yml
+++ b/autodocs/.github/workflows/php.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Pin github actions to full-length commit SHAs.

Ref: https://github.com/chainguard-dev/prodsec/issues/60