### PR TITLE
Changing code block behavior on Academy

### DIFF
--- a/assets/js/snippets.js
+++ b/assets/js/snippets.js
@@ -57,7 +57,7 @@ const customizeUI = (pre) => {
   // } else {
   const output = document.createElement("span");
   output.classList.add("language-selector");
-  output.textContent = language || "Output";
+  output.textContent = language || "";
   actionContainer.append(output);
   // }
 

--- a/assets/scss/snippets.scss
+++ b/assets/scss/snippets.scss
@@ -23,7 +23,6 @@
       border: none;
       outline: none;
       // cursor: pointer;
-      text-transform: capitalize;
       margin: 0 12px;
       align-self: center;
       font-size: 14px;


### PR DESCRIPTION
## Type of change

<!-- Please be sure to add the appropriate label to your PR. -->

**Enhancement / UI behavior update**

This PR updates the behavior of markdown code blocks in **Chainguard Academy** by:

* Removing the automatic capitalization of code block labels.
* Removing the default `"Output"` label when no label is provided.
* Ensuring that code blocks display labels exactly as authored, or remain unlabeled if none is given.

### Why are we making this change?

Currently, Chainguard Academy automatically capitalizes code block labels and defaults to `"Output"` when a label is omitted. This can be confusing or misleading for learners and contributors, especially when precise labeling is important for clarity.

This change gives authors more flexibility and preserves the intent of their written examples, resulting in a more accurate and consistent learning experience.

### What are the acceptance criteria?

* Code block labels should no longer be auto-capitalized.
* Code blocks with no label should not default to `"Output"`.
* Existing labeled code blocks should render exactly as authored.
* Documentation and examples across Academy content continue to display correctly.
* No regressions in how code blocks render across supported languages.

### How should this PR be tested?

Find a page in the Deploy preview with blank code blocks, then compare that with the current public version. For example:

[Public Debugging Distroless](https://edu.chainguard.dev/chainguard/chainguard-images/troubleshooting/debugging-distroless-images/)
[Deploy preview Debugging Distroless](https://deploy-preview-2524--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/troubleshooting/debugging-distroless-images/)

If you're so inclined, you can also pull down these changes and do the following to ensure the behavior follows expectations:

1. Create a markdown file with several code blocks:
   * A code block with a lowercase label (e.g., `bash` or `json`).
   * A code block with a custom label in lowercase.
   * A code block with no label.
2. Render the markdown in Chainguard Academy.
3. Confirm:
   * Labels remain exactly as authored (no forced capitalization).
   * Code blocks without labels remain unlabeled (do not default to `"Output"`).
   * Existing labeled code blocks still display correctly.
