### PR TITLE
chainctl update does not always require admin rights

### DIFF
--- a/content/chainguard/chainctl-usage/chainctl-version-update.md
+++ b/content/chainguard/chainctl-usage/chainctl-version-update.md
@@ -74,11 +74,9 @@ To update your `chainctl` installation to the latest release, use:
 chainctl update
 ```
 
-Updating requires administrative privileges, so enter as `root` or use `sudo` and be prepared to enter your machine's admin password.
+This will present the following:
 
 ```shell
-sudo chainctl update
-[sudo] password for user: 
 Current version         v0.2.66
 Latest version          0.2.73
 


### PR DESCRIPTION
[ x] Check if this is a typo or other quick fix and ignore the rest :)

See [this comment](https://github.com/chainguard-dev/edu/pull/2221#discussion_r2058762949) for why this is being pushed. It turns out that admin privileges are not needed in some instances.