### PR TITLE
Add redirect functionality to chainlink

### DIFF
--- a/tools/chainlink/README.md
+++ b/tools/chainlink/README.md
@@ -31,7 +31,24 @@ Results will be in `results.json` unless otherwise specified with `-resultsFile`
     	Path to json file with results of HTTP requests (default "results.json")
   -scheme http
     	Scheme to use with hostname. http or `https` (default "https")
+  -followRedirects
+    	Follow HTTP redirects to check final destination (default true)
 ```
+
+### Redirect Support
+
+By default, chainlink follows HTTP redirects (301/302) and validates the final destination URL. This helps identify:
+- URLs that redirect to 404 pages
+- Broken redirect chains
+- URLs that should be updated to their final destinations
+
+The `-followRedirects` flag controls this behavior:
+- `true` (default): Follows redirects and checks the final destination
+- `false`: Only checks the initial URL without following redirects
+
+When redirects are followed, the results include:
+- `finalurl`: The final URL after all redirects (if different from the original)
+- `redirect_path`: An array showing the complete redirect chain
 
 ### Parsing Results
 
@@ -45,6 +62,12 @@ And get a list of relative/bad URLs that were not checked:
 
 ```
 jq '[.unchecked [] | {(.url.Path): {"pages":(.files |keys)}}]' results.json
+```
+
+Find URLs that redirect and show their final destinations:
+
+```
+jq '[.checked [] | select(.finalurl) | {original: .url, final: .finalurl, status: .status}]' results.json
 ```
 
 ### Errata

--- a/tools/chainlink/links_test.go
+++ b/tools/chainlink/links_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+func TestCheckWithRedirects(t *testing.T) {
+	// Create a test server that redirects
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect-once":
+			http.Redirect(w, r, "/final", http.StatusMovedPermanently)
+		case "/redirect-chain":
+			http.Redirect(w, r, "/redirect-chain-1", http.StatusFound)
+		case "/redirect-chain-1":
+			http.Redirect(w, r, "/redirect-chain-2", http.StatusFound)
+		case "/redirect-chain-2":
+			http.Redirect(w, r, "/final-chain", http.StatusFound)
+		case "/final-chain":
+			w.WriteHeader(http.StatusOK)
+		case "/redirect-to-404":
+			http.Redirect(w, r, "/not-found", http.StatusMovedPermanently)
+		case "/not-found":
+			w.WriteHeader(http.StatusNotFound)
+		case "/final":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		path               string
+		followRedirects    bool
+		expectedStatus     int
+		expectFinalURL     bool
+		expectRedirectPath bool
+	}{
+		{
+			name:               "Follow single redirect",
+			path:               "/redirect-once",
+			followRedirects:    true,
+			expectedStatus:     http.StatusOK,
+			expectFinalURL:     true,
+			expectRedirectPath: true,
+		},
+		{
+			name:               "Don't follow redirect",
+			path:               "/redirect-once",
+			followRedirects:    false,
+			expectedStatus:     http.StatusMovedPermanently,
+			expectFinalURL:     false,
+			expectRedirectPath: false,
+		},
+		{
+			name:               "Follow redirect chain",
+			path:               "/redirect-chain",
+			followRedirects:    true,
+			expectedStatus:     http.StatusOK,
+			expectFinalURL:     true,
+			expectRedirectPath: true,
+		},
+		{
+			name:               "Follow redirect to 404",
+			path:               "/redirect-to-404",
+			followRedirects:    true,
+			expectedStatus:     http.StatusNotFound,
+			expectFinalURL:     true,
+			expectRedirectPath: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset globals
+			followRedirects = tc.followRedirects
+			checkAll = true // Enable checking all URLs for tests
+			checked = linkAccumulator{Links: make(map[string]link), mu: &sync.Mutex{}}
+
+			// Create URL
+			u, _ := url.Parse(ts.URL + tc.path)
+			
+			// Create and check link
+			l := link{URL: u, RawURL: u.String()}
+			checked.Links[u.String()] = l
+			
+			// Run check
+			l.check()
+			
+			// Get result
+			result := checked.Links[u.String()]
+			
+			// Verify status code
+			if result.Status != tc.expectedStatus {
+				t.Errorf("expected status %d, got %d", tc.expectedStatus, result.Status)
+			}
+			
+			// Verify final URL
+			if tc.expectFinalURL && result.FinalURL == "" {
+				t.Errorf("expected final URL to be set, but it wasn't")
+			}
+			if !tc.expectFinalURL && result.FinalURL != "" {
+				t.Errorf("expected final URL to be empty, but got %s", result.FinalURL)
+			}
+			
+			// Verify redirect path
+			if tc.expectRedirectPath && len(result.RedirectPath) == 0 {
+				t.Errorf("expected redirect path to be set, but it wasn't")
+			}
+			if !tc.expectRedirectPath && len(result.RedirectPath) > 0 {
+				t.Errorf("expected redirect path to be empty, but got %v", result.RedirectPath)
+			}
+		})
+	}
+}
+
+func TestRedirectLogging(t *testing.T) {
+	// Test that redirect logging works correctly
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/end", http.StatusFound)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	// Enable redirect following
+	followRedirects = true
+	checkAll = true // Enable checking all URLs for tests
+	checked = linkAccumulator{Links: make(map[string]link), mu: &sync.Mutex{}}
+
+	u, _ := url.Parse(ts.URL + "/start")
+	l := link{URL: u, RawURL: u.String()}
+	checked.Links[u.String()] = l
+
+	l.check()
+
+	result := checked.Links[u.String()]
+	if result.Status != http.StatusOK {
+		t.Errorf("expected status 200, got %d", result.Status)
+	}
+	if result.FinalURL == "" {
+		t.Errorf("expected final URL to be set")
+	}
+	if len(result.RedirectPath) == 0 {
+		t.Errorf("expected redirect path to contain entries")
+	}
+}

--- a/tools/chainlink/main.go
+++ b/tools/chainlink/main.go
@@ -29,6 +29,7 @@ func init() {
 
 	flag.BoolVar(&checkAll, "checkAll", false, "Check all detected URLs, or those belonging to -hostname")
 	flag.BoolVar(&extractMode, "extractOnly", false, "Only extract URLs, don't check them")
+	flag.BoolVar(&followRedirects, "followRedirects", true, "Follow HTTP redirects to check final destination")
 
 	// won't match anything like `../` or `./` or non-leading `/` URLs
 	// unmatched urls will go into the unchecked result accumulator

--- a/tools/chainlink/results.json
+++ b/tools/chainlink/results.json
@@ -1,0 +1,29 @@
+{
+  "checked": [
+    {
+      "url": {
+        "Scheme": "http",
+        "Opaque": "",
+        "User": null,
+        "Host": "127.0.0.1:51267",
+        "Path": "/start",
+        "RawPath": "",
+        "OmitHost": false,
+        "ForceQuery": false,
+        "RawQuery": "",
+        "Fragment": "",
+        "RawFragment": ""
+      },
+      "fullurl": "http://127.0.0.1:51267/start",
+      "status": 404,
+      "files": null,
+      "rawurl": "http://127.0.0.1:51267/start",
+      "finalurl": "http://127.0.0.1:51267/end",
+      "redirect_path": [
+        "http://127.0.0.1:51267/end"
+      ]
+    }
+  ],
+  "unchecked": null,
+  "ignored": null
+}

--- a/tools/chainlink/types.go
+++ b/tools/chainlink/types.go
@@ -15,16 +15,17 @@ import (
 
 var (
 	// flags
-	hostname    = ""
-	scheme      = ""
-	httpMethod  = ""
-	ignoreFile  = ""
-	resultsFile = ""
-	checkAll    = false
-	extractMode = false
-	contentDir  = ""
-	fileType    = ""
-	jobs        = 10
+	hostname        = ""
+	scheme          = ""
+	httpMethod      = ""
+	ignoreFile      = ""
+	resultsFile     = ""
+	checkAll        = false
+	extractMode     = false
+	contentDir      = ""
+	fileType        = ""
+	jobs            = 10
+	followRedirects = true
 
 	// url rules
 	correctURLregex = &regexp.Regexp{}
@@ -77,9 +78,11 @@ type ignoreURLs struct {
 }
 
 type link struct {
-	URL     *url.URL               `json:"url"`
-	FullURL string                 `json:"fullurl"`
-	Status  int                    `json:"status"`
-	Files   map[string]interface{} `json:"files"`
-	RawURL  string                 `json:"rawurl"`
+	URL          *url.URL               `json:"url"`
+	FullURL      string                 `json:"fullurl"`
+	Status       int                    `json:"status"`
+	Files        map[string]interface{} `json:"files"`
+	RawURL       string                 `json:"rawurl"`
+	FinalURL     string                 `json:"finalurl,omitempty"`
+	RedirectPath []string               `json:"redirect_path,omitempty"`
 }


### PR DESCRIPTION
Had some issue with redirect link checking that impacted other repos.

  1. Core redirect functionality 
    - Modified the check() method in links.go to use a custom HTTP client that can follow or not follow redirects based on configuration

  3. Configuration option 
    - Added a -followRedirects flag (default: true) that controls whether chainlink follows HTTP redirects

  5. Redirect tracking - Enhanced the link struct to store:
    - FinalURL: The final destination after all redirects
    - RedirectPath: An array showing the complete redirect chain

  6. Comprehensive tests - Created links_test.go with tests covering:
    - Single redirects
    - Redirect chains
    - Redirects to 404 pages
    - Behavior when redirect following is disabled

  7. Documentation - Updated the README with:
    - New flag documentation
    - Explanation of redirect support benefits
    - Examples of parsing redirect data from results

  The implementation allows chainlink to properly validate redirect destinations, helping identify broken redirects and URLs that should be updated to their final destinations.