### PR TITLE
Fix link in dockerfile-conversion.md

### DIFF
--- a/content/chainguard/migration/dockerfile-conversion.md
+++ b/content/chainguard/migration/dockerfile-conversion.md
@@ -315,7 +315,7 @@ CMD ["python", "/app/main.py"]
 
 As you will notice, DFC used a _distroless_ Python Chainguard Container for the final runtime stage: `cgr.dev/ORG/python:3.9`. That is possible because DFC didn't detect any `RUN` instruction in the final stage. If we had system-level dependencies installed via `apk` or other `RUN` instructions in the runtime stage, DFC would instead default to the regular, fully-featured Python image from Chainguard Containers, which in this case would be `cgr.dev/ORG/python:3.9-dev`.
 
-For more details on distroless and how to work with multi-stage builds, check our guide on [Getting Started with Distroless](https://deploy-preview-2401--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/about/getting-started-distroless/).
+For more details on distroless and how to work with multi-stage builds, check our guide on [Getting Started with Distroless](https://edu.chainguard.dev/chainguard/chainguard-images/about/getting-started-distroless/).
 
 ## Customizing the Conversion
 There are several ways to customize the conversion process of Dockerfiles using `dfc`.

--- a/content/chainguard/migration/dockerfile-conversion.md
+++ b/content/chainguard/migration/dockerfile-conversion.md
@@ -315,7 +315,7 @@ CMD ["python", "/app/main.py"]
 
 As you will notice, DFC used a _distroless_ Python Chainguard Container for the final runtime stage: `cgr.dev/ORG/python:3.9`. That is possible because DFC didn't detect any `RUN` instruction in the final stage. If we had system-level dependencies installed via `apk` or other `RUN` instructions in the runtime stage, DFC would instead default to the regular, fully-featured Python image from Chainguard Containers, which in this case would be `cgr.dev/ORG/python:3.9-dev`.
 
-For more details on distroless and how to work with multi-stage builds, check our guide on [Getting Started with Distroless](https://edu.chainguard.dev/chainguard/chainguard-images/about/getting-started-distroless/).
+For more details on distroless and how to work with multi-stage builds, check our guide on [Getting Started with Distroless](/chainguard/chainguard-images/about/getting-started-distroless/).
 
 ## Customizing the Conversion
 There are several ways to customize the conversion process of Dockerfiles using `dfc`.


### PR DESCRIPTION
`Getting Started with Distroless Container Images` link was pointing at staging instance of docs.

Fixes #2431 
[x] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->