### PR TITLE
Removing Alpine reference in Migrating Dockerfiles to Containers doc

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use/how-to-use-chainguard-images.md
@@ -19,7 +19,7 @@ weight: 005
 toc: true
 ---
 
-[Chainguard Containers](https://images.chainguard.dev) are based on [Wolfi](/open-source/wolfi/overview/), our Linux _undistro_ designed specifically for containers. Wolfi uses the [Alpine apk](https://wiki.alpinelinux.org/wiki/Package_management) package format, which contributes in making packages smaller and more accountable, resulting in smaller images with traceable provenance information based on cryptographic signatures.
+[Chainguard Containers](https://images.chainguard.dev) are based on [Wolfi](/open-source/wolfi/overview/), our Linux _undistro_ designed specifically for containers. Wolfi uses the [apk](https://wiki.alpinelinux.org/wiki/Package_management) package format, which contributes in making packages smaller and more accountable, resulting in smaller images with traceable provenance information based on cryptographic signatures.
 
 In this guide, you'll find general instructions on how to get started using Chainguard Containers and how to migrate existing container-based workflows to use our images. For specific image usage instructions, please refer to our [Chainguard Containers Directory](https://images.chainguard.dev), which contains the full list of all images available to the public and their respective documentation.
 

--- a/content/chainguard/migration/migrating-to-chainguard-images.md
+++ b/content/chainguard/migration/migrating-to-chainguard-images.md
@@ -30,7 +30,7 @@ The next sections of this page contain distro-specific information that should h
 
 
 ## Migrating from Debian and Ubuntu Dockerfiles
-Chainguard Containers are based on the [Alpine apk](https://wiki.alpinelinux.org/wiki/Package_management) ecosystem, which differs from Debian-based `apt` in several aspects. Some of these features contribute in making packages smaller and more accountable, resulting in smaller images with traceable provenance information based on cryptographic signatures. The page [Why apk](/open-source/wolfi/apk-package-manager/) from the official Wolfi documentation explains in more detail why we use apk.
+Chainguard Containers use the [apk](https://wiki.alpinelinux.org/wiki/Package_management) package format, which differs from the Debian-based `apt` in several ways. Some of these features contribute in making packages smaller and more accountable, resulting in smaller images with traceable provenance information based on cryptographic signatures. The page [Why apk](/open-source/wolfi/apk-package-manager/) from the official Wolfi documentation explains in more detail why we use apk.
 
 If you are coming from a Debian-based Dockerfile, you'll need to adapt some of your commands to be compatible with the apk ecosystem:
 


### PR DESCRIPTION
[x] Check if this is a typo or other quick fix and ignore the rest :)

Quick fix in response to [Slack request](https://chainguard-dev.slack.com/archives/C03H64P08UT/p1751392109651129) from @johnfosborneiii 

Also includes a fix for a similar statement elsewhere in Academy.