### PR TITLE
Add related content for LLMs and front end. Also add time to read

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -72,6 +72,24 @@ notAlternative = true
 [taxonomies]
   contributor = "contributors"
   tags = "tags"
+[related]
+  # Only include matches with rank >= threshold
+  threshold = 60
+  # Show up to 5 related articles
+  includeNewer = true
+  toLower = false
+  [[related.indices]]
+    name = "section"
+    weight = 100  # Higher weight on section since tags need work
+  [[related.indices]]
+    name = "tags"
+    weight = 50   # Lower weight until tags are improved
+  [[related.indices]]
+    name = "title"
+    weight = 30   # Title similarity can help
+  [[related.indices]]
+    name = "date"
+    weight = 10
 [permalinks]
   blog = "/blog/:title/"
 # docs = "/docs/1.0/:sections[1:]/:title/"

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -36,6 +36,11 @@
       {{ if not .Params.hide_title -}}
         <h1>{{ .Title }}</h1>
         <div>{{ .Description }}</div>
+        {{ if .ReadingTime }}
+        <div class="text-muted small mt-2">
+          <i class="bi bi-clock"></i>&nbsp; {{ .ReadingTime }} min read
+        </div>
+        {{ end }}
       {{ end -}}
 
       <div class="contributors">
@@ -91,6 +96,15 @@
       {{ partial "rumble-vuln.html" . }}
       <div class="mb-5"></div>
       {{ .Content }}
+
+      {{/* Related Content Section */}}
+      {{ $related := .Site.RegularPages.Related . | first 5 }}
+      {{ with $related }}
+      <section class="related-content mt-5 pt-3 border-top">
+        <h3 class="h3 mb-3">Related Articles</h3>
+        {{ partial "related-content.html" . }}
+      </section>
+      {{ end }}
 
       {{ if not .Params.hide_lastmod -}}
         {{ if .Params.lastmod }}

--- a/layouts/partials/head/enhanced-structured-data.html
+++ b/layouts/partials/head/enhanced-structured-data.html
@@ -54,8 +54,21 @@
     {{ end }}
   ],
   {{ end }}
-  "datePublished": {{ .Date.Format "2025-01-02T15:04:05Z07:00" | jsonify }},
-  "dateModified": {{ .Lastmod.Format "2025-01-02T15:04:05Z07:00" | jsonify }}
+  {{/* Add related content for LLMs */}}
+  {{ $related := .Site.RegularPages.Related . | first 5 }}
+  {{ with $related }}
+  "relatedLink": [
+    {{ range $index, $page := . }}
+    {
+      "@type": "WebPage", 
+      "name": {{ $page.Title | jsonify }},
+      "url": {{ $page.Permalink | jsonify }}
+    }{{ if lt $index (sub (len $related) 1) }},{{ end }}
+    {{ end }}
+  ],
+  {{ end }}
+  "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | jsonify }}
 }
 </script>
 {{ end }}
@@ -97,6 +110,19 @@
   {{ end }}
   {{ if gt (len $languages) 0 }}
   "programmingLanguage": {{ delimit $languages ", " | jsonify }},
+  {{ end }}
+  {{/* Add related content for LLMs */}}
+  {{ $related := .Site.RegularPages.Related . | first 5 }}
+  {{ with $related }}
+  "relatedLink": [
+    {{ range $index, $page := . }}
+    {
+      "@type": "WebPage", 
+      "name": {{ $page.Title | jsonify }},
+      "url": {{ $page.Permalink | jsonify }}
+    }{{ if lt $index (sub (len $related) 1) }},{{ end }}
+    {{ end }}
+  ],
   {{ end }}
   "mainEntityOfPage": {
     "@type": "WebPage",

--- a/layouts/partials/related-content.html
+++ b/layouts/partials/related-content.html
@@ -1,0 +1,25 @@
+{{/* Related Content Partial - Shows related articles based on Hugo's related content feature */}}
+
+<div class="related-articles-list">
+  {{ range . }}
+  <article class="related-article mb-3">
+    <h4 class="h6 mb-1">
+      <a href="{{ .RelPermalink }}" class="stretched-link">{{ .Title }}</a>
+    </h4>
+    {{ with .Description }}
+    <p class="text-muted small mb-0">{{ . | truncate 120 }}</p>
+    {{ else }}
+      {{ with .Summary }}
+      <p class="text-muted small mb-0">{{ . | plainify | truncate 120 }}</p>
+      {{ end }}
+    {{ end }}
+    <div class="text-muted small">
+      {{ if .ReadingTime }}
+      <span>
+        <i class="bi bi-clock"></i>&nbsp; {{ .ReadingTime }} min read
+      </span>
+      {{ end }}
+    </div>
+  </article>
+  {{ end }}
+</div>


### PR DESCRIPTION
This modifies enhanced-structured-data.html to include related content so that LLMs can have an easier pathway to search related information. While making this change, I added a Related Articles section on the bottom to expose this to human readers on the front end. Additionally, added the read time to these related articles and to the front matter. 