### PR TITLE
Correct manual access verification

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -91,9 +91,16 @@ To use this pull token in another environment, supply the following for username
 and password valid for basic authentication. Note that the actual returned
 values are much longer.
 
-Use the credentials for manual testing in a browser or with a script if you know
-the URL for a specific library artifact, [for example a Java
-library](/chainguard/libraries/java/overview/#technical-details).
+### Verification
+
+Use the credentials for manual testing in a browser or with a script and curl if
+you know the URL for a specific library artifact. Refer to the following
+sections for more details:
+
+* [Technical details and manual testing for Java libraries](/chainguard/libraries/java/overview/#technical-details)
+* [Technical details and manual testing for Python libraries](/chainguard/libraries/python/overview/#technical-details)
+* [Use environment variables](#env)
+* [.netrc for authentication](#netrc)
 
 <a name="env"></a>
 

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -140,14 +140,25 @@ interest.
 If you use the URL directly in a browser, you have to provide the username and
 password to log in to the Chainguard repository to download the file.
 
-Use curl and specify the [username and password retrieved with
-chainctl](/chainguard/libraries/access/) for basic user authentication and the
-URL of the file to download and save the file with the original name:
+Use `curl`, specify the username and password retrieved with [chainctl for basic
+user authentication](chainguard/libraries/access) and use the URL of the file to
+download and save the file with the original name.
+
+With [.netrc authentication](/chainguard/libraries/access/#netrc):
 
 ```
-curl --user "exampleusername:examplepassword" \
+curl -n -L --user "$CHAINGUARD_JAVA_IDENTITY_ID:$CHAINGUARD_JAVA_TOKEN" \
   -O https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
 ```
+
+With [environment variables](/chainguard/libraries/access/#env):
+
+```
+curl -L --user "$CHAINGUARD_JAVA_IDENTITY_ID:$CHAINGUARD_JAVA_TOKEN" \
+  -O https://libraries.cgr.dev/java/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
+```
+
+The option `-L` is required to follow redirects for the actual file locations.
 
 [Use checksums of any file to
 verify](/chainguard/libraries/java/management/#java-verification) if it

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -99,17 +99,24 @@ Use the search functionality on [pypi.org](https://pypi.org/) to locate packages
 of interest and then browse in the simple index to determine available versions
 in Chainguard Libraries for Python.
 
-You can also use `curl` and specify the [username and password retrieved using
-chainctl](/chainguard/libraries/access/) for basic user authentication after
-browsing for the correct URL.
+Use `curl`, specify the username and password retrieved with [chainctl for basic
+user authentication](/chainguard/libraries/access/) and use the URL of the file
+to download and save the file with the original name:
+
+With [.netrc authentication](/chainguard/libraries/access/#netrc):
 
 ```
-curl --user "exampleusername:examplepassword" \
+curl -n -L -O https://libraries.cgr.dev/files/...
+```
+
+With [environment variables](/chainguard/libraries/access/#env):
+
+```
+curl -L --user '$CHAINGUARD_PYTHON_IDENTITY_ID:$CHAINGUARD_PYTHON_TOKEN' \
   -O https://libraries.cgr.dev/files/...
 ```
 
-Curl also supports using [.netrc for
-authentication](/chainguard/libraries/access#netrc).
+The option `-L` is required to follow redirects for the actual file locations.
 
 The Chainguard Libraries for Python repository does not include all packages
 from PyPI. Chainguard Libraries for Python are rebuilt from source and require


### PR DESCRIPTION
## Type of change

### What should this PR do?

- Adjust to the new use of redirects
- Add info for netrc and env variable use
- Link to Python and Java section

### Why are we making this change?

Old info no longer works and was incomplete

### What are the acceptance criteria? 

review

### How should this PR be tested?

Could be manually reproduced. I did that already myself.