### PR TITLE
Add env var use for authenticated registry access

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -55,9 +55,17 @@ With the latest release of `chainctl`, this will print a `docker login` command 
 
 You can also pass the `--save` flag, which will update your Docker config file with the pull token directly.
 
-This token expires in 30 days by default, which can be shortened using the `--ttl` flag (for example, `--ttl=24h`).
+This token expires in 30 days by default, which can be modified using the
+`--ttl` flag. It sets the duration for the validity of the token. The maximum
+valid value is `8760h` (equivalent to 365 days), Valid unit strings range from
+nanoseconds to hours and are `ns`, `us`, `ms`, `s`, `m`, and `h`, for example
+`--ttl=24h`.
 
 Pulls authenticated in this way are associated with a Chainguard identity, which is associated with the organization selected when the pull token was created.
+
+You can also export the pull token details into environment variables for
+[authentication in automated
+systems](/chainguard/chainguard-images/features/private-apk-repos/#pull-token-automation).
 
 ### Note on Multiple Pull Tokens
 

--- a/content/chainguard/chainguard-images/features/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/private-apk-repos/index.md
@@ -107,6 +107,51 @@ apk update
 
 Following that, you can proceed to search and install packages from your private APK repository.
 
+<a id="pull-token-automation"></a>
+
+## Pull Token for Authentication in Automated Workflows
+
+Use a pull token with a custom time to live (TTL) to authenticate to your
+private APK repository. The following example creates a pull token with a TTL of
+2190 hours, equivalent to 3 months, and produces an output with `export`
+commands to set environment variables `CHAINGUARD_IDENTITY_ID` for username and
+`CHAINGUARD_TOKEN` for password values and basic authentication use.
+
+```shell
+$ chainctl auth pull-token --ttl=2190h --output=env --parent=ORGANIZATION
+export CHAINGUARD_IDENTITY_ID=45a.....424eb0
+export CHAINGUARD_TOKEN=eeyJhbGciO..........WF0IjoxN
+```
+
+* `--ttl=2190d`: set the duration for the validity of the token, defaults to
+  `720h` (equivalent to 30 days), maximum valid value is `8760h` (equivalent to
+  365 days), valid unit strings range from nanoseconds to hours and are `ns`,
+  `us`, `ms`, `s`, `m`, and `h`.
+* `--output=env`: set the command output to use export commands for environment
+  variables.
+* `--parent=ORGANIZATION`: specify the parent organization for your account as
+  provided when requesting access and replace `ORGANIZATION`.
+
+Each invocation of the command creates a new identity with access rights as a
+pull token.
+
+Combine the call with `eval` to populate the environment variables directly by
+calling `chainctl`. The following example uses the default TTL value of 30 days,
+which is suitable for regular CI runs:
+
+```shell
+eval $(chainctl auth pull-token --output env --parent=ORGANIZATION)
+```
+
+The generated pull token can be provided in the `HTTP_AUTH` environment variable
+for accessing the private APK repository:
+
+```shell
+export HTTP_AUTH=basic:apk.cgr.dev:user:${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}
+```
+
+Now you can structure your CI workflow to utilize this variable for
+authentication against the APK repository.
 
 ## Searching for and Installing Packages
 


### PR DESCRIPTION
### What should this PR do?

Replace, improve, and expand on https://github.com/chainguard-dev/edu/pull/2380

Cover private apk repo as well as container registry access

Follow up to https://github.com/chainguard-dev/customer-issues/issues/2357

This PR https://github.com/chainguard-dev/mono/pull/25463 also updates the built-in help.

Fix [4880](https://github.com/chainguard-dev/internal/issues/4880)

### Why are we making this change?

Env var use directly is better and easier to use than hacking with json output and jq.

### What are the acceptance criteria? 

Review

### How should this PR be tested?

Probably not necessary. I tested the chainctl commands but not the auth stuff to the registry,.. but thats not new.