### PR TITLE
chainguard-images: architecture ISA baselines

### DIFF
--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -41,7 +41,7 @@ Note that there is often a development variant of each Chainguard Container avai
 
 Chainguard originally took a single-layer approach to container images built [with apko](/open-source/build-tools/apko/getting-started-with-apko/) in order to offer simplicity and clarity. However, in an effort to deliver better stability, security, and efficiency for larger and more complex applications, Chainguard introduced multi-layer container images in May 2025. This approach leverages container runtime caching so that a layer used by multiple images does not need to be downloaded more than once, and you don't need to download the whole image each time there is an update on one layer.
 
-Chainguard's approach to layering is a "per-origin" strategy, where packages that derive from the same upstream source are grouped in the same layer because they tend to receive updates together. 
+Chainguard's approach to layering is a "per-origin" strategy, where packages that derive from the same upstream source are grouped in the same layer because they tend to receive updates together.
 
 We observed that this approach achieved the following:
 * A ~70% reduction in the total size of unique layer data across our image catalog compared to the single-layer approach
@@ -49,8 +49,8 @@ We observed that this approach achieved the following:
 
 To maximize the stability and re-useability of our layers, Chainugard identified, analyzed, and implemented three additional technical changes:
 * Added in an additional final layer that captures frequently updated OS-level metadata
-* Developed intelligent layer ordering to optimize compatibility 
-* Ensured sufficient layer counts to optimize parallel downloads by container clients 
+* Developed intelligent layer ordering to optimize compatibility
+* Ensured sufficient layer counts to optimize parallel downloads by container clients
 
 The primary benefit of this layered approach is that when one package changes it impacts only its particular layer, requiring only that layer to be downloaded again. Because the other layers don't need to be downloaded again, Chainguard's multi-layer container images support greater efficiency and developer velocity.
 
@@ -80,7 +80,12 @@ You can review more comparisons of Chainguard Containers and external images by 
 
 ## Architecture
 
-By default, all Wolfi-based images are built for x86_64 (also known as AMD64) and AArch64 (also known as ARM64) architectures. Being able to provide multi-platform Chainguard Containers enables the support of more than one runtime environment, like those available on all three major clouds, AWS, GCP, and Azure. The macOS M1 and M2 chips are also based on ARM architecture. Chainguard Containers allow you to take advantage of ARM's power consumption and cost benefits.
+By default, all Wolfi-based images are built for x86_64 (also known as AMD64) and AArch64 (also known as ARM64) architecture with the following CPU Instruction Set Architecture (ISA) baseline features:
+
+* x86_64: x86-64-v2 (Sapphire Rapids)
+* AArch64: Armv8-A with CRC and Cryptographic extensions (Neoverse V2)
+
+Being able to provide multi-platform Chainguard Containers enables the support of more than one runtime environment, like those available on all three major clouds, AWS, GCP, and Azure. The macOS M1 and M2 chips are also based on ARM architecture. Chainguard Containers allow you to take advantage of ARM's power consumption and cost benefits.
 
 You can confirm the available architecture of a given Chainguard Container with Crane. In this example, we'll use the latest Ruby image, but you can opt to use an alternate image.
 


### PR DESCRIPTION
Add detail on specific CPU ISA baselines we use for Chainguard
images; running on older CPU's which do not support these features
is not supported.
