### PR TITLE
Adjust to final URL for Chainguard Libraries for Java

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -224,7 +224,7 @@ access](/chainguard/libraries/access/):
       <repositories>
         <repository>
           <id>chainguard</id>
-          <url>https://libraries.cgr.dev/maven/</url>
+          <url>https://libraries.cgr.dev/java/</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -246,7 +246,7 @@ access](/chainguard/libraries/access/):
       <pluginRepositories>
         <pluginRepository>
           <id>chainguard</id>
-          <url>https://libraries.cgr.dev/maven/</url>
+          <url>https://libraries.cgr.dev/java/</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -361,7 +361,7 @@ repositories:
 ```
 repositories {
     maven {
-        url = uri("https://libraries.cgr.dev/maven/")
+        url = uri("https://libraries.cgr.dev/java/")
         credentials {
             username = "CG_PULLTOKEN_USERNAME"
             password = "CG_PULLTOKEN_PASSWORD"

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -100,7 +100,7 @@ Configure an upstream proxy for the Chainguard Libraries for Java repository:
 1. Configure an upstream proxy with the format **Maven** and the following details:
     * **Name** *chainguard* 
     * **Priority** *1*
-    * **Proxy URL** *https://libraries.cgr.dev/maven/*
+    * **Proxy URL** *https://libraries.cgr.dev/java/*
     * **Mode** *Cache and Proxy*
     * Add the **Username** and **Password** value from [Chainguard Libraries
       access](/chainguard/libraries/access/) in **Authentication Settings**
@@ -189,7 +189,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Set the **Format** to *Maven*.
 1. Select *Remote* for the **Mode**.
 1. Select *Custom* for the **Remote repository source**.
-1. Set the URL for the Custom repository to *https://libraries.cgr.dev/maven*.
+1. Set the URL for the Custom repository to *https://libraries.cgr.dev/java*.
 1. Select *Authenticated* in **Remote repository authentication mode**.
 1. Set **Username for the upstream repository** to the [value as retrieved
    with chainctl](/chainguard/libraries/access/).
@@ -266,7 +266,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Press **Create a Repository** and choose the **Remote** option.
 1. Select *Maven* as the **Package type**.
 1. Set the **Repository Key** to *chainguard*.
-1. Set the **URL** to *https://libraries.cgr.dev/maven/*.
+1. Set the **URL** to *https://libraries.cgr.dev/java/*.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
 1. Check the **Enable Token Authentication** checkbox.
@@ -355,7 +355,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Select the **maven2 (proxy)** recipe.
 1. Provide a new name *chainguard*.
 1. Ensure **Maven 2 - Version policy** is set to *Release*.
-1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/maven/*.
+1. In the **Proxy - Remote storage** input add the URL *https://libraries.cgr.dev/java/*.
 1. In **HTTP - Authentication** with the **Authentication type** *username*,
    provide the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -54,7 +54,7 @@ chainctl](/chainguard/libraries/access/) are required to access the Chainguard
 Libraries for Java repository. The URL for the repository is:
 
 ```
-https://libraries.cgr.dev/maven/
+https://libraries.cgr.dev/java/
 ```
 
 The URL does not expose a browsable directory structure. However, if you know the
@@ -81,7 +81,7 @@ And combine it with the URL for the Chainguard Libraries for Java repository to
 check for the presence of the same file:
 
 ```
-https://libraries.cgr.dev/maven/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
 ```
 
 Use the [Maven Central Repository search](https://central.sonatype.com/) or
@@ -97,7 +97,7 @@ URL of the file to download and save the file with the original name:
 
 ```
 curl --user "exampleusername:examplepassword" \
-  -O https://libraries.cgr.dev/maven/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+  -O https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
 ```
 
 The Chainguard Libraries for Java repository does not include all artifacts from


### PR DESCRIPTION
## Type of change

### What should this PR do?

Update docs to the final URL.

### Why are we making this change?

New URL is more in line with naming of the product and should be used going forward. 

### What are the acceptance criteria? 

Review.

### How should this PR be tested?

URL must be live in production and a test should be run manually and with a repo manager. Done by Manfred as soon as prod deployment is ready.