### PR TITLE
Set-up should be set up

### DIFF
--- a/content/chainguard/chainguard-registry/pull-through-guides/cloudsmith-pull-through/index.md
+++ b/content/chainguard/chainguard-registry/pull-through-guides/cloudsmith-pull-through/index.md
@@ -17,7 +17,7 @@ toc: true
 weight: 020
 ---
 
-Organizations often have their own internal software repositories and registries integrated into their systems. This guide explains how to set-up the Cloudsmith artifact repository to ingest [Chainguard Containers](/chainguard/chainguard-images/overview/) by acting as a pull-through cache.
+Organizations often have their own internal software repositories and registries integrated into their systems. This guide explains how to set up the Cloudsmith artifact repository to ingest [Chainguard Containers](/chainguard/chainguard-images/overview/) by acting as a pull-through cache.
 
 This tutorial outlines how to set up a remote repository with [Cloudsmith](https://cloudsmith.com/). It will walk you through how to set up a Cloudsmith repository you can use as a pull through cache for Chainguard's public Starter containers or for Production containers originating from a private Chainguard repository.
 


### PR DESCRIPTION
In the first paragraph, “set-up” should be 2 words (set up) without a hyphen. “Set up” is a verb, whereas “set-up” is a noun.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->