### PR TITLE
Add docs page covering catalog pricing details

### DIFF
--- a/content/chainguard/chainguard-images/about/pricing.md
+++ b/content/chainguard/chainguard-images/about/pricing.md
@@ -38,7 +38,7 @@ The catalog pricing model is an option that requires you to be on the Catalog Pr
 
 To add an image to your organization, select **Images** in the sidebar menu and then select the **Chainguard catalog** tab.
 
-Scroll through the list or use search to find the image you want. If the image is available to your organization, use the **Add to org** button in the row for the image listing. If your organization doesn't not have access to FIPS images, you will not be able to add them. The **Add image** dialog will appear. Click **Add image** to close the dialog and finish.
+Scroll through the list or use search to find the image you want. If the image is available to your organization, use the **Add to org** button in the row for the image listing. If your organization does not have access to FIPS images, you will not be able to add them. The **Add image** dialog will appear. Click **Add image** to close the dialog and finish.
 
 > NOTE: If you see **Available in org** in the place of the add button, return to **Images** and click the **Add image** button above the list of organization images. Use search in the dialog that appears to find the image and click the bookmark icon next to the image name. You will be required to enter a different name for the new image, which will be added alongside the existing image when you click **Add image**.
 

--- a/content/chainguard/chainguard-images/about/pricing.md
+++ b/content/chainguard/chainguard-images/about/pricing.md
@@ -17,7 +17,7 @@ toc: true
 
 Chainguard offers catalog pricing for our container catalog, providing access across the Chainguard Container images catalog.
 
-Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to request individual images in the console to be added to your repository from the wider Chainguard catalog.
+Catalog pricing is an alternative pricing model for container usage that replaces the manual ticket process for adding images to an organization, like must be done using a per-image pricing model. Catalog pricing enables you to request individual images in the console to be added to your repository from the wider Chainguard catalog.
 
 The catalog pricing model is an option that requires you to be on the Catalog Pricing plan.
 
@@ -28,7 +28,7 @@ The catalog pricing model is an option that requires you to be on the Catalog Pr
 
 - **What’s included**: Unlimited access to the full Chainguard-maintained container image catalog.
 - **Benefits**:
-  - One subscription covers the entire catalog if your plan includes FIPS, otherwise it includes all non-FIPS catalog options.
+  - One subscription covers the entire catalog within your purchased options, for example whether or not your license includes FIPS images.
   - No more per-repository licenses.
   - Predictable monthly or annual costs.
 - **Use cases**: Ideal for organizations that pull many different Chainguard images across multiple teams or projects.

--- a/content/chainguard/chainguard-images/pricing.md
+++ b/content/chainguard/chainguard-images/pricing.md
@@ -1,0 +1,82 @@
+---
+title: "Chainguard Container Catalog Pricing"
+linktitle: "Catalog Pricing"
+type: "article"
+description: "Explains Chainguard Container catalog pricing, repository quotas, renaming, and sync, and helps you understand how to make the most of your subscription."
+date: 2025-08-19T08:49:31+00:00
+lastmod: 2025-08-19T08:49:31+00:00
+draft: false
+tags: ["Chainguard Containers", "pricing"]
+images: []
+menu:
+  docs:
+    parent: "chainguard-images"
+weight: 055
+toc: true
+---
+
+Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to self-service request individual images to be added to your repository from the wider Chainguard catalog.
+
+The catalog pricing model is an option that requires you to be on the Catalog Pricing plan.
+
+> NOTE: If you would like to provide feedback, need troubleshooting assistance, or if your organization is not yet participating and would like to, please reach out to your account team.
+
+---
+
+## Catalog Pricing
+
+Chainguard offers catalog pricing for our container catalog, providing access across the Chainguard Container images catalog.
+
+- **What’s included**: Unlimited access to the full Chainguard-maintained container image catalog.
+- **Benefits**:  
+  - One subscription covers the entire catalog.  
+  - No more per-repository licenses.  
+  - Predictable monthly or annual costs.  
+- **Use cases**: Perfect for organizations that pull many different Chainguard images across multiple teams or projects.  
+
+---
+
+## Repository Quotas
+
+Your subscription includes a repository quota, which is the number of private repositories you can create or link.  
+
+- **Checking quota**: Go to **Dashboard → Usage & Billing** to see your current quota and usage.  
+- **Exceeding quota**:  
+  - You’ll receive a warning if you approach your limit.  
+  - To continue adding repositories, upgrade your plan or remove unused ones.  
+- **Public repositories**: May not count toward your quota (check your plan details).  
+
+---
+
+## Repository Renaming
+
+Repositories can now be renamed safely without disrupting your workflows.  
+
+- **Backward compatibility**: Old repository names will continue to work temporarily.  
+- **Recommended action**: Update CI/CD pipelines and image references to the new name as soon as possible.
+
+To rename a repository, first open the repository in the Chainguard console.
+
+Then, in **Settings → Rename Repository**, enter the new name and save.  
+
+---
+
+## Repository Sync
+
+The repository sync feature keeps your repositories aligned with the upstream Chainguard catalog.  
+
+- **What it does**:  
+  - Automatically updates your repository with the latest secure image builds.  
+  - Helps ensure compliance and reduces supply-chain risks.  
+- **When to use**: Ideal for teams that want guaranteed up-to-date images without manual intervention.  
+
+To enable repository sync, first open the repository in the console.
+
+Then, navigate to **Repository Settings → Sync** and toggle **Sync with Catalog** on.
+
+---
+
+## Learn More
+
+- [Blog announcement: Unlock the Full Chainguard Containers Catalog – Now with a Catalog Pricing Option](https://www.chainguard.dev/unchained/unlock-the-full-chainguard-containers-catalog-now-with-a-catalog-pricing-option)
+- [Chainguard Pricing](https://www.chainguard.dev/pricing?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)  

--- a/content/chainguard/chainguard-images/pricing.md
+++ b/content/chainguard/chainguard-images/pricing.md
@@ -15,13 +15,12 @@ weight: 055
 toc: true
 ---
 
-Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to self-service request individual images to be added to your repository from the wider Chainguard catalog.
+Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to self-service request individual images in the console to be added to your repository from the wider Chainguard catalog.
 
 The catalog pricing model is an option that requires you to be on the Catalog Pricing plan.
 
 > NOTE: If you would like to provide feedback, need troubleshooting assistance, or if your organization is not yet participating and would like to, please reach out to your account team.
 
----
 
 ## Catalog Pricing
 
@@ -29,37 +28,33 @@ Chainguard offers catalog pricing for our container catalog, providing access ac
 
 - **What’s included**: Unlimited access to the full Chainguard-maintained container image catalog.
 - **Benefits**:  
-  - One subscription covers the entire catalog.  
-  - No more per-repository licenses.  
-  - Predictable monthly or annual costs.  
-- **Use cases**: Perfect for organizations that pull many different Chainguard images across multiple teams or projects.  
+  - One subscription covers the entire catalog if your plan includes FIPS, otherwise it includes all non-FIPS catalog options.
+  - No more per-repository licenses.
+  - Predictable monthly or annual costs.
+- **Use cases**: Perfect for organizations that pull many different Chainguard images across multiple teams or projects.
 
----
+
+## Add a Container Image
+
+To add an image to your organization, select **Images** in the sidebar menu and then select the **Chainguard catalog** tab.
+
+Scroll through the list or use search to find the image you want. If the images is available to your organization, use the **Add to org** button in the row for the image listing. If your organization doesn't not have access to FIPS images, you will not be able to add them. The **Add image** dialog will appear. Click **Add image** to close the dialog and finish.
+
+> NOTE: If you see **Available in org** in the place of the add button, return to **Images** and click the **Add image** button above the list of organization images. Use search in the dialog that appears to find the image and click the bookmark icon next to the image name. You will be required to enter a different name for the new image, which will be added alongside the existing image when you click **Add image**.
+
+It can take up to 60 minutes for the image to be added to your organization, but often happens in as few as 10 minutes.
+
 
 ## Repository Quotas
 
-Your subscription includes a repository quota, which is the number of private repositories you can create or link.  
+Your subscription includes a repository quota, which is the number of private repositories you can create or link. **custom assembled images you can add**
 
-- **Checking quota**: Go to **Dashboard → Usage & Billing** to see your current quota and usage.  
-- **Exceeding quota**:  
-  - You’ll receive a warning if you approach your limit.  
-  - To continue adding repositories, upgrade your plan or remove unused ones.  
-- **Public repositories**: May not count toward your quota (check your plan details).  
+- **Checking quota**: Go to **Settings → Plan & Subscription** to see your current quota and usage.
+- **Exceeding quota**:
+  - You’ll receive a warning if you approach your limit.
+  - To continue adding repositories, upgrade your plan or remove unused ones.
+- **Public repositories**: May not count toward your quota (check your plan details).
 
----
-
-## Repository Renaming
-
-Repositories can now be renamed safely without disrupting your workflows.  
-
-- **Backward compatibility**: Old repository names will continue to work temporarily.  
-- **Recommended action**: Update CI/CD pipelines and image references to the new name as soon as possible.
-
-To rename a repository, first open the repository in the Chainguard console.
-
-Then, in **Settings → Rename Repository**, enter the new name and save.  
-
----
 
 ## Repository Sync
 
@@ -70,11 +65,6 @@ The repository sync feature keeps your repositories aligned with the upstream Ch
   - Helps ensure compliance and reduces supply-chain risks.  
 - **When to use**: Ideal for teams that want guaranteed up-to-date images without manual intervention.  
 
-To enable repository sync, first open the repository in the console.
-
-Then, navigate to **Repository Settings → Sync** and toggle **Sync with Catalog** on.
-
----
 
 ## Learn More
 

--- a/content/chainguard/chainguard-images/pricing.md
+++ b/content/chainguard/chainguard-images/pricing.md
@@ -6,7 +6,7 @@ description: "Explains Chainguard Container catalog pricing, repository quotas, 
 date: 2025-08-19T08:49:31+00:00
 lastmod: 2025-08-19T08:49:31+00:00
 draft: false
-tags: ["Chainguard Containers", "pricing"]
+tags: ["Chainguard Containers"]
 images: []
 menu:
   docs:
@@ -15,7 +15,9 @@ weight: 055
 toc: true
 ---
 
-Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to self-service request individual images in the console to be added to your repository from the wider Chainguard catalog.
+Chainguard offers catalog pricing for our container catalog, providing access across the Chainguard Container images catalog.
+
+Catalog pricing is Chainguard's pricing model for container usage that replaces the manual ticket process for adding images to an organization. This enables you to request individual images in the console to be added to your repository from the wider Chainguard catalog.
 
 The catalog pricing model is an option that requires you to be on the Catalog Pricing plan.
 
@@ -24,32 +26,31 @@ The catalog pricing model is an option that requires you to be on the Catalog Pr
 
 ## Catalog Pricing
 
-Chainguard offers catalog pricing for our container catalog, providing access across the Chainguard Container images catalog.
-
 - **What’s included**: Unlimited access to the full Chainguard-maintained container image catalog.
-- **Benefits**:  
+- **Benefits**:
   - One subscription covers the entire catalog if your plan includes FIPS, otherwise it includes all non-FIPS catalog options.
   - No more per-repository licenses.
   - Predictable monthly or annual costs.
-- **Use cases**: Perfect for organizations that pull many different Chainguard images across multiple teams or projects.
+- **Use cases**: Ideal for organizations that pull many different Chainguard images across multiple teams or projects.
 
 
 ## Add a Container Image
 
 To add an image to your organization, select **Images** in the sidebar menu and then select the **Chainguard catalog** tab.
 
-Scroll through the list or use search to find the image you want. If the images is available to your organization, use the **Add to org** button in the row for the image listing. If your organization doesn't not have access to FIPS images, you will not be able to add them. The **Add image** dialog will appear. Click **Add image** to close the dialog and finish.
+Scroll through the list or use search to find the image you want. If the image is available to your organization, use the **Add to org** button in the row for the image listing. If your organization doesn't not have access to FIPS images, you will not be able to add them. The **Add image** dialog will appear. Click **Add image** to close the dialog and finish.
 
 > NOTE: If you see **Available in org** in the place of the add button, return to **Images** and click the **Add image** button above the list of organization images. Use search in the dialog that appears to find the image and click the bookmark icon next to the image name. You will be required to enter a different name for the new image, which will be added alongside the existing image when you click **Add image**.
 
-It can take up to 60 minutes for the image to be added to your organization, but often happens in as few as 10 minutes.
+Please allow up to 60 minutes for the image to be added to your organization.
 
 
 ## Repository Quotas
 
-Your subscription includes a repository quota, which is the number of private repositories you can create or link. **custom assembled images you can add**
+Your subscription includes a repository quota, which is the number of custom assembled images you can add to your organization.
 
-- **Checking quota**: Go to **Settings → Plan & Subscription** to see your current quota and usage.
+To see your current quota and usage go to **Settings → Plan & Subscription**.
+
 - **Exceeding quota**:
   - You’ll receive a warning if you approach your limit.
   - To continue adding repositories, upgrade your plan or remove unused ones.
@@ -58,15 +59,16 @@ Your subscription includes a repository quota, which is the number of private re
 
 ## Repository Sync
 
-The repository sync feature keeps your repositories aligned with the upstream Chainguard catalog.  
+The repository sync feature keeps your repositories aligned with the upstream Chainguard catalog by automatically updating your repository with the latest secure image builds. This helps ensure compliance and reduces supply-chain risks.
 
-- **What it does**:  
-  - Automatically updates your repository with the latest secure image builds.  
-  - Helps ensure compliance and reduces supply-chain risks.  
-- **When to use**: Ideal for teams that want guaranteed up-to-date images without manual intervention.  
+This is ideal for teams that want guaranteed up-to-date images without manual intervention.
 
 
 ## Learn More
 
-- [Blog announcement: Unlock the Full Chainguard Containers Catalog – Now with a Catalog Pricing Option](https://www.chainguard.dev/unchained/unlock-the-full-chainguard-containers-catalog-now-with-a-catalog-pricing-option)
-- [Chainguard Pricing](https://www.chainguard.dev/pricing?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)  
+Chainguard's catalog pricing provides access across the Chainguard container images catalog.
+
+To learn more, you may be interested in the following resources:
+
+- [Blog announcement: Unlock the Full Chainguard Containers Catalog – Now with a Catalog Pricing Option](https://www.chainguard.dev/unchained/unlock-the-full-chainguard-containers-catalog-now-with-a-catalog-pricing-option?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)
+- [Chainguard Pricing](https://www.chainguard.dev/pricing?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/internal/issues/5270 by adding a new docs page that covers:

- What catalog pricing is
- Requirements to participate (customers need to be on the Catalog Pricing plan)
- Repository quotas, renaming, and sync