### PR TITLE
Improve direct access docs for Chainguard Libraries

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -168,7 +168,7 @@ VMs
 STIGs
 cryptographic
 Cryptographic
-Chainguard’s
+Chainguard's
 userspace
 entrypoint
 reproducibility
@@ -193,3 +193,7 @@ JARs
 remediations
 codebase
 codebases
+proxying
+scalable
+sbt
+Leiningen

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -44,6 +44,8 @@ Successfully exchanged token.
 Valid! Id: 8a4141a........7d9904d98c
 ```
 
+<a id name="pull-token"></a>
+
 ## Pull token for libraries
 
 Create a new pull token for the Chainguard Libraries for Java with the [chainctl
@@ -82,13 +84,24 @@ Password: eyJhbGciO..........WF0IjoxN
 The returned username and password combination is a new credential set in the
 organization that is independent of the account used to create and retrieve the
 credential set. It is therefore suitable for use in any service application,
-such as [a repository manager](/chainguard/libraries/java/global-configuration/)
-or [a build tool](/chainguard/libraries/java/build-configuration/) that is not
-tied to a specific user.
+such as a repository manager or a build tool that is not tied to a specific
+user. You can also use the token as an individual for your development with
+direct access to Chainguard Libraries.
 
-To use this pull token in another environment, supply the following for username
-and password valid for basic authentication. Note that the actual returned
-values are much longer.
+To use the pull token in another environment, supply the username and password
+for basic authentication. Note that the actual returned values are much longer.
+
+> **Note**: Chainguard does not offer an SLA for uptime availability of the
+> Chainguard Libraries repositories at `libraries.cgr.dev`. To reduce production
+> risk and ensure reliability, we recommend proxying the repositories through
+> your own artifact repository whenever possible.
+
+Refer to the following resources for more specific information for your needs:
+
+* [Repository manager configuration with Java](/chainguard/libraries/java/global-configuration/)
+* [Build tool and direct access configuration with Java](/chainguard/libraries/java/build-configuration/)
+* [Repository manager configuration with Python](/chainguard/libraries/python/global-configuration/)
+* [Build tool and direct access configuration with Python](/chainguard/libraries/python/build-configuration/)
 
 You can not create pull tokens for Chainguard Libraries in the Chainguard
 console.

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -63,6 +63,14 @@ Follow the steps from the [global
 configuration](/chainguard/libraries/java/global-configuration/#sonatype-nexus-repository)
 to determine URL and authentication details.
 
+## Direct access
+
+Build configuration to retrieve artifacts **directly** from the Chainguard
+Libraries
+for Java repository at `https://libraries.cgr.dev/java/` requires authentication
+with username and password from a pull token as detailed in
+[access documentation](/chainguard/libraries/access/#pull-token).
+
 ## Apache Maven
 
 [Apache Maven](https://maven.apache.org/) is the most widely used build tool in
@@ -87,7 +95,7 @@ for Java. If the administrator for your organization’s repository manager
 created a new repository or virtual repository or group repository, you must
 update your settings defined in `~/.m2/settings.xml`.
 
-A typical setup defines a global mirror (id `ecosystems`) for all artifacts and
+A typical setup defines a global mirror (id `repo-example`) for all artifacts and
 configures the URL of the repository group or virtual repository from your
 repository manager `https://repo.example.com/group/`. Since the group or virtual
 repository combines release and snapshot artifacts you must override the
@@ -111,6 +119,8 @@ activated profile.
       <!-- <url>https://example.jfrog.io/artifactory/java-all/</url> -->
       <!-- Sonatype Nexus example -->
       <!-- <url>https://repo.example.com:8443/repository/java-all/</url> -->
+      <!-- Direct access example -->
+      <!-- <url>https://libraries.cgr.dev/java/</url> -->
     </mirror>
   </mirrors>
 
@@ -323,7 +333,7 @@ Before running a new build you must configure access to the Chainguard Libraries
 for Java. If the administrator for your organization’s repository manager
 created a new repository or virtual repository or group repository, you must
 update your Gradle configuration. Artifact download is Gradle can be configured
-in an [init
+in an [`init`
 script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
 using the repositories definition. Each project can also [declare
 repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
@@ -449,7 +459,7 @@ configuration to use the repository manager.
 Bazel uses `MODULE.bazel` files to define external dependencies as `artifacts`.
 You can configure a Maven repository for artifact retrieval using `repositories`
 from the
-[rules_jvm_external](https://github.com/bazel-contrib/rules_jvm_external) rule: 
+[`rules_jvm_external`](https://github.com/bazel-contrib/rules_jvm_external) rule: 
 
 Following is an example configuration for a repository manager:
 
@@ -527,7 +537,7 @@ For more complex Bazel setups, you can use [.netrc for
 authentication](/chainguard/libraries/access/#netrc).
 
 Refer to the [official Bazel documentation for
-rules_jvm_external](https://github.com/bazel-contrib/rules_jvm_external) for
+`rules_jvm_external`](https://github.com/bazel-contrib/rules_jvm_external) for
 more detailed configuration options.
 
 ## Other build tools

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -48,7 +48,9 @@ Adopting the use of a repository manager is the recommended approach, however if
 your organization does not use a repository manager, you can still use
 Chainguard Libraries. All access to the Chainguard libraries repository is then
 distributed across all your build platforms and therefore more complex to
-configure and control. 
+configure and control. Refer to the [direct access documentation for build
+tools](/chainguard/libraries/java/build-configuration/#direct-access) for more
+information.
 
 <a name="cloudsmith"></a>
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -26,7 +26,8 @@ These changes must be performed on all workstations of individual developers and
 
 ## Retrieving authentication credentials
 
-To configure any build tool, you must first access credentials from your organization's repository manager.
+To configure any build tool, you must first access credentials from your
+organization's repository manager or for direct access.
 
 <a id="cloudsmith"></a>
 
@@ -99,6 +100,14 @@ for accessing your organization's Sonatype Nexus repository group.
    authentication is required, you must use the relevant details such as
    username and password in your build tool configuration.
 
+### Direct access
+
+Build configuration to retrieve artifacts **directly** from the Chainguard Libraries
+for Python repository at `https://libraries.cgr.dev/python/` with the simple
+index at `https://libraries.cgr.dev/python/simple` requires authentication with
+username and password from a pull token as detailed in [access
+documentation](/chainguard/libraries/access/#pull-token).
+
 ## Configuring build tools
 
 Once you have credentials and the index URL from your organization's repository
@@ -163,6 +172,26 @@ Refer to the official documentation for [configuring authentication with
 pip](https://pip.pypa.io/en/stable/topics/authentication/) if you are not using
 [.netrc for authentication](/chainguard/libraries/access/#netrc).
 
+When using [direct access](#direct-access) to the Chainguard Libraries for
+Python repository with `pip`, you must ensure the following are set in your
+configuration file:
+
+* Replace any `/` in the username value `CG_PULLTOKEN_USERNAME` with `_`.
+* Ensure the `simple` context is used for the URL.
+* The password value `CG_PULLTOKEN_PASSWORD` remains unchanged.
+
+Example for `requirements.txt`:
+
+```example
+--index-url https://CG_PULLTOKEN_USERNAME:CG_PULLTOKEN_PASSWORD@libraries.cgr.dev/python/simple/
+```
+
+Example for `~/.pip/pip.conf`:
+
+```example
+[global]
+index-url = https://CG_PULLTOKEN_USERNAME:CG_PULLTOKEN_PASSWORD@libraries.cgr.dev/python/simple/
+```
 
 <a id="poetry"></a>
 
@@ -171,7 +200,6 @@ pip](https://pip.pypa.io/en/stable/topics/authentication/) if you are not using
 [Poetry](https://python-poetry.org/) helps you declare, manage, and install
 dependencies of Python projects, and can be used with Chainguard Libraries for
 Python."
-
 
 List the Python package caches used by your Poetry project:
 
@@ -202,20 +230,20 @@ The authentication is used for the `python-all` repository that you add to the
 `pyproject.toml` with the following command:
 
 ```shell
-poetry source add python-all https://repo.example.com/../python-all/simple
+poetry source add python-all https://repo.example.com/../python-all/simple/
 ```
 
 Example URLs including the required `simple` context:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/api/pypi/python-all/simple`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/python-all/simple`
+* JFrog Artifactory: `https://example.jfrog.io/artifactory/api/pypi/python-all/simple/`
+* Sonatype Nexus: `https://repo.example.com:8443/repository/python-all/simple/`
 
 The following configuration is added:
 
 ```toml
 [[tool.poetry.source]]
 name = "python-all"
-url = "https://repo.example.com/../python-all/simple"
+url = "https://repo.example.com/../python-all/simple/"
 priority = "primary"
 ```
 
@@ -236,6 +264,23 @@ Proceed to build your project:
 
 ```shell
 poetry build
+```
+
+For [direct access](#direct-access) to Chainguard Libraries for Python with
+Poetry, use your username `CG_PULLTOKEN_USERNAME` and password
+`CG_PULLTOKEN_PASSWORD` values from the pull token creation and the URL with the
+simple context `https://libraries.cgr.dev/python/simple/`:
+
+
+```shell
+poetry config http-basic.chainguard CG_PULLTOKEN_USERNAME CG_PULLTOKEN_PASSWORD
+```
+
+The authentication is used for the `chainguard` repository that you add to the
+`pyproject.toml` with the following command:
+
+```shell
+poetry source add chainguard https://libraries.cgr.dev/python/simple/
 ```
 
 The [Poetry documentation](https://python-poetry.org/docs/) contains more
@@ -280,48 +325,22 @@ indexes](https://docs.astral.sh/uv/guides/integration/alternative-indexes/) if
 you are not using [.netrc for
 authentication](/chainguard/libraries/access/#netrc).
 
-## Direct Access 
-> NOTE: Chainguard does not offer an SLA for uptime availability of the Libraries repository at `libraries.cgr.dev`. To reduce production risk and ensure reliability, we recommend mirroring or proxying Chainguard Libraries through your own artifact repository whenever possible.
+For [direct access](#direct-access) to Chainguard Libraries for Python with
+uv, use .netrc or your username `CG_PULLTOKEN_USERNAME` and password
+`CG_PULLTOKEN_PASSWORD` values from the pull token creation and the URL with the
+simple context `https://libraries.cgr.dev/python/simple/`:
 
-If your organization does not use a supported repository manager, you can directly pull from the Chainguard Python Libraries repository using basic authentication.
+Example for `pyproject.toml`:
 
-Use the following index URL:
-https://libraries.cgr.dev/python/simple/
-
-### Authentication via Pull Token
-
-Authentication requires a pull token, which you can create using the `chainctl` CLI using the instructions at [Pull Token for Libraries](https://edu.chainguard.dev/chainguard/libraries/access/#pull-token-for-libraries).
-
-Once you have a pull token, use the generated username and password in your existing build tool’s configuration.
-
-> NOTE: The generated username will typically contain a `/`, which must be replaced with `_` when used in the URL for your build tool configuration file. 
-
-### Example pip Configuration
-
-In `requirements.txt`:
-
-```
---index-url https://your_token_username:your_token_password@libraries.cgr.dev/python/simple/
-```
-
-In  `~/.pip/pip.conf`:
-```
-[global]
-index-url = https://your_token_username:your_token_password@libraries.cgr.dev/python/simple/
-```
-
-### Example uv Configuration
-In `pyproject.toml`: 
 ```
 [[tool.uv.index]]
 name = "chainguard"
-url = "https://your_token_username:your_token_password@libraries.cgr.dev/python/simple/
+url = "https://CG_PULLTOKEN_USERNAME:CG_PULLTOKEN_PASSWORD@libraries.cgr.dev/python/simple/
 ```
 
-In `uv.toml`:
+Example for `uv.toml`:
+
 ```
 [[index]]
-url = "https://your_token_username:your_token_password@libraries.cgr.dev/python/simple/
+url = "https://CG_PULLTOKEN_USERNAME:CG_PULLTOKEN_PASSWORD@libraries.cgr.dev/python/simple/
 ```
-
-You may choose to authenticate using other supported methods, such as a `.netrc` file or environment variables, depending on your build tool’s capabilities and your security practices. The examples above demonstrate inline configuration for convenience, but they are not the only supported approaches. Refer to your build tool's documentation for additional authentication mechanisms.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -28,7 +28,13 @@ You should also:
 * Remove all prior cached artifacts in the virtual server or proxy public repository. This step reduces confusion about the origin of libraries and assists technical evaluation and adoption of Chainguard Libraries.
 * Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
 
-If your organization does not use a repository manager, you can still use Chainguard Libraries. However, this approach requires configuration of multiple build and development platforms and utilities to use Chainguard Libraries. For this reason, adopting the use of a repository manager is the recommended approach. 
+If your organization does not use a repository manager, you can still use
+Chainguard Libraries. However, this approach requires configuration of multiple
+build and development platforms and utilities to use Chainguard Libraries. For
+this reason, adopting the use of a repository manager is the recommended
+approach. Refer to the [direct access documentation for build
+tools](/chainguard/libraries/python/build-configuration/#direct-access) for more
+information.
 
 <a id="cloudsmith"></a>
 


### PR DESCRIPTION
## Type of change

Doc improvement.

### What should this PR do?

Add info in the overview access file and then set up the docs in Java and Python consistently where the example is with the build tool.

### Why are we making this change?

Improve consistency and correctness. 

Resolve https://github.com/chainguard-dev/internal/issues/5301

### What are the acceptance criteria? 

Review 

### How should this PR be tested?

Just review is sufficient.