### PR TITLE
Improve docs for Java repo manager config

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -38,26 +38,28 @@ Build configuration to retrieve artifacts from Cloudsmith requires you to
 authenticate. Use your username and password for Cloudsmith in your build tool
 configuration.
 
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#cloudsmith) to
+determine URL and authentication details.
+
 ## JFrog Artifactory
 
 Build configuration to retrieve artifacts from Artifactory typically requires
 you to authenticate and use the identity token in the configuration of your
-build tool:
+build tool.
 
-1. Log in as user with access to the configured virtual repository.
-1. Select **Edit Profile** from the drop down in the top right corner from your
-   user name.
-1. Press **Generate Identity Token**.
-1. Provide a description such as *Chainguard Libraries* for the token as a
-   reminder for the use of the token.
-1. Copy the token value and use it as your password in your build tool
-   configuration.
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#artifactory) to
+determine URL and authentication details.
 
 ## Sonatype Nexus Repository
 
-Build configuration to retrieve artifacts from Nexus requires you to
-authenticate. Use your username and password for Nexus in your build tool
-configuration.
+Build configuration to retrieve artifacts from Nexus may require authentication.
+Use your username and password for Nexus in your build tool configuration.
+
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#nexus) to
+determine URL and authentication details.
 
 ## Apache Maven
 
@@ -96,20 +98,27 @@ activated profile.
 
   <mirrors>
     <mirror>
+      <!-- Set the identifier for the server credentials for repository manager access -->
+      <id>chainguard-maven</id>
       <!--Send all requests to the repository manager -->
-      <id>ecosystems</id>
       <mirrorOf>*</mirrorOf>
-      <url>https://repo.example.com/group/</url>
+      <url>https://repo.example.com/repository/group</url>
+      <!-- Cloudsmith example -->
+      <!-- <url>https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/</url> -->
+      <!-- JFrog Artifactory example -->
+      <!-- <url>https://example.jfrog.io/artifactory/chainguard-maven/</url> -->
+      <!-- Sonatype Nexus example -->
+      <!-- <url>https://repo.example.com:8443/repository/chainguard-maven/</url> -->
     </mirror>
   </mirrors>
 
+  <!-- Activate repo manager and override central repo from Maven itself with invalid URLs -->
   <activeProfiles>
-    <activeProfile>ecosystems</activeProfile>
+    <activeProfile>repo-manager</activeProfile>
   </activeProfiles>
-
   <profiles>
     <profile>
-      <id>ecosystems</id>
+      <id>repo-manager</id>
       <repositories>
         <repository>
           <id>central</id>
@@ -141,9 +150,11 @@ activated profile.
 ```
 
 If your repository manager requires authentication, you must specify credentials
-for the server. The id value in the server element must match the id value in
-the mirror configuration. The username and password values vary depending on the
-repository manager and the configured authentication.
+for the server. The `id` value in the server element must match the `id` value
+in the mirror configuration - `chainguard-maven` in the example. The username
+and password values vary depending on the repository manager and the configured
+authentication, contact the administrator and refer to the [global configuration
+documentation](/chainguard/libraries/java/global-configuration).
 
 ```xml
 <settings>
@@ -151,7 +162,7 @@ repository manager and the configured authentication.
 
   <servers>
     <server>
-      <id>ecosystems</id>
+      <id>chainguard-maven</id>
       <username>YOUR_USERNAME_FOR_REPOSITORY_MANAGER</username>
       <password>YOUR_PASSWORD</password>
     </server>

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -49,6 +49,8 @@ Chainguard Libraries. All access to the Chainguard libraries repository is then
 distributed across all your build platforms and therefore more complex to
 configure and control. 
 
+<a name="cloudsmith"></a>
+
 ## Cloudsmith
 
 [Cloudsmith](https://cloudsmith.com/) supports Maven repositories for proxying
@@ -62,40 +64,75 @@ by defining multiple upstream repositories.
 Use the following steps to add a repository with the Maven Central Repository
 and the Chainguard Libraries for Java repository as Maven upstream repositories. 
 
+Configure a *chainguard-maven* repository:
+
 1. Log in as a user with administrator privileges.
 1. Select the **Repositories** tab near the top of the screen.
-1. On the **Repositories** page, click the **+ New Repository** button.
-1. Enter the name *maven* for your new repository. The name should include
-   *maven* to identify the repository format. This convention helps avoiding
-   confusion since repositories in Cloudsmith are multi-format.
+1. On the **Repositories** page, click the **+ New repository** button.
+1. Enter the name *chainguard-maven* for your new repository. The name should
+   include *maven* to identify the repository format. This convention helps
+   avoid confusion since repositories in Cloudsmith are multi-format. 
+1. Select a storage region that is appropriate for your organization and
+   infrastructure.
 1. Press **+ Create Repository**. 
-1. Click the name of the new repository on the repositories page to configure
-   it.
-1. Access the **Upstreams** tab and click **+ Add Upstream Proxy** and proceed
-   to configure two upstream proxies.
-1. Configure an upstream proxy with the following details:
-    * **Name** *chainguard* 
-    * **Priority** *1*
-    * **Upstream URL** *https://libraries.cgr.dev/maven/*
-    * **Mode** *Cache and Proxy*
-    * Add the **Username** and **Password** value from [Chainguard Libraries
-      access](/chainguard/libraries/access/) in **Authentication**
-1. Press **Create Maven Upstream**.
+
+Configure an upstream proxy for the Maven Central Repository:
+
+1. Click the name of the new *chainguard-maven* repository on the repositories
+   page to configure it.
+1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
+1. Configure an upstream proxy with the format **Maven** and the following details:
 1. Configure another upstream proxy with the following details
     * **Name** *central* 
     * **Priority** *2*
     * **Upstream URL** *https://repo1.maven.org/maven2/*
     * **Mode** *Cache and Proxy*
-1. Press **Create Maven Upstream**.
+1. Press **Create Upstream Proxy**.
+
+Configure an upstream proxy for the Chainguard Libraries for Java repository:
+
+1. Click the name of the new *chainguard-maven* repository on the repositories
+   page to configure it.
+1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
+1. Configure an upstream proxy with the format **Maven** and the following details:
+    * **Name** *chainguard* 
+    * **Priority** *1*
+    * **Proxy URL** *https://libraries.cgr.dev/maven/*
+    * **Mode** *Cache and Proxy*
+    * Add the **Username** and **Password** value from [Chainguard Libraries
+      access](/chainguard/libraries/access/) in **Authentication Settings**
+1. Press **Create Upstream Proxy**.
 
 Use this setup for initial testing with Chainguard Libraries for Java. For
-production usage add the `chainguard` upstream proxy to your production
+production usage, add the `chainguard` upstream proxy to your production
 repository.
 
-Use the URL of the repository in the [build
-configuration](/chainguard/libraries/java/build-configuration) and build a
-first test project. In a working setup all libraries retrieved from Chainguard
-are tagged with the name of the upstream proxy.
+The following steps allow you to determine the URL and authentication details
+for accessing the repository:
+
+1. Select the **Packages** tab.
+1. Press **Push/Pull Packages**.
+1. Choose the format **Maven**.
+1. Copy the value in the `<url>` tag from the XML snippet with the
+   `<repositories>` entry. For example,
+   `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/` with
+   `exampleorg` replaced with the name of your organization. Note that the name
+   of the repository `chainguard-maven` as well as `maven` as identifier for the
+   format are part of the URL.
+1. Copy the username and password values block from the second code snippet for
+   authentication after choosing the desired authentication of *Default* or
+   *API Key*.
+
+Choose a different format and the equivalent sections if you are using another
+build tools such as Gradle.
+
+Use the URL of the repository, the username, and the password for the server
+authentication block in the [build
+configuration](/chainguard/libraries/java/build-configuration). and build a firs
+test project. In a working setup all libraries retrieved from Chainguard are
+tagged with the name of the upstream proxy.
+
+<a name="artifactory"></a>
 
 ## JFrog Artifactory
 
@@ -117,9 +154,9 @@ Configure a remote repository for the Maven Central Repository:
 
 1. Press **Create a Repository** and choose the **Remote** option.
 1. Select *Maven* as the Package type.
-1. Set the **Repository Key** to *maven-central*.
+1. Set the **Repository Key** to *central*.
 1. Set the **URL** to *https://repo1.maven.org/maven2/* .
-1. Press Create Remote Repository.
+1. Press **Create Remote Repository**.
 
 Configure a remote repository for the Chainguard Libraries for Java repository:
 
@@ -127,29 +164,47 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Select *Maven* as the **Package type**.
 1. Set the **Repository Key** to *chainguard*.
 1. Set the **URL** to *https://libraries.cgr.dev/maven/*.
-1. Set **User Name** and Password / Access Token to the [values as retrieved
+1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
 1. Check the **Enable Token Authentication** checkbox.
-1. Press Test to validate the connection.
-1. Press Create Remote Repository.
+1. Press **Test** to validate the connection.
+1. Press **Create Remote Repository**.
 
 Combine the two repositories in a new virtual repository:
 
 1. Press **Create a Repository** and choose the **Virtual** option.
-1. Set the **Repository Key** to *chainguard-group*.
+1. Set the **Repository Key** to *chainguard-maven*.
 1. Scroll down to the **Repositories** section
-1. Add the *chainguard* and *maven-central* repositories. Ensure the *chainguard* repository is the
-   first in the displayed list.
+1. Add the *chainguard* and *maven-central* repositories. Ensure the
+   *chainguard* repository is the first in the displayed list.
 1. Press **Create Virtual Repository**.
 
 Use this setup for initial testing with Chainguard Libraries for Java. For
 production usage add the `chainguard` repository to your production virtual
 repository.
 
+The following steps allow you to determine the URL and authentication details
+for accessing the repository:
+
+1. Press **Administration** in the top navigation bar.
+1. Select **Repositories** in the left hand navigation.
+1. Select the **Virtual** tab in the repositories view.
+1. Locate the *chainguard-maven** repository.
+1. Hover over the row and click the **...** in the last column on the right.
+1. Select **Set Me Up** in the dialog.
+1. Press **Generate Token & Create Instructions**
+1. Copy the generated token value to use as the password for authentication.
+1. Press **Generate Settings**.
+1. Copy the value from a *url* field. The are all identical. For example,
+   `https://exampleorg.jfrog.io/artifactory/chainguard-maven` with `exampleorg`
+   replaced with the name of your organization.
+
 Use the URL of the virtual repository in the [build
 configuration](/chainguard/libraries/java/build-configuration) and build a first
 test project. In a working setup the chainguard remote repository contains all
 libraries retrieved from Chainguard.
+
+<a name="nexus"></a>
 
 ## Sonatype Nexus Repository
 
@@ -188,7 +243,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Press **Create repository**.
 1. Select the **maven2 (proxy)** recipe.
 1. Provide a new name *chainguard*.
-1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven*.
+1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven/*.
 1. In **HTTP - Authentication** with the **Authentication type** *username*,
    provide the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).
@@ -199,14 +254,28 @@ Combine a new repository group and add the two repositories:
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Press **Create repository**.
 1. Select the **maven2 (group)** recipe.
-1. Provide a new name *chainguard-group*.
+1. Provide a new name *chainguard-maven*.
 1. In the section **Group - Member repositories**, move the new repositories
    `central` and `chainguard` to the right and move the `chainguard` repository
    to the top of the list with the arrow control.
 
+The following steps allow you to determine the URL and authentication details
+for accessing the repository:
+
+1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top
+   navigation bar.
+1. Locate the **URL** column for the *chainguard-maven* repository group and
+   press **copy**. For example,
+   `https://repo.example.com/repository/chainguard-maven/`  with
+   `repo.example.com` replaced with the hostname of you repository manager.
+1. Copy the URL in the dialog.
+1. Use your configured username and password unless **Security** - **Anonymous
+   Access** - **Access** - **Allow anonymous users to access the server** is
+   activated. Details vary based on your configured authentication system.
+
 Use the URL of the repository group, such as
-*https://repo.example.com/repository/chainguard-group/* or
+*https://repo.example.com/repository/chainguard-maven/* or
 *https://repo.example.com/repository/maven-public/* in the [build
 configuration](/chainguard/libraries/java/build-configuration) and build a first
 test project. In a working setup the `chainguard` proxy repository contains all
-libraries retrieved from Chainguard.
+libraries retrieved frohttps://github.com/chainguard-dev/edu/pull/2148avoidm Chainguard.

--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -30,10 +30,11 @@ steps on the repository manager and the build tool.
 You can verify what artifacts are retrieved from the Chainguard Libraries
 repository on a global level:
 
-* Browse the proxy repository on your Artifactory or Nexus server.
-* Browse the Maven repository on your Cloudsmith instance and locate the
-  artifacts with the tag from the Chainguard upstream proxy. The tag uses the
-  name of the upstream proxy.
+* Browse the `chainguard` proxy repository on your Artifactory or Nexus server.
+* Access the **Packages** tab of the the repository on your Cloudsmith instance.
+  Filter the package list with the tag value with the name for your upstream
+  proxy for Chainguard, for example `tag:chainguard`. The tag uses the name of
+  the upstream proxy, with spaces replaced with dashes.
 
 Use the browsing access to locate specific artifacts and identify their name,
 filesize, checksum values, timestamp and other identifiers. With these details


### PR DESCRIPTION
## Type of change

### What should this PR do?

Improve docs for Java repo manager config as a result of further reviewing and testing. Changes create more consistency and expand on the necessary steps to get the build tool configuration set up. All that is now also fully tested. The only issue is that Cloudsmith docs are correct now .. but its not working. I am investigating with the engineering team.

Part of https://github.com/chainguard-dev/internal/issues/4803

### Why are we making this change?

better is better

### What are the acceptance criteria? 

Passing review

### How should this PR be tested?

Not really necessary but if desired reviewer and follow setup steps with desired repo manager.