### PR TITLE
Update index.md

### DIFF
--- a/content/chainguard/chainguard-images/features/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/private-apk-repos/index.md
@@ -107,6 +107,36 @@ apk update
 
 Following that, you can proceed to search and install packages from your private APK repository.
 
+## Generating a pull token for Authentication 
+
+To generate a longer lived token for authentication purposes, it is necessary to create a pull token to access your private APK repository. 
+
+In this example we will setup a pull token that expires in 35 days, to be used with CI. 
+
+**Generate a Pull Token:**
+
+```shell
+chainctl auth pull-token --parent=<YOUR_CHAINGUARD_ORG> --ttl=850h -o json > /tmp/token.json
+export IDENTITY=$(jq -r .identity_id /tmp/token.json)
+export IDENTITY_TOKEN=$(jq -r .token /tmp/token.json)
+rm /tmp/token.json
+```
+**Set Up Role Bindings:**
+
+After generating the pull token, ensure you bind the required roles appropriately:
+
+```shell
+chainctl iam role-bindings create --parent=<YOUR_CHAINGUARD_ORG> --identity=${IDENTITY} --role=apk.pull
+```
+**Using the Pull Token in CI:**
+
+The generated pull token can be provided in the HTTP_AUTH environment variable for accessing the private APK repository:
+
+```shell
+export HTTP_AUTH=basic:apk.cgr.dev:user:${IDENTITY}:${IDENTITY_TOKEN}
+```
+
+Now you can structure your CI workflow to utilize this variable for authentication against the APK repository.
 
 ## Searching for and Installing Packages
 

--- a/content/chainguard/chainguard-images/features/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/private-apk-repos/index.md
@@ -111,7 +111,7 @@ Following that, you can proceed to search and install packages from your private
 
 To generate a longer lived token for authentication purposes, it is necessary to create a pull token to access your private APK repository. 
 
-In this example we will setup a pull token that expires in 35 days, to be used with CI. 
+In this example we set up a pull token that expires in 35 days, to use with CI. 
 
 **Generate a Pull Token:**
 

--- a/content/chainguard/chainguard-images/features/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/private-apk-repos/index.md
@@ -107,7 +107,7 @@ apk update
 
 Following that, you can proceed to search and install packages from your private APK repository.
 
-## Generating a pull token for Authentication 
+## Generating a Pull Token for Authentication 
 
 To generate a longer lived token for authentication purposes, it is necessary to create a pull token to access your private APK repository. 
 

--- a/content/chainguard/chainguard-images/features/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/private-apk-repos/index.md
@@ -113,7 +113,7 @@ To generate a longer lived token for authentication purposes, it is necessary to
 
 In this example we set up a pull token that expires in 35 days, to use with CI. 
 
-**Generate a Pull Token:**
+**Generate a pull token:**
 
 ```shell
 chainctl auth pull-token --parent=<YOUR_CHAINGUARD_ORG> --ttl=850h -o json > /tmp/token.json


### PR DESCRIPTION
Adding section to authenticate to APK's using long lived tokens. Based upon prospect escalation here:

https://github.com/chainguard-dev/customer-issues/issues/2357

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
documentation

### What should this PR do?
adds instructions on how to authenticate to an apk registry using a pull token

### Why are we making this change?
Addresses prospect issue here - https://github.com/chainguard-dev/customer-issues/issues/2357

### What are the acceptance criteria? 
Just make sure you can follow the steps and it works

### How should this PR be tested?
After complete the steps are completed, run a simple command like the following to verify your token works:

(Use an image with a shell/apk)

docker run --rm -it  -e HTTP_AUTH --entrypoint /bin/sh cgr.dev/$ORGINIZATION/$IMAGE:$TAG-dev 

apk update

Here is an example of my test:

jovan@Dales-MacBook-Pro ~ % docker run --rm -it  -e HTTP_AUTH --entrypoint /bin/sh cgr.dev/dale.rodriguez/chainguard-base
/ # apk update
fetch https://apk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836/aarch64/APKINDEX.tar.gz
WARNING: updating and opening https://apk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836: Permission denied
fetch https://virtualapk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/chainguard/aarch64/APKINDEX.tar.gz
fetch https://virtualapk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/extra-packages/aarch64/APKINDEX.tar.gz
 [https://virtualapk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/chainguard]
 [https://virtualapk.cgr.dev/de767c7cdef05a49e0433dc083cd9473c01bc836/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/extra-packages]
2 unavailable, 0 stale; 118974 distinct packages available