### PR TITLE
Add examples of running Renovate with GitHub Actions and Docker

### DIFF
--- a/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
@@ -132,6 +132,69 @@ The following screenshot shows the PR to update the static image:
 
 ![Screenshot showing Renovate PR to update static image digest](static_update.png)
 
+## Pinning Digests
+
+The `pinDigests` option configures Renovate to add digests to image references
+that don't contain them.
+
+Here is an example `renovate.json` that sets this.
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "pinDigests": true
+    }
+  ]
+}
+```
+
+This configures Renovate to open PRs that will pin a reference like
+`cgr.dev/chainguard/python:3.12` to a digest like
+`cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3`.
+
+## Disabling Non-Digest Updates
+
+You can use the `matchUpdateTypes` option to disable updates for any update
+types other than `digest`.
+
+Here is an example `renovate.json` that does this.
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    }
+  ]
+}
+```
+
+This will configure Renovate to update the digest for a reference like
+`cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3`
+but not the tag.
+
+The benefit of this approach is that it allows you to define your update
+strategy for each image reference by the use of a mutable tag, rather than having
+separate rules for different images in your Renovate configuration. Similar to
+Chainguard's [Digestabot](https://github.com/chainguard-dev/digestabot)
+Github Action.
+
 ## Running Renovate in Github Actions
 
 You can use

--- a/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "How to use Renovate to automatically keep Chainguard Containers updated"
 date: 2023-09-05T11:07:52+02:00
-lastmod: 2024-09-05T11:07:52+02:00
+lastmod: 2025-09-18T11:07:52+02:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -18,7 +18,7 @@ weight: 020
 toc: true
 ---
 
-[Renovate](https://github.com/renovatebot/renovate) can be used to alert on updates to Chainguard Containers. This can be an effective way to keep your images up-to-date and CVE free. This article will explain how to configure Renovate to support Chainguard Containers.
+[Renovate](https://github.com/renovatebot/renovate) can be used to alert on updates to Chainguard Containers. This can be an effective way to keep your images up-to-date and free of CVEs. This article explains how to configure Renovate to support Chainguard Containers.
 
 > **NOTE*: This article describes using Renovate to alert on new versions of Chainguard Containers. It is not about alerts for Wolfi packages (which is unsupported at the time of writing).
 
@@ -27,16 +27,18 @@ toc: true
 
 This guide assumes you have successfully installed and configured Renovate. If you haven't already set this up, please refer to the [installation instructions](https://docs.renovatebot.com/getting-started/installing-onboarding/).
 
+Additionally, several examples in this guide assume you have `chainctl` — Chainguard's command-line interface — installed on your local machine. Follow our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) to set this up. 
+
 
 ## Setting up Credentials for Renovate
 
-In order to support versioned images from a private repository, you will need to provide Renovate with credentials to access the Chainguard registry at `cgr.dev`. You can do this by creating a token with `chainctl`, as in this example:
+In order to support versioned images from a private repository, you must provide Renovate with credentials to access the [Chainguard registry](/chainguard/chainguard-images/chainguard-registry/overview/) at `cgr.dev`. You can do this by creating a token with `chainctl`, as in this example:
 
 ```shell
 chainctl auth configure-docker --pull-token
 ```
 
-This will respond with output such as:
+This command responds with output such as:
 
 ```shell
 To use this pull token in another environment, run this command:
@@ -46,7 +48,7 @@ To use this pull token in another environment, run this command:
 
 By default, this credential is good for 30 days.
 
-You can now configure `hostRules` in Renovate to support our registry. Depending on how Renovate was set up, you can add this to `renovate.json` or `config.json` with a setting such as:
+You can now configure `hostRules` in Renovate to support the Chainguard registry. Depending on how Renovate was set up, you can add this to your Renovate configuration with a setting such as:
 
 ```json
 {
@@ -76,20 +78,20 @@ module.exports = {
 };
 ```
 
-But an even more secure solution would be to create a script which automatically updates the configuration with the correct values by calling `chainctl`. If you do this, you should also set the credential lifetime to a much shorter period with the `–ttl` flag:
+But an even more secure solution would be to create a script which automatically updates the configuration with the correct values by calling `chainctl`. If you do this, you should also set the credential lifetime to a much shorter period with the `--ttl` flag:
 
 ```shell
-chainctl auth configure-docker --pull-token –ttl 10m
+chainctl auth configure-docker --pull-token --ttl 10m
 ```
 
-This will set the lifetime to 10 minutes, which limits the risk posed if the token should leak. You can also set the lifetime to a longer period for more manual configurations.
+This sets the pull token's lifetime to 10 minutes, which limits the risk posed if the token should leak. You can also set the lifetime to a longer period for more manual configurations.
 
 
 ## Updating Versioned Container Images
 
 By default, Renovate will now open PRs for any out-of-date versions of images it finds. For example, you can run Renovate by pushing the following Dockerfile to a repository overseen by Renovate:
 
-```
+```dockerfile
 FROM cgr.dev/chainguard.edu/python:3.11-dev AS builder
 ...
 
@@ -109,9 +111,9 @@ Ideally, image references should also be pinned to a digest, as shown in the fol
 
 Renovate also supports updating image references that are pinned to digests. This allows you to keep floating tags such as `:latest` in sync with the most up-to-date version.
 
-As an example, for the following Dockerfile Renovate opened two similar pull requests:
+As an example, the following Dockerfile prompts Renovate to open two similar pull requests:
 
-```
+```dockerfile
 FROM cgr.dev/chainguard/go:latest-dev@sha256:ff187ecd4bb5b45b65d680550eed302545e69ec4ed45f276f385e1b4ff0c6231 AS builder
 
 WORKDIR /work
@@ -134,10 +136,9 @@ The following screenshot shows the PR to update the static image:
 
 ## Pinning Digests
 
-The `pinDigests` option configures Renovate to add digests to image references
-that don't contain them.
+The `pinDigests` option configures Renovate to add digests to image references that don't contain them.
 
-Here is an example `renovate.json` that sets this.
+The following example Renovate configuration includes this option:
 
 ```json
 {
@@ -154,16 +155,15 @@ Here is an example `renovate.json` that sets this.
 }
 ```
 
-This configures Renovate to open PRs that will pin a reference like
-`cgr.dev/chainguard/python:3.12` to a digest like
-`cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3`.
+This configures Renovate to open PRs that will pin a reference like `cgr.dev/chainguard/python:3.12` to a digest like the following:
 
-## Disabling Non-Digest Updates
+```
+cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3
+```
 
-You can use the `matchUpdateTypes` option to disable updates for any update
-types other than `digest`.
+You can also use the `matchUpdateTypes` option to disable updates for any types other than `digest`.
 
-Here is an example `renovate.json` that does this.
+Here is an example Renovate configuration that does this:
 
 ```json
 {
@@ -185,37 +185,19 @@ Here is an example `renovate.json` that does this.
 }
 ```
 
-This will configure Renovate to update the digest for a reference like
-`cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3`
-but not the tag.
+This configures Renovate to update the digest for a reference but not the tag.
 
-The benefit of this approach is that it allows you to define your update
-strategy for each image reference by the use of a mutable tag, rather than having
-separate rules for different images in your Renovate configuration. Similar to
-Chainguard's [Digestabot](https://github.com/chainguard-dev/digestabot)
-Github Action.
+The benefit of this approach is that it allows you to define your update strategy for each image reference by the use of a mutable tag, rather than having separate rules for different images in your Renovate configuration, similar to Chainguard's [Digestabot](https://github.com/chainguard-dev/digestabot) Github Action.
 
 ## Running Renovate in Github Actions
 
-You can use
-[`renovatebot/github-action`](https://github.com/renovatebot/github-action) to
-run Renovate from a GitHub Actions workflow. This can be combined with an
-[assumable identity](/chainguard/administration/assumable-ids/assumable-ids/) to
-authenticate to `cgr.dev` and update references to Chainguard images in your
-repository.
+You can use [`renovatebot/github-action`](https://github.com/renovatebot/github-action) to run Renovate from a GitHub Actions workflow. This can be combined with an [assumable identity](/chainguard/administration/assumable-ids/assumable-ids/) to authenticate to `cgr.dev` and update references to Chainguard container images in your repository.
 
-To follow these steps, you must have:
-- `chainctl` — the Chainguard command line interface tool — installed on your
-  local machine. Follow our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/)
-  to set this up.
-- Access to an account with permissions to create identities in your Chainguard
-  organization. For instance, the `owner` role.
+> **Note**: This section assumes you have permissions to create identities in your Chainguard organization.
 
-First, create a `renovate.json` file at the root of your GitHub repository.
-Refer to the [official documentation](https://docs.renovatebot.com/configuration-options/)
-for all the supported options.
+First, create a Renovate configuration file at the root of your GitHub repository. Refer to the [official documentation](https://docs.renovatebot.com/configuration-options/) for all the supported options.
 
-This is an example of the most minimal configuration:
+This is an example of a minimal configuration:
 
 ```json
 {
@@ -223,9 +205,9 @@ This is an example of the most minimal configuration:
 }
 ```
 
-Push this file to the `main` branch.
+Push this file to the `main` branch of your repository.
 
-Next, create an assumable identity for your GitHub repository.
+Next, create an assumable identity for your GitHub repository:
 
 ```shell
 chainctl iam identities create github <identity-name> \
@@ -234,8 +216,7 @@ chainctl iam identities create github <identity-name> \
   --role=registry.pull
 ```
 
-Then, create `.github/workflows/renovate.yaml` with this
-content. Replace `<identity-id>` with the ID returned by the previous command.
+Create a workflow file named `.github/workflows/renovate.yaml` with the following content. Replace `<identity-id>` with the ID returned by the previous command.
 
 ```yaml
 name: Renovate
@@ -260,20 +241,16 @@ jobs:
       id-token: write
 
     steps:
-    # Install chainctl and log in as the assumed identity
     - uses: chainguard-dev/setup-chainctl@be0acd273acf04bfdf91f51198327e719f6af978 # v0.4.0
       with:
         identity: "<identity-id>"
 
-    # Export a short lived token for cgr.dev as RENOVATE_DOCKER_CGR_DEV_PASSWORD
     - shell: bash
       run: |
         RENOVATE_DOCKER_CGR_DEV_PASSWORD=$(chainctl auth token --audience=cgr.dev)
         echo "::add-mask::$RENOVATE_DOCKER_CGR_DEV_PASSWORD"
         echo "RENOVATE_DOCKER_CGR_DEV_PASSWORD=$RENOVATE_DOCKER_CGR_DEV_PASSWORD" >> $GITHUB_ENV
 
-    # Run renovate with RENOVATE_DETECT_HOST_RULES_FROM_ENV=true so that it will
-    # use the password exported by the previous step
     - name: Run Renovate
       uses: renovatebot/github-action@6927a58a017ee9ac468a34a5b0d2a9a9bd45cac3 # v43.0.11
       env:
@@ -283,42 +260,33 @@ jobs:
         RENOVATE_DOCKER_CGR_DEV_USERNAME: "_token"
 ```
 
-Push this file to the `main` branch.
+This workflow performs the following steps:
 
-This workflow is scheduled to run every morning at 3 AM. You can trigger it
-manually by navigating to **Actions > Renovate** and selecting **Run workflow**.
+* Installs chainctl and logs in as the assumable identity you created.
+* Exports a short lived token for cgr.dev as `RENOVATE_DOCKER_CGR_DEV_PASSWORD`.
+* Runs renovate with `RENOVATE_DETECT_HOST_RULES_FROM_ENV=true` so that it uses the password exported by the previous step.
 
-Once the workflow has ran successfully, you should see pull requests in your
-repository for any image references that need to be updated.
+Push this file to your repository's `main` branch.
+
+This workflow is scheduled to run at 3:00 a.m. every morning. You can trigger it manually by navigating to **Actions > Renovate** and selecting **Run workflow**.
+
+Once the workflow has ran successfully, you will find pull requests in your repository for any image references that need to be updated.
 
 ## Running Renovate with Docker
 
-Chainguard provide [an image for
-Renovate](https://images.chainguard.dev/directory/image/renovate/overview). This
-is an example of how you can run this image to keep references to Chainguard
-images up to date in a GitHub repository.
+Chainguard provide [an image for Renovate](https://images.chainguard.dev/directory/image/renovate/overview). This is an example of how you can run this image to keep references to Chainguard images up to date in a GitHub repository.
 
-To follow these steps, you must have:
-- `chainctl` — the Chainguard command line interface tool — installed on your
-  local machine. Follow our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/)
-  to set this up.
-- Access to an account with permissions to pull Chainguard container images
-  from your organization’s repository within the Chainguard registry.
-- The `renovate` image present in your Chainguard registry.
+> **Note**: To follow along with this section, you must have access to Chainguard's `renovate` container image.
 
-Firstly, if you don't already have one, generate a Personal Access Token for
-your GitHub user as described in Renovate's [official
-documentation](https://docs.renovatebot.com/modules/platform/github/#authentication).
+To begin, generate a Personal Access Token for your GitHub user as described in Renovate's [official documentation](https://docs.renovatebot.com/modules/platform/github/#authentication).
 
-Export the token as `RENOVATE_TOKEN` for use in subsequent steps.
+Export the token as an environment variable named `RENOVATE_TOKEN`:
 
 ```shell
 export RENOVATE_TOKEN=ghp_XXXXXXXXXXXXXXXXXX
 ```
 
-Next, create a `renovate.json` file at the root of any GitHub repositories you
-want to target with Renovate. Refer to the [official documentation](https://docs.renovatebot.com/configuration-options/)
-for all the supported options.
+Next, create a Renovate configuration file at the root of any GitHub repositories you want to target with Renovate. Refer to the [official documentation](https://docs.renovatebot.com/configuration-options/) for all the supported options.
 
 This is an example of the most minimal configuration:
 
@@ -328,15 +296,13 @@ This is an example of the most minimal configuration:
 }
 ```
 
-Then, login with `chainctl`.
+Then, log in with `chainctl`:
 
 ```shell
 chainctl auth login
 ```
 
-Finally, run Renovate. Substitute `<org-name>` with the name of your Chainguard
-organization and provide any GitHub repositories that you want to target as
-arguments in the form `<github-org>/<github-repo-name>`.
+Finally, run Renovate. Substitute `<org-name>` with the name of your Chainguard organization and provide any GitHub repositories that you want to target as arguments in the form `<github-org>/<github-repo-name>`:
 
 ```shell
 docker run \
@@ -350,8 +316,7 @@ docker run \
   <github-org>/<github-repo-name>
 ```
 
-This example passes a short-lived token for `cgr.dev` via the
-`RENOVATE_DOCKER_CGR_DEV_PASSWORD` environment variable.
+This example passes a short-lived token for `cgr.dev` using the `RENOVATE_DOCKER_CGR_DEV_PASSWORD` environment variable.
 
 ## Troubleshooting
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

Documentation.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

Add instructions for running Renovate in GitHub Actions and with Docker using our `renovate` image.

### Why are we making this change?
<!-- What larger problem does this PR address? -->

Customers will often want to introduce a tool like Renovate when they adopt Chainguard Containers. Renovate is very feature rich and can be ran in a number of different ways. Its not always clear to customers from the official documentation how they can run Renovate and also provide credentials for `cgr.dev`.

These two sections provide tangible examples.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

🤷 

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->

1. Create a new GitHub repository under your user.
2. Push a few example configuration files to the repository. Substitute `<org-name>` with your organization name. Add the corresponding images to your org if you don't have them, or replace them with images you do have.

```
# Dockerfile
FROM cgr.dev/<org-name>/busybox:latest@sha256:257157f6c6aa88dd934dcf6c2f140e42c2653207302788c0ed3bebb91c5311e1
```

```
# values.yaml
image:
  repository: '<org-name>/nginx'
  tag: '1.26'
  registry: 'cgr.dev'
```

```
# docker-compose.yml
services:
  cert-manager-controller:
    image: cgr.dev/<org-name>/cert-manager-controller:1.15.4@sha256:9c48138a45dd9e7b62dabaa3a0756ceabb00202d0f1a46fbe912c05333699bf0
```

3. Follow the instructions in this PR and hopefully it works as expected!