### PR TITLE
Add identifiers to duplicate menu items to remove Hugo warnings.

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly/index.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Chainguard Custom Assembly"
 linktitle: "Overview"
+identifier: "Custom Assembly Overview"
 aliases:
 - /chainguard/chainguard-images/features/custom-assembly/
 type: "article"
@@ -13,6 +14,7 @@ images: []
 menu:
   docs:
     parent: "features"
+    identifier: "Custom Assembly Introduction"
 weight: 001
 toc: true
 ---

--- a/content/open-source/sigstore/fulcio/an-introduction-to-fulcio/index.md
+++ b/content/open-source/sigstore/fulcio/an-introduction-to-fulcio/index.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "fulcio"
+    identifier: "Fulcio Introduction"
 weight: 230
 toc: true
 ---

--- a/content/open-source/sigstore/policy-controller/how-to-install-policy-controller.md
+++ b/content/open-source/sigstore/policy-controller/how-to-install-policy-controller.md
@@ -13,6 +13,7 @@ tags: ["policy-controller", "Procedural"]
 images: []
 menu:
   docs:
+    identifier: "Install Policy Controller"
     parent: "policy-controller"
 weight: 001
 toc: true

--- a/content/open-source/sigstore/rekor/an-introduction-to-rekor.md
+++ b/content/open-source/sigstore/rekor/an-introduction-to-rekor.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "rekor"
+    identifier: "Rekor Introduction"
 weight: 001
 toc: true
 ---

--- a/content/open-source/sigstore/rekor/how-to-install-rekor.md
+++ b/content/open-source/sigstore/rekor/how-to-install-rekor.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "rekor"
+    identifier: "Rekor CLI Install"
 weight: 002
 toc: true
 ---


### PR DESCRIPTION
## Description

We have Hugo build warnings since we have duplicate linktitles. This adds a unique identifier that should get rid of the warnings. This won't affect display or links, these IDs are mostly used by Hugo internally.