### PR TITLE
CSS fixes for responsive issues and dark mode issues with link color contrast

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1170,6 +1170,10 @@ code {
     max-width: calc(100dvw - 616px);
 }
 
+.sl-bg-canvas .sl-w-full {
+    min-width: 325px;
+}
+
 // Reduce center padding under specified screen width
 @media (max-width: $ReduceContentPaddingWidth) {
     .docs-content {
@@ -1213,6 +1217,12 @@ code {
 .docs-content.docs-content a:not(.tag),
 .card-link.card-link.card-link.card-link {
     color: var(--article-link-color);
+}
+
+.docs-content.docs-content {
+    a.sl-block, a.sl-link {
+        color: var(--article-link-secondary-color);
+    }
 }
 
 h4, .h4 {

--- a/assets/scss/common/_theming.scss
+++ b/assets/scss/common/_theming.scss
@@ -22,6 +22,7 @@
     --active-element-shadow: var(--secondary-2);
     --active-link-color: var(--secondary-2);
     --article-link-color: var(--primary-1);
+    --article-link-secondary-color: var(--primary-2);
     --basics-card-background: inherit;
     --basics-card-border: var(--primary-3-border);
     --blockquote-background: var(--secondary-3-border);
@@ -144,6 +145,7 @@
     --active-element-shadow: var(--primary-2);
     --active-link-color: var(--secondary-1);
     --article-link-color: var(--primary-2);
+    --article-link-secondary-color: var(--primary-1);
     --basics-card-background: -var(--desaturated-primary-3);
     --basics-card-border: var(--secondary-3-border);
     --blockquote-background: var(--secondary-3-border);


### PR DESCRIPTION

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Minor UI fixes

### What should this PR do?
Fixes responsive layout issue described in [this issue](https://github.com/chainguard-dev/console-ui/issues/3590) as well as fit and finish issue where lightblue links were on a white background that would hard to read and not pass color contrast testing for a11y.

### Why are we making this change?
UX quality issues on the Edu site

### What are the acceptance criteria? 
Sanity check from Docs team, both on light mode and dark mode.  Note that this doesn't fix all responsive issues with API docs pages but it fixes the specific bug that was filed.

### How should this PR be tested?
You can check [this issue](https://github.com/chainguard-dev/console-ui/issues/3590) but generally, open any API Docs page and check that the code snippet is viewable at lower resolutions (still may require page scroll but the code viewer as well as the copy code button should be usable). 
Also check the tab and link colors across dark mode pages especially, but also double check light mode didn't break.