### PR TITLE
Add llms-full.txt

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -18,7 +18,7 @@ disableLanguages = ["de", "nl"]
 # defaultContentLanguageInSubdir = true
 # add redirects/headers
 [outputs]
-home = ["HTML", "RSS", "ALIASES", "REDIRECTS", "HEADERS", "TXT", "AIMETADATA"]
+home = ["HTML", "RSS", "ALIASES", "REDIRECTS", "HEADERS", "TXT", "FULLTXT", "AIMETADATA"]
 section = ["HTML", "RSS", "SITEMAP"]
 # remove .{ext} from text/netlify
 [mediaTypes."text/netlify"]
@@ -54,6 +54,11 @@ rel  = "sitemap"
 [outputFormats.TXT]
 mediaType = "text/plain"
 baseName = "llms"
+isPlainText = true
+# add output format for llms-full.txt
+[outputFormats.FULLTXT]
+mediaType = "text/plain"
+baseName = "llms-full"
 isPlainText = true
 # add output format for ai-metadata.json
 [outputFormats.AIMETADATA]

--- a/layouts/index.fulltxt.txt
+++ b/layouts/index.fulltxt.txt
@@ -1,0 +1,40 @@
+# Chainguard Academy - Full Content
+
+Generated: {{ now.Format "January 2, 2006 at 3:04 PM MST" }}
+
+## License
+Documentation: CC BY-SA 4.0 | Code Examples: Apache 2.0
+
+---
+
+## Content Index
+
+{{ range $section, $pages := .Site.RegularPages.GroupBy "Section" }}
+### {{ $section | title }}
+{{ range $pages.Pages }}
+- [{{ .Title }}]({{ .Permalink }})
+{{- end }}
+{{ end }}
+
+---
+
+## Full Documentation
+
+{{ range $section, $pages := .Site.RegularPages.GroupBy "Section" }}
+## Section: {{ $section | title }}
+
+{{ range $pages.Pages }}
+### {{ .Title }}
+
+URL: {{ .Permalink }}
+Last Modified: {{ .Lastmod.Format "January 2, 2006" }}
+{{- if .Params.tags }}
+Tags: {{ delimit .Params.tags ", " }}
+{{- end }}
+
+{{ .Content | plainify }}
+
+---
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Adds all of the documentation on Chainguard Academy into a text file that is easily consumable by an llm. 

### How should this PR be tested?
Make sure the llms-full.txt is generated upon building the site and visible at /llms-full.txt

Deploy preview: https://deploy-preview-2368--ornate-narwhal-088216.netlify.app/llms-full.txt