### PR TITLE
Update security advisories docs

### DIFF
--- a/content/chainguard/chainguard-images/features/custom-assembly/index.md
+++ b/content/chainguard/chainguard-images/features/custom-assembly/index.md
@@ -17,14 +17,14 @@ toc: true
 
 Chainguard has created Custom Assembly, a tool that allows users to create customized container images with extra packages added. This enables customers to reduce their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs.
 
-This guide outlines how to build customized Chainguard Images using Custom Assembly in the Chainguard Console. It includes a brief overview of how Custom Assembly works, as well as its limitations.
+This guide outlines how to build customized Chainguard Containers using Custom Assembly in the Chainguard Console. It includes a brief overview of how Custom Assembly works, as well as its limitations.
 
 > **NOTE**: The Custom Assembly tool is currently in its beta phase and it is likely to go through changes before it becomes generally available.
 
 
 ## About Custom Assembly
 
-Custom Assembly is only available to customers that have access to Production Chainguard Images. Additionally, your account team must enable Custom Assembly before you will be able to begin using it. Contact your account team directly to start the process.
+Custom Assembly is only available to customers that have access to Production Chainguard Containers. Additionally, your account team must enable Custom Assembly before you will be able to begin using it. Contact your account team directly to start the process.
 
 When you enable the Custom Assembly tool for your organization, you must select at least one of Chainguard's application images to serve as the source for your customized container image. For example, if you want to build a custom base for a Python application, you would likely elect to use the [Python Chainguard Container](https://images.chainguard.dev/directory/image/python/versions) as the source for your customized image.
 
@@ -35,7 +35,7 @@ After selecting the packages for your customized container image, Chainguard wil
 
 Custom Assembly only allows you to add packages into a given container image; you cannot remove the packages included in the source application image by default. For example, Chainguard's Node.js container image comes with packages like `nodejs-23`, `npm`, and `glibc` by default. These packages can't be removed from a Node.js image using the Custom Assembly tool but you can add other packages into it, and you can remove these added packages in later builds.
 
-The packages you can add to a container image are those that your organization already has access to based on the Chainguard Images you have already purchased. Additionally, you can only add supported versions of packages to a customized image.
+The packages you can add to a container image are those that your organization already has access to based on the Chainguard Containers you have already purchased. Additionally, you can only add supported versions of packages to a customized image.
 
 The changes you make to your customized container image may affect its functional behavior when deployed. Chainguard doesn’t test your final customized image and therefore doesn't guarantee its functional behavior. Please test your customized images extensively to ensure they meet your requirements.
 

--- a/content/chainguard/chainguard-images/staying-secure/security-advisories/how-chainguard-issues/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/security-advisories/how-chainguard-issues/index.md
@@ -6,9 +6,9 @@ aliases:
 type: "article"
 description: "The life cycle of Chainguard-Issued Security Advisories"
 date: 2024-07-26T18:09:12+00:00
-lastmod: 2024-08-29T12:26:23+00:00
+lastmod: 2025-04-11T12:26:23+00:00
 draft: false
-tags: ["Overview", "Product", "Chainguard Images", "CVE"]
+tags: ["Product", "Chainguard Containers", "CVE"]
 images: []
 menu:
   docs:
@@ -17,9 +17,13 @@ weight: 020
 toc: true
 ---
 
-When you scan a newly-built Chainguard Image with a vulnerability scanner, typically, no CVEs will be reported. However, as software packages age, more vulnerabilities are reported and CVEs will begin to accumulate in images. When this happens, Chainguard releases security advisories to communicate these vulnerabilities to downstream Images users.
+When you scan a newly-built Chainguard Container with a vulnerability scanner, typically, no CVEs will be reported. However, as software packages age, more vulnerabilities are reported and CVEs will begin to accumulate in container images. When this happens, Chainguard releases security advisories to communicate these vulnerabilities to downstream images users.
 
-Chainguard publishes its security advisories to a dedicated [Security Advisories page](https://images.chainguard.dev/security/?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-chainguard-issues) on its Images Directory. There, you can find a complete listing of CVEs found in various Chainguard Images, including their CVE ID, affected packages, and vulnerability status. Each advisory is built from the metadata associated with a security vulnerability.
+In alignment with the [Chainguard Container Product Release Lifecycle](/chainguard/chainguard-images/about/versions/#what-chainguard-supports-and-maintains-for-chainguard-containers), our vulnerability management strategy focuses on the latest versions of any given release track, as these are the versions we actively maintain and secure. Accordingly, we only publish new CVE advisories for packages that fall within our defined support scope.
+
+We do not actively monitor non-supported versions of a package or image. Our efforts are centered on keeping the latest versions up-to-date and as close to zero CVEs as we can, while encouraging customers to upgrade and stay on supported versions.
+
+Chainguard publishes its security advisories to a dedicated [Security Advisories page](https://images.chainguard.dev/security/?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-chainguard-issues) on its container images Directory. There, you can find a complete listing of CVEs found in various Chainguard Containers, including their CVE ID, affected packages, and vulnerability status. Each advisory is built from the metadata associated with a security vulnerability.
 
 ![Snapshot of the Chainguard Security Advisories Page](advisories-page.png)
 
@@ -112,9 +116,9 @@ Rarely, a vulnerability is found in a package but there is no current status upd
 
 ## Further Reading
 
-Chainguard’s Security Advisory feed is a helpful tool to have at hand when scanning your containers for the presence of vulnerabilities. Though you won’t need it often thanks to the low CVE counts of our Images, it is a useful reference when working with your scans, giving you insight into how you can approach and fix any vulnerabilities which pop up.
+Chainguard’s Security Advisory feed is a helpful tool to have at hand when scanning your containers for the presence of vulnerabilities. Though you won’t need it often thanks to the low CVE counts of our container images, it is a useful reference when working with your scans, giving you insight into how you can approach and fix any vulnerabilities which pop up.
 
 For more information on how to use Chainguard’s Security Advisories page to inform your vulnerability remediation, consider reading our article on [How to Use Chainguard Security Advisories](
 /chainguard/chainguard-images/staying-secure/security-advisories/how-to-use/).
 
-If you are using Chainguard Images at your organization or want to learn more about advisories for enterprise Images, please [contact us!](https://www.chainguard.dev/contact)
+If you are using Chainguard Containers at your organization or want to learn more about advisories for enterprise container images, please [contact us](https://www.chainguard.dev/contact).

--- a/content/chainguard/chainguard-images/staying-secure/security-advisories/how-to-use/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/security-advisories/how-to-use/index.md
@@ -7,11 +7,11 @@ aliases:
 - /chainguard/chainguard-images/working-with-images/security-advisories
 - /chainguard/chainguard-images/working-with-images/security-advisories/how-to-use
 type: "article"
-description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Image Directory."
+description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Container Directory."
 date: 2023-12-27T11:07:52+02:00
-lastmod: 2024-12-06T15:16:50+01:00
+lastmod: 2025-04-11T15:16:50+01:00
 draft: false
-tags: ["OVERVIEW", "PRODUCT", "CHAINGUARD IMAGES", "CVE"]
+tags: ["Chainguard Containers", "CVEs", "Prouct"]
 images: []
 menu:
   docs:
@@ -22,9 +22,13 @@ toc: true
 
 When using scanners such as [Grype](https://github.com/anchore/grype) or [Docker Scout](https://docs.docker.com/scout/) to scan for vulnerabilities in Chainguard Containers, you'll often find that there are few or no CVEs present. However, CVEs can sometimes be found in Chainguard Containers, and you may also encounter CVEs if you're using older tags. In these cases, you will likely wish to check Chainguard's security advisories for information on which CVEs will cause security issues in your deployment.
 
-To help demystify the nature of CVEs within Chainguard Containers, we've created a self-service [Security Advisories page](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-to-use) that lists every security advisory published for Chainguard Images. Having this information available allows you to view whether Chainguard is aware of a specific vulnerability reported to exist within a Chainguard Image and whether we've mitigated or are planning to mitigate the CVE.
+To help demystify the nature of CVEs within Chainguard Containers, we've created a self-service [Security Advisories page](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-to-use) that lists every security advisory published for Chainguard Containers. Having this information available allows you to view whether Chainguard is aware of a specific vulnerability reported to exist within a Chainguard Container and whether we've mitigated or are planning to mitigate the CVE.
 
-This guide outlines how you can use Chainguard's Security Advisories to learn more about the status of a CVE within a given package. It will walk through a practical example of discovering a vulnerability in a Chainguard Image, searching for Security Advisories associated with this vulnerability, and then comparing the original Image with a later version.
+In alignment with the [Chainguard Container Product Release Lifecycle](/chainguard/chainguard-images/about/versions/#what-chainguard-supports-and-maintains-for-chainguard-containers), our vulnerability management strategy focuses on the latest versions of any given release track, as these are the versions we actively maintain and secure. Accordingly, we only publish new CVE advisories for packages that fall within our defined support scope.
+
+We do not actively monitor non-supported versions of a package or image. Our efforts are centered on keeping the latest versions up-to-date and as close to zero CVEs as we can, while encouraging customers to upgrade and stay on supported versions.
+
+This guide outlines how you can use Chainguard's Security Advisories to learn more about the status of a CVE within a given package. It will walk through a practical example of discovering a vulnerability in a Chainguard Container, searching for Security Advisories associated with this vulnerability, and then comparing the original container image with a later version.
 
 ## Prerequisites
 
@@ -39,9 +43,9 @@ To follow along with these examples, you'll need the following tools installed.
 Lastly, note that this guide includes examples involving a sample organization with a private Chainguard Registry named `example.com`. If you would like to follow along with your own private Chainguard Containers, be sure to change this where relevant to reflect your own setup. If you don't have access to a private Chainguard Registry, you can also follow along using Chainguard's public [Starter Containers](/chainguard/chainguard-images/about/images-categories/#starter-containers), but be aware that these are limited to only the `latest` or `latest-dev` tags. You can download public Starter Containers from the `cgr.dev/chainguard` registry, as in `cgr.dev/chainguard/go:latest`.
 
 
-## So you've encountered a CVE in a Chainguard Image
+## So you've encountered a CVE in a Chainguard Container
 
-Say you use a vulnerability scanner like Grype or Docker Scout to inspect a certain Chainguard Image. This example uses Grype to scan a Chainguard Production Image, specifically one tagged with `1.21.2`.
+Say you use a vulnerability scanner like Grype or Docker Scout to inspect a certain Chainguard Container. This example uses Grype to scan a Production container image, specifically one tagged with `1.21.2`.
 
 As of this writing, the `go:1.21.2` image points to the image digest `sha256:04ab6905552b54a6977bed40a4105e9c95f78033e1cde67806259efc4beb959d`. Be aware that this tag will be withdrawn in the future, but the digest will remain available.
 
@@ -49,7 +53,7 @@ As of this writing, the `go:1.21.2` image points to the image digest `sha256:04a
 grype cgr.dev/example.com/go:1.21.2
 ```
 
-Because this is the digest for an older version of Chainguard's Go Image, this command's output will show a number of vulnerabilities that have been found to exist within this specific version of the Image. 
+Because this is the digest for an older version of Chainguard's Go container image, this command's output will show a number of vulnerabilities that have been found to exist within this specific version of the container image. 
 
 ```
 . . .
@@ -60,7 +64,7 @@ Because this is the digest for an older version of Chainguard's Go Image, this c
 
 This output shows that this particular image has many critical and high vulnerabilities. The Grype output also lists each of the packages affected by CVEs as well as the specific vulnerabilities it found for each.
 
-> Note: All of these vulnerabilities have been addressed in newer versions of the Chainguard Go Image.
+> Note: All of these vulnerabilities have been addressed in newer versions of the Go Chainguard Container.
 
 Within this output,, we find that the package `nghttp2` is referenced. 
 
@@ -82,7 +86,7 @@ Copy or note down the CVE identifier (`2023-44487` in this case). Additionally, 
 
 ## Searching the Security Advisories
 
-After finding a vulnerability in a Chainguard Image, you can navigate to [Chainguard's **Security Advisories** page](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-to-use). This is a helpful resource you can use to determine the status for any CVE found within a Chainguard Image.
+After finding a vulnerability in a Chainguard Container, you can navigate to [Chainguard's **Security Advisories** page](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=website&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-how-to-use). This is a helpful resource you can use to determine the status for any CVE found within a Chainguard Container.
 
 The Security Advisories page is self-service, allowing you to check whether Chainguard is aware of a specific vulnerability and whether it has been mitigated in a certain package version. You can search the Security Advisories page by entering any CVE identifier to find what packages are affected by that CVE. You can also enter the names of individual packages to find what CVEs have been reported within them.
 
@@ -101,11 +105,11 @@ As with the Security Advisories landing page, you can filter by package name her
 As the previous screenshot highlights, for CVE-2023-44487, the `nghttp2` package's **Status** is marked as **Fixed** in version `1.57.0-r0` as of October 11, 2023.
 
 
-## Comparing Images
+## Comparing Containers
 
-Chainguard's Security Advisories have told us that the CVE-2023-44487 was fixed and removed from `nghttp2` with a more recent version than the one available in Chainguard's `go:1.21.2` Image. However, we don't have to take that report at face value; we can inspect a later version of the same Image and compare it with version `1.21.2` to determine whether the vulnerability is still present in the later version.
+Chainguard's Security Advisories have told us that the CVE-2023-44487 was fixed and removed from `nghttp2` with a more recent version than the one available in Chainguard's `go:1.21.2` image. However, we don't have to take that report at face value; we can inspect a later version of the same container image and compare it with version `1.21.2` to determine whether the vulnerability is still present in the later version.
 
-If you inspect a later version of the Image with Grype, you'll find that this time it does not report the high CVE we noted earlier. This example inspects version `1.21.5` of the Image.
+If you inspect a later version of the image with Grype, you'll find that this time it does not report the high CVE we noted earlier. This example inspects version `1.21.5` of the image.
 
 ```shell
 grype cgr.dev/example.com/go:1.21.5 | grep nghttp2
@@ -121,7 +125,7 @@ cgr.dev/example.com/go:1.21.2 \
 cgr.dev/example.com/go:1.21.5 | jq .
 ```
 
-This example will return a lot of output, as there are significant differences from version `1.21.2` to `1.21.5` of the Go Image. If you scroll down to the `vulnerabilities` section of this output, you'll find a list of vulnerabilities that are present in version `1.21.2` but have been removed by version `1.21.5`.
+This example will return a lot of output, as there are significant differences from version `1.21.2` to `1.21.5` of the Go container image. If you scroll down to the `vulnerabilities` section of this output, you'll find a list of vulnerabilities that are present in version `1.21.2` but have been removed by version `1.21.5`.
 
 ```
   "vulnerabilities": {
@@ -137,10 +141,10 @@ This example will return a lot of output, as there are significant differences f
 	. . .
 ```
 
-As this output indicates, `CVE0223-44487` is no longer present in later versions of the Go Chainguard Image. If you were using version `1.21.2`, you should seriously consider upgrading to a later version.
+As this output indicates, `CVE0223-44487` is no longer present in later versions of the Go Chainguard Container. If you were using version `1.21.2`, you should seriously consider upgrading to a later version.
 
 ## Learn More
 
 The Security Advisories page serves as a helpful resource for anyone who wants to learn more about CVEs reported within Chainguard Containers. You can search the database of advisories to learn more about any CVEs you encounter as you work with Chainguard Containers.
 
-Additionally, we encourage you to explore the [Chainguard Images Directory](https://images.chainguard.dev/), the parent site of the Security Advisories page. The Directory allows users to explore the complete inventory of Chainguard Containers. Finally, we encourage you to learn more about [noisy scan results](/chainguard/chainguard-images/scanners/false-results/) when scanning Chainguard Containers. 
+Additionally, we encourage you to explore the [Chainguard Containers Directory](https://images.chainguard.dev/), the parent site of the Security Advisories page. The Directory allows users to explore the complete inventory of Chainguard Containers. Finally, we encourage you to learn more about [noisy scan results](/chainguard/chainguard-images/scanners/false-results/) when scanning Chainguard Containers. 


### PR DESCRIPTION
## Type of change
Adding security advisory language as advised by @tazinprogga and @luhring to two security advisory pages. Also updated stray "Images" language in the custom assembly doc. 

### What should this PR do?
Adds some more context to help users on what to expect for security advisories. 

### Why are we making this change?
https://chainguard-dev.slack.com/archives/C03H64P08UT/p1743713693978439

### What are the acceptance criteria? 
Language is what is expected and in a relevant position within the docs. 

### How should this PR be tested?
Review preview or markdown files. 