### PR TITLE
Add instructions to auth using circleci oidc

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -149,6 +149,65 @@ Pulls authenticated in this way are associated with the Chainguard identity you 
 
 If the identity is configured to only work with GitHub Actions workflow runs from a given repo and branch, that identity will not be able to pull from other repos or branches, including pull requests targeting the specified branch.
 
+
+## Authenticating with CircieCI OIDC Token
+
+As with GitHub Actions, you can configure authentication with OIDC-aware CircleCI platform.
+
+First, use chainctl to create an assumed identity. This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
+
+```sh
+chainctl iam identities create circleci-identity
+--identity-issuer="https://oidc.circleci.com/org/1234"
+--subject-pattern="org/1234/project/.+$"
+--role=registry.pull
+--parent=$ORGANIZATION
+```
+
+Then, use the identity created (5678 in this example) in the above command for the CircleCL config.yml:
+
+```yaml
+version: 2.1
+
+jobs:
+  install-and-authenticate:
+    machine: true
+    environment:
+    CHAINCTL_TOKEN_FILE: "/tmp/oidc_token"
+
+  steps:
+    - checkout
+
+    - run:
+          name: Download chainctl
+          command: |
+            curl -o chainctl "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')"
+
+    - run:
+        name: Install chainctl
+        command: |
+          sudo install -o $UID -g $(id -g) -m 0755 chainctl /usr/local/bin/
+
+    - run:
+        name: Configure Docker auth
+        command: |
+          sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "5678"
+
+    - run:
+        name: Pull Docker image
+        command: |
+          sudo docker pull cgr.dev/cgr-demo.com/python:latest
+
+workflows:
+  version: 2
+  chainctl-workflow:
+    jobs:
+      - install-and-authenticate  
+```
+
+See the [CircleCI documentation](https://circleci.com/docs/openid-connect-tokens/#format-of-the-openid-connect-id-token) to learn more about using OpenID Connect tokens in CircleCI jobs.
+
+
 ## Authenticating with Kubernetes
 
 You can also configure a Kubernetes cluster to use a pull token, as described above.

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -164,7 +164,7 @@ chainctl iam identities create circleci-identity
 --parent=$ORGANIZATION
 ```
 
-Then, use the identity created (5678 in this example) in the above command for the CircleCL config.yml:
+Then, use the identity created in the above command for the CircleCL config.yml:
 
 ```yaml
 version: 2.1
@@ -191,7 +191,7 @@ jobs:
     - run:
         name: Configure Docker auth
         command: |
-          sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "5678"
+          sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "1234"
           # Here is the created identity that was mentioned ^^^^
 
     - run:

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -4,7 +4,7 @@ linktitle: "Authenticate"
 type: "article"
 description: "A guide on authenticating to Chainguard's registry to get container images"
 date: 2023-03-21T15:10:16+00:00
-lastmod: 2025-04-11T15:22:20+01:00
+lastmod: 2025-08-06T15:22:20+01:00
 tags: ["Chainguard Containers", "Registry"]
 draft: false
 images: []
@@ -150,11 +150,11 @@ Pulls authenticated in this way are associated with the Chainguard identity you 
 If the identity is configured to only work with GitHub Actions workflow runs from a given repo and branch, that identity will not be able to pull from other repos or branches, including pull requests targeting the specified branch.
 
 
-## Authenticating with CircieCI OIDC Token
+## Authenticating with CircleCI OIDC Token
 
 You can configure authentication with OIDC-aware CircleCI platform.
 
-First, use `chainctl` to create an assumed identity. This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
+First, use `chainctl` to create an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Replace `1234` with your identity issuer. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
 
 ```sh
 chainctl iam identities create circleci-identity
@@ -164,7 +164,7 @@ chainctl iam identities create circleci-identity
 --parent=$ORGANIZATION
 ```
 
-Then, use the identity created in the above command for the CircleCL config.yml, shown here in the third `run` section:
+Then, use the identity created in the above command for the CircleCI config.yml, shown here in the third `run` section as `5678`:
 
 ```yaml
 version: 2.1
@@ -191,7 +191,7 @@ jobs:
     - run:
         name: Configure Docker auth
         command: |
-          sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "1234"
+          sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "5678"
 
     - run:
         name: Pull Docker image

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -154,7 +154,7 @@ If the identity is configured to only work with GitHub Actions workflow runs fro
 
 You can configure authentication with OIDC-aware CircleCI platform.
 
-First, use `chainctl` to create an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Replace `1234` with your identity issuer. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
+First, use `chainctl` to create an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Replace `1234` with your identity issuer org. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
 
 ```sh
 chainctl iam identities create circleci-identity

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -192,6 +192,7 @@ jobs:
         name: Configure Docker auth
         command: |
           sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "5678"
+          # Here is the created identity that was mentioned ^^^^
 
     - run:
         name: Pull Docker image

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -164,7 +164,7 @@ chainctl iam identities create circleci-identity
 --parent=$ORGANIZATION
 ```
 
-Then, use the identity created in the above command for the CircleCL config.yml:
+Then, use the identity created in the above command for the CircleCL config.yml, shown here in the third `run` section:
 
 ```yaml
 version: 2.1
@@ -192,7 +192,6 @@ jobs:
         name: Configure Docker auth
         command: |
           sudo chainctl auth configure-docker --identity-token="$CIRCLE_OIDC_TOKEN" --identity "1234"
-          # Here is the created identity that was mentioned ^^^^
 
     - run:
         name: Pull Docker image

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -152,9 +152,9 @@ If the identity is configured to only work with GitHub Actions workflow runs fro
 
 ## Authenticating with CircieCI OIDC Token
 
-As with GitHub Actions, you can configure authentication with OIDC-aware CircleCI platform.
+You can configure authentication with OIDC-aware CircleCI platform.
 
-First, use chainctl to create an assumed identity. This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
+First, use `chainctl` to create an assumed identity. This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
 
 ```sh
 chainctl iam identities create circleci-identity

--- a/content/chainguard/chainguard-images/getting-started/cilium/index.md
+++ b/content/chainguard/chainguard-images/getting-started/cilium/index.md
@@ -58,6 +58,9 @@ options:
       - arg: --flannel-backend=none
         nodeFilters:
           - server:*
+      - arg: --snapshotter=fuse-overlayfs
+        nodeFilters:
+          - server:*
 EOF
 ```
 


### PR DESCRIPTION
This adds a new section to the Authenticate to Chainguard's Registry doc for authenticating with a CircleCI OIDC token. The new section is somewhat parallel to the existing Authenticating with GitHub Actions section, which uses a similar process.

Fixes #2435