### PR TITLE
 Implementing JS-based code block logic

### DIFF
--- a/assets/js/snippets.js
+++ b/assets/js/snippets.js
@@ -11,6 +11,46 @@ function toast(textContent) {
   requestAnimationFrame(() => notification.classList.add("notification-toast"));
 }
 
+// Function to normalize code block labels with consistent formatting
+const normalizeCodeBlockLabel = (rawLabel) => {
+  if (!rawLabel) {
+    return ''; // Keep unlabeled blocks unlabeled
+  }
+
+  // Define transformation rules for existing labels only
+  const labelTransforms = {
+    // Shell variants
+    'shell': 'Shell',
+    'sh': 'Shell', 
+    'bash': 'Shell',
+    
+    // Configuration formats
+    'yaml': 'YAML',
+    'yml': 'YAML',
+    'json': 'JSON',
+    'xml': 'XML',
+    
+    // Database
+    'sql': 'SQL',
+    'mariadb': 'SQL',
+    'mysql': 'SQL',
+    'postgresql': 'SQL',
+    'postgres': 'SQL',
+    
+    // Container formats
+    'dockerfile': 'Dockerfile',
+    
+    // Output
+    'output': 'Output'
+  };
+
+  const lowerLabel = rawLabel.toLowerCase();
+  
+  // Return transformed label or capitalize first letter as fallback
+  return labelTransforms[lowerLabel] || 
+         (rawLabel.charAt(0).toUpperCase() + rawLabel.slice(1));
+};
+
 const expandCode = (expanded, codeContent, expandButtonText, expandIcon) => {
   if (expanded) {
     expandButtonText.textContent = "Expand code";
@@ -57,7 +97,7 @@ const customizeUI = (pre) => {
   // } else {
   const output = document.createElement("span");
   output.classList.add("language-selector");
-  output.textContent = language || "";
+  output.textContent = normalizeCodeBlockLabel(language);
   actionContainer.append(output);
   // }
 


### PR DESCRIPTION
## Type of change
Enhancement to markdown code block label handling logic.  
(Label normalization and capitalization applied via JavaScript transformation.)

I've confirmed with Julien that Academy already uses JS to apply logic to how code blocks are rendered, so this change shouldn't slow down the site or add any kind of overhead to its deployment.

### What should this PR do?
This PR updates the logic that standardizes code block labels on the markdown site. Specifically:
- Capitalizes certain labels (`shell`, `output`, `dockerfile`, etc.).
- Maps related labels to a single, more consistent label:
  - `sh` and `bash` → `Shell`
  - `postgres`, `mysql`, `mariadb` → `SQL`
  - (Other similar transformations handled by the script)
- It also leaves unlabeled code blocks as unlabeled.

### Why are we making this change?
Currently, code block labels are inconsistent, making documentation harder to read and less polished. By normalizing and capitalizing these labels, we improve clarity, readability, and the professional appearance of our docs.

### What are the acceptance criteria?
- All targeted code block labels are transformed as specified.
- Labels like `shell` appear consistently as `Shell`.
- Database-related labels (`postgres`, `mysql`, `mariadb`) appear as `SQL`.
- No unintended labels are altered.
- Existing markdown rendering continues to work without errors.

### How should this PR be tested?
1. Check pages with code blocks in the deploy preview ([example](https://deploy-preview-2546--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/)).
2. Confirm labels are transformed according to the mapping rules.
3. Verify no regressions in code block formatting or rendering.
