### PR TITLE
Correct order in Product Docs navigation

### DIFF
--- a/content/chainguard/administration/_index.md
+++ b/content/chainguard/administration/_index.md
@@ -7,5 +7,5 @@ date: 2023-10-26T08:48:45+00:00
 lastmod: 2023-10-26T08:48:45+00:00
 draft: false
 images: []
-weight: 40
+weight: 050
 ---

--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-0320T08:49:15+00:00
 draft: false
 tags: ["chainctl", "Usage", "Product", "Overview"]
 images: []
-weight: 50
+weight: 060
 ---
 
 `chainctl` (Chainguard Control) is a CLI tool that helps you control aspects of your Chainguard account and resources. You can use it to manage users, roles, images, tokens, and more. In many ways, `chainctl` parallels the abilities of the <ins>[Chainguard Console](https://console.chainguard.dev)</ins>, but with a different user interface that is both more complex and more powerful.

--- a/content/chainguard/chainctl/_index.md
+++ b/content/chainguard/chainctl/_index.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-21T08:49:15+00:00
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []
-weight: 100
+weight: 070
 ---
 
 The CLI tool `chainctl` helps you interact with the account model that Chainguard provides. The tool uses the familiar `<context> <noun> <verb>` style of CLI interactions. Below find the current reference for `chainctl`.

--- a/content/chainguard/chainguard-images/_index.md
+++ b/content/chainguard/chainguard-images/_index.md
@@ -7,7 +7,7 @@ date: 2022-09-05T08:49:15+00:00
 lastmod: 2025-04-07T08:49:15+00:00
 draft: false
 images: []
-weight: 001
+weight: 010
 topic: true
 banner: {
     image: "/icon-box-fill.svg",

--- a/content/chainguard/chainguard-registry/_index.md
+++ b/content/chainguard/chainguard-registry/_index.md
@@ -8,5 +8,5 @@ date: 2023-03-21T08:48:45+00:00
 lastmod: 2025-01-07T08:48:45+00:00
 draft: false
 images: []
-weight: 20
+weight: 030
 ---

--- a/content/chainguard/libraries/_index.md
+++ b/content/chainguard/libraries/_index.md
@@ -6,5 +6,5 @@ type: "article"
 date: 2025-03-25T08:04:00+00:00
 lastmod: 2025-04-07T15:17:00+00:00
 draft: false
-weight: 001
+weight: 020
 ---

--- a/content/chainguard/migration/_index.md
+++ b/content/chainguard/migration/_index.md
@@ -7,7 +7,7 @@ date: 2024-02-26T08:48:45+00:00
 lastmod: 2024-05-228T08:48:45+00:00
 draft: false
 images: []
-weight: 050
+weight: 040
 topic: true
 banner: {
     image: "/icon-arrows.svg",


### PR DESCRIPTION
## Type of change

### What should this PR do?

Set the order in the Product Docs navigation section so it makes sense

* Containers
* Libraries
* Registry
* Migration
* Administration
* chainctl Usage
* chainctl Reference

Also note that I am NOT updating timestamps since this is not a content change.

### Why are we making this change?

Somehow adding the timestamps for Libraries bumped it to the very top and it should not be above all the container related content.

### What are the acceptance criteria? 

review

### How should this PR be tested?

run locally and verify