### PR TITLE
Add Learning Labs section

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -466,6 +466,11 @@ header .search-container {
     margin-right: 0;
 }
 
+// Beat <a> reset
+.topic-container.topic-container a:not(.tag) {
+   color: var(--article-link-color);
+}
+
 .topic-title {
     font-size: 36px;
     font-weight: 600;

--- a/content/software-security/learning-labs/_index.md
+++ b/content/software-security/learning-labs/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Learning Labs"
+description: "Education and training videos on demand"
+type: "article"
+date: 2025-06-18T21:00:00+00:00
+lastmod: 2025-06-18T21:00:00+00:00
+draft: false
+images: []
+tags: ["Learning Labs", "Overview"]
+toc: true
+---
+
+Learning Labs are [regularly run, virtual events from
+Chainguard](https://www.chainguard.dev/events) that provide educational and
+training material about Chainguard products, software supply chain security, and
+related topics.
+
+## Lab Notes
+
+The lab notes often include demo projects, a slide presentation, sample
+commands, links to specific sections in the video, and pointers to more
+resources:
+
+- [Chainguard Libraries for Java - May 2025](/software-security/learning-labs/ll202505/)
+
+Older labs are available in the [YouTube
+playlist](https://www.youtube.com/playlist?list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn):
+
+- [Building Guardcraft using Chainguard Images - Mar 2025](https://www.youtube.com/watch?v=q6I0JC3h06U&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard's Python Image - Feb 2025](https://www.youtube.com/watch?v=922G7SLs0b0&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard Static Images – Jan 2025](https://www.youtube.com/watch?v=YAo7Bp6S4bY&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard FIPS Images – Dec 2024](https://www.youtube.com/watch?v=SYeym1SinA0&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard's Python Image – Nov 2024](https://www.youtube.com/watch?v=Pja990V0Rfc&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Building Secure Java Images with Chainguard Images - Oct 2024](https://www.youtube.com/watch?v=SX4xeRzbpYo&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard's WordPress Image - Sep 2024](https://www.youtube.com/watch?v=HAC0Nyt6_Uc&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard AI Images - Aug 2024](https://www.youtube.com/watch?v=Dbh4OMsZkNg&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Building Secure and Minimal Images with Chainguard Static Images - Jun 2024](https://www.youtube.com/watch?v=IQr-wmVzaK0&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Unlock 0 CVEs by Migrating Your Python Application to Chainguard Images - May 2024](https://www.youtube.com/watch?v=cc2qxhZmMDo&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
+- [Chainguard's PHP and Laravel Image x- Apr 2024](https://www.youtube.com/watch?v=0PSsJsKXqok&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn&index=12)
+- [Chainguard's Java Container Image - Mar 2024](https://www.youtube.com/watch?v=8v8xlFnRHfs&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn&index=14)
+- [Build and Secure Minimal Images with Chainguard Static Images - Feb 2024](https://www.youtube.com/watch?v=YBrczgb7e58&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)

--- a/content/software-security/learning-labs/ll202505.md
+++ b/content/software-security/learning-labs/ll202505.md
@@ -1,0 +1,88 @@
+---
+title: "Chainguard Libraries for Java"
+linktitle: "Chainguard Libraries for Java"
+description: "Learnning Lab in May 2025 with Manfred Moser"
+type: "article"
+date: 2025-06-18T21:00:00+00:00
+lastmod: 2025-06-18T21:00:00+00:00
+draft: false
+tags: ["Learning Labs", "Chainguard Libraries", "Overview"]
+menu:
+  docs:
+    parent: "learning-labs"
+weight: 100
+toc: true
+---
+
+The May 2025 Learning Lab with Manfred Moser covers Chainguard Libraries for
+Java. It starts with an overview about libraries and the Java ecosystem and
+progresses to a demo with Apache Maven and Sonatype Nexus.
+
+{{< youtube z42b2_lePNI >}}
+
+## Sections
+
+- [0:00](https://www.youtube.com/watch?v=z42b2_lePNI) Introduction and agenda
+- [2:38](https://www.youtube.com/watch?v=z42b2_lePNI&t=158s) Chainguard and containers
+- [3:47](https://www.youtube.com/watch?v=z42b2_lePNI&t=227s) Chainguard Factory
+- [4:57](https://www.youtube.com/watch?v=z42b2_lePNI&t=297s) Concepts - from containers to libraries
+- [9:00](https://www.youtube.com/watch?v=z42b2_lePNI&t=540s) Java and Java libraries
+- [12:45](https://www.youtube.com/watch?v=z42b2_lePNI&t=765s) Software supply chain of libraries and attacks
+- [19:27](https://www.youtube.com/watch?v=z42b2_lePNI&t=1167s) Dependency supply in Java
+- [20:30](https://www.youtube.com/watch?v=z42b2_lePNI&t=1230s) Repository concept and Maven Central
+- [24:32](https://www.youtube.com/watch?v=z42b2_lePNI&t=1472s) Chainguard Libraries for Java and repository manager intro
+- [28:17](https://www.youtube.com/watch?v=z42b2_lePNI&t=1697s) Developer tools
+- [29:21](https://www.youtube.com/watch?v=z42b2_lePNI&t=1761s) Demo start and setup with chainctl
+- [32:55](https://www.youtube.com/watch?v=z42b2_lePNI&t=1975s) Sonatype Nexus configuration
+- [37:30](https://www.youtube.com/watch?v=z42b2_lePNI&t=2250s) Maven configuration
+- [40:41](https://www.youtube.com/watch?v=z42b2_lePNI&t=2441s) Example project setup, build, and results
+- [44:57](https://www.youtube.com/watch?v=z42b2_lePNI&t=2697s) Dependency list and tree
+- [47:00](https://www.youtube.com/watch?v=z42b2_lePNI&t=2820s) Results and verification
+- [49:37](https://www.youtube.com/watch?v=z42b2_lePNI&t=2977s) Summary
+- [50:43](https://www.youtube.com/watch?v=z42b2_lePNI&t=3043s) Up next
+- [52:55](https://www.youtube.com/watch?v=z42b2_lePNI&t=3175s) Questions
+
+## Demo
+
+Following are some of the commands used in the demo. More information can be
+found in the slide deck, the linked resources, and the video.
+
+Creating a pull token:
+
+```shell
+chainctl auth login
+
+chainctl libraries entitlements list
+
+chainctl auth pull-token --library-ecosystem=java --ttl=1h
+```
+
+Cleaning up the local Maven repository cache:
+
+```shell
+rm -rf ~/.m2/repository
+```
+
+Building [Trino Gateway](https://github.com/trinodb/trino-gateway) from source
+and looking at dependencies:
+
+```shell
+cd trino-gateway
+
+./mvnw clean install -DskipTests=true
+
+./mvnw dependency:list
+
+./mvnw dependency:tree
+```
+
+## Reesource Links
+
+- [Chainguard Libraries](https://www.chainguard.dev/libraries)
+- [Chainguard Libraries documentation](/chainguard/libraries/overview/)
+- [Chainguard Libraries for Java documentation](/chainguard/libraries/java/overview/)
+- [Slide deck](/downloads/learning-lab-chainguard-libraries-java.pdf)
+- [Apache Maven](https://maven.apache.org/)
+- [Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository)
+- [Apache Maven dependency plugin](https://maven.apache.org/plugins/maven-dependency-plugin/)
+


### PR DESCRIPTION
We need to figure out if we should move the folder elsewhere (a level up??) and how we then make the nav work .. and where we want the nav even to sit... its currently in the Education section but kinda randomly in terms of order.

Also .. for the lab notes I just used a simple naming convention with the date so they are sorted automatically in the directory. For sorting on the index I think we have to use the weight in addition .. but currently there is only one so... 

And fyi @smythp .. the timestamping is easy to do in yt and then just cut and paste from there. You can just supply the info to @willdolinsky when yours is live .. 

### What should this PR do?

Add a new section in Education on the left hand nav for Learning Labs.

Fix https://github.com/chainguard-dev/internal/issues/5068

### Why are we making this change?

Each lab has a bunch of useful content and we need a place for our viewers to access more information after the show and also create a spot for finding the labs on the docs rather than on YouTube only. This will also contribute to our traffic on the docs and be a good signal.

### What are the acceptance criteria? 

Passing review.

### How should this PR be tested?

Read and test links. 