### PR TITLE
Improve the chainctl events page

### DIFF
--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -1,29 +1,19 @@
 ---
-title: "chainctl events"
+title: "create, view, and delete chainctl events"
 lead: ""
 description: "chainctl events basics"
 type: "article"
-date: 2025-03-06T08:49:15+00:00
-lastmod: 2025-03-06T08:49:15+00:00
+date: 2025-05-06T08:49:15+00:00
+lastmod: 2025-05-06T08:49:15+00:00
 draft: false
 tags: ["chainctl", "events", "Product"]
 images: []
 weight: 050
 ---
 
-This page presents some of the more commonly used `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+This page shows you the basic usage of `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/). In addition, Chainguard Academy has several deeper guides on [CloudEvents](/chainguard/administration/cloudevents/). You may find our guide on [Subscribing to Chainguard CloudEvents](/chainguard/administration/cloudevents/events-example/) to be particularly useful for understanding how to work with events from Chainguard.
 
-There are three commands available: create, delete, and list. We'll start with list to see what subscriptions exist.
-
-## View your event subscriptions
-
-Get a list of all your Chainguard account's subscriptions with:
-
-```shell
-chainctl events subscriptions list
-```
-
-This will return a list of IDs and SINKs for all of your subscriptions. You know what an ID is. A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
+There are three `chainctl events` commands available: `create`, `list`, and `delete`.
 
 
 ## Create event subscriptions
@@ -34,7 +24,20 @@ To create a new event and subscribe to events in that organization or folder, us
 chainctl events subscriptions create $SINK_URL
 ```
 
+A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
+
 Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
+
+
+## View your event subscriptions
+
+To retrieve a list of all your Chainguard account's subscriptions, use:
+
+```shell
+chainctl events subscriptions list
+```
+
+This will return a list of IDs and SINKs for all of your subscriptions.
 
 
 ## Delete event subscriptions
@@ -46,7 +49,3 @@ chainctl events subscriptions delete $SUBSCRIPTION_ID
 ```
 
 Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
-
-## Learn More
-
-Chainguard Academy has several guides on [CloudEvents](/chainguard/administration/cloudevents/). You may find our guide on [Subscribing to Chainguard CloudEvents](/chainguard/administration/cloudevents/events-example/) to be particularly useful for understanding how to work with events from Chainguard.

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -28,9 +28,9 @@ To create a new event and subscribe to events in that organization or folder, us
 chainctl events subscriptions create $SINK_URL
 ```
 
-A SINK is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the SINK.
+A sink is an addressable or callable resource that can receive incoming events delivered over HTTPS and will translate the delivered event into a returned response that includes promised information. The style and type of response is set by the sink.
 
-Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
+Depending on the sink, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
 
 
 ## View your event subscriptions
@@ -41,7 +41,7 @@ To retrieve a list of all your Chainguard account's subscriptions, use:
 chainctl events subscriptions list
 ```
 
-This will return a list of IDs and SINKs for all of your subscriptions.
+This will return a list of IDs and sinks for all of your subscriptions.
 
 
 ## Delete event subscriptions
@@ -52,4 +52,4 @@ To delete an existing event, use:
 chainctl events subscriptions delete $SUBSCRIPTION_ID
 ```
 
-Depending on the SINK, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.
+Depending on the sink, you may be prompted to respond to some questions before this action is complete. You can add a `-y` to the command to automatically assume `yes` and run without interaction.

--- a/content/chainguard/chainctl-usage/chainctl-events.md
+++ b/content/chainguard/chainctl-usage/chainctl-events.md
@@ -1,7 +1,7 @@
 ---
-title: "create, view, and delete chainctl events"
+title: "Create, View, and Delete chainctl Events"
 lead: ""
-description: "chainctl events basics"
+description: "A simple introduction to chainctl events usage"
 type: "article"
 date: 2025-05-06T08:49:15+00:00
 lastmod: 2025-05-06T08:49:15+00:00
@@ -11,7 +11,11 @@ images: []
 weight: 050
 ---
 
-This page shows you the basic usage of `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/). In addition, Chainguard Academy has several deeper guides on [CloudEvents](/chainguard/administration/cloudevents/). You may find our guide on [Subscribing to Chainguard CloudEvents](/chainguard/administration/cloudevents/events-example/) to be particularly useful for understanding how to work with events from Chainguard.
+This page shows you the basic usage of `chainctl events` commands. For a full reference of all commands with details and switches, see [chainctl Reference](/chainguard/chainctl/).
+
+Chainguard events use the [CloudEvents](https://cloudevents.io/) specification for describing event data.
+
+Chainguard Academy has several deeper guides on [Chainguard CloudEvents](/chainguard/administration/cloudevents/). You may find our guide on [Subscribing to Chainguard CloudEvents](/chainguard/administration/cloudevents/events-example/) to be particularly useful for understanding how to work with events from Chainguard while [Chainguard Events](https://edu.chainguard.dev/chainguard/administration/cloudevents/events-reference/) provides a deeper dive into the content and make up of events.
 
 There are three `chainctl events` commands available: `create`, `list`, and `delete`.
 


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/internal/issues/4722 by transforming the content into a better and more useful format.

I added some contextual information as well as links to existing content that readers will find useful.