### PR TITLE
Fixes Internal #4686

### DIFF
--- a/content/chainguard/chainctl-usage/_index.md
+++ b/content/chainguard/chainctl-usage/_index.md
@@ -17,15 +17,15 @@ Like most control commands that end with `ctl`, such as `systemctl` or `loginctl
 
 This page lists a curated set of `chainctl` resources to help you get started.
 
-To install `chainctl`, follow our <ins>[installation guide](/chainguard/administration/how-to-install-chainctl/)</ins>.
+To install `chainctl`, follow our <ins>[installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/)</ins>.
 
 Once installed, these will help you on your path to success:
 
-* <ins>[Getting Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl/)</ins>
+* <ins>[Get Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl/)</ins>
 * <ins>[Authenticate to Chainguard Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
-* <ins>[How to Manage chainctl Configuration](/chainguard/administration/manage-chainctl-config/)</ins>
-* <ins>[How To Compare Chainguard Images with chainctl diff](/chainguard/chainguard-images/how-to-use/comparing-images/)</ins>
+* <ins>[Manage Your chainctl Configuration](/chainguard/chainctl-usage/manage-chainctl-config/)</ins>
 * <ins>[Find and Update Your chainctl Release Version](/chainguard/chainctl-usage/chainctl-version-update/)</ins>
+* <ins>[Compare Chainguard Images with chainctl diff](/chainguard-usage/comparing-images/)</ins>
 * <ins>[chainctl events](/chainguard/chainctl-usage/chainctl-events/)</ins>
 * <ins>[chainctl iam](/chainguard/chainctl-usage/chainctl-iam/)</ins>
 * <ins>[chainctl images](/chainguard/chainctl-usage/chainctl-images/)</ins>

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "events", "Product"]
 images: []
-weight: 50
+weight: 050
 ---
 
 This page presents some of the more commonly used `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).

--- a/content/chainguard/chainctl-usage/chainctl-iam.md
+++ b/content/chainguard/chainctl-usage/chainctl-iam.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "iam", "Product", "authentication", "access", "identity", "management"]
 images: []
-weight: 60
+weight: 060
 ---
 
 This page presents some of the more commonly used `chainctl iam` commands. These commands all relate to identity and access management (IAM), enabling your organization to control access to various resources and actions.

--- a/content/chainguard/chainctl-usage/chainctl-images-history.md
+++ b/content/chainguard/chainctl-usage/chainctl-images-history.md
@@ -8,7 +8,7 @@ lastmod: 2025-04-09T08:49:15+00:00
 draft: false
 tags: ["chainctl", "images", "history", "Product"]
 images: []
-weight: 75
+weight: 090
 ---
 
 This page demonstrates how to use the `chainctl images history` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).

--- a/content/chainguard/chainctl-usage/chainctl-images.md
+++ b/content/chainguard/chainctl-usage/chainctl-images.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "images", "Product"]
 images: []
-weight: 70
+weight: 070
 ---
 
 This page presents some of the more commonly used `chainctl images` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).

--- a/content/chainguard/chainctl-usage/chainctl-packages.md
+++ b/content/chainguard/chainctl-usage/chainctl-packages.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "packages", "Product"]
 images: []
-weight: 80
+weight: 100
 ---
 
 This page presents the most commonly used `chainctl packages` command. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).

--- a/content/chainguard/chainctl-usage/chainctl-version-update.md
+++ b/content/chainguard/chainctl-usage/chainctl-version-update.md
@@ -8,7 +8,7 @@ lastmod: 2025-03-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "version", "update", "Product"]
 images: []
-weight: 100
+weight: 040
 ---
 
 This page shows you how to check which release version of `chainctl` you have installed and how to update to the latest release.

--- a/content/chainguard/chainctl-usage/comparing-images.md
+++ b/content/chainguard/chainctl-usage/comparing-images.md
@@ -18,7 +18,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 080
+weight: 045
 toc: true
 ---
 

--- a/content/chainguard/chainctl-usage/comparing-images.md
+++ b/content/chainguard/chainctl-usage/comparing-images.md
@@ -1,6 +1,6 @@
 ---
 title: "How To Compare Chainguard Containers with chainctl"
-linktitle: "Compare with chainctl"
+linktitle: "Compare Images with chainctl"
 aliases: 
 - /chainguard/chainguard-images/comparing-images/
 - /chainguard/chainguard-images/comparing-images/comparing-images/
@@ -18,7 +18,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 025
+weight: 080
 toc: true
 ---
 

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started with chainctl"
+title: "Get Started with chainctl"
 lead: ""
 description: "chainctl basics for beginners"
 type: "article"
@@ -8,7 +8,7 @@ lastmod: 2025-03-03T08:49:15+00:00
 draft: false
 tags: ["chainctl", "Getting Started", "Product", "Basics"]
 images: []
-weight: 10
+weight: 020
 ---
 
 This page presents some of the more commonly used basic `chainctl` commands to help you get started. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).

--- a/content/chainguard/chainctl-usage/how-to-install-chainctl.md
+++ b/content/chainguard/chainctl-usage/how-to-install-chainctl.md
@@ -14,7 +14,7 @@ menu:
   docs:
     parent: "administration"
 toc: true
-weight: 005
+weight: 010
 ---
 
 The Chainguard command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard provides, and enable you to make queries into the state of your Chainguard resources.

--- a/content/chainguard/chainctl-usage/manage-chainctl-config.md
+++ b/content/chainguard/chainctl-usage/manage-chainctl-config.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Manage chainctl Configuration"
-linktitle: "chainctl Config"
+title: "Manage Your chainctl Configuration"
+linktitle: "Manage Your chainctl Configuration"
 aliases:
 - /chainguard/chainguard-enforce/manage-chainctl-config/
 type: "article"
@@ -13,7 +13,7 @@ menu:
   docs:
     parent: "administration"
 toc: true
-weight: 006
+weight: 030
 ---
 
 The Chainguard command line interface (CLI) tool, `chainctl`, will help you interact with the account model that Chainguard provides, and enable you to make queries into what's available to you on the Chainguard platform.


### PR DESCRIPTION
## Type of change
This moves several pages that document chainctl features from varied locations in the docs into the chainctl Usage section. It fixes https://github.com/chainguard-dev/internal/issues/4686

### What are the acceptance criteria? 
Since this PR rearranges pages, I would really like @smythp to take a look and determine whether we need any rewrites to cover the moves.

I would also like @erikaheidi and @SharpRake  to take a look to see if they think the new titles and new page locations/order make sense. Note that the pages with short names and no verbs in the titles are slated to be expanded, so I'll rename them one by one as that happens in future work, but that's why there are two different title styles. The "Verb Something" titles are either existing or newer tutorial-ish pages and not solely reference like the others.