### PR TITLE
Feedback buttons w/ embedded form

### DIFF
--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const feedbackContainers = document.querySelectorAll('.feedback-container');
+  
+  feedbackContainers.forEach(container => {
+    const yesBtn = container.querySelector('.feedback-yes');
+    const noBtn = container.querySelector('.feedback-no');
+    const feedbackForm = container.querySelector('.feedback-form');
+    const responseDiv = container.querySelector('.feedback-response');
+    
+    function getPageData() {
+      return {
+        url: encodeURIComponent(window.location.href),
+        title: encodeURIComponent(document.title)
+      };
+    }
+    
+    function handlePositiveFeedback() {
+      // Update button appearance
+      const clickedBtnText = yesBtn.querySelector('.feedback-btn-text');
+      clickedBtnText.textContent = '👍';
+      yesBtn.classList.add('feedback-clicked');
+      
+      // Disable both buttons
+      yesBtn.disabled = true;
+      noBtn.disabled = true;
+      
+      // Show thank you message
+      responseDiv.style.display = 'block';
+      setTimeout(() => {
+        responseDiv.classList.add('feedback-response-visible');
+      }, 100);
+    }
+    
+    function handleNegativeFeedback() {
+      // Update button appearance
+      const clickedBtnText = noBtn.querySelector('.feedback-btn-text');
+      clickedBtnText.textContent = '👎';
+      noBtn.classList.add('feedback-clicked');
+      
+      // Disable both buttons
+      yesBtn.disabled = true;
+      noBtn.disabled = true;
+      
+      // Create and show embedded Google Form
+      const pageData = getPageData();
+      const formUrl = `https://docs.google.com/forms/d/e/1FAIpQLScaZRQAfqr0CL9fsJ4y4oTdt1A6UQVazmEXw-wibcrqr0UFhg/viewform?embedded=true&entry.561897852=${pageData.url}&entry.408557657=${pageData.title}`;
+      
+      const iframe = document.createElement('iframe');
+      iframe.src = formUrl;
+      iframe.style.width = '100%';
+      iframe.style.height = '500px';
+      iframe.style.border = 'none';
+      iframe.style.marginTop = '1rem';
+      iframe.setAttribute('frameborder', '0');
+      iframe.setAttribute('marginheight', '0');
+      iframe.setAttribute('marginwidth', '0');
+      iframe.innerHTML = 'Loading feedback form...';
+      
+      feedbackForm.innerHTML = '';
+      feedbackForm.appendChild(iframe);
+      feedbackForm.style.display = 'block';
+      
+      setTimeout(() => {
+        feedbackForm.classList.add('feedback-form-visible');
+      }, 100);
+    }
+    
+    if (yesBtn) {
+      yesBtn.addEventListener('click', handlePositiveFeedback);
+    }
+    
+    if (noBtn) {
+      noBtn.addEventListener('click', handleNegativeFeedback);
+    }
+  });
+});

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -22,6 +22,7 @@
 @import "components/code";
 @import "components/copypage";
 @import "components/details";
+@import "components/feedback";
 @import "components/syntax";
 @import "components/comments";
 @import "components/forms";

--- a/assets/scss/components/feedback.scss
+++ b/assets/scss/components/feedback.scss
@@ -1,0 +1,207 @@
+// Feedback component styles
+.feedback-wrapper {
+  display: flex;
+  justify-content: center;
+  margin: 32px 0;
+}
+
+.feedback-container {
+  padding: 24px;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  background: #d0cfee;
+//  background: var(--bs-body-bg);
+  transition: all 0.2s ease;
+  display: inline-block;
+  max-width: fit-content;
+  
+  &:hover {
+    border-color: var(--primary-1);
+  }
+}
+
+.feedback-question {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  
+  .feedback-text {
+    font-size: 18px;
+    font-weight: 600;
+    color: #14003d;
+    margin-right: 8px;
+  }
+}
+
+.feedback-buttons {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.feedback-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 16px;
+  background: transparent;
+  border: 2px solid var(--primary-1);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--bs-body-color);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 60px;
+  
+  &:hover:not(:disabled) {
+    background: var(--primary-1);
+    border-color: var(--primary-1);
+    color: white;
+    transform: translateY(-1px);
+  }
+  
+  &:active:not(:disabled) {
+    transform: scale(0.98);
+  }
+  
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  
+  &.feedback-clicked {
+    border-color: var(--secondary-2);
+    background: var(--bs-success-bg-subtle);
+    
+    .feedback-btn-text {
+      color: var(--secondary-2);
+    }
+  }
+}
+
+.feedback-response {
+  margin-top: 16px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  
+  &.feedback-response-visible {
+    opacity: 1;
+  }
+}
+
+.feedback-thanks {
+  font-size: 16px;
+  font-weight: 500;
+  color: #14003d;
+  margin-bottom: 8px;
+}
+
+.feedback-form {
+  margin-top: 16px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  
+  &.feedback-form-visible {
+    opacity: 1;
+  }
+}
+
+.feedback-textarea-container {
+  margin-bottom: 12px;
+}
+
+.feedback-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 12px;
+  border: 2px solid var(--bs-border-color);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+  resize: vertical;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  transition: border-color 0.2s ease;
+  
+  &:focus {
+    outline: none;
+    border-color: var(--primary-1);
+  }
+  
+  &::placeholder {
+    color: var(--bs-secondary-color);
+  }
+}
+
+.feedback-submit-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 20px;
+  background: transparent;
+  border: 2px solid var(--primary-1);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--bs-body-color);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  
+  &:hover:not(:disabled) {
+    background: var(--primary-1);
+    border-color: var(--primary-1);
+    color: white;
+    transform: translateY(-1px);
+  }
+  
+  &:active:not(:disabled) {
+    transform: scale(0.98);
+  }
+  
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    background: var(--bs-secondary);
+    border-color: var(--bs-secondary);
+    color: white;
+  }
+}
+
+
+// Mobile responsive
+@media (max-width: 768px) {
+  .feedback-wrapper {
+    margin: 24px 0;
+  }
+  
+  .feedback-container {
+    padding: 16px;
+  }
+  
+  .feedback-question {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    
+    .feedback-text {
+      margin-right: 0;
+    }
+  }
+  
+  .feedback-buttons {
+    width: 100%;
+    justify-content: center;
+  }
+  
+  .feedback-btn {
+    flex: 1;
+    max-width: 100px;
+  }
+}

--- a/assets/scss/components/feedback.scss
+++ b/assets/scss/components/feedback.scss
@@ -93,6 +93,10 @@
   }
 }
 
+.feedback-response[style*="display: block"] {
+  opacity: 1;
+}
+
 .feedback-thanks {
   font-size: 16px;
   font-weight: 500;
@@ -108,6 +112,10 @@
   &.feedback-form-visible {
     opacity: 1;
   }
+}
+
+.feedback-form[style*="display: block"] {
+  opacity: 1;
 }
 
 .feedback-textarea-container {

--- a/layouts/article/single.html
+++ b/layouts/article/single.html
@@ -126,6 +126,10 @@
           {{ end }}-->
       </div>
 
+      {{ if not .Params.hide_feedback -}}
+        {{ partial "feedback.html" . }}
+      {{ end -}}
+
       <!-- <a class="btn cta-button" href="https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement">Contact Us</a> -->
 
       {{ partial "footer/main/docs-navigation.html" . }}
@@ -144,6 +148,9 @@
     {{- $copypage := resources.Get "js/copypage.js" -}}
     {{ $copypage := $copypage | minify }}
     <script src="{{ $copypage.Permalink }}" integrity="{{ $copypage.Data.Integrity }}"></script>
+    {{- $feedback := resources.Get "js/feedback.js" -}}
+    {{ $feedback := $feedback | minify }}
+    <script src="{{ $feedback.Permalink }}" integrity="{{ $feedback.Data.Integrity }}"></script>
     {{ if ne .Params.toc false -}}
     <nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }}" aria-label="Secondary navigation">
       {{ partial "sidebar/docs-toc.html" . }}

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,0 +1,21 @@
+<div class="feedback-wrapper">
+  <div class="feedback-container">
+    <div class="feedback-question">
+      <span class="feedback-text">Was this helpful?</span>
+      <div class="feedback-buttons">
+        <button class="feedback-btn feedback-yes" data-feedback="yes" aria-label="Yes, this was helpful">
+          <span class="feedback-btn-text">Yes</span>
+        </button>
+        <button class="feedback-btn feedback-no" data-feedback="no" aria-label="No, this was not helpful">
+          <span class="feedback-btn-text">No</span>
+        </button>
+      </div>
+    </div>
+    <div class="feedback-form" style="display: none;">
+      <!-- Embedded Google Form will be inserted here dynamically -->
+    </div>
+    <div class="feedback-response" style="display: none;">
+      <div class="feedback-thanks">Thanks for the feedback!</div>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -1,7 +1,7 @@
 <meta http-equiv="Content-Security-Policy"
       content="
        default-src 'self';
-       frame-src 'self' edu.chainguard.dev https://player.vimeo.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://syndication.twitter.com https://visualization-ui.chainguard.app https://terminal.inky.wtf;
+       frame-src 'self' edu.chainguard.dev https://player.vimeo.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://syndication.twitter.com https://visualization-ui.chainguard.app https://terminal.inky.wtf https://docs.google.com;
        style-src 'self' 'unsafe-inline' edu.chainguard.dev https://tagmanager.google.com/ cdn.jsdelivr.net https://fonts.googleapis.com https://unpkg.com https://use.fontawesome.com;
        form-action 'self';
        font-src 'self' edu.chainguard.dev https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net https://use.fontawesome.com;


### PR DESCRIPTION
[  ] Check if this is a typo or other quick fix and ignore the rest :)

follow up to: https://github.com/chainguard-dev/edu/pull/2381

(previous PR failed, now I'm trying a different strategy)

This PR adds a feedback element to Chainguard Academy. It consists of a prompt (`Was this helpful?`) and two response buttons: `Yes` and `No`. 

In this current state, when a user clicks "Yes", nothing really happens. The button turns into a :+1:  and the text `Thanks for your feedback` appears.

When a user clicks "No," an embedded Google form appears allowing users to submit feedback on the given page. After entering their feedback and submitting the form, the response gets recorded in this spreadsheet: https://docs.google.com/spreadsheets/d/1bOka5T3fV55VPpS2En-5J4ZFDb7kjdv1HPuaasgHy5w/edit?usp=sharing

## Testing

I'm able to submit negative feedback by running the site locally with `npm` run start. I would recommend [pulling down the changes in this PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally), running them locally, testing the functionality of both buttons, and then checking the spreadsheet linked above to ensure that the feedback was recorded.

### PLEASE NOTE

I set up some very basic response validation for the URL field. Any URL you pass through the form must start with `https://edu.chainguard.dev/`, so watch out for this when you test locally.