### PR TITLE
Add button for copying a page's Markdown

### DIFF
--- a/assets/js/copypage.js
+++ b/assets/js/copypage.js
@@ -1,0 +1,202 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const copyButton = document.querySelector('.copy-page-btn');
+  const tooltip = document.querySelector('.copy-tooltip');
+  
+  if (!copyButton) return;
+  
+  copyButton.addEventListener('click', async function() {
+    const content = await getPageAsMarkdown();
+    
+    if (content && await copyToClipboard(content)) {
+      // Show success state
+      copyButton.classList.add('copy-success');
+      tooltip.classList.add('show');
+      
+      // Update button text
+      const textElement = copyButton.querySelector('.copy-btn-text');
+      const originalText = textElement ? textElement.textContent : '';
+      if (textElement) {
+        textElement.textContent = 'Copied to clipboard!';
+      }
+      
+      // Reset after 2 seconds
+      setTimeout(() => {
+        copyButton.classList.remove('copy-success');
+        tooltip.classList.remove('show');
+        if (textElement) {
+          textElement.textContent = originalText;
+        }
+      }, 2000);
+    }
+  });
+});
+
+async function getPageAsMarkdown() {
+  const article = document.querySelector('main.docs-content');
+  if (!article) return '';
+  
+  // Get page title
+  const title = document.querySelector('h1')?.textContent || document.title;
+  
+  // Get page description
+  const description = document.querySelector('meta[name="description"]')?.content || '';
+  
+  // Get main content
+  let mainContent = article.cloneNode(true);
+  
+  // Remove elements that shouldn't be included
+  const elementsToRemove = [
+    '.back-button',
+    '.contributors',
+    '.tag-container',
+    '.page-footer-meta',
+    '.copy-page-btn',
+    '.copy-tooltip',
+    '.notice',
+    '.rumble-comparison',
+    '.rumble-vuln',
+    'nav',
+    'script',
+    'style'
+  ];
+  
+  elementsToRemove.forEach(selector => {
+    mainContent.querySelectorAll(selector).forEach(el => el.remove());
+  });
+  
+  // Build markdown
+  let markdown = `# ${title}\n\n`;
+  
+  if (description) {
+    markdown += `${description}\n\n`;
+  }
+  
+  markdown += `Source: ${window.location.href}\n\n---\n\n`;
+  markdown += convertHtmlToMarkdown(mainContent);
+  
+  return markdown;
+}
+
+function convertHtmlToMarkdown(element) {
+  let markdown = '';
+  
+  const processNode = (node, listLevel = 0) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent;
+    }
+    
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const tagName = node.tagName.toLowerCase();
+      let content = '';
+      
+      // Process children
+      node.childNodes.forEach(child => {
+        content += processNode(child, tagName === 'ul' || tagName === 'ol' ? listLevel + 1 : listLevel);
+      });
+      
+      // Convert based on tag
+      switch (tagName) {
+        case 'h1': return `# ${content.trim()}\n\n`;
+        case 'h2': return `## ${content.trim()}\n\n`;
+        case 'h3': return `### ${content.trim()}\n\n`;
+        case 'h4': return `#### ${content.trim()}\n\n`;
+        case 'h5': return `##### ${content.trim()}\n\n`;
+        case 'h6': return `###### ${content.trim()}\n\n`;
+        case 'p': return `${content.trim()}\n\n`;
+        case 'strong':
+        case 'b': return `**${content.trim()}**`;
+        case 'em':
+        case 'i': return `*${content.trim()}*`;
+        case 'code':
+          if (node.parentElement?.tagName.toLowerCase() === 'pre') {
+            return content;
+          }
+          return `\`${content.trim()}\``;
+        case 'pre':
+          const lang = node.querySelector('code')?.className.match(/language-(\w+)/)?.[1] || '';
+          return `\`\`\`${lang}\n${content.trim()}\n\`\`\`\n\n`;
+        case 'a':
+          const href = node.getAttribute('href');
+          if (href && !href.startsWith('#')) {
+            return `[${content.trim()}](${href})`;
+          }
+          return content;
+        case 'ul': return content + '\n';
+        case 'ol': return content + '\n';
+        case 'li':
+          const listPrefix = node.parentElement?.tagName.toLowerCase() === 'ol' 
+            ? `${Array.from(node.parentElement.children).indexOf(node) + 1}. `
+            : '- ';
+          const indent = '  '.repeat(listLevel - 1);
+          return `${indent}${listPrefix}${content.trim()}\n`;
+        case 'blockquote':
+          return content.split('\n').map(line => `> ${line}`).join('\n') + '\n\n';
+        case 'img':
+          const alt = node.getAttribute('alt') || '';
+          const src = node.getAttribute('src') || '';
+          return `![${alt}](${src})\n\n`;
+        case 'hr': return '---\n\n';
+        case 'br': return '\n';
+        case 'table': return processTable(node) + '\n\n';
+        default: return content;
+      }
+    }
+    
+    return '';
+  };
+  
+  element.childNodes.forEach(child => {
+    markdown += processNode(child);
+  });
+  
+  // Clean up excessive newlines
+  return markdown.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function processTable(table) {
+  const rows = table.querySelectorAll('tr');
+  if (rows.length === 0) return '';
+  
+  let markdown = '';
+  
+  // Process header row
+  const headerCells = rows[0].querySelectorAll('th, td');
+  if (headerCells.length > 0) {
+    markdown += '| ' + Array.from(headerCells).map(cell => cell.textContent.trim()).join(' | ') + ' |\n';
+    markdown += '|' + Array.from(headerCells).map(() => ' --- ').join('|') + '|\n';
+  }
+  
+  // Process data rows
+  for (let i = headerCells.length > 0 ? 1 : 0; i < rows.length; i++) {
+    const cells = rows[i].querySelectorAll('td');
+    if (cells.length > 0) {
+      markdown += '| ' + Array.from(cells).map(cell => cell.textContent.trim()).join(' | ') + ' |\n';
+    }
+  }
+  
+  return markdown;
+}
+
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    // Fallback for older browsers
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
+    document.body.appendChild(textArea);
+    textArea.select();
+    
+    try {
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      return true;
+    } catch (err) {
+      document.body.removeChild(textArea);
+      return false;
+    }
+  }
+}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -20,6 +20,7 @@
 @import "components/alerts";
 @import "components/buttons";
 @import "components/code";
+@import "components/copypage";
 @import "components/details";
 @import "components/syntax";
 @import "components/comments";

--- a/assets/scss/components/copypage.scss
+++ b/assets/scss/components/copypage.scss
@@ -1,0 +1,144 @@
+// Copy page button styles
+.copy-page-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 16px;
+  background: transparent;
+  border: 1px solid var(--watch-btn-border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--watch-btn-color);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  
+  &:hover {
+    background: var(--watch-btn-hover-background);
+    border-color: var(--primary-1);
+    color: var(--primary-1);
+    
+    svg {
+      stroke: var(--primary-1);
+    }
+  }
+  
+  &:active {
+    transform: scale(0.98);
+  }
+  
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    transition: stroke 0.2s ease;
+  }
+  
+  &.copy-success {
+    svg {
+      stroke: var(--secondary-2);
+    }
+    
+    .copy-btn-text {
+      color: var(--secondary-2);
+    }
+  }
+}
+
+// Tooltip styles
+.copy-tooltip {
+  position: absolute;
+  top: -40px;
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  padding: 6px 12px;
+  background: var(--tooltip-background);
+  color: var(--tooltip-color);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: all 0.2s ease;
+  z-index: 1000;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: var(--tooltip-background);
+  }
+  
+  &.show {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+  }
+}
+
+// Tags and copy wrapper
+.tags-and-copy-wrapper {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 16px 0 20px 0;
+  min-height: 36px; // Ensure consistent height even without tags
+  
+  .tag-container {
+    flex: 1 1 auto;
+    margin: 0;
+  }
+  
+  .copy-page-btn {
+    flex: 0 0 auto;
+    margin-left: auto; // Always pushes button to the right
+  }
+}
+
+// Dark mode adjustments
+[data-dark-mode] {
+  .copy-page-btn {
+    &:hover {
+      border-color: var(--primary-2);
+      color: var(--primary-2);
+      
+      svg {
+        stroke: var(--primary-2);
+      }
+    }
+  }
+}
+
+// Mobile responsive
+@media (max-width: 768px) {
+  .copy-page-btn {
+    padding: 0 12px;
+    font-size: 13px;
+    
+    svg {
+      display: none;
+    }
+  }
+  
+  .tags-and-copy-wrapper {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    
+    .tag-container {
+      width: 100%;
+    }
+    
+    .copy-page-btn {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+}

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -62,13 +62,16 @@
         {{ end -}}
       </div>
 
-      {{ if .Params.tags -}}
-      <div class="tag-container">
-        {{ range $index, $tag := .Params.tags -}}
-          <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" role="button">{{ . }}</a>
-        {{end}}
+      <div class="tags-and-copy-wrapper">
+        {{ if .Params.tags -}}
+        <div class="tag-container">
+          {{ range $index, $tag := .Params.tags -}}
+            <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" role="button">{{ . }}</a>
+          {{end}}
         </div>
-      {{end}}
+        {{end}}
+        {{ partial "copy-page-button.html" . }}
+      </div>
 
       {{ if .Params.images }}
         <div class="mt-4">
@@ -124,6 +127,9 @@
     {{- $titles := resources.Get "js/titles.js" -}}
     {{ $titles := $titles | minify }}
     <script src="{{ $titles.Permalink }}" integrity="{{ $titles.Data.Integrity }}"></script>
+    {{- $copypage := resources.Get "js/copypage.js" -}}
+    {{ $copypage := $copypage | minify }}
+    <script src="{{ $copypage.Permalink }}" integrity="{{ $copypage.Data.Integrity }}"></script>
     {{ if ne .Params.toc false -}}
     <nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }}" aria-label="Secondary navigation">
       {{ partial "sidebar/docs-toc.html" . }}

--- a/layouts/partials/copy-page-button.html
+++ b/layouts/partials/copy-page-button.html
@@ -1,0 +1,8 @@
+<button class="copy-page-btn" title="Copy page as Markdown for LLMs" aria-label="Copy page as Markdown for LLMs">
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path d="M2 3.5C2 2.67157 2.67157 2 3.5 2H9.5L14 6.5V12.5C14 13.3284 13.3284 14 12.5 14H3.5C2.67157 14 2 13.3284 2 12.5V3.5Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M9 2V7H14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+  <span class="copy-btn-text">Copy Markdown for LLMs</span>
+</button>
+<div class="copy-tooltip" role="tooltip">Page copied!</div>


### PR DESCRIPTION
This change adds a button that allows the user to copy the Markdown of a page for LLM ingestion.