### PR TITLE
Standardize tag capitalization across documentation

### DIFF
--- a/content/software-security/compliance/cis-benchmarks.md
+++ b/content/software-security/compliance/cis-benchmarks.md
@@ -7,7 +7,7 @@ date: 2024-09-18T14:05:09+00:00
 lastmod: 2024-09-18T14:05:09+00:00
 contributors: []
 draft: false
-tags: ["COMPLIANCE", "STANDARDS"]
+tags: ["Compliance", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/cmmc-2/cmmc-2-levels/index.md
+++ b/content/software-security/compliance/cmmc-2/cmmc-2-levels/index.md
@@ -7,7 +7,7 @@ date: 2024-08-09T19:10:09+00:00
 lastmod: 2024-08-15T19:10:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "CMMC 2.0", "standards"]
+tags: ["Compliance", "CMMC 2.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/cmmc-2/cmmc-chainguard.md
+++ b/content/software-security/compliance/cmmc-2/cmmc-chainguard.md
@@ -7,7 +7,7 @@ date: 2024-08-09T19:10:09+00:00
 lastmod: 2024-08-15T19:10:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "CMMC 2.0", "standards"]
+tags: ["Compliance", "CMMC 2.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/cmmc-2/cmmc-practices.md
+++ b/content/software-security/compliance/cmmc-2/cmmc-practices.md
@@ -7,7 +7,7 @@ date: 2024-08-09T19:10:09+00:00
 lastmod: 2024-08-15T19:10:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "CMMC 2.0", "standards"]
+tags: ["Compliance", "CMMC 2.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/cmmc-2/intro-cmmc-2.md
+++ b/content/software-security/compliance/cmmc-2/intro-cmmc-2.md
@@ -7,7 +7,7 @@ date: 2024-08-09T19:10:09+00:00
 lastmod: 2024-08-15T19:10:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "CMMC 2.0", "standards"]
+tags: ["Compliance", "CMMC 2.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/pci-dss-4/intro-pci-dss-4.md
+++ b/content/software-security/compliance/pci-dss-4/intro-pci-dss-4.md
@@ -7,7 +7,7 @@ date: 2024-08-21T14:05:09+00:00
 lastmod: 2024-08-21T14:05:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "PCI DSS 4.0", "standards"]
+tags: ["Compliance", "PCI DSS 4.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/pci-dss-4/pci-dss-chainguard.md
+++ b/content/software-security/compliance/pci-dss-4/pci-dss-chainguard.md
@@ -7,7 +7,7 @@ date: 2024-08-21T14:05:09+00:00
 lastmod: 2024-08-21T14:05:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "PCI DSS 4.0", "standards"]
+tags: ["Compliance", "PCI DSS 4.0", "Standards"]
 images: []
 menu:
   docs:

--- a/content/software-security/compliance/pci-dss-4/pci-dss-practices.md
+++ b/content/software-security/compliance/pci-dss-4/pci-dss-practices.md
@@ -7,7 +7,7 @@ date: 2024-08-21T14:05:09+00:00
 lastmod: 2024-08-21T14:05:09+00:00
 contributors: []
 draft: false
-tags: ["compliance", "PCI DSS 4.0", "standards"]
+tags: ["Compliance", "PCI DSS 4.0", "Standards"]
 images: []
 menu:
   docs:


### PR DESCRIPTION
  - Convert 'compliance'/'COMPLIANCE' to 'Compliance'
  - Convert 'standards'/'STANDARDS' to 'Standards'
  - Maintain acronyms in uppercase (CVE, SBOM, FAQ, etc.)
  - Affects 8 files in compliance documentation