### PR TITLE
fips updates

### DIFF
--- a/content/chainguard/chainguard-images/features/fips/fips-images.md
+++ b/content/chainguard/chainguard-images/features/fips/fips-images.md
@@ -9,7 +9,7 @@ aliases:
 type: "article"
 description: "A conceptual overview of Chainguard FIPS Containers."
 date: 2024-02-08T15:56:52-07:00
-lastmod: 2025-04-08T15:56:52-07:00
+lastmod: 2025-05-24T09:58:00+00:00
 draft: false
 tags: ["Chainguard Containers", "Product", "FIPS"]
 images: []
@@ -28,17 +28,7 @@ One of the primary requirements of federal compliance frameworks — including [
 
 ## What To Expect from Chainguard FIPS Containers
 
-‍Chainguard warranties the following with respect to Chainguard container images:
-
-Chainguard FIPS Containers available to be delivered in compliance with FIPS specifications are listed [here](https://images.chainguard.dev/?category=fips)  (each a "Chainguard FIPS Container"). Containers will be made available in compliance with FIPS specifications provided a customer’s applicable order form designates the purchase of Chainguard FIPS images.
-
-The Chainguard FIPS Containers contain FIPS-validated software cryptographic modules. Entropy must be provided as specified in its cryptographic policy. The cryptographic module may provide non-approved algorithms, which will result in operating in FIPS non-approved mode. The cryptographic FIPS modules currently provided are:
-
-- OpenSSL FIPS 3.0 Provider Module (CVMP [#4856](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4856))
-- Bouncy Castle FIPS Java API (CMVP [#4743](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743), CMVP [#4616](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4616))
-- Chainguard CPU Time Jitter RNG Entropy Source (ESV Entropy Certificate [#E191](https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191))
-
-These modules may be updated occasionally; for further information, contact <fips-contact@chainguard.dev>.
+‍Chainguard warranties are listed on the [FIPS Commitment](https://www.chainguard.dev/legal/fips-commitment) page. It also includes tables of relevant certifications as well as SBOM indicators of package names and versions.
 
 ## Chainguard Kernel-Independent FIPS Containers
 

--- a/content/chainguard/chainguard-images/features/fips/fips-images.md
+++ b/content/chainguard/chainguard-images/features/fips/fips-images.md
@@ -56,14 +56,6 @@ All of Chainguard's FIPS Containers have [STIGs](/chainguard/chainguard-images/w
 
 ‍If Customer requests an image not currently available as a Chainguard FIPS Container, Chainguard will use commercially reasonable efforts to determine if such request is feasible. For further information, contact <fips-contact@chainguard.dev>.
 
-### Regarding Java-based FIPS Containers
-
-FIPS 140-3 is now supported for Java-based container images (`jdk-fips` and `jre-fips`) using the newly certified Bouncy Castle 2.0 cryptographic modules.
-
-The Bouncy Castle 1.x certificate providing FIPS 140-2 verification has moved to Historical. Most likely, those using it in an existing FedRAMP environment can continue using it, but you should check with your auditor. 
-
-You can learn more by reviewing the [blog announcement](https://www.chainguard.dev/unchained/chainguard-java-images-now-support-fips-140-3). 
-
 ## Learn more
 
 We encourage you to check our list of FIPS Containers in the [Chainguard Containers Directory](https://images.chainguard.dev/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-fips-images). After navigating to the directory, you can either click the **FIPS** tag in the left-hand sidebar menu to filter out any non-FIPS Containers, or use the search function to find every container image with "fips" in its name. Additionally, we encourage you to check out the documentation for [the OpenSSL FIPS module](https://www.openssl.org/docs/manmaster/man7/fips_module.html) and the [Bouncy Castle FIPS Crypto package](https://www.bouncycastle.org/about/bouncy-castle-fips-faq/) to better understand how they work.


### PR DESCRIPTION
- **fips: remove obsolete warranties text, with a link to up to date information**
  The Edu article contains out of date copy of the fips-commitment
  page. Instead of continuing to duplicate the information, simply link
  to the fips-commitment page which has been recently revamped to
  include a lot more information with SBOM indicators of package names
  and versions.
  

- **fips: remove notice about BC-FIPS 1.x, transition ended months ago**
  The bcfips 1.x -> 2.0 transition lasted 6 months and has ended months ago.
  We even have upgraded from 2.0 to 2.1 now.
  Thus remove this no longer relevant information.
  