### PR TITLE
Add info for Java artifact verification

### DIFF
--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -27,6 +27,8 @@ needed artifacts.
 The following sections detail optional management, maintenance, and auditing
 steps on the repository manager and the build tool.
 
+<a id="java-verification">
+
 ## Source Verification
 
 You can verify what artifacts are retrieved from the Chainguard Libraries
@@ -39,13 +41,43 @@ repository on a global level:
   the upstream proxy, with spaces replaced with dashes.
 
 Use the browsing access to locate specific artifacts and identify their name,
-filesize, checksum values, timestamp and other identifiers. With these details
+file size, checksum values, timestamp and other identifiers. With these details
 you can verify your libraries use in the following locations:
 
 * Local cache repositories on developer workstation
 * Cache repositories in your CI pipeline
 * Libraries in your application bundles
 * Installed applications on your hosts or in your container images
+
+A uniquely identifying characteristic of library artifacts are their checksums.
+Contrary to filenames and timestamps, checksums do not change in the use of
+libraries during an application build or the assembly of a deployment artifact
+like a tarball or container. This allows you to identify a library artifact by
+determining the checksum and then locating it in your repository manager.
+
+Calculate the different commonly used sums for a file `example.jar` with the
+following commands and output examples:
+
+```shell
+$ sha1sum example.jar
+aea83e64ebec6a37e0be100f968a55fb381143c2  example.jar
+
+$ sha256sum example.jar
+87a25c44e0fdb0c71e898c57f67b236d2205bfa76a25dbbb9779ebe2f93e787e  example.jar
+
+$ md5sum example.jar
+fefd660ddc795900d48bdf49c17b3135  example.jar
+```
+
+Use the search features in your repository manager, such as Sonatype Nexus, to
+locate the library. For the specific example, you find that the checksums
+correspond to the file `junit-4.13.2.jar` found in `junit/junit/4.13.2/` and
+that the artifact is found in the `chainguard` proxy repository. You can
+therefore conclude that the `example.jar` file originates from Chainguard, was
+built in the Chainguard Factory from source, and is available at
+`https://libraries.cgr.dev/java/junit/junit/4.13.2/junit-4.13.2.jar`. You can
+[manually download the file to
+compare](/chainguard/libraries/java/overview/#java-repo-test), if desired.
 
 ## Increase Chainguard Library Use
 

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -57,48 +57,13 @@ Libraries for Java repository. The URL for the repository is:
 https://libraries.cgr.dev/java/
 ```
 
-The URL does not expose a browsable directory structure. However, if you know the
-location of any particular artifact you can use the login credentials and a set
-path URL to access a file.
-
 This Chainguard Libraries for Java repository uses the Maven repository format
 and only includes release artifacts of the libraries built by Chainguard from
 source. Snapshot versions are not available.
 
-For example, you can locate a Maven POM file on the Maven Central Repository:
-
-```
-https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
-```
-
-And then use the path composed from the Maven coordinates
-
-```
-commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
-```
-
-And combine it with the URL for the Chainguard Libraries for Java repository to
-check for the presence of the same file:
-
-```
-https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
-```
-
-Use the [Maven Central Repository search](https://central.sonatype.com/) or
-[browse functionality](https://repo1.maven.org/maven2/) to locate artifacts of
-interest.
-
-If you use the URL directly in a browser, you have to provide the username and
-password to log in to the Chainguard repository to download the file.
-
-Use curl and specify the [username and password retrieved with
-chainctl](/chainguard/libraries/access/) for basic user authentication and the
-URL of the file to download and save the file with the original name:
-
-```
-curl --user "exampleusername:examplepassword" \
-  -O https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
-```
+The URL does not expose a browsable directory structure. However, if you know the
+location of any particular artifact you can use the login credentials and a set
+path URL to access a file.
 
 The Chainguard Libraries for Java repository does not include all artifacts from
 the Maven Central Repository and other repositories.
@@ -141,3 +106,49 @@ is strongly recommended.
 Alternatively, you can use the token for direct access from a build tool as
 discussed in [Build
 configuration](/chainguard/libraries/java/build-configuration/).
+
+<a id="java-repo-test">
+
+### Manual Testing
+
+You can manually download specific artifacts from the repository if you know the
+URL as determined by the identifying GAV coordinates for an artifact.
+
+For example, you can locate a Maven POM file on the Maven Central Repository:
+
+```
+https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+And then use the path composed from the Maven coordinates
+
+```
+commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+And combine it with the URL for the Chainguard Libraries for Java repository to
+check for the presence of the same file:
+
+```
+https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+Use the [Maven Central Repository search](https://central.sonatype.com/) or
+[browse functionality](https://repo1.maven.org/maven2/) to locate artifacts of
+interest.
+
+If you use the URL directly in a browser, you have to provide the username and
+password to log in to the Chainguard repository to download the file.
+
+Use curl and specify the [username and password retrieved with
+chainctl](/chainguard/libraries/access/) for basic user authentication and the
+URL of the file to download and save the file with the original name:
+
+```
+curl --user "exampleusername:examplepassword" \
+  -O https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+[Use checksums of any file to
+verify](/chainguard/libraries/java/management/#java-verification) if it
+originates from the Chainguard repository.


### PR DESCRIPTION
## Type of change

### What should this PR do?

Add info for Java artifact verification using checksum of random binary.

Fix https://github.com/chainguard-dev/internal/issues/4859

### Why are we making this change?

Customers need to be able to verify origin of a binary from  Chainguard.

### What are the acceptance criteria? 

Review

### How should this PR be tested?

Reviewer could follow process for any other file from Chainguard repo.