### PR TITLE
Update getting-started-with-apko.md

### DIFF
--- a/content/open-source/build-tools/apko/getting-started-with-apko.md
+++ b/content/open-source/build-tools/apko/getting-started-with-apko.md
@@ -22,7 +22,7 @@ toc: true
 ## Why apko
 Container images are typically assembled in multiple steps. A tool like Docker, for example, combines building steps (as in, running commands to copy files, build and deploy applications) and composition (as in, composing a base image with pre-built packages) in a single piece of software. apko, on the other hand, is solely a **composition** tool that focuses on producing lightweight, "flat" base images that are fully reproducible and contain auto generated [SBOM](https://www.cisa.gov/sbom) files for every successful build.
 
-Instead of building your application together with your components and system dependencies, you can build your application once and compose it into different architectures and distributions, using a tool such as [melange](https://github.com/chainguard-dev/melange) in combination with apko. For more information on how melange and apko work together, you can check this blog post: [Secure your Software Factory with melange and apko](https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/).
+Instead of building your application together with your components and system dependencies, you can build your application once and compose it into different architectures and distributions, using a tool such as [melange](https://github.com/chainguard-dev/melange) in combination with apko. For more information on how melange and apko work together, you can check this blog post: [Secure your Software Factory with melange and apko](https://www.chainguard.dev/unchained/secure-your-software-factory-with-melange-and-apko).
 
 In this guide, we'll learn how to use apko to build a base [Wolfi](/open-source/wolfi/overview/) image.
 


### PR DESCRIPTION
[ X] Check if this is a typo or other quick fix and ignore the rest :)
[This doc](https://edu.chainguard.dev/open-source/build-tools/apko/getting-started-with-apko/) has the following sentence:
For more information on how melange and apko work together, you can check this blog post: [Secure your Software Factory with melange and apko](https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/).
Although the link means to direct users here: https://blog.chainguard.dev/secure-your-software-factory-with-melange-and-apko/
... it redirects them here: https://www.chainguard.dev/unchained .
Instead, it should redirect them here: https://www.chainguard.dev/unchained/secure-your-software-factory-with-melange-and-apko

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->