### PR TITLE
Chainguard Libraries for Python docs draft

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -23,7 +23,7 @@ Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
 repository manager acts as a single point of access for developers and
 development tools to retrieve the required libraries.
 
-At a high level, adopting the use of Chainguard Libraries consists of the
+At a high level, adopting the use of Chainguard Libraries consists of the the
 following steps:
 
 * Add Chainguard Libraries as a remote repository for library retrieval.

--- a/content/chainguard/libraries/python/_index.md
+++ b/content/chainguard/libraries/python/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Chainguard Libraries for Python"
+linkTitle: "Python"
+description: "Python libraries for your application development"
+type: "article"
+date: 2025-04-09T08:04:00+00:00
+lastmod: 2025-04-09T08:04:00+00:00
+draft: false
+weight: 060
+---

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -1,0 +1,392 @@
+---
+title: "Build Configuration"
+linktitle: "Build Configuration "
+description: "Configuring Chainguard Libraries for Java on your workstation"
+type: "article"
+date: 2025-03-25T08:04:00+00:00
+lastmod: 2025-04-07T14:11:00+00:00
+draft: false
+tags: ["Chainguard Libraries", "Java"]
+menu:
+  docs:
+    parent: "java"
+weight: 053
+toc: true
+---
+
+The configuration for the use of Chainguard Libraries depends on your build
+tools, continuous integration, and continuous deployment setups
+
+At a high level adopting the use of Chainguard Libraries consists of the
+following steps:
+
+* Remove local caches on workstations and CI/CD pipelines. This step ensures that
+  any libraries that were already sourced from other repositories are requested
+  again and the version from Chainguard Libraries is used instead of other
+  binaries.
+* Change configuration to access Chainguard Libraries via your repository
+  manager after the changes from the [global
+  configuration](/chainguard/libraries/java/global-configuration) are
+  implemented.
+
+These changes must be performed on all workstations of individual developers and
+other engineers running relevant application builds. They must also be performed
+on any build server such as Jenkins, TeamCity, GitHub or other infrastructure
+that builds the applications or otherwise downloads and uses relevant libraries.
+
+## Cloudsmith
+
+Build configuration to retrieve artifacts from Cloudsmith requires you to
+authenticate. Use your username and password for Cloudsmith in your build tool
+configuration.
+
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#cloudsmith) to
+determine URL and authentication details.
+
+## JFrog Artifactory
+
+Build configuration to retrieve artifacts from Artifactory typically requires
+you to authenticate and use the identity token in the configuration of your
+build tool.
+
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#artifactory) to
+determine URL and authentication details.
+
+## Sonatype Nexus Repository
+
+Build configuration to retrieve artifacts from Nexus may require authentication.
+Use your username and password for Nexus in your build tool configuration.
+
+Follow the steps from the [global
+configuration](/chainguard/libraries/java/global-configuration#nexus) to
+determine URL and authentication details.
+
+## Apache Maven
+
+[Apache Maven](https://maven.apache.org/) is the most widely used build tool in
+the Java ecosystem. 
+
+### Remove Maven Caches
+
+Apache Maven uses a local cache of libraries. When adopting Chainguard Libraries
+for Java you must delete that local cache so that libraries are downloaded
+again. By default the cache, also known as the local repository, is located in a
+hidden `.m2/repository` directory in your user's home directory. Use the
+following command to delete it:
+
+```shell
+rm -rf ~/.m2/repository
+```
+
+### Change Maven Configuration
+
+Before running a new build you must configure access to the Chainguard Libraries
+for Java. If the administrator for your organization’s repository manager
+created a new repository or virtual repository or group repository, you must
+update your settings defined in `~/.m2/settings.xml`.
+
+A typical setup defines a global mirror (id `ecosystems`) for all artifacts and
+configures the URL of the repository group or virtual repository from your
+repository manager `https://repo.example.com/group/`. Since the group or virtual
+repository combines release and snapshot artifacts you must override the
+built-in `central` repository and its configuration in an automatically
+activated profile.
+
+
+```xml
+<settings>
+
+  <mirrors>
+    <mirror>
+      <!-- Set the identifier for the server credentials for repository manager access -->
+      <id>chainguard-maven</id>
+      <!--Send all requests to the repository manager -->
+      <mirrorOf>*</mirrorOf>
+      <url>https://repo.example.com/repository/group</url>
+      <!-- Cloudsmith example -->
+      <!-- <url>https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/</url> -->
+      <!-- JFrog Artifactory example -->
+      <!-- <url>https://example.jfrog.io/artifactory/chainguard-maven/</url> -->
+      <!-- Sonatype Nexus example -->
+      <!-- <url>https://repo.example.com:8443/repository/chainguard-maven/</url> -->
+    </mirror>
+  </mirrors>
+
+  <!-- Activate repo manager and override central repo from Maven itself with invalid URLs -->
+  <activeProfiles>
+    <activeProfile>repo-manager</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>repo-manager</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>
+```
+
+If your repository manager requires authentication, you must specify credentials
+for the server. The `id` value in the server element must match the `id` value
+in the mirror configuration - `chainguard-maven` in the example. The username
+and password values vary depending on the repository manager and the configured
+authentication, contact the administrator and refer to the [global configuration
+documentation](/chainguard/libraries/java/global-configuration).
+
+```xml
+<settings>
+...
+  <servers>
+    <server>
+      <id>chainguard-maven</id>
+      <username>YOUR_USERNAME_FOR_REPOSITORY_MANAGER</username>
+      <password>YOUR_PASSWORD</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Note that you can use a secret manager application to populate the credentials
+for each user on their workstation as well as for service applications in your
+CI/CD pipelines into environment variables, for example `CG_JAVA_USERNAME` and
+`CG_JAVA_PASSWORD`. You can then use an identical server configuration, and
+therefore settings file, for all users:
+
+```xml
+<settings>
+...
+  <servers>
+    <server>
+      <id>chainguard-maven</id>
+      <username>${env.CG_JAVA_USERNAME}</username>
+      <password>${env.CG_JAVA_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Refer to the [official documentation for the Maven settings
+file](https://maven.apache.org/settings.html) for more details.
+
+If the administrator only re-configured the existing repository group or virtual
+repository, you can trigger a build to initiate use of Chainguard Libraries for
+Java.
+
+If you are not using a repository manager at your organization, you can
+configure access to the Chainguard Libraries for Java repository directly in
+your settings or pom files. Note that the order of the repositories in these
+files is significant and you must configure the chainguard repository to be
+located on the top of the list.
+
+If you organization does not use a repository manager you can configure the
+Chainguard Libraries for Java repository. Ensure that the Chainguard
+repository is located above the necessary override for the built-in `central`
+repository and any other repositories.
+
+The following listing shows a complete `~/.m2/settings.xml` file with the
+desired configuration and placeholder values `CG_PULLTOKEN_USERNAME` and
+`CG_PULLTOKEN_PASSWORD` for the pull token detailed in [Chainguard Libraries
+access](/chainguard/libraries/access/):
+
+```xml
+<settings>
+ <activeProfiles>
+    <activeProfile>chainguard-maven</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>chainguard-maven</id>
+      <repositories>
+        <repository>
+          <id>chainguard</id>
+          <url>https://libraries.cgr.dev/maven/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>chainguard</id>
+          <url>https://libraries.cgr.dev/maven/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <servers>
+    <server>
+      <id>chainguard</id>
+      <!-- pick up values from environment variables -->
+      <username>${env.CG_JAVA_USERNAME}</username>
+      <password>${env.CG_JAVA_PASSWORD}</password>
+      <!-- or use literal values -->
+      <!-- <username>CG_PULLTOKEN_USERNAME</username> -->
+      <!-- <password>CG_PULLTOKEN_PASSWORD</password> -->
+    </server>
+  </servers>
+</settings>
+```
+
+The preceding settings affects all projects built on the machine where the file
+is configured. Alternatively you can add the `repositories` and
+`pluginRepositories` to individual project `pom.xml` files. Authentication
+details must remain within the settings file.
+
+## Gradle
+
+[Gradle](https://gradle.org/) is a commonly used build tool in the Java
+ecosystem.
+
+### Remove Gradle Caches
+
+Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
+Java you must delete that local cache so that libraries are downloaded again. By
+default the cache is located in a hidden `.gradle/.cache` directory in your
+users home directory. Use the following command to delete it:
+
+```shell
+rm -rf ~/.gradle/caches/
+```
+
+Gradle can also be configured to use a local Maven repository with a repository
+configuration in the global `init.gradle` or a project specific `build.gradle`
+file:
+
+```
+repositories {
+   ...
+    mavenLocal()    
+}
+```
+
+If this configuration is used, ensure to [delete the local Maven repository as
+well](#remove-maven-caches). 
+
+### Change Gradle Configuration
+
+Before running a new build you must configure access to the Chainguard Libraries
+for Java. If the administrator for your organization’s repository manager
+created a new repository or virtual repository or group repository, you must
+update your Gradle configuration. Artifact download is Gradle can be configured
+in an [init
+script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
+using the repositories definition. Each project can also [declare
+repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
+separately.
+
+A typical setup removes the direct reference to Maven Central `mavenCentral()`
+and any other repositories, and adds a replacement definition with the URL of the
+repository group or virtual repository from your repository manager
+`https://repo.example.com/group/` and any applicable authentication details.
+
+```
+repositories {
+    maven {
+        url = uri("https://repo.example.com/group/")
+        credentials {
+            username = "YOUR_USERNAME_FOR_REPOSITORY_MANAGER"
+            password = "YOUR_PASSWORD"
+        }
+    }
+}
+```
+
+Example URLs for repository managers:
+
+* Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/`
+* JFrog Artifactory: `https://example.jfrog.io/artifactory/chainguard-maven/`
+* Sonatype Nexus: `https://repo.example.com:8443/repository/chainguard-maven/`
+
+If your organization does not use a repository manager you can configure the
+Chainguard Libraries for Java repository with the credentials from [Chainguard
+Libraries access](/chainguard/libraries/access/) replacing the placeholders
+`CG_PULLTOKEN_USERNAME` and `CG_PULLTOKEN_PASSWORD`. Ensure that the Chainguard
+repository is located above the `mavenCentral` repository and any other
+repositories:
+
+```
+repositories {
+    maven {
+        url = uri("https://libraries.cgr.dev/maven/")
+        credentials {
+            username = "CG_PULLTOKEN_USERNAME"
+            password = "CG_PULLTOKEN_PASSWORD"
+        }
+    }
+    mavenCentral()
+}
+```
+
+## Other Build Tools
+
+Other build tools such as [Apache Ant](https://ant.apache.org/) with the [Maven
+Artifact Resolver Ant Tasks](https://maven.apache.org/resolver-ant-tasks/),
+[sbt](https://www.scala-sbt.org/), [Bazel](https://bazel.build/),
+[Leiningen](https://leiningen.org/) and others use Maven or Gradle caches or
+similar approaches. Refer to the documentation of your specific tool and the
+preceding sections to determine how to remove any used caches.
+
+These tools also include their own mechanisms to configure repositories for
+binary artifact retrieval. Consult the specific documentation and adjust your
+configuration to use your repository manager and newly created repository group
+or virtual repository.
+
+Example URLs for repository managers:
+
+* Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/`
+* JFrog Artifactory: `https://example.jfrog.io/artifactory/chainguard-maven/`
+* Sonatype Nexus: `https://repo.example.com:8443/repository/chainguard-maven/`

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -1,392 +1,123 @@
 ---
 title: "Build Configuration"
 linktitle: "Build Configuration "
-description: "Configuring Chainguard Libraries for Java on your workstation"
+description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
 lastmod: 2025-04-07T14:11:00+00:00
 draft: false
-tags: ["Chainguard Libraries", "Java"]
+tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
-    parent: "java"
+    parent: "python"
 weight: 053
 toc: true
 ---
 
-The configuration for the use of Chainguard Libraries depends on your build
-tools, continuous integration, and continuous deployment setups
+The configuration for the use of Chainguard Libraries depends on how you've set up your build tools and CI/CD workflows. At a high level, adopting the use of Chainguard Libraries in your development, build, and deployment workflows involves the following steps:
 
-At a high level adopting the use of Chainguard Libraries consists of the
-following steps:
+- If you or an administrator have not done so already, [set up your organization's repository manager to use Chainguard Libraries for Python](/chainguard/libraries/python/global-configuration).
+- Log into your organization's repository manager and retrieve credentials for the build tool you are configuration.
+- Configure your development or build tool with this information.
+- Remove local caches on workstations and CI/CD pipelines. This step ensures that dependencies are preferentially sourced from Chainguard Libraries.
+- Finally, confirm that your development tools and CI/CD workflows are correctly ingesting dependencies from Chainguard Libraries.
 
-* Remove local caches on workstations and CI/CD pipelines. This step ensures that
-  any libraries that were already sourced from other repositories are requested
-  again and the version from Chainguard Libraries is used instead of other
-  binaries.
-* Change configuration to access Chainguard Libraries via your repository
-  manager after the changes from the [global
-  configuration](/chainguard/libraries/java/global-configuration) are
-  implemented.
+These changes must be performed on all workstations of individual developers and other engineers running relevant application builds. They must also be performed on any build tool such as Jenkins, TeamCity, GitHub Actions, or other infrastructure that draws in dependencies.
 
-These changes must be performed on all workstations of individual developers and
-other engineers running relevant application builds. They must also be performed
-on any build server such as Jenkins, TeamCity, GitHub or other infrastructure
-that builds the applications or otherwise downloads and uses relevant libraries.
+## Retrieving Authentication Credentials
 
-## Cloudsmith
+TO configure any build tool, you must first access credentials from your organization's repository manager.
 
-Build configuration to retrieve artifacts from Cloudsmith requires you to
-authenticate. Use your username and password for Cloudsmith in your build tool
-configuration.
+<a name="cloudsmith"></a>
+### Cloudsmith
 
-Follow the steps from the [global
-configuration](/chainguard/libraries/java/global-configuration#cloudsmith) to
-determine URL and authentication details.
+The following steps allow you to determine the URL and authentication details for accessing your organization's Cloudsmith repository manager.
 
-## JFrog Artifactory
+1. Log into Cloudsmith.
+1. Select the **Packages** tab.
+1. Select **Push/Pull Packages**.
+1. Choose the **PyPI** format.
+1. Copy the value in the `<url>` tag from the XML snippet with the `<repositories>` entry. For example, `https://dl.cloudsmith.io/basic/exampleorg/chainguard-python/python/` with `exampleorg` replaced with the name of your organization. Note the URL contains both the name of the repository `chainguard-python` as well as `python` as an identifier for the format.
+1. Select your desired authentication method (either *Default* or *API Key*). Copy the provided username and password values for configuration of tools. You can perform this step multiple times if you're using different authentication methods for different tools.
 
-Build configuration to retrieve artifacts from Artifactory typically requires
-you to authenticate and use the identity token in the configuration of your
-build tool.
+<a name="artifactory"></a>
+### JFrog Artifactory
 
-Follow the steps from the [global
-configuration](/chainguard/libraries/java/global-configuration#artifactory) to
-determine URL and authentication details.
+The following steps allow you to determine the identity token and URL for accessing your organization's JFrog Artifactory repository manager.
 
+1. Select **Administration** in the top navigation bar.
+1. Select **Repositories** in the left hand navigation.
+1. Select the **Virtual** tab in the repositories view.
+1. Locate the *chainguard-python** repository row and select the elipsis (**...**) in the last column on the right.
+1. Select **Set Me Up** in the dialog.
+1. Select **Generate Token & Create Instructions**
+1. Copy the generated token value to use as the password for authentication.
+1. Select **Generate Settings**.
+1. Copy the value from one of the *URL* fields. The are all identical. For example, `https://exampleorg.jfrog.io/artifactory/chainguard-python` with `exampleorg`. 
+
+<a name="nexus"></a>
 ## Sonatype Nexus Repository
 
-Build configuration to retrieve artifacts from Nexus may require authentication.
-Use your username and password for Nexus in your build tool configuration.
+The following steps allow you to determine the URL and authentication details for accessing your organization's Sonatype Nexus repository group.
 
-Follow the steps from the [global
-configuration](/chainguard/libraries/java/global-configuration#nexus) to
-determine URL and authentication details.
+1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top navigation bar.
+1. Locate the **URL** column for the *chainguard-python* repository group and press **copy**. The URL should take the following format: `https://repo.example.com/repository/chainguard-python/` .
+1. Use your configured username and password unless **Security** - **Anonymous Access** - **Access** - **Allow anonymous users to access the server** is activated. Details vary based on your configured authentication system.
 
-## Apache Maven
+## Configuring Build Tools
 
-[Apache Maven](https://maven.apache.org/) is the most widely used build tool in
-the Java ecosystem. 
+Once you have credentials and the index URL from your organization's repository manager, you're ready to set up specific build tools for local development or CI/CD.
 
-### Remove Maven Caches
+### `pip`
 
-Apache Maven uses a local cache of libraries. When adopting Chainguard Libraries
-for Java you must delete that local cache so that libraries are downloaded
-again. By default the cache, also known as the local repository, is located in a
-hidden `.m2/repository` directory in your user's home directory. Use the
-following command to delete it:
+The `pip` tool is the most widely used utility for installing Python packages. In this section, we'll use the credentials from your organization's repository manager to configure `pip` to ingest dependencies from Chainguard Libraries.
 
-```shell
-rm -rf ~/.m2/repository
+First, let's clear your local `pip` cache to ensure that packages are sourced from Chainguard Libraries for Python:
+
+```sh
+pip cache purge
 ```
 
-### Change Maven Configuration
+To install a package with `pip` one time (useful for testing your credentials), you can use the following command:
 
-Before running a new build you must configure access to the Chainguard Libraries
-for Java. If the administrator for your organization’s repository manager
-created a new repository or virtual repository or group repository, you must
-update your settings defined in `~/.m2/settings.xml`.
+To update `pip` to use our repository manager's URL globally, create or edit your `~/.pip/pip.conf` file . (You may need to create the `~/.pip` folder as well.) For example:
 
-A typical setup defines a global mirror (id `ecosystems`) for all artifacts and
-configures the URL of the repository group or virtual repository from your
-repository manager `https://repo.example.com/group/`. Since the group or virtual
-repository combines release and snapshot artifacts you must override the
-built-in `central` repository and its configuration in an automatically
-activated profile.
-
-
-```xml
-<settings>
-
-  <mirrors>
-    <mirror>
-      <!-- Set the identifier for the server credentials for repository manager access -->
-      <id>chainguard-maven</id>
-      <!--Send all requests to the repository manager -->
-      <mirrorOf>*</mirrorOf>
-      <url>https://repo.example.com/repository/group</url>
-      <!-- Cloudsmith example -->
-      <!-- <url>https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/</url> -->
-      <!-- JFrog Artifactory example -->
-      <!-- <url>https://example.jfrog.io/artifactory/chainguard-maven/</url> -->
-      <!-- Sonatype Nexus example -->
-      <!-- <url>https://repo.example.com:8443/repository/chainguard-maven/</url> -->
-    </mirror>
-  </mirrors>
-
-  <!-- Activate repo manager and override central repo from Maven itself with invalid URLs -->
-  <activeProfiles>
-    <activeProfile>repo-manager</activeProfile>
-  </activeProfiles>
-  <profiles>
-    <profile>
-      <id>repo-manager</id>
-      <repositories>
-        <repository>
-          <id>central</id>
-          <url>http://central</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>central</id>
-          <url>http://central</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
-
-</settings>
+```sh
+mkdir -p ~/.pip
+nano ~/.pip/pip.conf
 ```
 
-If your repository manager requires authentication, you must specify credentials
-for the server. The `id` value in the server element must match the `id` value
-in the mirror configuration - `chainguard-maven` in the example. The username
-and password values vary depending on the repository manager and the configured
-authentication, contact the administrator and refer to the [global configuration
-documentation](/chainguard/libraries/java/global-configuration).
-
-```xml
-<settings>
-...
-  <servers>
-    <server>
-      <id>chainguard-maven</id>
-      <username>YOUR_USERNAME_FOR_REPOSITORY_MANAGER</username>
-      <password>YOUR_PASSWORD</password>
-    </server>
-  </servers>
-</settings>
-```
-
-Note that you can use a secret manager application to populate the credentials
-for each user on their workstation as well as for service applications in your
-CI/CD pipelines into environment variables, for example `CG_JAVA_USERNAME` and
-`CG_JAVA_PASSWORD`. You can then use an identical server configuration, and
-therefore settings file, for all users:
-
-```xml
-<settings>
-...
-  <servers>
-    <server>
-      <id>chainguard-maven</id>
-      <username>${env.CG_JAVA_USERNAME}</username>
-      <password>${env.CG_JAVA_PASSWORD}</password>
-    </server>
-  </servers>
-</settings>
-```
-
-Refer to the [official documentation for the Maven settings
-file](https://maven.apache.org/settings.html) for more details.
-
-If the administrator only re-configured the existing repository group or virtual
-repository, you can trigger a build to initiate use of Chainguard Libraries for
-Java.
-
-If you are not using a repository manager at your organization, you can
-configure access to the Chainguard Libraries for Java repository directly in
-your settings or pom files. Note that the order of the repositories in these
-files is significant and you must configure the chainguard repository to be
-located on the top of the list.
-
-If you organization does not use a repository manager you can configure the
-Chainguard Libraries for Java repository. Ensure that the Chainguard
-repository is located above the necessary override for the built-in `central`
-repository and any other repositories.
-
-The following listing shows a complete `~/.m2/settings.xml` file with the
-desired configuration and placeholder values `CG_PULLTOKEN_USERNAME` and
-`CG_PULLTOKEN_PASSWORD` for the pull token detailed in [Chainguard Libraries
-access](/chainguard/libraries/access/):
-
-```xml
-<settings>
- <activeProfiles>
-    <activeProfile>chainguard-maven</activeProfile>
-  </activeProfiles>
-  <profiles>
-    <profile>
-      <id>chainguard-maven</id>
-      <repositories>
-        <repository>
-          <id>chainguard</id>
-          <url>https://libraries.cgr.dev/maven/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-        <repository>
-          <id>central</id>
-          <url>https://repo1.maven.org/maven2/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>chainguard</id>
-          <url>https://libraries.cgr.dev/maven/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-          <id>central</id>
-          <url>https://repo1.maven.org/maven2/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
-  <servers>
-    <server>
-      <id>chainguard</id>
-      <!-- pick up values from environment variables -->
-      <username>${env.CG_JAVA_USERNAME}</username>
-      <password>${env.CG_JAVA_PASSWORD}</password>
-      <!-- or use literal values -->
-      <!-- <username>CG_PULLTOKEN_USERNAME</username> -->
-      <!-- <password>CG_PULLTOKEN_PASSWORD</password> -->
-    </server>
-  </servers>
-</settings>
-```
-
-The preceding settings affects all projects built on the machine where the file
-is configured. Alternatively you can add the `repositories` and
-`pluginRepositories` to individual project `pom.xml` files. Authentication
-details must remain within the settings file.
-
-## Gradle
-
-[Gradle](https://gradle.org/) is a commonly used build tool in the Java
-ecosystem.
-
-### Remove Gradle Caches
-
-Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
-Java you must delete that local cache so that libraries are downloaded again. By
-default the cache is located in a hidden `.gradle/.cache` directory in your
-users home directory. Use the following command to delete it:
-
-```shell
-rm -rf ~/.gradle/caches/
-```
-
-Gradle can also be configured to use a local Maven repository with a repository
-configuration in the global `init.gradle` or a project specific `build.gradle`
-file:
+Update this configuration file with the following, replacing `<repoistory-url>` with the URL provided by your repository manager:
 
 ```
-repositories {
-   ...
-    mavenLocal()    
-}
+[global]
+index-url = <repository-url>
 ```
 
-If this configuration is used, ensure to [delete the local Maven repository as
-well](#remove-maven-caches). 
-
-### Change Gradle Configuration
-
-Before running a new build you must configure access to the Chainguard Libraries
-for Java. If the administrator for your organization’s repository manager
-created a new repository or virtual repository or group repository, you must
-update your Gradle configuration. Artifact download is Gradle can be configured
-in an [init
-script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
-using the repositories definition. Each project can also [declare
-repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
-separately.
-
-A typical setup removes the direct reference to Maven Central `mavenCentral()`
-and any other repositories, and adds a replacement definition with the URL of the
-repository group or virtual repository from your repository manager
-`https://repo.example.com/group/` and any applicable authentication details.
+Note that updating this global configuration eaffects all projects built on the workstation. Alternately, if your project uses a `requirements.txt` file in projects, you can add the following to it to configure on a project-by-project basis:
 
 ```
-repositories {
-    maven {
-        url = uri("https://repo.example.com/group/")
-        credentials {
-            username = "YOUR_USERNAME_FOR_REPOSITORY_MANAGER"
-            password = "YOUR_PASSWORD"
-        }
-    }
-}
+--index-url <repository-url>
+package-name==version
 ```
 
-Example URLs for repository managers:
+### `uv`
 
-* Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/`
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/chainguard-maven/`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/chainguard-maven/`
+`uv` is an up-and-coming package and project manager for Python written in Rust.
 
-If your organization does not use a repository manager you can configure the
-Chainguard Libraries for Java repository with the credentials from [Chainguard
-Libraries access](/chainguard/libraries/access/) replacing the placeholders
-`CG_PULLTOKEN_USERNAME` and `CG_PULLTOKEN_PASSWORD`. Ensure that the Chainguard
-repository is located above the `mavenCentral` repository and any other
-repositories:
+To update yoru global configuration to use your organization's repository manager with `uv`, create or edit the `~/.config/uv/uv.toml` configuration file. (You may also need to create the `~/.config/uv/` folder first.) For example:
 
-```
-repositories {
-    maven {
-        url = uri("https://libraries.cgr.dev/maven/")
-        credentials {
-            username = "CG_PULLTOKEN_USERNAME"
-            password = "CG_PULLTOKEN_PASSWORD"
-        }
-    }
-    mavenCentral()
-}
+```sh
+mkdir -p ~/.config/uv
+nano ~/.config/uv/uv.toml
 ```
 
-## Other Build Tools
+Add the following to your `uv` global configuration file:
 
-Other build tools such as [Apache Ant](https://ant.apache.org/) with the [Maven
-Artifact Resolver Ant Tasks](https://maven.apache.org/resolver-ant-tasks/),
-[sbt](https://www.scala-sbt.org/), [Bazel](https://bazel.build/),
-[Leiningen](https://leiningen.org/) and others use Maven or Gradle caches or
-similar approaches. Refer to the documentation of your specific tool and the
-preceding sections to determine how to remove any used caches.
+```toml
+[[tool.uv.index]]
+name = "<repository-manager-name>"
+url = "<repository-url>"
+```
 
-These tools also include their own mechanisms to configure repositories for
-binary artifact retrieval. Consult the specific documentation and adjust your
-configuration to use your repository manager and newly created repository group
-or virtual repository.
-
-Example URLs for repository managers:
-
-* Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/`
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/chainguard-maven/`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/chainguard-maven/`
+Select any identifying name for your repository name, such as `Cloudsmith`. Make sure to retain the quotes.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -67,15 +67,7 @@ Next, configure an upstream proxy for the PyPI Repository:
 
 ### Build tool access
 
-The following steps allow you to determine the URL and authentication details for accessing the repository:
-
-1. Select the **Packages** tab.
-1. Select **Push/Pull Packages**.
-1. Choose the **PyPI** format.
-1. Copy the value in the `<url>` tag from the XML snippet with the `<repositories>` entry. For example, `https://dl.cloudsmith.io/basic/exampleorg/chainguard-python/python/` with `exampleorg` replaced with the name of your organization. Note the URL contains both the name of the repository `chainguard-python` as well as `python` as an identifier for the format.
-1. Select your desired authentication method (either *Default* or *API Key*). Copy the provided username and password values for configuration of tools such as `pip` or `uv`. You can perform this step multiple times if you're using different authentication methods for different tools.
-
-You are now ready to [configure your build tools.]((/chainguard/libraries/python/build-configuration)) using this information. After building a fiirst test project, confirm all libraries retrieved from Chainguard are tagged with the name of the upstream proxy.
+See the page on [build tool configuration for Chainguard Libraries for Python](/chainguard/libraries/python/build-configuration.md#cloudsmith) for information on accessing credentials and setting up build tools.
 
 <a name="artifactory"></a>
 
@@ -118,22 +110,9 @@ Combine the two repositories in a new virtual repository:
 
 ### Build tool access
 
-The following steps allow you to determine the URL and authentication details for accessing the repository using your build tools:
-
-1. Select **Administration** in the top navigation bar.
-1. Select **Repositories** in the left hand navigation.
-1. Select the **Virtual** tab in the repositories view.
-1. Locate the *chainguard-python** repository row and select the elipsis (**...**) in the last column on the right.
-1. Select **Set Me Up** in the dialog.
-1. Select **Generate Token & Create Instructions**
-1. Copy the generated token value to use as the password for authentication.
-1. Select **Generate Settings**.
-1. Copy the value from one of the *URL* fields. The are all identical. For example, `https://exampleorg.jfrog.io/artifactory/chainguard-python` with `exampleorg`. 
-
-Use the URL of the virtual repository in the [build configuration](/chainguard/libraries/python/build-configuration) and build a test project. In a working setup, the chainguard remote repository contains all libraries retrieved from Chainguard.
+See the page on [build tool configuration for Chainguard Libraries for Python](/chainguard/libraries/python/build-configuration.md#artifactory) for information on accessing credentials and setting up build tools.
 
 <a name="nexus"></a>
-
 ## Sonatype Nexus Repository
 
 [Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository) allows for merging multiple remote repositories as a repository group. The below instructions for  are based on the [Nexus documentation for PyPI](https://help.sonatype.com/en/pypi-repositories.html) 
@@ -173,10 +152,4 @@ Finally, create a new repository group and add the two repositories:
 
 ### Build tool access
 
-The following steps allow you to find the URL and authentication details for accessing the repository group:
-
-1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top navigation bar.
-1. Locate the **URL** column for the *chainguard-python* repository group and press **copy**. The URL should take the following format: `https://repo.example.com/repository/chainguard-python/` .
-1. Use your configured username and password unless **Security** - **Anonymous Access** - **Access** - **Allow anonymous users to access the server** is activated. Details vary based on your configured authentication system.
-
-Use the copied URL of the repository group [to configure your build tools of choice](/chainguard/libraries/python/build-configuration) and build a test project. In a working setup the `chainguard` proxy repository contains all libraries retrieved from the Chainguard Libraries for Python package index.
+See the page on [build tool configuration for Chainguard Libraries for Python](/chainguard/libraries/python/build-configuration.md#nexus) for information on accessing credentials and setting up build tools.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -15,23 +15,15 @@ weight: 052
 toc: true
 ---
 
-Python library consumption in a large organization is typically managed by
-a repository manager. Commonly used repository manager applications are
-[Cloudsmith](https://cloudsmith.com/), [JFrog
-Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus
-Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
-repository manager acts as a single point of access for developers and
-development tools to retrieve the required libraries.
+Python library consumption in a large organization is typically managed by a repository manager. Commonly used repository manager applications are [Cloudsmith](https://cloudsmith.com/), [JFrog Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The repository manager acts as a single point of access for developers and development tools to retrieve the required libraries.
 
-At a high level, adopting the use of Chainguard Libraries consists of the
-following steps:
+At a high level, adopting the use of Chainguard Libraries consists of the following steps:
 
 * Add Chainguard Libraries as a remote repository for library retrieval.
-* Add any internal repositories set up by your organization.
-* Add a public repository, likely PyPPI,, as a remove repository.
-* Set up a virtual server or other proxy configuration such that the Chainguard Libraries repository is the first choice for any request to the virtual server (after any internal repositories). 
+* Add a public repository, likely [PyPI](https://pypi.org/), as a remote repository.
+* Create a group, virtual, or polyglot repository combining these repository sources with any desired internal repositories. Configure the Chainguard Libraries repository as the first choice for any library access after any desired internal repositories.
 
-As part of this process, you may also wish to:
+You may also wish to:
 
 * Remove all prior cached artifacts in the virtual server or proxy public repository. This step will reduce confusion about the origin of libraries and will assist technical evaluation and adoption of Chainguard Libraries.
 * Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
@@ -42,15 +34,15 @@ If your organization does not use a repository manager, you can still use Chaing
 
 ## Cloudsmith
 
-[Cloudsmith](https://cloudsmith.com/) supports Python repositories for proxying and hosting and polyglot repositories that combine multiple repositories sources with compatible formats. Refer to the [Clouthsmith Python Repository documentation](https://help.cloudsmith.io/docs/python-repository) and the [Cloudsmith documentation for creating a repository](https://help.cloudsmith.io/docs/create-a-repository) for more information. 
+[Cloudsmith](https://cloudsmith.com/) supports Python repositories for proxying and hosting and polyglot repositories that combine multiple repositories sources with compatible formats. Refer to the [Cloudsmith Python Repository documentation](https://help.cloudsmith.io/docs/python-repository) and the [Cloudsmith documentation for creating a repository](https://help.cloudsmith.io/docs/create-a-repository) for more information. 
 
 ### Initial configuration
 
 Use the following steps to add a polyglot repository with both Chainguard Libraries and PyPI as upstream sources.
 
-First, let's create a repository:
+First, create a repository:
 
-1. Log in as a user with administrator privileges.
+1. Log in to your Cloudsmith instance as a user with administrator privileges.
 1. Select the **Repositories** tab near the top of the screen.
 1. Navigate to the **Repositories Overview**, then select **+ New repository**.
 1. At the new repository form, enter the name *chainguard-python* for your new repository. The name should include *python* to identify the repository format. This convention helps avoid confusion, since repositories in Cloudsmith are multi-format. 
@@ -62,15 +54,15 @@ Next, configure an upstream proxy for the PyPI Repository:
 1. Select the name of the new *chainguard-python* repository on the repositories page to configure it.
 1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
 1. Configure an upstream proxy with the format **python** and the following details: 
-    * **Name**: chainguard-libraries
-    * **Priority**: 1
-    * **Upstream URL**: https://libraries.cgr.dev/python/
-    * **Mode**: Cache and Proxy
+    * **Name**: `chainguard-libraries`
+    * **Priority**: `1`
+    * **Upstream URL**: `https://libraries.cgr.dev/python/`
+    * **Mode**: `Cache and Proxy`
 1. Configure another upstream proxy with the following details
-    * **Name**: pypi
-    * **Priority**: 2
-    * **Upstream URL**:*https://pypi.org/
-    * **Mode**: Cache and Proxy
+    * **Name**: `pypi`
+    * **Priority**: `2`
+    * **Upstream URL**: `https://pypi.org/`
+    * **Mode**: `Cache and Proxy`
 1. Select **Create Upstream Proxy**.
 
 ### Build tool access
@@ -78,185 +70,113 @@ Next, configure an upstream proxy for the PyPI Repository:
 The following steps allow you to determine the URL and authentication details for accessing the repository:
 
 1. Select the **Packages** tab.
-1. Press **Push/Pull Packages**.
-1. Choose the format **PyPI**.
-1. Copy the value in the `<url>` tag from the XML snippet with the
-   `<repositories>` entry. For example,
-   `https://dl.cloudsmith.io/basic/exampleorg/chainguard-python/maven/` with
-   `exampleorg` replaced with the name of your organization. Note that the name
-   of the repository `chainguard-python` as well as `maven` as identifier for the
-   format are part of the URL.
-1. Copy the username and password values block from the second code snippet for
-   authentication after choosing the desired authentication of *Default* or
-   *API Key*.
+1. Select **Push/Pull Packages**.
+1. Choose the **PyPI** format.
+1. Copy the value in the `<url>` tag from the XML snippet with the `<repositories>` entry. For example, `https://dl.cloudsmith.io/basic/exampleorg/chainguard-python/python/` with `exampleorg` replaced with the name of your organization. Note the URL contains both the name of the repository `chainguard-python` as well as `python` as an identifier for the format.
+1. Select your desired authentication method (either *Default* or *API Key*). Copy the provided username and password values for configuration of tools such as `pip` or `uv`. You can perform this step multiple times if you're using different authentication methods for different tools.
 
-Choose a different format and the equivalent sections if you are using another
-build tools such as Gradle.
-
-Use the URL of the repository, the username, and the password for the server
-authentication block in the [build
-configuration](/chainguard/libraries/python/build-configuration). and build a firs
-test project. In a working setup all libraries retrieved from Chainguard are
-tagged with the name of the upstream proxy.
+You are now ready to [configure your build tools.]((/chainguard/libraries/python/build-configuration)) using this information. After building a fiirst test project, confirm all libraries retrieved from Chainguard are tagged with the name of the upstream proxy.
 
 <a name="artifactory"></a>
 
 ## JFrog Artifactory
 
-[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories
-for proxying and hosting, and virtual repositories to combine them. Refer to the
-[PyPI Repository documentation for
-Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/maven-repository)
-for more information.
+[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories for proxying and virtual repositories to combine multiple sources into a single repository. The following instructions are based on on the [PyPI Repository documentation for Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
 
 ### Initial configuration
 
-Use the following steps to add the PyPI Repository and the Chainguard
-Libraries for Python repository as remote repositories and combine them as a
-virtual repository:
+Use the following steps to add the Chainguard Libraries for Python index and the PyPI public index as remote repositories and combine them as a virtual repository:
 
-1. Log in as a user with administrator privileges.
-1. Press **Administration** in the top navigation bar.
-1. Select **Repositories** in the left hand navigation.
+First, configure a remote repository for the Chainguard Libraries for Python index:
 
-Configure a remote repository for the PyPI Repository:
-
-1. Press **Create a Repository** and choose the **Remote** option.
-1. Select *PyPI* as the Package type.
-1. Set the **Repository Key** to *central*.
-1. Set the **URL** to *https://repo1.maven.org/maven2/* .
-1. Deactivate **PyPI Settings - Handle Snapshots**.
-1. Press **Create Remote Repository**.
-
-Configure a remote repository for the Chainguard Libraries for Python repository:
-
-1. Press **Create a Repository** and choose the **Remote** option.
+1. Log in to your Artifactory instance as a user with administrator privileges.
+1. Select **Create a Repository** and choose the **Remote** option.
 1. Select *PyPI* as the **Package type**.
-1. Set the **Repository Key** to *chainguard*.
-1. Set the **URL** to *https://libraries.cgr.dev/maven/*.
-1. Set **User Name** and **Password / Access Token** to the [values as retrieved
-   with chainctl](/chainguard/libraries/access/).
+1. Set the **Repository Key** to `chainguard`.
+1. Set the **URL** to `https://libraries.cgr.dev/python/`.
+1. Set **User Name** and **Password / Access Token** to the [values as retrieved with chainctl](/chainguard/libraries/access/).
 1. Check the **Enable Token Authentication** checkbox.
-1. Press **Test** to validate the connection.
-1. Deactivate **PyPI Settings - Handle Snapshots**.
+1. Select **Test** to validate the connection.
 1. Press **Create Remote Repository**.
+
+Configure a remote repositry for the PyPI public index:
+
+1. Select **Administration** in the top navigation bar. 
+1. Select **Repositories** in the left hand navigation. 
+1. Select **Create a Repository** and choose the **Remote** option.
+1. Select *PyPI* as the Package type.
+1. Set the **Repository Key** to `pypi`.
+1. Set the **URL** to `https://pypi.org/`.
+1. Select **Create Remote Repository**.
 
 Combine the two repositories in a new virtual repository:
 
 1. Press **Create a Repository** and choose the **Virtual** option.
-1. Set the **Repository Key** to *chainguard-python*.
-1. Scroll down to the **Repositories** section
-1. Add the *chainguard* and *maven-central* repositories. Ensure the
-   *chainguard* repository is the first in the displayed list. Use the icon on
-   the right of the repository name to drag and drop repositories into the
-   desired position.
-1. Press **Create Virtual Repository**.
-
-Use this setup for initial testing with Chainguard Libraries for Python. For
-production usage add the `chainguard` repository to your production virtual
-repository.
+1. Set the **Repository Key** to `chainguard-python`.
+1. In the **Repositories** section,, find the `chainguard` and `pypi` repositories. Ensure the `chainguard` repository is the first in the displayed list. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
+1. Select **Create Virtual Repository**.
 
 ### Build tool access
 
-The following steps allow you to determine the URL and authentication details
-for accessing the repository:
+The following steps allow you to determine the URL and authentication details for accessing the repository using your build tools:
 
-1. Press **Administration** in the top navigation bar.
+1. Select **Administration** in the top navigation bar.
 1. Select **Repositories** in the left hand navigation.
 1. Select the **Virtual** tab in the repositories view.
-1. Locate the *chainguard-python** repository.
-1. Hover over the row and click the **...** in the last column on the right.
+1. Locate the *chainguard-python** repository row and select the elipsis (**...**) in the last column on the right.
 1. Select **Set Me Up** in the dialog.
-1. Press **Generate Token & Create Instructions**
+1. Select **Generate Token & Create Instructions**
 1. Copy the generated token value to use as the password for authentication.
-1. Press **Generate Settings**.
-1. Copy the value from a *url* field. The are all identical. For example,
-   `https://exampleorg.jfrog.io/artifactory/chainguard-python` with `exampleorg`
-   replaced with the name of your organization.
+1. Select **Generate Settings**.
+1. Copy the value from one of the *URL* fields. The are all identical. For example, `https://exampleorg.jfrog.io/artifactory/chainguard-python` with `exampleorg`. 
 
-Use the URL of the virtual repository in the [build
-configuration](/chainguard/libraries/python/build-configuration) and build a first
-test project. In a working setup the chainguard remote repository contains all
-libraries retrieved from Chainguard.
+Use the URL of the virtual repository in the [build configuration](/chainguard/libraries/python/build-configuration) and build a test project. In a working setup, the chainguard remote repository contains all libraries retrieved from Chainguard.
 
 <a name="nexus"></a>
 
 ## Sonatype Nexus Repository
 
-[Sonatype Nexus
-Repository](https://www.sonatype.com/products/sonatype-nexus-repository)
-includes a *maven-public* repository group out of the box. It groups access to
-the PyPI Repository from the *maven-central* repository with the
-internal *maven-releases* and *maven-snapshot* repositories. Refer to the [PyPI
-Repositories documentation for
-Nexus](https://help.sonatype.com/en/maven-repositories.html) for more
-information.
-
-If you are using this group, you can add a proxy repository for Chainguard
-Libraries for Python repository for production use.
+[Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository) allows for merging multiple remote repositories as a repository group. The below instructions for  are based on the [Nexus documentation for PyPI](https://help.sonatype.com/en/pypi-repositories.html) 
 
 ### Initial configuration
 
-For initial testing and adoption it is advised to create a separate proxy
-repository for the PyPI Repository, a separate proxy repository
-Chainguard Libraries for Python repository, and a separate repository group:
+The following will create remote repositories for Chainguard Libraries for Python, a remote repository for the public PyPI index, and a repository group combining these sources.
 
-1. Log in as a user with administrator privileges.
-1. Access the **Server administration** and configuration section with the gear
-   icon in the top navigation bar.
+First, log in to Sonatype Nexus as a user with administrator privileges and access the **Server administration** and configuration section within the gear icon in the top navigation bar.
 
-Configure a remote repository for the PyPI Repository:
+Next, configure a remote repository for the public PyPI index:
 
 1. Select **Repository - Repositories** in the left hand navigation.
-1. Press **Create repository**.
-1. Select the **maven2 (proxy)** recipe.
-1. Provide a new name *central*.
-1. Ensure **PyPI 2 - Version policy** is set to *Release*.
-1. In the **Proxy - Remote storage** input add the URL *https://repo1.maven.org/maven2/*.
-1. Press **Create repository**.
+1. Select **Create repository**.
+1. Select the PyPI (proxy) recipe.
+1. Provide a new name, such as `pypi-proxy`.
+1. In the **Proxy - Remote storage** field, add the following URL: `https://pypi.org/`.
+1. Select **Create repository**.
 
 Configure a remote repository for the Chainguard Libraries for Python repository:
 
 1. Select **Repository - Repositories** in the left hand navigation.
-1. Press **Create repository**.
-1. Select the **maven2 (proxy)** recipe.
-1. Provide a new name *chainguard*.
-1. Ensure **PyPI 2 - Version policy** is set to *Release*.
-1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven/*.
-1. In **HTTP - Authentication** with the **Authentication type** *username*,
-   provide the [username and password values as retrieved with
-   chainctl](/chainguard/libraries/access/).
-1. Press **Create repository**. 
+1. Select **Create repository**.
+1. Select the PyPI (proxy) recipe.
+1. Provide a new name, such as `chainguard-proxy`.
+1. In the **Proxy - Remote storage**field, add the following URL: `https://libraries.cgr.dev/python/`.
+1. In **HTTP - Authentication**, set the **Authentication type** to *username* and enter the the [username and password values as retrieved with chainctl](/chainguard/libraries/access/).
+1. Select **Create repository**. 
 
-Combine a new repository group and add the two repositories:
+Finally, create a new repository group and add the two repositories:
 
 1. Select **Repository - Repositories** in the left hand navigation.
-1. Press **Create repository**.
-1. Select the **maven2 (group)** recipe.
-1. Provide a new name *chainguard-python*.
-1. In the section **Group - Member repositories**, move the new repositories
-   `central` and `chainguard` to the right and move the `chainguard` repository
-   to the top of the list with the arrow control.
+1. Select **Create repository**.
+1. Select the **PyPI (group)** recipe.
+1. Provide a new name, such as `chainguard-python`.
+1. In the section **Group - Member repositories**, move the new repositories `pypi-proxy` and `chainguard-proxy` to the right and move the `chainguard` repository to the top of the list with the arrow control.
 
 ### Build tool access
 
-The following steps allow you to determine the URL and authentication details
-for accessing the repository:
+The following steps allow you to find the URL and authentication details for accessing the repository group:
 
-1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top
-   navigation bar.
-1. Locate the **URL** column for the *chainguard-python* repository group and
-   press **copy**. For example,
-   `https://repo.example.com/repository/chainguard-python/`  with
-   `repo.example.com` replaced with the hostname of you repository manager.
-1. Copy the URL in the dialog.
-1. Use your configured username and password unless **Security** - **Anonymous
-   Access** - **Access** - **Allow anonymous users to access the server** is
-   activated. Details vary based on your configured authentication system.
+1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top navigation bar.
+1. Locate the **URL** column for the *chainguard-python* repository group and press **copy**. The URL should take the following format: `https://repo.example.com/repository/chainguard-python/` .
+1. Use your configured username and password unless **Security** - **Anonymous Access** - **Access** - **Allow anonymous users to access the server** is activated. Details vary based on your configured authentication system.
 
-Use the URL of the repository group, such as
-*https://repo.example.com/repository/chainguard-python/* or
-*https://repo.example.com/repository/maven-public/* in the [build
-configuration](/chainguard/libraries/python/build-configuration) and build a first
-test project. In a working setup the `chainguard` proxy repository contains all
-libraries retrieved frohttps://github.com/chainguard-dev/edu/pull/2148avoidm Chainguard.
+Use the copied URL of the repository group [to configure your build tools of choice](/chainguard/libraries/python/build-configuration) and build a test project. In a working setup the `chainguard` proxy repository contains all libraries retrieved from the Chainguard Libraries for Python package index.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -1,21 +1,21 @@
 ---
 title: "Global Configuration"
-linktitle: "Global Configuration"
-description: "Configuring Chainguard Libraries for Java in your organization"
+linktitle: "Global Configuration "
+description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
-date: 2025-03-25T08:04:00+00:00
-lastmod: 2025-04-07T14:42:00+00:00
+date: 2025-04-09:04:00+00:00
+lastmod: 2025-04-09T14:42:00+00:00
 draft: false
-tags: ["Chainguard Libraries", "Java"]
+tags: ["Chainguard Libraries", "Python"]
 images: []
 menu:
   docs:
-    parent: "java"
+    parent: "python"
 weight: 052
 toc: true
 ---
 
-Java and JVM library consumption in a large organization is typically managed by
+Python library consumption in a large organization is typically managed by
 a repository manager. Commonly used repository manager applications are
 [Cloudsmith](https://cloudsmith.com/), [JFrog
 Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus
@@ -65,7 +65,7 @@ by defining multiple upstream repositories.
 ### Initial configuration
 
 Use the following steps to add a repository with the Maven Central Repository
-and the Chainguard Libraries for Java repository as Maven upstream repositories. 
+and the Chainguard Libraries for Python repository as Maven upstream repositories. 
 
 Configure a *chainguard-maven* repository:
 
@@ -92,7 +92,7 @@ Configure an upstream proxy for the Maven Central Repository:
     * **Mode** *Cache and Proxy*
 1. Press **Create Upstream Proxy**.
 
-Configure an upstream proxy for the Chainguard Libraries for Java repository:
+Configure an upstream proxy for the Chainguard Libraries for Python repository:
 
 1. Click the name of the new *chainguard-maven* repository on the repositories
    page to configure it.
@@ -106,7 +106,7 @@ Configure an upstream proxy for the Chainguard Libraries for Java repository:
       access](/chainguard/libraries/access/) in **Authentication Settings**
 1. Press **Create Upstream Proxy**.
 
-Use this setup for initial testing with Chainguard Libraries for Java. For
+Use this setup for initial testing with Chainguard Libraries for Python. For
 production usage, add the `chainguard` upstream proxy to your production
 repository.
 
@@ -133,7 +133,7 @@ build tools such as Gradle.
 
 Use the URL of the repository, the username, and the password for the server
 authentication block in the [build
-configuration](/chainguard/libraries/java/build-configuration). and build a firs
+configuration](/chainguard/libraries/python/build-configuration). and build a firs
 test project. In a working setup all libraries retrieved from Chainguard are
 tagged with the name of the upstream proxy.
 
@@ -150,7 +150,7 @@ for more information.
 ### Initial configuration
 
 Use the following steps to add the Maven Central Repository and the Chainguard
-Libraries for Java repository as remote repositories and combine them as a
+Libraries for Python repository as remote repositories and combine them as a
 virtual repository:
 
 1. Log in as a user with administrator privileges.
@@ -166,7 +166,7 @@ Configure a remote repository for the Maven Central Repository:
 1. Deactivate **Maven Settings - Handle Snapshots**.
 1. Press **Create Remote Repository**.
 
-Configure a remote repository for the Chainguard Libraries for Java repository:
+Configure a remote repository for the Chainguard Libraries for Python repository:
 
 1. Press **Create a Repository** and choose the **Remote** option.
 1. Select *Maven* as the **Package type**.
@@ -190,7 +190,7 @@ Combine the two repositories in a new virtual repository:
    desired position.
 1. Press **Create Virtual Repository**.
 
-Use this setup for initial testing with Chainguard Libraries for Java. For
+Use this setup for initial testing with Chainguard Libraries for Python. For
 production usage add the `chainguard` repository to your production virtual
 repository.
 
@@ -213,7 +213,7 @@ for accessing the repository:
    replaced with the name of your organization.
 
 Use the URL of the virtual repository in the [build
-configuration](/chainguard/libraries/java/build-configuration) and build a first
+configuration](/chainguard/libraries/python/build-configuration) and build a first
 test project. In a working setup the chainguard remote repository contains all
 libraries retrieved from Chainguard.
 
@@ -231,13 +231,13 @@ Nexus](https://help.sonatype.com/en/maven-repositories.html) for more
 information.
 
 If you are using this group, you can add a proxy repository for Chainguard
-Libraries for Java repository for production use.
+Libraries for Python repository for production use.
 
 ### Initial configuration
 
 For initial testing and adoption it is advised to create a separate proxy
 repository for the Maven Central Repository, a separate proxy repository
-Chainguard Libraries for Java repository, and a separate repository group:
+Chainguard Libraries for Python repository, and a separate repository group:
 
 1. Log in as a user with administrator privileges.
 1. Access the **Server administration** and configuration section with the gear
@@ -253,7 +253,7 @@ Configure a remote repository for the Maven Central Repository:
 1. In the **Proxy - Remote storage** input add the URL *https://repo1.maven.org/maven2/*.
 1. Press **Create repository**.
 
-Configure a remote repository for the Chainguard Libraries for Java repository:
+Configure a remote repository for the Chainguard Libraries for Python repository:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Press **Create repository**.
@@ -295,6 +295,6 @@ for accessing the repository:
 Use the URL of the repository group, such as
 *https://repo.example.com/repository/chainguard-maven/* or
 *https://repo.example.com/repository/maven-public/* in the [build
-configuration](/chainguard/libraries/java/build-configuration) and build a first
+configuration](/chainguard/libraries/python/build-configuration) and build a first
 test project. In a working setup the `chainguard` proxy repository contains all
 libraries retrieved frohttps://github.com/chainguard-dev/edu/pull/2148avoidm Chainguard.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -3,8 +3,8 @@ title: "Global Configuration"
 linktitle: "Global Configuration "
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
-date: 2025-04-09:04:00+00:00
-lastmod: 2025-04-09T14:42:00+00:00
+date: 2025-03-25T08:04:00+00:00
+lastmod: 2025-04-07T14:42:00+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -27,102 +27,64 @@ At a high level, adopting the use of Chainguard Libraries consists of the
 following steps:
 
 * Add Chainguard Libraries as a remote repository for library retrieval.
-* Configure the Chainguard Libraries repository as the first choice for any
-  library access. This ensures that any future requests of new libraries access
-  the version supplied by Chainguard. Typically this is accomplished by creating a
-  group repository or virtual repository that combines the repository with other
-  external and internal repositories.
+* Add any internal repositories set up by your organization.
+* Add a public repository, likely PyPPI,, as a remove repository.
+* Set up a virtual server or other proxy configuration such that the Chainguard Libraries repository is the first choice for any request to the virtual server (after any internal repositories). 
 
-Additional steps depend on the desired insights and can include the following
-optional measures:
+As part of this process, you may also wish to:
 
-* Remove all cached artifacts in the proxy repository of Maven Central and other
-  repositories. This step allows you to validate which libraries are not
-  available from Chainguard Libraries and proceed with potential next steps with
-  Chainguard and your own development efforts. 
-* Remove any repositories that are no longer desired or necessary. Depending on
-  your library requirements this step can result in removal of some proxy
-  repositories or even removal of all proxy repositories. 
+* Remove all prior cached artifacts in the virtual server or proxy public repository. This step will reduce confusion about the origin of libraries and will assist technical evaluation and adoption of Chainguard Libraries.
+* Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
 
-Adopting the use of a repository manager is the recommended approach, however if
-your organization does not use a repository manager, you can still use
-Chainguard Libraries. All access to the Chainguard libraries repository is then
-distributed across all your build platforms and therefore more complex to
-configure and control. 
+If your organization does not use a repository manager, you can still use Chainguard Libraries. However, this approach may require configuration of multiple build and development platforms and utilities to use Chainguard Libraries. For this reason, adopting the use of a repository manager is the recommended approach. 
 
 <a name="cloudsmith"></a>
 
 ## Cloudsmith
 
-[Cloudsmith](https://cloudsmith.com/) supports Maven repositories for proxying
-and hosting. Refer to the [Maven Repository
-documentation](https://help.cloudsmith.io/docs/maven-repository) and the [Maven
-Upstream
-documentation](https://help.cloudsmith.io/docs/upstream-proxying-caching#create-a-maven-upstream)
-for Cloudsmith for more information. Cloudsmith supports combining repositories
-by defining multiple upstream repositories.
+[Cloudsmith](https://cloudsmith.com/) supports Python repositories for proxying and hosting and polyglot repositories that combine multiple repositories sources with compatible formats. Refer to the [Clouthsmith Python Repository documentation](https://help.cloudsmith.io/docs/python-repository) and the [Cloudsmith documentation for creating a repository](https://help.cloudsmith.io/docs/create-a-repository) for more information. 
 
 ### Initial configuration
 
-Use the following steps to add a repository with the Maven Central Repository
-and the Chainguard Libraries for Python repository as Maven upstream repositories. 
+Use the following steps to add a polyglot repository with both Chainguard Libraries and PyPI as upstream sources.
 
-Configure a *chainguard-maven* repository:
+First, let's create a repository:
 
 1. Log in as a user with administrator privileges.
 1. Select the **Repositories** tab near the top of the screen.
-1. On the **Repositories** page, click the **+ New repository** button.
-1. Enter the name *chainguard-maven* for your new repository. The name should
-   include *maven* to identify the repository format. This convention helps
-   avoid confusion since repositories in Cloudsmith are multi-format. 
-1. Select a storage region that is appropriate for your organization and
-   infrastructure.
-1. Press **+ Create Repository**. 
+1. Navigate to the **Repositories Overview**, then select **+ New repository**.
+1. At the new repository form, enter the name *chainguard-python* for your new repository. The name should include *python* to identify the repository format. This convention helps avoid confusion, since repositories in Cloudsmith are multi-format. 
+1. Select a storage region that is appropriate for your organization and infrastructure.
+1. Select **+ Create Repository**. 
 
-Configure an upstream proxy for the Maven Central Repository:
+Next, configure an upstream proxy for the PyPI Repository:
 
-1. Click the name of the new *chainguard-maven* repository on the repositories
-   page to configure it.
+1. Select the name of the new *chainguard-python* repository on the repositories page to configure it.
 1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
-1. Configure an upstream proxy with the format **Maven** and the following details:
+1. Configure an upstream proxy with the format **python** and the following details: 
+    * **Name**: chainguard-libraries
+    * **Priority**: 1
+    * **Upstream URL**: https://libraries.cgr.dev/python/
+    * **Mode**: Cache and Proxy
 1. Configure another upstream proxy with the following details
-    * **Name** *central* 
-    * **Priority** *2*
-    * **Upstream URL** *https://repo1.maven.org/maven2/*
-    * **Mode** *Cache and Proxy*
-1. Press **Create Upstream Proxy**.
-
-Configure an upstream proxy for the Chainguard Libraries for Python repository:
-
-1. Click the name of the new *chainguard-maven* repository on the repositories
-   page to configure it.
-1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
-1. Configure an upstream proxy with the format **Maven** and the following details:
-    * **Name** *chainguard* 
-    * **Priority** *1*
-    * **Proxy URL** *https://libraries.cgr.dev/maven/*
-    * **Mode** *Cache and Proxy*
-    * Add the **Username** and **Password** value from [Chainguard Libraries
-      access](/chainguard/libraries/access/) in **Authentication Settings**
-1. Press **Create Upstream Proxy**.
-
-Use this setup for initial testing with Chainguard Libraries for Python. For
-production usage, add the `chainguard` upstream proxy to your production
-repository.
+    * **Name**: pypi
+    * **Priority**: 2
+    * **Upstream URL**:*https://pypi.org/
+    * **Mode**: Cache and Proxy
+1. Select **Create Upstream Proxy**.
 
 ### Build tool access
 
-The following steps allow you to determine the URL and authentication details
-for accessing the repository:
+The following steps allow you to determine the URL and authentication details for accessing the repository:
 
 1. Select the **Packages** tab.
 1. Press **Push/Pull Packages**.
-1. Choose the format **Maven**.
+1. Choose the format **PyPI**.
 1. Copy the value in the `<url>` tag from the XML snippet with the
    `<repositories>` entry. For example,
-   `https://dl.cloudsmith.io/basic/exampleorg/chainguard-maven/maven/` with
+   `https://dl.cloudsmith.io/basic/exampleorg/chainguard-python/maven/` with
    `exampleorg` replaced with the name of your organization. Note that the name
-   of the repository `chainguard-maven` as well as `maven` as identifier for the
+   of the repository `chainguard-python` as well as `maven` as identifier for the
    format are part of the URL.
 1. Copy the username and password values block from the second code snippet for
    authentication after choosing the desired authentication of *Default* or
@@ -141,15 +103,15 @@ tagged with the name of the upstream proxy.
 
 ## JFrog Artifactory
 
-[JFrog Artifactory](https://jfrog.com/artifactory/) supports Maven repositories
+[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories
 for proxying and hosting, and virtual repositories to combine them. Refer to the
-[Maven Repository documentation for
+[PyPI Repository documentation for
 Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/maven-repository)
 for more information.
 
 ### Initial configuration
 
-Use the following steps to add the Maven Central Repository and the Chainguard
+Use the following steps to add the PyPI Repository and the Chainguard
 Libraries for Python repository as remote repositories and combine them as a
 virtual repository:
 
@@ -157,32 +119,32 @@ virtual repository:
 1. Press **Administration** in the top navigation bar.
 1. Select **Repositories** in the left hand navigation.
 
-Configure a remote repository for the Maven Central Repository:
+Configure a remote repository for the PyPI Repository:
 
 1. Press **Create a Repository** and choose the **Remote** option.
-1. Select *Maven* as the Package type.
+1. Select *PyPI* as the Package type.
 1. Set the **Repository Key** to *central*.
 1. Set the **URL** to *https://repo1.maven.org/maven2/* .
-1. Deactivate **Maven Settings - Handle Snapshots**.
+1. Deactivate **PyPI Settings - Handle Snapshots**.
 1. Press **Create Remote Repository**.
 
 Configure a remote repository for the Chainguard Libraries for Python repository:
 
 1. Press **Create a Repository** and choose the **Remote** option.
-1. Select *Maven* as the **Package type**.
+1. Select *PyPI* as the **Package type**.
 1. Set the **Repository Key** to *chainguard*.
 1. Set the **URL** to *https://libraries.cgr.dev/maven/*.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
 1. Check the **Enable Token Authentication** checkbox.
 1. Press **Test** to validate the connection.
-1. Deactivate **Maven Settings - Handle Snapshots**.
+1. Deactivate **PyPI Settings - Handle Snapshots**.
 1. Press **Create Remote Repository**.
 
 Combine the two repositories in a new virtual repository:
 
 1. Press **Create a Repository** and choose the **Virtual** option.
-1. Set the **Repository Key** to *chainguard-maven*.
+1. Set the **Repository Key** to *chainguard-python*.
 1. Scroll down to the **Repositories** section
 1. Add the *chainguard* and *maven-central* repositories. Ensure the
    *chainguard* repository is the first in the displayed list. Use the icon on
@@ -202,14 +164,14 @@ for accessing the repository:
 1. Press **Administration** in the top navigation bar.
 1. Select **Repositories** in the left hand navigation.
 1. Select the **Virtual** tab in the repositories view.
-1. Locate the *chainguard-maven** repository.
+1. Locate the *chainguard-python** repository.
 1. Hover over the row and click the **...** in the last column on the right.
 1. Select **Set Me Up** in the dialog.
 1. Press **Generate Token & Create Instructions**
 1. Copy the generated token value to use as the password for authentication.
 1. Press **Generate Settings**.
 1. Copy the value from a *url* field. The are all identical. For example,
-   `https://exampleorg.jfrog.io/artifactory/chainguard-maven` with `exampleorg`
+   `https://exampleorg.jfrog.io/artifactory/chainguard-python` with `exampleorg`
    replaced with the name of your organization.
 
 Use the URL of the virtual repository in the [build
@@ -224,8 +186,8 @@ libraries retrieved from Chainguard.
 [Sonatype Nexus
 Repository](https://www.sonatype.com/products/sonatype-nexus-repository)
 includes a *maven-public* repository group out of the box. It groups access to
-the Maven Central Repository from the *maven-central* repository with the
-internal *maven-releases* and *maven-snapshot* repositories. Refer to the [Maven
+the PyPI Repository from the *maven-central* repository with the
+internal *maven-releases* and *maven-snapshot* repositories. Refer to the [PyPI
 Repositories documentation for
 Nexus](https://help.sonatype.com/en/maven-repositories.html) for more
 information.
@@ -236,20 +198,20 @@ Libraries for Python repository for production use.
 ### Initial configuration
 
 For initial testing and adoption it is advised to create a separate proxy
-repository for the Maven Central Repository, a separate proxy repository
+repository for the PyPI Repository, a separate proxy repository
 Chainguard Libraries for Python repository, and a separate repository group:
 
 1. Log in as a user with administrator privileges.
 1. Access the **Server administration** and configuration section with the gear
    icon in the top navigation bar.
 
-Configure a remote repository for the Maven Central Repository:
+Configure a remote repository for the PyPI Repository:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Press **Create repository**.
 1. Select the **maven2 (proxy)** recipe.
 1. Provide a new name *central*.
-1. Ensure **Maven 2 - Version policy** is set to *Release*.
+1. Ensure **PyPI 2 - Version policy** is set to *Release*.
 1. In the **Proxy - Remote storage** input add the URL *https://repo1.maven.org/maven2/*.
 1. Press **Create repository**.
 
@@ -259,7 +221,7 @@ Configure a remote repository for the Chainguard Libraries for Python repository
 1. Press **Create repository**.
 1. Select the **maven2 (proxy)** recipe.
 1. Provide a new name *chainguard*.
-1. Ensure **Maven 2 - Version policy** is set to *Release*.
+1. Ensure **PyPI 2 - Version policy** is set to *Release*.
 1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven/*.
 1. In **HTTP - Authentication** with the **Authentication type** *username*,
    provide the [username and password values as retrieved with
@@ -271,7 +233,7 @@ Combine a new repository group and add the two repositories:
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Press **Create repository**.
 1. Select the **maven2 (group)** recipe.
-1. Provide a new name *chainguard-maven*.
+1. Provide a new name *chainguard-python*.
 1. In the section **Group - Member repositories**, move the new repositories
    `central` and `chainguard` to the right and move the `chainguard` repository
    to the top of the list with the arrow control.
@@ -283,9 +245,9 @@ for accessing the repository:
 
 1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top
    navigation bar.
-1. Locate the **URL** column for the *chainguard-maven* repository group and
+1. Locate the **URL** column for the *chainguard-python* repository group and
    press **copy**. For example,
-   `https://repo.example.com/repository/chainguard-maven/`  with
+   `https://repo.example.com/repository/chainguard-python/`  with
    `repo.example.com` replaced with the hostname of you repository manager.
 1. Copy the URL in the dialog.
 1. Use your configured username and password unless **Security** - **Anonymous
@@ -293,7 +255,7 @@ for accessing the repository:
    activated. Details vary based on your configured authentication system.
 
 Use the URL of the repository group, such as
-*https://repo.example.com/repository/chainguard-maven/* or
+*https://repo.example.com/repository/chainguard-python/* or
 *https://repo.example.com/repository/maven-public/* in the [build
 configuration](/chainguard/libraries/python/build-configuration) and build a first
 test project. In a working setup the `chainguard` proxy repository contains all

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -23,12 +23,12 @@ At a high level, adopting the use of Chainguard Libraries consists of the follow
 * Add a public repository, likely [PyPI](https://pypi.org/), as a remote repository.
 * Create a group, virtual, or polyglot repository combining these repository sources with any desired internal repositories. Configure the Chainguard Libraries repository as the first choice for any library access after any desired internal repositories.
 
-You may also wish to:
+You should also:
 
 * Remove all prior cached artifacts in the virtual server or proxy public repository. This step will reduce confusion about the origin of libraries and will assist technical evaluation and adoption of Chainguard Libraries.
 * Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
 
-If your organization does not use a repository manager, you can still use Chainguard Libraries. However, this approach may require configuration of multiple build and development platforms and utilities to use Chainguard Libraries. For this reason, adopting the use of a repository manager is the recommended approach. 
+If your organization does not use a repository manager, you can still use Chainguard Libraries. However, this approach requires configuration of multiple build and development platforms and utilities to use Chainguard Libraries. For this reason, adopting the use of a repository manager is the recommended approach. 
 
 <a name="cloudsmith"></a>
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -20,12 +20,12 @@ Python library consumption in a large organization is typically managed by a rep
 At a high level, adopting the use of Chainguard Libraries consists of the following steps:
 
 * Add Chainguard Libraries as a remote repository for library retrieval.
-* Add a public repository, likely [PyPI](https://pypi.org/), as a remote repository.
+* Add the public [PyPI](https://pypi.org/) repository as a remote repository.
 * Create a group, virtual, or polyglot repository combining these repository sources with any desired internal repositories. Configure the Chainguard Libraries repository as the first choice for any library access after any desired internal repositories.
 
 You should also:
 
-* Remove all prior cached artifacts in the virtual server or proxy public repository. This step will reduce confusion about the origin of libraries and will assist technical evaluation and adoption of Chainguard Libraries.
+* Remove all prior cached artifacts in the virtual server or proxy public repository. This step reduces confusion about the origin of libraries and assists technical evaluation and adoption of Chainguard Libraries.
 * Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
 
 If your organization does not use a repository manager, you can still use Chainguard Libraries. However, this approach requires configuration of multiple build and development platforms and utilities to use Chainguard Libraries. For this reason, adopting the use of a repository manager is the recommended approach. 

--- a/content/chainguard/libraries/python/management.md
+++ b/content/chainguard/libraries/python/management.md
@@ -1,0 +1,68 @@
+---
+title: "Management and Maintenance "
+linktitle: "Management "
+description: "Working with your Chainguard Libraries for Java use"
+type: "article"
+date: 2025-03-25T08:04:00+00:00
+lastmod: 2025-04-03T09:09:00+00:00
+draft: false
+tags: ["Chainguard Libraries", "Java"]
+images: []
+menu:
+  docs:
+    parent: "java"
+weight: 053
+toc: true
+---
+
+After the initial [global
+configuration](/chainguard/libraries/java/global-configuration/) and [build
+configuration](/chainguard/libraries/java/build-configuration/) the use of
+Chainguard Libraries for Java is transparently in progress. Newly use artifacts
+from new projects or new artifact versions are automatically retrieved from the
+Chainguard repository as they are available and the Maven Central Repository and
+other configure repositories serve as backstop to provide any additionally
+needed artifacts.
+
+The following sections detail optional management, maintenance, and auditing
+steps on the repository manager and the build tool.
+
+## Source Verification
+
+You can verify what artifacts are retrieved from the Chainguard Libraries
+repository on a global level:
+
+* Browse the `chainguard` proxy repository on your Artifactory or Nexus server.
+* Access the **Packages** tab of the the repository on your Cloudsmith instance.
+  Filter the package list with the tag value with the name for your upstream
+  proxy for Chainguard, for example `tag:chainguard`. The tag uses the name of
+  the upstream proxy, with spaces replaced with dashes.
+
+Use the browsing access to locate specific artifacts and identify their name,
+filesize, checksum values, timestamp and other identifiers. With these details
+you can verify your libraries use in the following locations:
+
+* Local cache repositories on developer workstation
+* Cache repositories in your CI pipeline
+* Libraries in your application bundles
+* Installed applications on your hosts or in your container images
+
+## Increase Chainguard Library Use
+
+The number of available artifacts in Chainguard Libraries for Java increases
+over time. If an artifact was already retrieved from the Maven Central
+Repository and is available in your repository manager or local repository it is
+not automatically replaced with the equivalent Chainguard Library version. 
+
+You can force a download of new libraries by erasing them from your local
+repositories on your workstations and the Maven Central proxy repository in your
+repository manager. Both these repositories are caches only and it is therefore
+safe to delete them.
+
+After the deletion any new build retrieves the artifact again and attempts to
+download from the Chainguard repository. As a result, newly available artifacts
+replace old artifacts that originated from Maven Central and your use of
+Chainguard Libraries increased.
+
+For a more fine-grained approach you can also delete subsections of local
+repositories and the proxy repositories.

--- a/content/chainguard/libraries/python/management.md
+++ b/content/chainguard/libraries/python/management.md
@@ -1,16 +1,16 @@
 ---
 title: "Management and Maintenance "
 linktitle: "Management "
-description: "Working with your Chainguard Libraries for Java use"
+description: "Working with your Chainguard Libraries for Python use"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
 lastmod: 2025-04-03T09:09:00+00:00
 draft: false
-tags: ["Chainguard Libraries", "Java"]
+tags: ["Chainguard Libraries", "Python"]
 images: []
 menu:
   docs:
-    parent: "java"
+    parent: "Python"
 weight: 053
 toc: true
 ---
@@ -18,10 +18,10 @@ toc: true
 After the initial [global
 configuration](/chainguard/libraries/java/global-configuration/) and [build
 configuration](/chainguard/libraries/java/build-configuration/) the use of
-Chainguard Libraries for Java is transparently in progress. Newly use artifacts
+Chainguard Libraries for Python is transparently in progress. Newly use artifacts
 from new projects or new artifact versions are automatically retrieved from the
-Chainguard repository as they are available and the Maven Central Repository and
-other configure repositories serve as backstop to provide any additionally
+Chainguard repository as they are available and the PyPI repository and
+other configured repositories serve as backstop to provide any additionally
 needed artifacts.
 
 The following sections detail optional management, maintenance, and auditing
@@ -49,19 +49,19 @@ you can verify your libraries use in the following locations:
 
 ## Increase Chainguard Library Use
 
-The number of available artifacts in Chainguard Libraries for Java increases
-over time. If an artifact was already retrieved from the Maven Central
+The number of available artifacts in Chainguard Libraries for Python increases
+over time. If an artifact was already retrieved from the PyPI
 Repository and is available in your repository manager or local repository it is
 not automatically replaced with the equivalent Chainguard Library version. 
 
 You can force a download of new libraries by erasing them from your local
-repositories on your workstations and the Maven Central proxy repository in your
+repositories on your workstations and the PyPI proxy repository in your
 repository manager. Both these repositories are caches only and it is therefore
 safe to delete them.
 
 After the deletion any new build retrieves the artifact again and attempts to
 download from the Chainguard repository. As a result, newly available artifacts
-replace old artifacts that originated from Maven Central and your use of
+replace old artifacts that originated from PyPI and your use of
 Chainguard Libraries increased.
 
 For a more fine-grained approach you can also delete subsections of local

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -18,7 +18,7 @@ toc: true
 
 Python is one of the most popular programming languages in the world and the open [Python Package Index (PyPI)](https://pypi.org/) contains over 600,000 libraries for application development, machine learning, data science, and many other use cases. Chainguard Libraries for Python rebuilds these powerful open source projects within the Chainguard Factory, enabling access to the Python ecosystem while dramatically reducing risk from an untrusted software supply chain.
 
-Chainguard Libraries for Python enables access to a growing collection of Python packages rebuilt from source. New releases of common libraries or artifacts requested by customers are added to the index by an automated system. Any request for a library or library version missing in Chainguard Libraries automatically triggers a process to provision the artifacts from relevant sources (such as GitHub) if available. In combination with third-party software repository managers, you can use Chainguard Libraries for Python as a secure source of truth for your development process.
+Chainguard Libraries for Python enables access to a growing collection of Python packages rebuilt from source. New releases of common libraries or artifacts requested by customers are added to the index by an automated system. Any request for a library or library version missing in Chainguard Libraries automatically triggers a process to provision the artifacts from relevant sources if available. In combination with third-party software repository managers, you can use Chainguard Libraries for Python as a secure source of truth for your development process.
 
 ## Technical Details
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -34,13 +34,11 @@ The URL does not expose a browsable directory structure. However, if you know th
 
 This Chainguard Libraries for Python repository uses the PyPI repository format and only includes release artifacts of the libraries built by Chainguard from source. 
 
-For example, you can locate a Maven POM file on the Maven Central Repository:
+For example, you can locate a `tar.gz` file on PyPI:
 
 ```
 https://files.pythonhosted.org/packages/source/f/flask/flask-3.1.0.tar.gz
 ```
-
-And then use the path composed from the Maven coordinates
 
 Combine it with the URL for the Chainguard Libraries for Python repository to check for the presence of the same file:
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -60,9 +60,8 @@ curl --user "exampleusername:examplepassword" \
   -O https://libraries.cgr.dev/python/flask/flask-3.1.0.tar.gz
 ```
 
-The Chainguard Libraries for Python repository does not include all packages from PyPI. Chainguard Libraries for Python are rebuilt from source and require that source be available. Therefore, packages that do not provide a valid source URL cannot be rebuilt within the Chainguard Factory. In addition, initial package rebuild coverage for Chainguard Libraries for Python is not comprehensive. The number of libraries rebuilt within the Chainguard Factory are growing fast, and you can request that a specific package be prioritized as we grow the index.
+The Chainguard Libraries for Python repository does not include all packages from PyPI. Chainguard Libraries for Python are rebuilt from source and require that source be available. Therefore, packages that do not provide a valid source URL cannot be rebuilt within the Chainguard Factory. In addition, initial package rebuild coverage for Chainguard Libraries for Python is not comprehensive. 
 
-Since coverage within Chainguard Libraries for Python is not comprehensive, you may consider setting the PyPI public package index as a fallback within your artifact repository manager. In this case, failed requests are logged by Chainguard and, where possible, the package will be prioritized for rebuild from source. Typically, access is [configured globally on a repository manager for your
-organization](/chainguard/libraries/python/global-configuration/).
+Since coverage within Chainguard Libraries for Python is not comprehensive, you should strongly consider setting the PyPI public package index as a fallback within your artifact repository manager. In this case, failed requests are logged by Chainguard and, where possible, the package will be prioritized for rebuild from source. Typically, access is [configured globally on a repository manager for your organization](/chainguard/libraries/python/global-configuration/).
 
-Alternatively, you can use the token for direct access from a build tool as discussed in [Build configuration](/chainguard/libraries/python/build-configuration/).
+Alternatively, you can use the token for direct access to the Chainguard Libraries for Python index as discussed in [Build configuration](/chainguard/libraries/python/build-configuration/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -1,0 +1,70 @@
+---
+title: "Chainguard Libraries for Python Overview"
+linktitle: "Python Overview "
+description: "Python libraries for your application development"
+type: "article"
+date: 2025-04-09:04:00+00:00
+lastmod: 2025-04-09:04:00+00:00
+draft: false
+tags: ["Chainguard Libraries", "Python", "Overview"]
+menu:
+  docs:
+    parent: "python"
+weight: 010
+toc: true
+---
+
+## Introduction
+
+Python is the second most popular programming language in the world and the open [Python Package Index (PyPI)](https://pypi.org/) contains over 600,000 libraries for application development, machine learning, data science, and many other use cases. Chainguard Libraries for Python rebuilds these powerful open source projects within the Chainguard Factory, enabling access to the Python ecosystem while dramatically reducing risk from an untrusted software supply chain.
+
+Chainguard Libraries for Python enables access to a growing collection of Python packages rebuilt from source. New releases of common libraries or artifacts requested by customers are added to the index by an automated system. Any request for a library or library version missing in Chainguard Libraries automatically triggers a process to provision the artifacts from relevant sources (such as GitHub) if available. In combination with third-party software repository managers, you can use Chainguard Libraries for Python as a secure source of truth for your development process.
+
+## Technical Details
+
+A [username and password retrieved with
+chainctl](/chainguard/libraries/access/) are required to access the Chainguard
+Libraries for Python repository. The URL for the repository is:
+
+```
+https://libraries.cgr.dev/python/
+```
+
+The URL does not expose a browsable directory structure. However, if you know the location of any particular artifact, you can use the login credentials and a set path URL to access a file.
+
+This Chainguard Libraries for Python repository uses the PyPI repository format and only includes release artifacts of the libraries built by Chainguard from source. 
+
+For example, you can locate a Maven POM file on the Maven Central Repository:
+
+```
+https://files.pythonhosted.org/packages/source/f/flask/flask-3.1.0.tar.gz
+```
+
+And then use the path composed from the Maven coordinates
+
+Combine it with the URL for the Chainguard Libraries for Python repository to check for the presence of the same file:
+
+```
+https://libraries.cgr.dev/python/flask/flask-3.1.0.tar.gz
+```
+
+Use the search functionality on [pypi.org](https://pypi.org/) to locate packages of interest.
+
+If you use the URL directly in a browser, you have to provide the username and
+password to log in to the Chainguard repository to download the file.
+
+Use curl and specify the [username and password retrieved with
+chainctl](/chainguard/libraries/access/) for basic user authentication and the
+URL of the file to download and save the file with the original name:
+
+```
+curl --user "exampleusername:examplepassword" \
+  -O https://libraries.cgr.dev/python/flask/flask-3.1.0.tar.gz
+```
+
+The Chainguard Libraries for Python repository does not include all packages from PyPI. Chainguard Libraries for Python are rebuilt from source and require that source be available. Therefore, packages that do not provide a valid source URL cannot be rebuilt within the Chainguard Factory. In addition, initial package rebuild coverage for Chainguard Libraries for Python is not comprehensive. The number of libraries rebuilt within the Chainguard Factory are growing fast, and you can request that a specific package be prioritized as we grow the index.
+
+Since coverage within Chainguard Libraries for Python is not comprehensive, you may consider setting the PyPI public package index as a fallback within your artifact repository manager. In this case, failed requests are logged by Chainguard and, where possible, the package will be prioritized for rebuild from source. Typically, access is [configured globally on a repository manager for your
+organization](/chainguard/libraries/python/global-configuration/).
+
+Alternatively, you can use the token for direct access from a build tool as discussed in [Build configuration](/chainguard/libraries/python/build-configuration/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -16,7 +16,7 @@ toc: true
 
 ## Introduction
 
-Python is the second most popular programming language in the world and the open [Python Package Index (PyPI)](https://pypi.org/) contains over 600,000 libraries for application development, machine learning, data science, and many other use cases. Chainguard Libraries for Python rebuilds these powerful open source projects within the Chainguard Factory, enabling access to the Python ecosystem while dramatically reducing risk from an untrusted software supply chain.
+Python is one of the most popular programming languages in the world and the open [Python Package Index (PyPI)](https://pypi.org/) contains over 600,000 libraries for application development, machine learning, data science, and many other use cases. Chainguard Libraries for Python rebuilds these powerful open source projects within the Chainguard Factory, enabling access to the Python ecosystem while dramatically reducing risk from an untrusted software supply chain.
 
 Chainguard Libraries for Python enables access to a growing collection of Python packages rebuilt from source. New releases of common libraries or artifacts requested by customers are added to the index by an automated system. Any request for a library or library version missing in Chainguard Libraries automatically triggers a process to provision the artifacts from relevant sources (such as GitHub) if available. In combination with third-party software repository managers, you can use Chainguard Libraries for Python as a secure source of truth for your development process.
 


### PR DESCRIPTION
## Description

Getting the ball rolling on our docs for Chainguard Libraries. This PR includes a draft of the overview page. I'll add to these docs as I learn more. Currently, the production artifacts are being pulled down and rebuilt and there are a number of unknowns as to URL structure and etc.

Update: added draft for global configuration (repository manager configuration).

## Notes

References https://github.com/chainguard-dev/internal/issues/4839