### PR TITLE
Small edits for clarity, added one step to adding virtual repository

### DIFF
--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -67,6 +67,8 @@ accessing your organization's JFrog Artifactory repository manager.
 1. Select **Administration** in the top navigation bar.
 1. Select **Repositories** in the left hand navigation.
 1. Select the **Virtual** tab in the repositories view.
+1. Locate the *python-all** repository row and press the three dots
+   (**...**) in the last column on the right.
 1. Locate the virtual repository set up by your organization to use Chainguard Libraries and select the three dots (`...`) in the last column on the right. (*python-all** is the recommended name for this virtual repository.)
 1. Select **Set Me Up** in the dialog.
 1. Select **Generate Token & Create Instructions**

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -67,8 +67,7 @@ accessing your organization's JFrog Artifactory repository manager.
 1. Select **Administration** in the top navigation bar.
 1. Select **Repositories** in the left hand navigation.
 1. Select the **Virtual** tab in the repositories view.
-1. Locate the *python-all** repository row and press the three dots
-   (**...**) in the last column on the right.
+1. Locate the virtual repository set up by your organization to use Chainguard Libraries and select the three dots (`...`) in the last column on the right. (*python-all** is the recommended name for this virtual repository.)
 1. Select **Set Me Up** in the dialog.
 1. Select **Generate Token & Create Instructions**
 1. Copy the generated token value to use as the password for authentication.

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -69,7 +69,6 @@ accessing your organization's JFrog Artifactory repository manager.
 1. Select the **Virtual** tab in the repositories view.
 1. Locate the *python-all** repository row and press the three dots
    (**...**) in the last column on the right.
-1. Locate the virtual repository set up by your organization to use Chainguard Libraries and select the three dots (`...`) in the last column on the right. (*python-all** is the recommended name for this virtual repository.)
 1. Select **Set Me Up** in the dialog.
 1. Select **Generate Token & Create Instructions**
 1. Copy the generated token value to use as the password for authentication.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -81,7 +81,7 @@ accessing credentials and setting up build tools.
 
 ## JFrog Artifactory
 
-[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories for proxying and virtual repositories to combine multiple sources into a single repository. The following instructions are based on on the [PyPI Repository documentation for Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
+[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories for proxying and virtual repositories to combine multiple sources into a single repository. The following instructions are based on the [PyPI Repository documentation for Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
 
 ### Initial configuration
 
@@ -117,12 +117,15 @@ Configure a remote repository for the PyPI public index:
 Combine the two repositories in a new virtual repository:
 
 1. Press **Create a Repository** and choose the **Virtual** option.
+1. Select *PyPI* as the Package type.
 1. Set the **Repository Key** to `python-all`.
 1. In the **Repositories** section, find the `python-chainguard` and
    `python-public` repositories. Ensure the `python-chainguard` repository is
    the first in the displayed list. Use the icon on the right of the repository
    name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
+
+At this point, you have a virtual repository set up in Artifactory that will allow you or others at your organization to access Chainguard Libraries for Python with your chosen tools. This setup will fall back to the public PyPI index in cases where a package is not available in Chainguard's index
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -125,7 +125,7 @@ Combine the two repositories in a new virtual repository:
    name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
 
-At this point, you have a virtual repository set up in Artifactory that will allow you or others at your organization to access Chainguard Libraries for Python with your chosen tools. This setup will fall back to the public PyPI index in cases where a package is not available in Chainguard's index
+At this point, you have a virtual repository set up in Artifactory that allows you or others in your organization to access Chainguard Libraries for Python with your chosen tools. This setup falls back to the public PyPI index in cases where a package is not available in Chainguard's index.
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -108,7 +108,7 @@ apiflask-0.12.0.tar.gz
 ...
 ```
 
-Each package name is a link with to the specific binary. The link includes long
+Each package name is a link to the specific binary. The link includes long
 unique identifiers and cannot be determined without browsing. The list uses
 ascending order for the full name including the version.
 
@@ -116,8 +116,7 @@ Use the search functionality on [pypi.org](https://pypi.org/) to locate packages
 of interest and then browse in the simple index to determine available versions
 in Chainguard Libraries for Python.
 
-Use `curl`, specify the username and password retrieved with [chainctl for basic
-user authentication](/chainguard/libraries/access/) and use the URL of the file
+Use `curl`, specifying the username and password retrieved with [chainctl](/chainguard/libraries/access/), and use the URL of the file
 to download and save the file with the original name:
 
 With [.netrc authentication](/chainguard/libraries/access/#netrc):

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -116,7 +116,8 @@ Use the search functionality on [pypi.org](https://pypi.org/) to locate packages
 of interest and then browse in the simple index to determine available versions
 in Chainguard Libraries for Python.
 
-Use `curl`, specifying the username and password retrieved with [chainctl](/chainguard/libraries/access/), and use the URL of the file
+Use `curl`, specifying the username and password retrieved with
+[chainctl](/chainguard/libraries/access/), and use the URL of the file
 to download and save the file with the original name:
 
 With [.netrc authentication](/chainguard/libraries/access/#netrc):


### PR DESCRIPTION
## Description

I ran through Artifactory setup and local config for pip for Learning Lab, these are some small edits on that path. Most notably added a (pretty obvious) step to the section on adding a virtual repository. I made one other edit in the assumption that some would be following the docs without being the same person who set up the repositories (i.e. not assume that they used our default name, but sharing what the default name is).

cc @mosabua 