### PR TITLE
add note to tag history api page re using chainctl

### DIFF
--- a/content/chainguard/chainguard-images/features/using-the-tag-history-api.md
+++ b/content/chainguard/chainguard-images/features/using-the-tag-history-api.md
@@ -27,6 +27,8 @@ A container image digest is a unique identifier that is generated for each and e
 
 If you have a container environment that was working fine but suddenly breaks with a new build, using a previous container image build version by declaring an image digest instead of a tag is a way to keep things up and running until you're able to assert that a new version of a container environment works as expected with your application.
 
+> NOTE: If you are looking for a quick way to learn the tag history of a container image, you may want to consider using the `chainctl images history` command instead of the API. See **Examine the History of Container Images** in [this page](../../chainctl-usage/chainctl-images.md) for more information.
+
 
 ## Obtaining a Registry Token
 


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/internal/issues/4868 by adding a note on the API page with guidance on considering using `chainctl images history` for quick checks.

The request was to rewrite the page to use only this command, but it's likely there are customers using the API and others who have use cases where it is still useful. Since the chainctl command is already documented, pointing to that as an alternative seems a reasonable compromise.