### PR TITLE
Document network requirements for Chibbies

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -172,3 +172,36 @@ can also remove a Chainguard Libraries entitlement:
 chainctl libraries entitlements rm ENTITLEMENT_ID
 ```
 -->
+
+## Network Requirements
+
+The following section details the required network access to use Chainguard
+Libraries and the related tools such as chainctl.
+
+### Access for chainctl and Other Tools
+
+For initial configuration with chainctl as well as for verification of
+downloaded libraries with cosign and other tools, you must have HTTPS access to
+the following domains:
+
+* `dl.enforce.dev` for download and update of chainctl
+* `issuer.enforce.dev` for authentication in web console and with chainctl
+* `console-api.enforce.dev` for web console and chainctl to administrate and use
+  your Chainguard accounts.
+* `console.chainguard.dev` for the web console to administrate and use your
+  Chainguard accounts.
+
+### Access for Libraries
+
+Chainguard Libraries use is transparent for development efforts and typically
+requires no additional network access for workstations and other infrastructure
+running builds because the libraries are provided by the repository manager as
+configured for [Java](/chainguard/libraries/java/global-configuration) or
+[Python](/chainguard/libraries/python/global-configuration).
+
+The repository manager application must have HTTPS access to the domain
+`libraries.cgr.dev` for library access and `issuer.enforce.dev` for
+authentication.
+
+If you are accessing Chainguard Libraries directly for testing with curl or with
+a build tool, the used workstation must have identical access.


### PR DESCRIPTION
## Type of change

Add network requirements for Chainguard Libraries similar to the ones for containers at https://edu.chainguard.dev/chainguard/administration/network-requirements/

### What should this PR do?

Clarify needed access for different scenarios

### Why are we making this change?

Resolve https://github.com/chainguard-dev/internal/issues/5023

### What are the acceptance criteria? 

Review.

### How should this PR be tested?

n.a.