### PR TITLE
[WIP] Increase width of index pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -120,7 +120,7 @@
       </div>
     </div>
     <div class="row justify-content-center topic-container flex-shrink-1">
-      <div class="col-md-12 col-lg-10 col-xl-8">
+      <div class="docs-content">
         <article>
           <h1 class="text-center">{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
           <div>{{ .Content }}</div>
@@ -150,10 +150,10 @@
                                 <path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
                             </svg>
                         </div>
-                    </a>
-                    {{ if .Description }}
+                        {{ if .Description }}
                         <div class="button-description">{{ .Description }}</div>
-                    {{ end }}
+                        {{ end }}
+                    </a>
                 {{ end }}
                 {{ template "_internal/pagination.html" . }}
             {{ end }}

--- a/layouts/article/list-images.html
+++ b/layouts/article/list-images.html
@@ -52,11 +52,11 @@
                                     <path d="M1.06199 5.729L0.291992 4.938L4.99999 0.229004L9.70799 4.938L8.93799 5.729L4.99999 1.792L1.06199 5.729Z" fill="currentColor"/>
                                 </svg>
                             </div>
-                        </a>
-                        {{ if .Description }}
+                            {{ if .Description }}
                             <div class="button-description">{{ .Description }}</div>
+                            {{ end }}
+                        </a>
                         {{ end }}
-                    {{ end }}
                     {{ template "_internal/pagination.html" . }}
                 {{ end }}
             </div>


### PR DESCRIPTION
## Type of change

### What should this PR do?

Increase width of index pages such as https://edu.chainguard.dev/software-security/learning-labs/# to be consistent with other doc pages without messing out layout otherwise.

Currently the tags pages  (and sections?) look bad since the buttons are center aligned and wide and the description is left aligned. The same issue exists originally but its less obvious due to the narrower width and the centering of the whole page. 

I also played with getting rid of the use of buttons and in my opionion that would be even better.

Another option would be to get rid of the description .. in most cases it seems to be a reworded longer version of the title and is not really that useful. 

### Why are we making this change?

Improve look and feel and usability.

Fix https://github.com/chainguard-dev/internal/issues/5158

### What are the acceptance criteria? 

Review and testing to verify that layout is better than before.. 

### How should this PR be tested?

check various pages for impact.