### PR TITLE
Adding new roles + capabilities reference doc

### DIFF
--- a/content/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference.md
+++ b/content/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference.md
@@ -2,7 +2,7 @@
 title: "Built-in Roles and Capabilities Reference"
 linktitle: "Built-in Roles & Capabilities"
 lead: "Reference for Chainguard's built-in roles and their specific capabilities"
-description: "A comprehensive reference documenting the capabilities and permissions of Chainguard's built-in IAM roles."
+description: "A resource documenting the capabilities and permissions of Chainguard's built-in IAM roles."
 type: "article"
 date: 2025-08-14T00:00:00Z
 lastmod: 2025-08-14T00:00:00Z
@@ -12,9 +12,9 @@ images: []
 weight: 010
 ---
 
-Chainguard provides customers with a set of built-in roles as part of its Identity and Access Management (IAM) system. These roles have different permissions and capabilties that allow them to serve specialized purposes purposes, from general administrative access to access for specific resources like registries, APK packages, and programming language libraries.
+Chainguard provides customers with a set of built-in roles as part of its Identity and Access Management (IAM) system. These roles have different permissions and capabilities that allow them to serve specialized purposes, from general administrative access to access for specific resources like registries, APK packages, and programming language libraries.
 
-This reference provides a comprehensive view of all Chainguard IAM capabilities and shows which built-in roles include each capability. Each capability represents a specific permission or action that can be performed within the Chainguard platform.
+This reference provides an overview of all Chainguard IAM capabilities and shows which built-in roles include each capability. Each capability represents a specific permission or action that can be performed within the Chainguard platform.
 
 For more information on roles and role-bindings within Chainguard's IAM model, please refer to our [Overview of Roles and Role-bindings](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/).
 
@@ -24,7 +24,7 @@ For more information on roles and role-bindings within Chainguard's IAM model, p
 This guide outlines the built-in Chainguard IAM roles available to most customer organizations. You can find more info about specific roles in your organization with the following `chainctl` command:
 
 ```shell
-chainctl iam roles list -o table
+chainctl iam roles list
 ```
 
 Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `owner` role can create, delete, list, and update custom roles within Chainguard, while the `viewer` role can only list them. 
@@ -43,9 +43,9 @@ This guide outlines the following twelve built-in roles provided by Chainguard:
     * `libraries.java.pull` - Java library access
     * `libraries.java.pull_token_creator` - Java token management
     * `libraries.python.pull` - Python library access
-    * `libraries.python.pull_token_creator` - Python token management
+    * `libraries.python.pull_token_creator` - Python library token management
     * `libraries.javascript.pull` - JavaScript library access
-    * `libraries.javascript.pull_token_creator` - JavaScript token management with extensive registry capabilities
+    * `libraries.javascript.pull_token_creator` - JavaScript library token management
 
 The administrative roles are useful for user profiles that require broad, but clearly defined capabilities. The registry, container, and library roles have limited permissions, allowing them to manage only one specific Chainguard resource. These specialized, resource-specific roles grant minimal required access.
 

--- a/content/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference.md
+++ b/content/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference.md
@@ -1,0 +1,124 @@
+---
+title: "Built-in Roles and Capabilities Reference"
+linktitle: "Built-in Roles & Capabilities"
+lead: "Reference for Chainguard's built-in roles and their specific capabilities"
+description: "A comprehensive reference documenting the capabilities and permissions of Chainguard's built-in IAM roles."
+type: "article"
+date: 2025-08-14T00:00:00Z
+lastmod: 2025-08-14T00:00:00Z
+draft: false
+tags: ["IAM", "Reference", "Product"]
+images: []
+weight: 010
+---
+
+Chainguard provides customers with a set of built-in roles as part of its Identity and Access Management (IAM) system. These roles have different permissions and capabilties that allow them to serve specialized purposes purposes, from general administrative access to access for specific resources like registries, APK packages, and programming language libraries.
+
+This reference provides a comprehensive view of all Chainguard IAM capabilities and shows which built-in roles include each capability. Each capability represents a specific permission or action that can be performed within the Chainguard platform.
+
+For more information on roles and role-bindings within Chainguard's IAM model, please refer to our [Overview of Roles and Role-bindings](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/).
+
+
+## Built-in Roles Summary
+
+This guide outlines the built-in Chainguard IAM roles available to most customer organizations. You can find more info about specific roles in your organization with the following `chainctl` command:
+
+```shell
+chainctl iam roles list -o table
+```
+
+Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `owner` role can create, delete, list, and update custom roles within Chainguard, while the `viewer` role can only list them. 
+
+This guide outlines the following twelve built-in roles provided by Chainguard:
+
+* **Administrative Roles:**
+    * `owner` - Full administrative access with all capabilities
+    * `editor` - Limited administrative access with mostly read permissions and event management
+    * `viewer` - Read-only access across all resources
+* **Registry and Container Roles:**
+    * `registry.pull` - Container image access
+    * `registry.pull_token_creator` - Chainguard registry token management with additional repository capabilities
+    * `apk.pull` - Access to the organization's APK packages, including the private APK repository
+* **Library Roles:**
+    * `libraries.java.pull` - Java library access
+    * `libraries.java.pull_token_creator` - Java token management
+    * `libraries.python.pull` - Python library access
+    * `libraries.python.pull_token_creator` - Python token management
+    * `libraries.javascript.pull` - JavaScript library access
+    * `libraries.javascript.pull_token_creator` - JavaScript token management with extensive registry capabilities
+
+The administrative roles are useful for user profiles that require broad, but clearly defined capabilities. The registry, container, and library roles have limited permissions, allowing them to manage only one specific Chainguard resource. These specialized, resource-specific roles grant minimal required access.
+
+For example, the `apk.pull` role only grants `list` access for APK packages and groups. This means identities with this role can pull the organization's APK packages and retrieve information about the organization, but won't have general access to the organization's [Chainguard registry](/chainguard/chainguard-images/chainguard-registry/overview/) access. 
+
+
+## Chainguard Role Capabilities
+
+The following table maps Chainguard resources to the built-in roles that have permissions for them. Each row represents a specific resource type (like `apk`, `repo`, `identity`, etc.), describes its purpose, and lists which built-in roles have what capabilities (create, delete, list, update) for that resource.
+
+<div style="overflow-x: auto;">
+
+| Resource | Purpose | Roles with access to this resource |
+|------------|---------|---------------------------|
+| `account_associations` | Link cloud provider accounts to organization | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `apk` | Manage APK packages in the registry | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`apk.pull` (list)</li></ul> |
+| `build_report` | Access detailed build and scan reports for images and packages | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `group_invites` | Send and manage invitations to join Chainguard organization | <ul><li>`owner` (create, delete, list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `groups` | Manage organization and hierarchical structures | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.java.pull_token_creator` (list)</li><li>`libraries.python.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `identity` | Create and manage user identities and service accounts | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull_token_creator` (create)</li><li>`libraries.java.pull_token_creator` (create)</li><li>`libraries.python.pull_token_creator` (create)</li><li>`libraries.javascript.pull_token_creator` (create)</li></ul> |
+| `identity_providers` | Configure [custom identity providers](/chainguard/administration/custom-idps/custom-idps/) (OIDC, SAML) for authentication | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `libraries.artifacts` | View Chainguard Library artifact metadata and information | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `libraries.entitlements` | Manage access permissions for Chainguard Libraries | <ul><li>`owner` (create, delete, list)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`libraries.java.pull` (list)</li><li>`libraries.python.pull` (list)</li><li>`libraries.javascript.pull` (list)</li><li>`libraries.java.pull_token_creator` (list)</li><li>`libraries.python.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `libraries.java` | Access [Chainguard Libraries for Java](/chainguard/libraries/java/overview/) | <ul><li>`owner` (list)</li><li>`libraries.java.pull` (list)</li><li>`libraries.java.pull_token_creator` (list)</li></ul> |
+| `libraries.javascript` | Access Chainguard Libraries for JavaScript | <ul><li>`owner` (list)</li><li>`libraries.javascript.pull` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `libraries.python` | Access [Chainguard Libraries for Python](/chainguard/libraries/python/overview/) | <ul><li>`owner` (list)</li><li>`libraries.python.pull` (list)</li><li>`libraries.python.pull_token_creator` (list)</li></ul> |
+| `manifest` | Access and manage container image manifests | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (create, delete, list, update)</li></ul> |
+| `manifest.metadata` | View container image manifest metadata and attestations | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `record_signatures` | View cryptographic signature verification records | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `registry.entitlements` | View registry access entitlements and permissions | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `repo` | Create and manage container repositories (including [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/) resources) | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (create, delete, list, update)</li></ul> |
+| `role_bindings` | [Assign roles to identities](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/#managing-role-bindings) (users and service accounts) | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull_token_creator` (create)</li><li>`libraries.java.pull_token_creator` (create)</li><li>`libraries.python.pull_token_creator` (create)</li><li>`libraries.javascript.pull_token_creator` (create)</li></ul> |
+| `roles` | Create, modify, and manage [custom Chainguard IAM roles](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull_token_creator` (list)</li><li>`libraries.java.pull_token_creator` (list)</li><li>`libraries.python.pull_token_creator` (list)</li><li>`libraries.javascript.pull_token_creator` (list)</li></ul> |
+| `sboms` | Access Software Bill of Materials for packages and images | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li></ul> |
+| `subscriptions` | Manage [CloudEvent](/chainguard/administration/cloudevents/events-reference/) subscriptions for notifications and automation | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (create, delete, list, update)</li><li>`viewer` (list)</li></ul> |
+| `tag` | Manage Chainguard container image tags | <ul><li>`owner` (create, delete, list, update)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li></ul> |
+| `version` | View version information across all resources and assets | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `vuln` | Create vulnerability reports and assessments | <ul><li>`owner` (create)</li></ul> |
+| `vuln_report` | Manage detailed vulnerability assessments for specific resources | <ul><li>`owner` (create, list)</li><li>`editor` (list)</li><li>`viewer` (list)</li></ul> |
+| `vuln_reports` | View high-level vulnerability report summaries | <ul><li>`owner` (list)</li><li>`editor` (list)</li><li>`viewer` (list)</li><li>`registry.pull` (list)</li><li>`registry.pull_token_creator` (list)</li></ul> |
+
+</div>
+
+## Role Capabilities Comparison
+
+The following table compares the general abilities of the twelve built-in roles described in the [previous summary](#built-in-roles-summary):
+
+<div style="overflow-x: auto;">
+
+| Role | Pull Images | List Tags/Repos | View SBOMs/Diffs | Create IAM Resources | Create Pull Tokens | Libraries Access |
+|------|-------------|-----------------|------------------|---------------------|--------------------|-----------------|
+| `owner` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `editor` | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `viewer` | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `registry.pull` | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `registry.pull_token_creator` | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `apk.pull` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `libraries.java.pull` | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| `libraries.java.pull_token_creator` | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
+| `libraries.python.pull` | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| `libraries.python.pull_token_creator` | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
+| `libraries.javascript.pull` | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| `libraries.javascript.pull_token_creator` | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
+
+</div>
+
+**Notes:**
+- **Pull Images/List Tags/Repos/View SBOMs**: These capabilities refer to container registry operations relating to the `manifest`, `repo`, `tag`, and `sboms` resources
+- **Library-specific roles**: `libraries.*.pull` and `libraries.*.pull_token_creator` roles are focused on their respective library ecosystems and don't have container registry access
+- **APK Pull**: The `apk.pull` role is specialized for APK package management, not container operations
+
+
+## Learn More
+
+- [Overview of Roles and Role-bindings in Chainguard](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) - Conceptual overview and basic management
+- [Overview of Chainguard IAM Model](/chainguard/administration/iam-organizations/overview-of-enforce-iam-model/) - Complete IAM architecture

--- a/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
+++ b/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
@@ -63,6 +63,26 @@ chainctl iam roles create new-role --parent=example-org --capabilities=roles.lis
 
 This example creates a new role named `new-role` under an organization named `example-org`. The new role will only have the ability to list roles in the organization.
 
+You can also grant multiple capabilities to a custom role with one command, as in this example:
+
+```sh
+chainctl iam roles create puller-role --parent=example-org --capabilities=apk.list,groups.list,manifest.list,manifest.metadata.list,record_signatures.list,repo.list,sboms.list,tag.list,vuln.list
+```
+
+This example command creates a role named `puller-role` that has the following capabilities:
+
+* `apk.list`
+* `groups.list`
+* `manifest.list`
+* `manifest.metadata.list`
+* `record_signatures.list`
+* `repo.list`
+* `sboms.list`
+* `tag.list`
+* `vuln.list`
+
+This essentially combines the capabilities of the `registry.pull` and `apk.pull` roles, allowing any identities bound to this role to be able to pull both Chainguard Containers and APKs.
+
 You can also use `chainctl` to delete custom roles.
 
 ```sh

--- a/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
+++ b/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
@@ -24,20 +24,28 @@ This guide includes several examples of how you can manage roles and role-bindin
 
 ## Roles
 
-There are a number of built-in roles in Chainguard's IAM model that customers can assign to identities within their organization. 
+There are a number of built-in roles in Chainguard's IAM model that customers can assign to identities within their organization. Most users within your organization will likely have one of three roles with broadly-defined privileges: `owner`, `editor`, or `viewer`.
 
 `owner` is the role with the most privileges. An owner can create, delete, view (list), and modify (update) organizations, account associations, role-bindings, organization invitations, custom roles, role-bindings, and subscriptions. 
 
-`editor` is the role with read access and limited creation and modification access. An editor can create, delete, and view images, clusters, role-bindings, and subscriptions. Additionally, an editor can modify role-bindings and subscriptions. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources.
+`editor` is the role with read access and limited creation and modification access. An editor can create, delete, and view images, role-bindings, and subscriptions. Additionally, an editor can modify role-bindings and subscriptions. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources.
 
-`viewer` is a role that generally only has read-only access. That is, a viewer can list images, policies, organizations (and organization invites), clusters, records, roles and role-bindings, subscriptions, and account associations.
+`viewer` is a role that generally only has read-only access. That is, a viewer can list images, policies, organizations (and organization invites), records, roles and role-bindings, subscriptions, and account associations.
 
 The remaining roles are for more specialized functions. For example, `registry.pull`, `registry.push`, and `registry.pull_token_creator` relate to administering a registry of Chainguard products.
+
+The `owner`, `editor`, and `viewer` roles are useful for user profiles that require broad, but clearly defined capabilities. The registry, container, and library roles have limited permissions, allowing them to manage only one specific Chainguard resource. These specialized, resource-specific roles grant minimal required access.
+
+Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `apk.pull` role only grants `list` access for APK packages and groups. This means identities with this role can pull the organization's APK packages and retrieve information about the organization, but won't have general access to the organization's [Chainguard registry](/chainguard/chainguard-images/chainguard-registry/overview/) access. 
+
+Chainguard's built-in default roles serve as building blocks and can be complemented with custom roles for specific use cases. Custom roles can extend or restrict default role capabilities, and offer or your organization greater flexibility, allowing you to mix default and custom roles based on your team's structure and needs.
+
+When assigning a role, do so based on the principle of least privilege; assign only the role needed for the indentity's function. For example, CI systems should have a role like `registry.pull`, not `editor`.
 
 You can run `chainctl iam roles list` to retrieve a list of all the roles available to your organization and review each of their specific capabilities. This command will list all the built-in roles as well as any custom roles created for your organization. The next section outlines how to create and manage such custom roles. 
 
 
-## Managing custom roles
+## Managing Custom Roles
 
 You can use `chainctl` to create custom roles for teams or individuals in your organization, like in the following example.
 


### PR DESCRIPTION
## Type of change

**Documentation Enhancement**
This PR adds a comprehensive capabilities reference document for Chainguard's built-in IAM roles and enhances the existing roles documentation with clearer explanations and best practices. The new doc is based on [this documentation from Google](https://cloud.google.com/iam/docs/roles-permissions/accessapproval).

## What should this PR do?

Resolves https://github.com/chainguard-dev/internal/issues/5225

## Why are we making this change?

Users need a detailed reference to understand the specific capabilities and permissions of each built-in role in Chainguard's IAM system. The existing roles documentation lacked granular details about what each role can actually do, making it difficult for administrators to assign appropriate roles based on the principle of least privilege.

## What are the acceptance criteria?

  - New capabilities reference document is complete and accurate
  - Existing roles documentation is updated with clearer role descriptions
  - Documentation follows established style and formatting guidelines
  - Cross-references between documents are working properly
  - Content is technically accurate and up-to-date

## How should this PR be tested?

  - Review the new capabilities-reference.md for completeness and accuracy
  - Verify that role descriptions align with actual system capabilities
  - Check that links between the roles overview and capabilities reference work correctly
  - Ensure formatting and style are consistent with other documentation
  - Validate that the content helps users understand role assignment decisions

[New doc preview link](https://deploy-preview-2514--ornate-narwhal-088216.netlify.app/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/)
