### PR TITLE
network requirements: add virtualapk.cgr.dev

### DIFF
--- a/content/chainguard/administration/network-requirements.md
+++ b/content/chainguard/administration/network-requirements.md
@@ -31,8 +31,9 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | dl.enforce.dev          | 443  | HTTPS    | `chainctl` downloads                            |
 | issuer.enforce.dev      | 443  | HTTPS    | Registry STS (Security Token Service)           |
 | apk.cgr.dev             | 443  | HTTPS    | Package repository                              |
+| virtualapk.cgr.dev      | 443  | HTTPS    | Package repository                              |
 | packages.cgr.dev        | 443  | HTTPS    | Package repository (Extra packages)             |
-| packages.wolfi.dev      | 443  | HTTPS    | Package repository (Starter containers)           |
+| packages.wolfi.dev      | 443  | HTTPS    | Package repository (Starter containers)         |
 
 
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change

Adding a network requirement for a new endpoint we're going to be communicating to users soon.

### What should this PR do?

Add a documented network requirement

### Why are we making this change?

To let users know we'll be serving packages from an additional endpoint.

### What are the acceptance criteria? 

Docs look good

### How should this PR be tested?

Check the preview 