### PR TITLE
Initial Python CVE Remediation docs

### DIFF
--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -16,7 +16,7 @@ toc: true
 
 CVE Remediation is a feature in Chainguard Libraries that provides security protection against High and Critical CVEs. Applications often rely on older versions of libraries, but upstream maintainers may not apply and release patches for those versions. CVE Remediation addresses this gap by applying vulnerability fixes from upstream to older releases, particularly in cases where maintainers are no longer able to support and provide fixes.
 
-CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview.md).
+CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview).
 
 ## About CVE Remediation
 CVE Remediation focuses on High and Critical vulnerabilities across several Python libraries. Chainguard backports fixes that are already available in the upstream project to older versions that may no longer receive updates.
@@ -36,8 +36,8 @@ Currently, Grype supports Chainguard remediated libraries starting with Grype **
 - Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
 - Scan the Python virtual environment (venv) directly. If your Python application is not containerized, this is recommended.
 
-For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index.md).
+For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index).
 
 ## Learn More
 
-- [Python Libraries Overview](/chainguard/libraries/python/overview.md)
+- [Python Libraries Overview](/chainguard/libraries/python/overview)

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -14,19 +14,19 @@ weight: 005
 toc: true
 ---
 
-CVE Remediation is a feature in Chainguard Libraries that provides security protection against High and Critical CVEs. Applications often rely on older versions of libraries, but upstream maintainers may not apply and release patches for those versions. CVE Remediation addresses this gap by applying vulnerability fixes from upstream to older releases, particularly in cases where maintainers are no longer able to support and provide fixes.
+CVE Remediation is a feature in Chainguard Libraries that provides security protection against high and critical CVEs. Applications often rely on older versions of libraries, but upstream maintainers may not apply and release patches for those versions. CVE Remediation addresses this gap by applying vulnerability fixes from upstream to older releases, particularly in cases where maintainers are no longer able to support and provide fixes. 
 
-CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview).
+CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview). CVE Remediation is available for a subset of Chainguard Libraries for Python. If you want to request CVE Remediation for additional libraries, reach out to your account team.
 
 ## About CVE Remediation
-CVE Remediation focuses on High and Critical vulnerabilities across several Python libraries. Chainguard backports fixes that are already available in the upstream project to older versions that may no longer receive updates.
+CVE Remediation focuses on high and critical vulnerabilities across several Python libraries. Chainguard backports fixes that are already available in the upstream project to older versions that may no longer receive updates.
 
 Before publishing a remediated version, Chainguard validates that the remediated version does not introduce regressions. All upstream test suites are run before and after applying the fix to confirm functional consistency. Chainguard also develops additional regression tests to validate the effectiveness of the CVE fix.
 
 Remediated libraries are distributed through a dedicated repository, giving you the option to choose when and whether to consume remediated versions.
 
 To provide transparency, advisories for each CVE addressed in our remediated libraries are published via a public VEX feed
-at `https://libraries.cgr.dev/openvex/v1/all.json`. Supported scanners use this feed to identify and recognize remediated versions.
+at <https://libraries.cgr.dev/openvex/v1/all.json>. Supported scanners use this feed to identify and recognize remediated versions.
 
 ## Scanning Remediated Libraries
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -32,9 +32,9 @@ at `https://libraries.cgr.dev/openvex/v1/all.json`. Supported scanners use this 
 
 Chainguard works closely with scanner partners so that remediated versions are properly recognized in vulnerability reports. This ensures that teams can maintain their existing scanning workflows while benefiting from patched dependencies.
 
-Currently, Grype supports Chainguard remediated libraries starting with Grype **version 0.100.0**. You can use Grype in two ways:
-- Containerized applications: Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
-- Non-containerized applications: If your Python application is not packaged in a container, you can use Grype to scan the Python virtual environment (venv) directly.
+Currently, Grype supports Chainguard remediated libraries starting with Grype **version 0.100.0**. You can use Grype in multiple ways:
+- Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
+- Scan the Python virtual environment (venv) directly. If your Python application is not containerized, this is recommended.
 
 For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index.md).
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -1,0 +1,43 @@
+---
+title: "CVE Remediation for Chainguard Libraries"
+linktitle: "CVE Remediation"
+description: "An overview of the CVE Remediation feature for Chainguard Libraries."
+type: "article"
+date: 2025-09-11
+lastmod: 2025-09-11
+draft: false
+tags: ["Chainguard Libraries", "CVE"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 005
+toc: true
+---
+
+CVE Remediation is a feature in Chainguard Libraries that provides security protection against High and Critical CVEs. Applications often rely on older versions of libraries, but upstream maintainers may not apply and release patches for those versions. CVE Remediation addresses this gap by applying vulnerability fixes from upstream to older releases, particularly in cases where maintainers are no longer able to support and provide fixes.
+
+CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview.md).
+
+## About CVE Remediation
+CVE Remediation focuses on High and Critical vulnerabilities across several Python libraries. Chainguard backports fixes that are already available in the upstream project to older versions that may no longer receive updates.
+
+Before publishing a remediated version, Chainguard validates that the remediated version does not introduce regressions. All upstream test suites are run before and after applying the fix to confirm functional consistency. Chainguard also develops additional regression tests to validate the effectiveness of the CVE fix.
+
+Remediated libraries are distributed through a dedicated repository, giving you the option to choose when and whether to consume remediated versions.
+
+To provide transparency, advisories for each CVE addressed in our remediated libraries are published via a public VEX feed
+at `https://libraries.cgr.dev/openvex/v1/all.json`. Supported scanners use this feed to identify and recognize remediated versions.
+
+## Scanning Remediated Libraries
+
+Chainguard works closely with scanner partners so that remediated versions are properly recognized in vulnerability reports. This ensures that teams can maintain their existing scanning workflows while benefiting from patched dependencies.
+
+Currently, Grype supports Chainguard remediated libraries starting with Grype **version 0.100.0**. You can use Grype in two ways:
+- Containerized applications: Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
+- Non-containerized applications: If your Python application is not packaged in a container, you can use Grype to scan the Python virtual environment (venv) directly.
+
+For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index.md).
+
+## Learn More
+
+- [Python Libraries Overview](/chainguard/libraries/python/overview.md)

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -34,7 +34,7 @@ Chainguard works closely with scanner partners so that remediated versions are p
 
 Currently, Grype supports Chainguard remediated libraries starting with Grype **version 0.100.0**. You can use Grype in multiple ways:
 - Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
-- Scan the Python virtual environment (venv) directly. If your Python application is not containerized, this is recommended.
+- Scan the Python virtual environment directly. If your Python application is not containerized, this is recommended.
 
 For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index).
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -102,11 +102,11 @@ for accessing your organization's Sonatype Nexus repository group.
 
 ### Direct access
 
-Build configuration to retrieve artifacts **directly** from the Chainguard Libraries
-for Python repository at `https://libraries.cgr.dev/python/` with the simple
-index at `https://libraries.cgr.dev/python/simple` requires authentication with
-username and password from a pull token as detailed in [access
-documentation](/chainguard/libraries/access/#pull-token).
+The build configuration to retrieve artifacts **directly** from the Chainguard Libraries
+for Python repositories requires authentication with username and password from a pull token as detailed in [access
+documentation](/chainguard/libraries/access/#pull-token). Note that there are multiple repositories:
+- `https://libraries.cgr.dev/python/` with the simple index at `https://libraries.cgr.dev/python/simple` 
+- `https://libraries.cgr.dev/python-remediated` with the simple index at `https://libraries.cgr.dev/python-remediated/simple` 
 
 ## Configuring build tools
 
@@ -360,4 +360,5 @@ url = "https://CG_PULLTOKEN_USERNAME:CG_PULLTOKEN_PASSWORD@libraries.cgr.dev/pyt
 In order to install Python libraries from multiple repositories with Chainguard Libraries
 for Python as the priority, `uv` supports [searching across multiple indexes](https://docs.astral.sh/uv/concepts/indexes/#searching-across-multiple-indexes) 
 while setting a priority index. You can use this to configure Chainguard Libraries for 
-Python as the first choice for any library access, with a fallback to the PyPI public index.
+Python as the first choice for any library access, with a fallback to the PyPI public index. 
+In addition, if you are consuming from our remediated Python libraries index, we recommend setting the [index-strategy setting](https://docs.astral.sh/uv/reference/settings/#index-strategy) to `unsafe-best-match`. This will ensure that index resolution continues to work when remediated libraries have dependencies on non-remediated librarie.

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -361,4 +361,4 @@ In order to install Python libraries from multiple repositories with Chainguard 
 for Python as the priority, `uv` supports [searching across multiple indexes](https://docs.astral.sh/uv/concepts/indexes/#searching-across-multiple-indexes) 
 while setting a priority index. You can use this to configure Chainguard Libraries for 
 Python as the first choice for any library access, with a fallback to the PyPI public index. 
-In addition, if you are consuming from our remediated Python libraries index, we recommend setting the [index-strategy setting](https://docs.astral.sh/uv/reference/settings/#index-strategy) to `unsafe-best-match`. This will ensure that index resolution continues to work when remediated libraries have dependencies on non-remediated librarie.
+In addition, if you are consuming from our remediated Python libraries index, we recommend setting the [index-strategy setting](https://docs.astral.sh/uv/reference/settings/#index-strategy) to `unsafe-best-match`. This will ensure that index resolution continues to work when remediated libraries have dependencies on non-remediated libraries.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -135,7 +135,7 @@ Combine the two repositories in a new virtual repository:
 
 At this point, you have a virtual repository set up in Artifactory that allows you or others in your organization to access Chainguard Libraries for Python with your chosen tools. This setup falls back to the public PyPI index in cases where a package is not available in Chainguard's index.
 
-#### Configure Remediated Libraries index
+### Additional configuration for CVE Remediation
 We recommend customers also configure the repository for **Python Libraries with CVE Remediation** so that remediated versions with High and Critical CVE fixes can be consumed automatically.  
 
 1. Create a new **Remote repository**:  
@@ -148,12 +148,12 @@ We recommend customers also configure the repository for **Python Libraries with
    - Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python-remediated/`.
    - Select **Create Remote Repository**.  
 
-2. Add this new repository to your existing **Virtual repository** (e.g. `python-all`):  
+2. Add this new repository to the existing **Virtual repository** (e.g. `python-all`):  
    - Edit the virtual repository configuration.  
    - Add `python-remediated` alongside `python-chainguard` and `python-public`.  
    - Drag `python-remediated` to the top of the list to ensure it take the highest priority. 
 
-With this configuration, Artifactory will prefer remediated versions whenever available (e.g. `gunicorn==20.1.0` resolves to `20.1.0+cgr.1`). If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
+With this configuration, Artifactory will prefer remediated versions whenever available. For example, `gunicorn` version `20.1.0` will resolve to the remediated version, `20.1.0+cgr.1`. If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -135,6 +135,26 @@ Combine the two repositories in a new virtual repository:
 
 At this point, you have a virtual repository set up in Artifactory that allows you or others in your organization to access Chainguard Libraries for Python with your chosen tools. This setup falls back to the public PyPI index in cases where a package is not available in Chainguard's index.
 
+#### Configure Remediated Libraries index
+We recommend customers also configure the repository for **Python Libraries with CVE Remediation** so that remediated versions with High and Critical CVE fixes can be consumed automatically.  
+
+1. Create a new **Remote repository**:  
+   - Select **Create a Repository** and choose the **Remote** option.  
+   - Select *PyPI* as the Package type.  
+   - Set the Repository Key to `python-remediated`.  
+   - Set the URL to `https://libraries.cgr.dev/python-remediated/`.  
+   - Set **User Name** and **Password / Access Token** to the same [values as retrieved
+   with chainctl](/chainguard/libraries/access/). 
+   - Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python-remediated/`.
+   - Select **Create Remote Repository**.  
+
+2. Add this new repository to your existing **Virtual repository** (e.g. `python-all`):  
+   - Edit the virtual repository configuration.  
+   - Add `python-remediated` alongside `python-chainguard` and `python-public`.  
+   - Drag `python-remediated` to the top of the list to ensure it take the highest priority. 
+
+With this configuration, Artifactory will prefer remediated versions whenever available (e.g. `gunicorn==20.1.0` resolves to `20.1.0+cgr.1`). If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
+
 ### Build tool access
 
 See the page on [build tool configuration for Chainguard Libraries for

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -136,7 +136,7 @@ Combine the two repositories in a new virtual repository:
 At this point, you have a virtual repository set up in Artifactory that allows you or others in your organization to access Chainguard Libraries for Python with your chosen tools. This setup falls back to the public PyPI index in cases where a package is not available in Chainguard's index.
 
 ### Additional configuration for CVE Remediation
-We recommend customers also configure the repository for **Python Libraries with CVE Remediation** so that remediated versions with High and Critical CVE fixes can be consumed automatically.  
+We recommend users also configure the repository for **Python Libraries with CVE Remediation** so that remediated versions with high and critical CVE fixes can be consumed automatically.  
 
 1. Create a new **Remote repository**:  
    - Select **Create a Repository** and choose the **Remote** option.  
@@ -148,12 +148,12 @@ We recommend customers also configure the repository for **Python Libraries with
    - Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python-remediated/`.
    - Select **Create Remote Repository**.  
 
-2. Add this new repository to the existing **Virtual repository** (e.g. `python-all`):  
+2. Add this new repository to the existing **Virtual repository** (for example, `python-all`):  
    - Edit the virtual repository configuration.  
    - Add `python-remediated` alongside `python-chainguard` and `python-public`.  
    - Drag `python-remediated` to the top of the list to ensure it take the highest priority. 
 
-With this configuration, Artifactory will prefer remediated versions whenever available. For example, `gunicorn` version `20.1.0` will resolve to the remediated version, `20.1.0+cgr.1`. If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
+With this configuration, Artifactory will select remediated versions whenever available. For example, `gunicorn` version `20.1.0` will resolve to the remediated version, `20.1.0+cgr.1`. If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -16,7 +16,7 @@ toc: true
 
 ## Introduction
 
-Chainguard Libraries for Python provides enhanced security for the vast Python ecosystem by rebuilding PyPI packages with comprehensive supply chain protection and automated patching. With over 600,000 packages on the [Python Package Index (PyPI)](https://pypi.org/) serving application development, machine learning, and data science needs, Chainguard addresses the critical security challenges of depending on packages from untrusted sources by rebuilding them within the controlled Chainguard Factory environment.
+Chainguard Libraries for Python provides enhanced security for the vast Python ecosystem by rebuilding PyPI packages with comprehensive supply chain protection and automated patching. With over 600,000 packages on the [Python Package Index (PyPI)](https://pypi.org/) serving application development, machine learning, and data science needs, Chainguard addresses the critical security challenges of depending on packages from untrusted sources by rebuilding them within the controlled Chainguard Factory environment. In addition, Chainguard eliminates security risk by remediating High and Critical vulnerabilities across older package versions where upstream maintainers are not able to prioritize fixes.
 
 Chainguard Libraries for Python enables access to a growing collection of Python
 packages rebuilt from source. New releases of common libraries or artifacts
@@ -47,6 +47,12 @@ apply:
 * Processor architecture of the runtime environment must be `x86_64` or
   `aarch64`.
 
+## CVE Remediation
+
+Chaingard Libraries for Python includes includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with High and Critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Python libraries with CVE remediation include a local version identifier of `+cgr.N`. For example, the `flask` library has CVE-2023-30861 remediated in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
+
+In some cases, multiple CVEs may be remediated in the same library version across separate local version bumps. For example, `aiohttp` has both CVE-2024-23334 and CVE-2024-30251 remediated in the version `3.9.1+cgr.2`. Python package management tools interpret the `+cgr.N` suffix as a local version, which takes precedence over versions without the version suffix during dependency resolution.
+
 ## Technical details
 
 Most organizations consume Chainguard Libraries for Python through a repository
@@ -56,23 +62,26 @@ documentation](/chainguard/libraries/python/global-configuration/). The rest of
 this article provides details of the underlying implementation of Chainguard
 Libraries for Python and how to access individual libraries manually.
 
-The Chainguard Libraries for Python index uses the PyPI repository format and
-only includes release artifacts of the libraries built by Chainguard from
-source.
+The Chainguard Libraries for Python indexes use the PyPI repository format and 
+only include release artifacts of the libraries built by Chainguard from source.
 
-The URL for the repository is:
+The URLs for the repositories are:
 
 ```
 https://libraries.cgr.dev/python/
+https://libraries.cgr.dev/python-remediated/
 ```
 
-Use the URL with your [username and password retrieved with
+The first index provides all Python libraries that we build from source, without remediated versions. The second index provides remediated libraries with High and Critical CVE fixes applied to older versions.
+
+Use the URLs with your [username and password retrieved with
 chainctl](/chainguard/libraries/access/) to access the Chainguard Libraries for
 Python repository manually with a browser.
 
 After successful login, you are redirected to the `simple` sub-context at
-`https://libraries.cgr.dev/python/simple/` that allows you to inspect the
-available packages. The top level contains an alphabetical list of packages:
+`https://libraries.cgr.dev/python/simple/` or `https://libraries.cgr.dev/python-remediated/simple/` 
+that allows you to inspect the available packages. The top level contains 
+an alphabetical list of packages:
 
 ```
 2captcha-python

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -72,7 +72,7 @@ https://libraries.cgr.dev/python/
 https://libraries.cgr.dev/python-remediated/
 ```
 
-The first index provides all Python libraries that we build from source, without remediated versions. The second index provides remediated libraries with High and Critical CVE fixes applied to older versions.
+The first index provides all Python libraries that we build from source, without remediated versions. The second index provides remediated libraries with high and critical CVE fixes applied to older versions. The separate indexes provide users the option to decide when they want to use remediated libraries. 
 
 Use the URLs with your [username and password retrieved with
 chainctl](/chainguard/libraries/access/) to access the Chainguard Libraries for

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -49,7 +49,7 @@ apply:
 
 ## CVE Remediation
 
-Chaingard Libraries for Python includes includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with High and Critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Remediated libraries include a local version identifier of `+cgr.N`. For example, the `flask` library has a fix for CVE-2023-30861 in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
+Chaingard Libraries for Python includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with high and critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Remediated libraries include a local version identifier of `+cgr.N`. For example, the `flask` library has a fix for CVE-2023-30861 in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
 
 In some cases, multiple CVEs may be remediated in a specific library version. For example, `aiohttp` has fixes for both  CVE-2024-23334 and CVE-2024-30251 in the version `3.9.1+cgr.2`. Python package management tools interpret the `+cgr.N` suffix as a local version, which takes precedence over versions without the version suffix during dependency resolution.
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -49,9 +49,9 @@ apply:
 
 ## CVE Remediation
 
-Chaingard Libraries for Python includes includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with High and Critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Python libraries with CVE remediation include a local version identifier of `+cgr.N`. For example, the `flask` library has CVE-2023-30861 remediated in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
+Chaingard Libraries for Python includes includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with High and Critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Remediated libraries include a local version identifier of `+cgr.N`. For example, the `flask` library has a fix for CVE-2023-30861 in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
 
-In some cases, multiple CVEs may be remediated in the same library version across separate local version bumps. For example, `aiohttp` has both CVE-2024-23334 and CVE-2024-30251 remediated in the version `3.9.1+cgr.2`. Python package management tools interpret the `+cgr.N` suffix as a local version, which takes precedence over versions without the version suffix during dependency resolution.
+In some cases, multiple CVEs may be remediated in a specific library version. For example, `aiohttp` has fixes for both  CVE-2024-23334 and CVE-2024-30251 in the version `3.9.1+cgr.2`. Python package management tools interpret the `+cgr.N` suffix as a local version, which takes precedence over versions without the version suffix during dependency resolution.
 
 ## Technical details
 


### PR DESCRIPTION
- overview doc for CVE Remediation
- updates to Python overview doc
- updates to Artifactory global configuration
- update to direct access section, specifically for uv

Notes:
- future additions and testing to be done for other artifact managers (Nexus, Cloudsmith) and build tools specifically for direct access (poetry, pip)
