### PR TITLE
Add minimal info for chainver

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In each post's header, the date format should follow year-month-day as `YYYY-MM-
 
 ### Adding Graphic Images
 
-Please reduce the image's file size before adding the image to this project to make page loadtimes faster and more accessible. You can use a tool such as [TinyPNG](https://tinypng.com/).
+Please reduce the image's file size before adding the image to this project to make page load times faster and more accessible. You can use a tool such as [TinyPNG](https://tinypng.com/).
 
 If you are using images, it's best to bundle it together with the appropriate Markdown file. Create a directory with the name of the new page. Within the directory, create an `index.md` file and add the images within the directory as well.
 

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -6,7 +6,7 @@ type: "article"
 date: 2025-03-25T00:08:04+00:00
 lastmod: 2025-04-07T15:17:00+00:00
 draft: false
-tags: ["Chainguard Libraries", "Overview"]
+tags: ["Chainguard Libraries"]
 menu:
   docs:
     parent: "libraries"

--- a/content/chainguard/libraries/faq.md
+++ b/content/chainguard/libraries/faq.md
@@ -10,7 +10,7 @@ tags: ["Chainguard Libraries", "Overview"]
 menu:
   docs:
     parent: "libraries"
-weight: 004
+weight: 010
 toc: true
 ---
 

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -1,0 +1,53 @@
+---
+title: "Chainguard Libraries Verification"
+linktitle: "Verification"
+description: "Verifying binaries or projects for Chainguard Libraries"
+type: "article"
+date: 2025-07-03T12:00:00+00:00
+lastmod: 2025-07-03T12:00:00+00:00
+draft: false
+tags: ["Chainguard Libraries"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 004
+toc: true
+---
+
+## Overview
+
+At any point in time of your use of Chainguard Libraries you can verify binary
+artifacts, project setups, or even entire directories and repositories for the
+use of binaries supplied by Chainguard Libraries. This allows you to check
+adoption of Chainguard Libraries, find opportunities for further replacements or
+gaps in Chainguard Libraries, and identify artifacts originating from other,
+less trusted sources.
+
+Chainguard provides the command line tool `chainver` to enable this
+verification with the following features:
+
+* Use a signature-based binary identification and a checksum fallback.
+* Support different binary formats, including JAR, WAR, EAR, ZIP, TAR, WHL, and
+  APK files as well as container images.
+* Allow analysis of directories and nested archive files.
+* Create output in text, json, yaml, and csv format.
+
+## Requirements
+
+The following requirements must be met:
+
+* Linux, MacOS, or Windows operating system.
+* x86_64 or arm64 processor architecture.
+* `chainctl` installed and available on the `PATH`.
+* `cosign` installed and available on the `PATH`.
+* Sufficient [network access](/chainguard/libraries/network-requirements) available.
+
+## Access 
+
+chainver is available to customers upon request. The archive includes binaries
+for different operating systems and processor architectures.
+
+## Documentation
+
+Detailed installation and user instructions are included with the provided
+distribution and with the `chainver help` command.


### PR DESCRIPTION
### What should this PR do?

Add minimal docs for chainver .. whats its for and how to get it. Usage docs are part of the binary.

Fix https://github.com/chainguard-dev/internal/issues/5176

### Why are we making this change?

Another feature we supply to prospects that is ready to write about.

### What are the acceptance criteria? 

Confirm that the minimal info approach is ok.

### How should this PR be tested?

Not really necessary.