### PR TITLE
Bump LB module consumption to remedy TLS issue

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -80,7 +80,7 @@ resource "google_dns_managed_zone" "edu-zone" {
 // Put the above domain in front of our regional services.
 module "serverless-gclb" {
   source  = "chainguard-dev/common/infra//modules/serverless-gclb"
-  version = "0.5.3"
+  version = "0.6.163"
 
   name       = var.name
   project_id = var.project_id


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
GCP infra

### What should this PR do?

Bumps the serverless LB consumer to a version that has a TLS policy that enforces at least `TLSv1.2`.

### Why are we making this change?

We require all in-transit encryption to meet a minimum standard of `TLSv1.2` or higher.

### What are the acceptance criteria? 

We should see the TF plan add a new SSL policy to LB.
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->