### PR TITLE
Fix broken link to chainctl docs.

### DIFF
--- a/content/chainguard/chainctl-usage/how-to-install-chainctl.md
+++ b/content/chainguard/chainctl-usage/how-to-install-chainctl.md
@@ -3,6 +3,7 @@ title: "How to Install chainctl"
 linktitle: "Install chainctl"
 aliases:
 - /chainguard/chainguard-enforce/how-to-install-chainctl
+- /chainguard/administration/how-to-install-chainctl
 type: "article"
 description: "Install the chainctl command line tool to work with Chainguard"
 date: 2022-09-22T15:56:52-07:00


### PR DESCRIPTION
This link (indexed by google) was broken: https://edu.chainguard.dev/chainguard/administration/how-to-install-chainctl/

I'm hoping this fixes it.