### PR TITLE
chainctl: fix cosign verify command

### DIFF
--- a/content/chainguard/administration/how-to-install-chainctl.md
+++ b/content/chainguard/administration/how-to-install-chainctl.md
@@ -124,10 +124,11 @@ If you received output that you did not expect, check your bash profile to make 
 You can verify the integrity of your `chainctl` binary using Cosign. Ensure that you have the latest version of Cosign installed by following our [How to Install Cosign guide](/open-source/sigstore/cosign/how-to-install-cosign/). Verify your `chainctl` binary with the following command:
 
 ```sh
+VERSION=$(chainctl version 2>&1 | awk '/GitVersion/ {print $2}' | sed 's/^v//')
 cosign verify-blob \
-   --signature "https://dl.enforce.dev/chainctl/$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).sig" \
-   --certificate "https://dl.enforce.dev/chainctl/$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).cert.pem" \
-   --certificate-identity "https://github.com/chainguard-dev/mono/.github/workflows/.release-drop.yaml@refs/tags/v$(chainctl version 2>&1 |awk '/GitVersion/ {print $2}')" \
+   --signature "https://dl.enforce.dev/chainctl/${VERSION}/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).sig" \
+   --certificate "https://dl.enforce.dev/chainctl/${VERSION}/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).cert.pem" \
+   --certificate-identity "https://github.com/chainguard-dev/mono/.github/workflows/.release-drop.yaml@refs/tags/v${VERSION}" \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    $(which chainctl)
 ```


### PR DESCRIPTION
I think the versioning output may have changed over time, so this was returning `v0.1.2` rather than `0.1.2`, throwing off the URLs resulting in the error:

Error: error during PEM decoding
main.go:74: error during command execution: error during PEM decoding

This fixes the version so the cert can be fetched.

[x] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->