### PR TITLE
Dockerfile for Hugo.

### DIFF
--- a/Dockerfile.hugo
+++ b/Dockerfile.hugo
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 cgr.dev/chainguard/node:latest-dev
+
+COPY . .
+USER root
+RUN npm install
+USER node
+ENTRYPOINT ["/bin/npm"]
+CMD ["run", "start"]
+
+# Run this Dockerfile with
+# docker run --platform linux/amd64 -p 1313:1313 <image-name>


### PR DESCRIPTION
Adds a very simple Dockerfile for building and running the docs server.

If iterating on code, you will want to mount the code directory as a volume.

Biggest advantage right now is you don't need install npm and old libraries on your host. Going forward it might give us a consistent base for testing changes (e.g. updating hugo version).

We don't need to merge this, but wanted to keep the Dockerfile somewhere at least.