### PR TITLE
Add Learning Lab page for Chainguard Libraries for Python (June 2025)

### DIFF
--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -10,7 +10,7 @@ tags: ["Learning Labs", "Chainguard Libraries", "Python"]
 menu:
   docs:
     parent: "learning-labs"
-weight: 110
+weight: 97
 toc: true
 ---
 
@@ -24,9 +24,10 @@ build tools, configuring repository managers, and running example application bu
 
 **Date:** June 24, 2025  
 **Time:** 1:00 PM - 2:00 PM EDT  
-**Presenter:** Patrick Smyth, Staff Developer Relations Engineer at Chainguard
+**Presenter:** Patrick Smyth, Staff Developer Relations Engineer at Chainguard  
+[Register](https://events.chainguard.dev/0bcb08ad-2ba1-447b-b87e-703f04d7ef11/)
 
-## Topics Covered
+## Topics
 
 - Software supply chain fundamentals
 - The Python ecosystem under threat

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -36,7 +36,26 @@ build tools, configuring repository managers, and running example application bu
 - Running an example application on Libraries
 - Checking provenance of dependencies
 
+## Demo
+
+In the demo, we'll switch the below Flask application to use Chainguard Libraries for Python, sourcing dependencies for a repository manager (Artifactory) set up to pull first from the Chaingaurd Libraries for Python index with a fallback to the Python Package Index (PyPI).
+
+[Demo Flask Application](https://github.com/chainguard-dev/cg-images-python-migration/tree/libraries-demo)
+
+We'll demonstrate two approaches. First, we'll modify the `~/.pip/pip.conf` file to pull from the virtual repository set up in the repository manager. 
+
+```
+[global]
+index-url = <repository-url>
+```
+
+After changing this global setting, we'll install and run the application from a virtual environment, then use Chainguard's `libcheck` tool to test the provenance of the packages in the virtual environment. (Chainguard is in the process of releasing this tool under an open source license.)
+
+We'll also update the demo application's `requirements.txt` file and build and run the application from a Chainguard Container.
+
 ## Resource Links
+
+- [Presentation](https://docs.google.com/presentation/d/158_oK3J4h1hCVhw0TLOj5vneT20FqDGx7WFNBcAX8mw/edit?slide=id.g369255d2a29_0_0#slide=id.g369255d2a29_0_0)
 
 - [Chainguard Libraries](https://www.chainguard.dev/libraries)
 - [Chainguard Libraries documentation](/chainguard/libraries/overview/)

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -39,7 +39,7 @@ build tools, configuring repository managers, and running example application bu
 
 ## Demo
 
-In the demo, we'll switch the below Flask application to use Chainguard Libraries for Python, sourcing dependencies for a repository manager (Artifactory) set up to pull first from the Chainguard Libraries for Python index with a fallback to the Python Package Index (PyPI).
+In the demo, we switch a Flask application to use Chainguard Libraries for Python, sourcing dependencies from a repository manager (Artifactory) set up to pull first from the Chainguard Libraries for Python index with a fallback to the Python Package Index (PyPI).
 
 [Demo Flask Application](https://github.com/chainguard-dev/cg-images-python-migration/tree/libraries-demo)
 
@@ -50,9 +50,9 @@ We'll demonstrate two approaches. First, we'll modify the `~/.pip/pip.conf` file
 index-url = <repository-url>
 ```
 
-After changing this global setting, we'll install and run the application from a virtual environment, then use Chainguard's `libcheck` tool to test the provenance of the packages in the virtual environment. (Chainguard is in the process of releasing this tool under an open source license.)
+After changing this global setting, we install and run the application from a virtual environment, then use Chainguard's `libCheck` tool to test the provenance of the packages in the virtual environment. Chainguard is in the process of releasing this tool under an open source license.
 
-We'll also update the demo application's `requirements.txt` file and build and run the application from a Chainguard Container.
+We also update the demo application's `requirements.txt` file and build and run the application from a Chainguard Container.
 
 ## Resource Links
 

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -43,7 +43,7 @@ In the demo, we switch a Flask application to use Chainguard Libraries for Pytho
 
 [Demo Flask Application](https://github.com/chainguard-dev/cg-images-python-migration/tree/libraries-demo)
 
-We'll demonstrate two approaches. First, we'll modify the `~/.pip/pip.conf` file to pull from the virtual repository set up in the repository manager. 
+We demonstrate two approaches. First, we modify the `~/.pip/pip.conf` file to pull from the virtual repository set up in the repository manager:
 
 ```
 [global]

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -1,0 +1,49 @@
+---
+title: "Chainguard Libraries for Python"
+linktitle: "Chainguard Libraries for Python"
+description: "Learning Lab for June 2025 on Chainguard Libraries for Python and Supply Chain Security"
+type: "article"
+date: 2025-06-22T17:00:00+00:00
+lastmod: 2025-06-22T00:00:00+00:00
+draft: false
+tags: ["Learning Labs", "Chainguard Libraries", "Python"]
+menu:
+  docs:
+    parent: "learning-labs"
+weight: 110
+toc: true
+---
+
+The June 2025 Learning Lab with Patrick Smyth covers Chainguard Libraries for
+Python. Open source libraries help you move fast, but pulling in external
+dependencies can introduce supply chain risk. This session covers fundamental
+concepts of Chainguard Libraries, package managers and dependencies, PyPI and
+build tools, configuring repository managers, and running example application builds.
+
+## Event Details
+
+**Date:** June 24, 2025  
+**Time:** 1:00 PM - 2:00 PM EDT  
+**Presenter:** Patrick Smyth, Staff Developer Relations Engineer at Chainguard
+
+## Topics Covered
+
+- Software supply chain fundamentals
+- The Python ecosystem under threat
+- Package managers and dependencies in Python
+- PyPI and Python build tools
+- Configuring repository managers for Python
+- Running an example application on Libraries
+- Checking provenance of dependencies
+
+## Resource Links
+
+- [Chainguard Libraries](https://www.chainguard.dev/libraries)
+- [Chainguard Libraries documentation](/chainguard/libraries/overview/)
+- [Chainguard Libraries for Python documentation](/chainguard/libraries/python/overview/)
+- [Python global configuration](/chainguard/libraries/python/global-configuration/)
+- [Python build configuration](/chainguard/libraries/python/build-configuration/)
+- [Python Package Index (PyPI)](https://pypi.org/)
+- [pip documentation](https://pip.pypa.io/)
+- [Python Packaging User Guide](https://packaging.python.org/)
+- [Cheese Must Stand: Defending the Python Library Ecosystem in 2025 at PyCon 2025](https://www.youtube.com/watch?v=5cdC5pVkCvU)

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -56,8 +56,7 @@ We also update the demo application's `requirements.txt` file and build and run 
 
 ## Resource Links
 
-- [Presentation](https://docs.google.com/presentation/d/158_oK3J4h1hCVhw0TLOj5vneT20FqDGx7WFNBcAX8mw/edit?slide=id.g369255d2a29_0_0#slide=id.g369255d2a29_0_0)
-
+- [Slide deck](/downloads/Learning-Lab_-Python-Libraries.pdf)
 - [Chainguard Libraries](https://www.chainguard.dev/libraries)
 - [Chainguard Libraries documentation](/chainguard/libraries/overview/)
 - [Chainguard Libraries for Python documentation](/chainguard/libraries/python/overview/)

--- a/content/software-security/learning-labs/ll202506.md
+++ b/content/software-security/learning-labs/ll202506.md
@@ -39,7 +39,7 @@ build tools, configuring repository managers, and running example application bu
 
 ## Demo
 
-In the demo, we'll switch the below Flask application to use Chainguard Libraries for Python, sourcing dependencies for a repository manager (Artifactory) set up to pull first from the Chaingaurd Libraries for Python index with a fallback to the Python Package Index (PyPI).
+In the demo, we'll switch the below Flask application to use Chainguard Libraries for Python, sourcing dependencies for a repository manager (Artifactory) set up to pull first from the Chainguard Libraries for Python index with a fallback to the Python Package Index (PyPI).
 
 [Demo Flask Application](https://github.com/chainguard-dev/cg-images-python-migration/tree/libraries-demo)
 


### PR DESCRIPTION
## Description

Basic page for Chainguard Libraries for Python learning lab.