### PR TITLE
Allow hiding of nested topic pages

### DIFF
--- a/content/software-security/learning-labs/_index.md
+++ b/content/software-security/learning-labs/_index.md
@@ -8,6 +8,7 @@ draft: false
 images: []
 tags: ["Learning Labs", "Overview"]
 toc: true
+hidepageslist: true
 ---
 
 Learning Labs are [regularly run, virtual events from

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -124,6 +124,7 @@
         <article>
           <h1 class="text-center">{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
           <div>{{ .Content }}</div>
+          {{ if not .Params.hidepageslist }}
           <div class="docs-navigation docs-navigation-summary">
             {{ if eq .Params.type "article" }}
                 {{ $currentSection := .CurrentSection }}
@@ -158,6 +159,7 @@
                 {{ template "_internal/pagination.html" . }}
             {{ end }}
           </div>
+          {{ end }}
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Type of change

### What should this PR do?

Allow hiding of nested topic pages

- Use the `hidepageslist: true` header
- Defaults to current behavior of listing pages, same as `hidepageslist: false`
- Add use in Learning Labs overview page
- Confirmed that it works for other pages including tag pages

Can be used in all _index.md pages

Fixes https://github.com/chainguard-dev/internal/issues/5157

### Why are we making this change?

Allow more flexible layout for the index pages so we don't need to have a separate overview page. For example, the learning labs _index page has content that replaces the topic pages display and by removing it the duplication is avoided, it looks better, and is better to read.

### What are the acceptance criteria? 
 
Review. Also do we need some readme changes to document this features?

### How should this PR be tested?

Maybe test with another page