### PR TITLE
moving Network Requirements doc from Admin ==> Containers

### DIFF
--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -1,16 +1,18 @@
 ---
-title: "Network Requirements"
+title: "Chainguard Containers Network Requirements"
 linktitle: "Network Requirements"
-lead: "Using Chainguard Containers with firewalls, access control lists, and proxies"
+aliases:
+- /chainguard/administration/network-requirements/
+lead: "Using Chainguard Containers with firewalls, access control lists, and proxies."
 type: "article"
-description: "Using Chainguard Containers with firewalls, access control lists, and proxies"
+description: "Using Chainguard Containers with firewalls, access control lists, and proxies."
 date: 2023-09-08T08:49:31+00:00
 lastmod: 2024-11-20T15:22:20+01:00
 draft: false
 tags: ["Product", "Reference"]
 images: []
 toc: true
-weight: 001
+weight: 010
 ---
 
 This document provides an overview of network requirements for using [Chainguard Containers](https://www.chainguard.dev/chainguard-images?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement). To use Chainguard tools and Containers in environments with firewalls, VPNs, and IDS/IPS systems, you will need to add some rules to allow traffic into and out of your networks.

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -12,7 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 010
+weight: 005
 toc: true
 ---
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Moving the containers Network Requirements doc from the Administration bucket to Containers. Also tweaked the title and added an alias pointing to the old path.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Resolves https://github.com/chainguard-dev/internal/issues/5032

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Making product-specific docs easier to find.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
Change should make sense and align with expectations for where this doc should live.

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Let me know if any further changes ought to be made and please test the redirect.

[preview link](https://deploy-preview-2321--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/network-requirements/)

old path which will redirect: deploy-preview-2321--ornate-narwhal-088216.netlify.app/chainguard/administration/network-requirements/