### PR TITLE
Improve Chainguard Libraries for Python docs

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -129,6 +129,46 @@ tool configuration with environment variable placeholders:
 *  [Java build tool configuration](/chainguard/libraries/java/build-configuration)
 *  [Python build tool configuration](/chainguard/libraries/python/build-configuration)
 
+<a id="netrc"></a>
+
+## .netrc for authentication
+
+[curl](https://curl.se/) and a number of other tools support configuration of
+username and password authentication details for a specific domain in the
+[`.netrc`
+file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html),
+typically located in the user's home directory.
+
+Use this approach for authentication to a repository manager in your
+organization or to Chainguard Libraries directly, for example with [pip and
+others for Chainguard Libraries for
+Python](/chainguard/libraries/python/build-configuration#pip), with [bazel for
+Chainguard Libraries for
+Java](/chainguard/libraries/java/build-configuration#bazel) or for manual
+testing with curl.
+
+The following example shows a suitable setup for a repo manager available at
+`repo.example.com`:
+
+```
+machine repo.example.com
+login YOUR_USERNAME_FOR_REPOSITORY_MANAGER
+password YOUR_PASSWORD
+```
+
+For a direct connection to Chainguard Libraries, for example for testing with
+curl, use the following example with the username
+`CHAINGUARD_PYTHON_IDENTITY_ID` and password `CHAINGUARD_PYTHON_TOKEN` value for
+the pull token for the desired language ecosystem:
+
+```
+machine libraries.cgr.dev
+login CHAINGUARD_PYTHON_IDENTITY_ID
+password CHAINGUARD_PYTHON_TOKEN
+```
+
+Note that the long string for the password value must use only one line.
+
 ## Verify entitlement
 
 You can verify entitlements for your organization `example` with the following

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -416,6 +416,8 @@ allprojects {
 }
 ```
 
+<a id="bazel"></a>
+
 ## Bazel
 
 [Bazel](https://bazel.build/) is a fast, scalable, and extensible build tool
@@ -521,14 +523,8 @@ maven.install(
 Ensure that the Chainguard repository is listed before any other repositories to
 prioritize it for artifact retrieval. 
 
-For more complex Bazel setups, you can use a `.netrc` file containing the
-credentials:
-
-```
-machine libraries.cgr.dev
-login CHAINGUARD_JAVA_IDENTITY_ID
-password CHAINGUARD_JAVA_TOKEN
-```
+For more complex Bazel setups, you can use [.netrc for
+authentication](/chainguard/libraries/access#netrc).
 
 Refer to the [official Bazel documentation for
 rules_jvm_external](https://github.com/bazel-contrib/rules_jvm_external) for

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -98,6 +98,16 @@ Once you have credentials and the index URL from your organization's repository
 manager, you're ready to set up specific build tools for local development or
 CI/CD.
 
+### Authentication
+
+[pip](#pip), [uv](#uv), poetry, and other Python build and packaging tools have
+dedicated support for configuring authentication to the repository manager or
+the Chainguard Libraries for Python directly. As an alternative that works
+across tools and is often preferred, use [.netrc for
+authentication](/chainguard/libraries/access#netrc).
+
+<a id="pip"></a>
+
 ### pip
 
 The [pip tool](https://pip.pypa.io/en/stable/) is the most widely used utility
@@ -139,6 +149,10 @@ basis:
 package-name==version
 ```
 
+Refer to the official documentation for [configuring authentication with
+pip](https://pip.pypa.io/en/stable/topics/authentication/) if you are not using
+[.netrc for authentication](/chainguard/libraries/access#netrc).
+
 ### uv
 
 [uv](https://docs.astral.sh/uv) is a fast Python package and project manager
@@ -170,3 +184,10 @@ including the `simple/`context.
 Note that updating the global configuration affects all projects built on the
 workstation. Alternately, you can update each project by adding the same
 configuration in `pyproject.toml`.
+
+Refer to the official documentation for [configuring authentication with
+uv](https://docs.astral.sh/uv/configuration/authentication/) and [using
+alternative package
+indexes](https://docs.astral.sh/uv/guides/integration/alternative-indexes/) if
+you are not using [.netrc for
+authentication](/chainguard/libraries/access#netrc).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -42,38 +42,75 @@ documentation](/chainguard/libraries/python/global-configuration). The rest of
 this article provides details of the underlying implementation of Chainguard
 Libraries for Python and how to access individual libraries manually.
 
-The Chainguard Libraries for Python index uses the PyPI repository format and only includes release artifacts of the libraries built by Chainguard from source. 
+The Chainguard Libraries for Python index uses the PyPI repository format and
+only includes release artifacts of the libraries built by Chainguard from
+source.
 
-A [username and password retrieved with
-chainctl](/chainguard/libraries/access/) are required to access the Chainguard
-Libraries for Python repository. The URL for the repository is:
+The URL for the repository is:
 
 ```
 https://libraries.cgr.dev/python/
 ```
 
-Following PyPI URL conventions, a browsable directory structure can be viewed at:
+Use the URL with your [username and password retrieved with
+chainctl](/chainguard/libraries/access/) to access the Chainguard Libraries for
+Python repository manually with a browser.
+
+After successful login, you see a message `Forbidden`. Following PyPI URL
+conventions, a browsable directory structure can be viewed at the `simple`
+sub-context at `https://libraries.cgr.dev/python/simple/`. The top level
+contains a list of packages:
 
 ```
-https://libraries.cgr.dev/python/simple/
+2captcha-python
+3d-converter
+absql
+ahrs
+amqpstorm
+annogesic
+apiflask
+apscheduler
+...
 ```
 
-Specific packages can be accessed by package name and version:
+A list of all wheels and tarballs for the versions of a specific package is
+available in the context of the package. For example, the `apiflask` context at
+`https://libraries.cgr.dev/python/simple/apiflask/` shows the following list:
 
 ```
-https://libraries.cgr.dev/files/flask/flask-1.1.3.tar.gz
+Links for apiflask
+apiflask-0.1.0-py3-none-any.whl
+apiflask-0.1.0.tar.gz
+apiflask-0.10.0-py3-none-any.whl
+apiflask-0.10.0.tar.gz
+apiflask-0.10.1-py3-none-any.whl
+apiflask-0.10.1.tar.gz
+apiflask-0.11.0-py3-none-any.whl
+apiflask-0.11.0.tar.gz
+apiflask-0.12.0-py3-none-any.whl
+apiflask-0.12.0.tar.gz
+...
 ```
 
-Use the search functionality on [pypi.org](https://pypi.org/) to locate packages of interest.
+Each package name is a link with to the specific binary. The link includes long
+unique identifiers and cannot be determined without browsing. The list uses
+ascending order for the full name including the version.
 
-If you use the URL directly in a browser, you are prompted to provide the username and password created using `chainctl` via basic auth.
+Use the search functionality on [pypi.org](https://pypi.org/) to locate packages
+of interest and then browse in the simple index to determine available versions
+in Chainguard Libraries for Python.
 
-You can also use `curl` and specify the [username and password retrieved using chainctl](/chainguard/libraries/access/) for basic user authentication:
+You can also use `curl` and specify the [username and password retrieved using
+chainctl](/chainguard/libraries/access/) for basic user authentication after
+browsing for the correct URL.
 
 ```
 curl --user "exampleusername:examplepassword" \
-  -O https://libraries.cgr.dev/files/flask/flask-1.1.3.tar.gz
+  -O https://libraries.cgr.dev/files/...
 ```
+
+Curl also supports using [.netrc for
+authentication](/chainguard/libraries/access#netrc).
 
 The Chainguard Libraries for Python repository does not include all packages from PyPI. Chainguard Libraries for Python are rebuilt from source and require that source be available. Therefore, packages that do not provide a valid source URL cannot be rebuilt within the Chainguard Factory. In addition, initial package rebuild coverage for Chainguard Libraries for Python is not comprehensive. 
 


### PR DESCRIPTION
## Type of change

- Consolidate and improve .netrc docs
- Correct the info about manual browsing and download for Python
- Bring together content from Bazel and testing with Chainguard Libraries for Python and expand details.

### What should this PR do?

Provide better info for authentication for Chainguard Libraries. Fix wrong info about browsing.

### Why are we making this change?

Found in testing and conversations with eng team.

### What are the acceptance criteria? 

Review

### How should this PR be tested?

Not sure .. maybe test with curl directly to Chainguard Libraries for Python.