### PR TITLE
Add advanced config for Artifactory

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -273,6 +273,8 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. Check the **Enable Token Authentication** checkbox.
 1. Press **Test** to validate the connection.
 1. Deactivate **Maven Settings - Handle Snapshots**.
+1. Access the **Advanced** configuration tab and deactivate the **Block
+   Mismatching Mime Types** setting in the **Others** section.
 1. Press **Create Remote Repository**.
 
 Combine the two repositories in a new virtual repository:

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -103,6 +103,8 @@ Configure a remote repository for the Chainguard Libraries for Python index:
    with chainctl](/chainguard/libraries/access/).
 1. Check the **Enable Token Authentication** checkbox.
 1. Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python/`.
+1. Access the **Advanced** configuration tab and deactivate the **Block
+   Mismatching Mime Types** setting in the **Others** section.
 1. Press **Create Remote Repository**.
 
 Configure a remote repository for the PyPI public index:


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?

Add a required advanced config for Artifactory for Java and Python.

Block Mismatching Mime Types must be deactivated. Default is on.

Javascript update is done in the ongoing separate PR.

### Why are we making this change?

User reported issue. Diagnosed by engineering that mimetypes off our proxy are wrong so preventatively we are adding this config. 

Fix https://github.com/chainguard-dev/internal/issues/5150

### What are the acceptance criteria? 

Review.

### How should this PR be tested?

Not necessary.