### PR TITLE
Improve CVE remediation docs

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -197,3 +197,9 @@ proxying
 scalable
 sbt
 Leiningen
+backports
+backported
+upstreams
+untrusted
+pypi
+PyPI

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -1,7 +1,7 @@
 ---
 title: "CVE Remediation for Chainguard Libraries"
 linktitle: "CVE Remediation"
-description: "An overview of the CVE Remediation feature for Chainguard Libraries."
+description: "An overview of the CVE remediation feature for Chainguard Libraries."
 type: "article"
 date: 2025-09-11
 lastmod: 2025-09-11
@@ -14,32 +14,72 @@ weight: 005
 toc: true
 ---
 
-CVE Remediation is a feature in Chainguard Libraries that provides security protection against high and critical CVEs. Applications often rely on older versions of libraries, but upstream maintainers may not apply and release patches for those versions. CVE Remediation addresses this gap by applying vulnerability fixes from upstream to older releases, particularly in cases where maintainers are no longer able to support and provide fixes. 
+CVE remediation is a feature in Chainguard Libraries that provides security
+protection against high and critical CVEs. Applications often rely on older
+versions of libraries, but upstream maintainers may not apply and release
+patches for those versions. CVE remediation addresses this gap by applying
+vulnerability fixes from upstream to older releases, particularly in cases where
+maintainers are no longer able to support and provide fixes.
 
-CVE Remediation helps reduce risk for organizations that cannot always upgrade quickly, without forcing disruptive dependency changes. This feature is included with [Chainguard Libraries for Python](/chainguard/libraries/python/overview). CVE Remediation is available for a subset of Chainguard Libraries for Python. If you want to request CVE Remediation for additional libraries, reach out to your account team.
+CVE remediation helps reduce risk for organizations that cannot always upgrade
+quickly since a larger upgrade to newer versions forces often disruptive
+changes. CVE remediation makes multiple incremental patch versions of affected
+older versions available and therefore allows a very minor upgrade that only
+addresses the CVE, but does not bring on other changes.
+
+CVE remediation is available for a subset of [Chainguard Libraries for
+Python](/chainguard/libraries/python/overview). If you want to request CVE
+remediation for additional libraries, reach out to your account team.
 
 ## About CVE Remediation
-CVE Remediation focuses on high and critical vulnerabilities across several Python libraries. Chainguard backports fixes that are already available in the upstream project to older versions that may no longer receive updates.
 
-Before publishing a remediated version, Chainguard validates that the remediated version does not introduce regressions. All upstream test suites are run before and after applying the fix to confirm functional consistency. Chainguard also develops additional regression tests to validate the effectiveness of the CVE fix.
+CVE remediation focuses on high and critical vulnerabilities. Chainguard
+backports fixes that are already available in the new versions of the upstream
+project to older versions that may no longer receive updates.
 
-Remediated libraries are distributed through a dedicated repository, giving you the option to choose when and whether to consume remediated versions.
+Before publishing a remediated version, Chainguard validates that the remediated
+version does not introduce regressions. All upstream test suites are run before
+and after applying the fix to confirm functional consistency. Chainguard also
+develops additional regression tests to validate the effectiveness of the CVE
+fix.
 
-To provide transparency, advisories for each CVE addressed in our remediated libraries are published via a public VEX feed
-at <https://libraries.cgr.dev/openvex/v1/all.json>. Supported scanners use this feed to identify and recognize remediated versions.
+Remediated libraries are distributed through a dedicated repository. This
+provides the option to make remediated versions available for your development
+or opt out of using these versions completely and continue to use upstream
+versions only.
+
+Advisories for each CVE addressed in our remediated libraries are published via
+a public VEX feed at
+[https://libraries.cgr.dev/openvex/v1/all.json](https://libraries.cgr.dev/openvex/v1/all.json).
+Supported scanners and your own custom tooling can use this feed to identify and
+recognize remediated versions.
 
 ## Scanning Remediated Libraries
 
-Chainguard works closely with scanner partners so that remediated versions are properly recognized in vulnerability reports. This ensures that teams can maintain their existing scanning workflows while benefiting from patched dependencies.
+Chainguard works closely with scanner partners so that remediated versions are
+properly recognized in vulnerability reports. This ensures that teams can
+maintain their existing scanning workflows while benefiting from patched
+dependencies.
 
-Currently, Grype supports Chainguard remediated libraries starting with Grype **version 0.100.0**. You can use Grype in multiple ways:
-- Scan the container image for your Python application as you would normally. Grype will detect and account for remediated versions inside the image.
-- Scan the Python virtual environment directly. If your Python application is not containerized, this is recommended.
+Grype supports Chainguard remediated libraries starting with Grype **version
+0.100.0**. You can use Grype in multiple ways:
 
-When scanning a directory that contains a dependency file such as `requirements.txt`, Grype reports against the declared versions rather than the installed versions. As a result, Chainguard’s remediated Python package versions are not recognized in this mode. To ensure accurate results, we recommend scanning the installed environment, such as a Python virtual environment directory, instead.
+- Scan the Python virtual environment directly. If your Python application is
+  not containerized, this is recommended.
+- Alternatively, scan the container image for your Python application. Grype
+  detects and accounts for remediated library versions inside the image.
 
-For additional guidance, see our documention on [Using Grype to Scan Container Images for Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index).
+When scanning a Python project source directory that contains a dependency file
+such as `requirements.txt`, Grype reports against the declared versions rather
+than the installed versions. As a result, Chainguard’s remediated Python package
+versions are not recognized in this mode. To ensure accurate results, we
+recommend scanning the installed environment, such as a Python virtual
+environment directory, instead.
+
+For additional guidance, see our documentation on [Using Grype to Scan Container
+Images for
+Vulnerabilities](/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/index).
 
 ## Learn More
 
-- [Python Libraries Overview](/chainguard/libraries/python/overview)
+- [Chainguard Libraries for Python Overview](/chainguard/libraries/python/overview)

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -15,18 +15,32 @@ weight: 052
 toc: true
 ---
 
-Python library consumption in a large organization is typically managed by a repository manager. Commonly used repository manager applications are [Cloudsmith](https://cloudsmith.com/), [JFrog Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The repository manager acts as a single point of access for developers and development tools to retrieve the required libraries.
+Python library consumption in a large organization is typically managed by a
+repository manager. Commonly used repository manager applications are
+[Cloudsmith](https://cloudsmith.com/), [JFrog
+Artifactory](https://jfrog.com/artifactory/), and [Sonatype Nexus
+Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
+repository manager acts as a single point of access for developers and
+development tools to retrieve the required libraries.
 
-At a high level, adopting the use of Chainguard Libraries consists of the following steps:
+At a high level, adopting the use of Chainguard Libraries consists of the
+following steps:
 
 * Add Chainguard Libraries as a remote repository for library retrieval.
 * Add the public [PyPI](https://pypi.org/) repository as a remote repository.
-* Create a group, virtual, or polyglot repository combining these repository sources with any desired internal repositories. Configure the Chainguard Libraries repository as the first choice for any library access after any desired internal repositories.
+* Create a group, virtual, or polyglot repository combining these repository
+  sources with any desired internal repositories. Configure the Chainguard
+  Libraries repository as the first choice for any library access after any
+  desired internal repositories.
 
 You should also:
 
-* Remove all prior cached artifacts in the virtual server or proxy public repository. This step reduces confusion about the origin of libraries and assists technical evaluation and adoption of Chainguard Libraries.
-* Remove any repositories that are no longer desired or necessary. Depending on your library requirements, this step can result in removal of some proxy repositories or even removal of all proxy repositories. 
+* Remove all prior cached artifacts in the virtual server or proxy public
+  repository. This step reduces confusion about the origin of libraries and
+  assists technical evaluation and adoption of Chainguard Libraries.
+* Remove any repositories that are no longer desired or necessary. Depending on
+  your library requirements, this step can result in removal of some proxy
+  repositories or even removal of all proxy repositories. 
 
 If your organization does not use a repository manager, you can still use
 Chainguard Libraries. However, this approach requires configuration of multiple
@@ -40,7 +54,13 @@ information.
 
 ## Cloudsmith
 
-[Cloudsmith](https://cloudsmith.com/) supports Python repositories for proxying and hosting and polyglot repositories that combine multiple repositories sources with compatible formats. Refer to the [Cloudsmith Python Repository documentation](https://help.cloudsmith.io/docs/python-repository) and the [Cloudsmith documentation for creating a repository](https://help.cloudsmith.io/docs/create-a-repository) for more information. 
+[Cloudsmith](https://cloudsmith.com/) supports Python repositories for proxying
+and hosting and polyglot repositories that combine multiple repositories sources
+with compatible formats. Refer to the [Cloudsmith Python Repository
+documentation](https://help.cloudsmith.io/docs/python-repository) and the
+[Cloudsmith documentation for creating a
+repository](https://help.cloudsmith.io/docs/create-a-repository) for more
+information. 
 
 ### Initial configuration
 
@@ -56,7 +76,8 @@ First, create a repository:
    repository. The name should include *python* to identify the repository
    format. This convention helps avoid confusion, since repositories in
    Cloudsmith are multi-format. 
-1. Select a storage region that is appropriate for your organization and infrastructure.
+1. Select a storage region that is appropriate for your organization and
+   infrastructure.
 1. Select **+ Create Repository**. 
 
 Next, configure the upstream proxies:
@@ -64,15 +85,23 @@ Next, configure the upstream proxies:
 1. Select the name of the new *python-all* repository on the repositories page
    to configure it.
 1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
-1. Configure an upstream proxy with the format **python** and the following details: 
+1. Configure an upstream proxy with the format **python** and the following
+   details: 
     * **Name**: `python-chainguard`
     * **Priority**: `1`
     * **Upstream URL**: `https://libraries.cgr.dev/python/`
     * **Mode**: `Cache and Proxy`
+   * Add the **Username** and **Password** value from [Chainguard Libraries
+      access](/chainguard/libraries/access/) in **Authentication Settings**
 1. Select **Create Upstream Proxy**.
+1. If you want to use the separate repository with
+   [remediated Python libraries](/chainguard/libraries/python/overview/#cve-remediation),
+   repeat the preceding two steps with the name `python-chainguard-remediated`,
+   the priority `2`, the same authentication details, and the URL
+   `https://libraries.cgr.dev/python-remediated/`.
 1. Configure another upstream proxy with the following details
     * **Name**: `python-public`
-    * **Priority**: `2`
+    * **Priority**: `3`
     * **Upstream URL**: `https://pypi.org/`
     * **Mode**: `Cache and Proxy`
 1. Select **Create Upstream Proxy**.
@@ -80,14 +109,18 @@ Next, configure the upstream proxies:
 ### Build tool access
 
 See the page on [build tool configuration for Chainguard Libraries for
-Python](/chainguard/libraries/python/build-configuration/#cloudsmith) for information on
-accessing credentials and setting up build tools.
+Python](/chainguard/libraries/python/build-configuration/#cloudsmith) for
+information on accessing credentials and setting up build tools.
 
 <a id="artifactory"></a>
 
 ## JFrog Artifactory
 
-[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories for proxying and virtual repositories to combine multiple sources into a single repository. The following instructions are based on the [PyPI Repository documentation for Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
+[JFrog Artifactory](https://jfrog.com/artifactory/) supports PyPI repositories
+for proxying and virtual repositories to combine multiple sources into a single
+repository. The following instructions are based on the [PyPI Repository
+documentation for
+Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
 
 ### Initial configuration
 
@@ -107,11 +140,18 @@ Configure a remote repository for the Chainguard Libraries for Python index:
 1. Set the **URL** to `https://libraries.cgr.dev/python/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-1. Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python/`.
+1. Set the **PyPI Settings - Registry URL** to
+   `https://libraries.cgr.dev/python/`.
 1. Optionally click the **Test** button to verify connection and authentication.
 1. Access the **Advanced** configuration tab and deactivate the **Block
    Mismatching Mime Types** setting in the **Others** section.
 1. Press **Create Remote Repository**.
+
+If you want to use the separate repository with [remediated Python
+libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
+preceding steps with the name `python-chainguard-remediated`, the same
+authentication details, and the URL
+`https://libraries.cgr.dev/python-remediated/`.
 
 Configure a remote repository for the PyPI public index:
 
@@ -119,7 +159,7 @@ Configure a remote repository for the PyPI public index:
 1. Select *PyPI* as the Package type.
 1. Set the **Repository Key** to `python-public`.
 1. Set the **URL** to `https://files.pythonhosted.org`.
-1. Set the **Pypi Settings - Registry URL** to `https://pypi.org/`.
+1. Set the **PyPI Settings - Registry URL** to `https://pypi.org/`.
 1. Select **Create Remote Repository**.
 
 Combine the two repositories in a new virtual repository:
@@ -133,27 +173,11 @@ Combine the two repositories in a new virtual repository:
    name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
 
-At this point, you have a virtual repository set up in Artifactory that allows you or others in your organization to access Chainguard Libraries for Python with your chosen tools. This setup falls back to the public PyPI index in cases where a package is not available in Chainguard's index.
-
-### Additional configuration for CVE Remediation
-We recommend users also configure the repository for **Python Libraries with CVE Remediation** so that remediated versions with high and critical CVE fixes can be consumed automatically.  
-
-1. Create a new **Remote repository**:  
-   - Select **Create a Repository** and choose the **Remote** option.  
-   - Select *PyPI* as the Package type.  
-   - Set the Repository Key to `python-remediated`.  
-   - Set the URL to `https://libraries.cgr.dev/python-remediated/`.  
-   - Set **User Name** and **Password / Access Token** to the same [values as retrieved
-   with chainctl](/chainguard/libraries/access/). 
-   - Set the **Pypi Settings - Registry URL** to `https://libraries.cgr.dev/python-remediated/`.
-   - Select **Create Remote Repository**.  
-
-2. Add this new repository to the existing **Virtual repository** (for example, `python-all`):  
-   - Edit the virtual repository configuration.  
-   - Add `python-remediated` alongside `python-chainguard` and `python-public`.  
-   - Drag `python-remediated` to the top of the list to ensure it take the highest priority. 
-
-With this configuration, Artifactory will select remediated versions whenever available. For example, `gunicorn` version `20.1.0` will resolve to the remediated version, `20.1.0+cgr.1`. If no remediated version exists, it will fall back to the standard Chainguard repository and then PyPI.  
+At this point, you have a virtual repository set up in Artifactory that allows
+you or others in your organization to access Chainguard Libraries for Python,
+optionally including remediated versions, with your chosen tools. This setup
+falls back to the public PyPI index in cases where a package is not available in
+Chainguard's index.
 
 ### Build tool access
 
@@ -165,7 +189,11 @@ information on accessing credentials and setting up build tools.
 
 ## Sonatype Nexus Repository
 
-[Sonatype Nexus Repository](https://www.sonatype.com/products/sonatype-nexus-repository) allows for merging multiple remote repositories as a repository group. The below instructions for  are based on the [Nexus documentation for PyPI](https://help.sonatype.com/en/pypi-repositories.html) 
+[Sonatype Nexus
+Repository](https://www.sonatype.com/products/sonatype-nexus-repository) allows
+for merging multiple remote repositories as a repository group. The below
+instructions for  are based on the [Nexus documentation for
+PyPI](https://help.sonatype.com/en/pypi-repositories.html) 
 
 ### Initial configuration
 
@@ -173,7 +201,9 @@ The following steps create remote repositories for Chainguard Libraries for
 Python, a remote repository for the public PyPI index, and a repository group
 combining these sources.
 
-First, log in to Sonatype Nexus as a user with administrator privileges and access the **Server administration** and configuration section within the gear icon in the top navigation bar.
+First, log in to Sonatype Nexus as a user with administrator privileges and
+access the **Server administration** and configuration section within the gear
+icon in the top navigation bar.
 
 Next, configure a remote repository for the public PyPI index:
 
@@ -181,7 +211,8 @@ Next, configure a remote repository for the public PyPI index:
 1. Select **Create repository**.
 1. Select the **PyPI (proxy)** recipe.
 1. Provide a new name, such as `python-public`.
-1. In the **Proxy - Remote storage** field, add the following URL: `https://pypi.org/`.
+1. In the **Proxy - Remote storage** field, add the following URL:
+   `https://pypi.org/`.
 1. Select **Create repository**.
 
 Configure a remote repository for the Chainguard Libraries for Python repository:
@@ -190,9 +221,18 @@ Configure a remote repository for the Chainguard Libraries for Python repository
 1. Select **Create repository**.
 1. Select the **PyPI (proxy)** recipe.
 1. Provide a new name, such as `python-chainguard`.
-1. In the **Proxy - Remote storage**field, add the following URL: `https://libraries.cgr.dev/python/`.
-1. In **HTTP - Authentication**, set the **Authentication type** to *username* and enter the the [username and password values as retrieved with chainctl](/chainguard/libraries/access/).
+1. In the **Proxy - Remote storage**field, add the following URL:
+   `https://libraries.cgr.dev/python/`.
+1. In **HTTP - Authentication**, set the **Authentication type** to *username*
+   and enter the the [username and password values as retrieved with
+   chainctl](/chainguard/libraries/access/).
 1. Select **Create repository**. 
+
+If you want to use the separate repository with [remediated Python
+libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
+preceding steps with the name `python-chainguard-remediated`, the same
+authentication details, and the URL
+`https://libraries.cgr.dev/python-remediated/`.
 
 Finally, create a new repository group and add the two repositories:
 
@@ -203,6 +243,8 @@ Finally, create a new repository group and add the two repositories:
 1. In the section **Group - Member repositories**, move the new repositories
    `python-public` and `python-chainguard` to the right and move the
    `python-chainguard` repository to the top of the list with the arrow control.
+   If you configured the  `python-chainguard-remediated` repository, also move
+   it to the right and the top of the list.
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -16,7 +16,15 @@ toc: true
 
 ## Introduction
 
-Chainguard Libraries for Python provides enhanced security for the vast Python ecosystem by rebuilding PyPI packages with comprehensive supply chain protection and automated patching. With over 600,000 packages on the [Python Package Index (PyPI)](https://pypi.org/) serving application development, machine learning, and data science needs, Chainguard addresses the critical security challenges of depending on packages from untrusted sources by rebuilding them within the controlled Chainguard Factory environment. In addition, Chainguard eliminates security risk by remediating High and Critical vulnerabilities across older package versions where upstream maintainers are not able to prioritize fixes.
+Chainguard Libraries for Python provides enhanced security for the vast Python
+ecosystem by rebuilding PyPI packages with comprehensive supply chain protection
+and automated patching. With over 600,000 packages on the [Python Package Index
+(PyPI)](https://pypi.org/) serving application development, machine learning,
+and data science needs, Chainguard addresses the critical security challenges of
+depending on packages from untrusted sources by rebuilding them within the
+controlled Chainguard Factory environment. In addition, Chainguard eliminates
+security risk by remediating High and Critical vulnerabilities across older
+package versions where upstream maintainers are not able to prioritize fixes.
 
 Chainguard Libraries for Python enables access to a growing collection of Python
 packages rebuilt from source. New releases of common libraries or artifacts
@@ -47,13 +55,28 @@ apply:
 * Processor architecture of the runtime environment must be `x86_64` or
   `aarch64`.
 
+<a id="cve-remediation"></a>
+
 ## CVE Remediation
 
-Chaingard Libraries for Python includes [CVE Remediation](/chainguard/libraries/cve-remediation.md). This provides access to remediated library versions with high and critical CVE fixes, particularly when upstream maintainers are not able to backport fixes to older versions. Remediated libraries include a local version identifier of `+cgr.N`. For example, the `flask` library has a fix for CVE-2023-30861 in versions `1.1.2+cgr.1` and `2.0.0+cgr.1`.
+Chainguard Libraries for Python includes the [CVE
+Remediation](/chainguard/libraries/cve-remediation/) feature. Remediated
+libraries include an appended local version identifier of `+cgr.N`. Python
+package management tools interpret the `+cgr.N` suffix as a local version that
+takes precedence over versions without the version suffix during dependency
+resolution.
 
-In some cases, multiple CVEs may be remediated in a specific library version. For example, `aiohttp` has fixes for both  CVE-2024-23334 and CVE-2024-30251 in the version `3.9.1+cgr.2`. Python package management tools interpret the `+cgr.N` suffix as a local version, which takes precedence over versions without the version suffix during dependency resolution.
+For example, the `flask` library has a fix for CVE-2023-30861 available in the
+upstream codebase. Upon customer request for a specific version, the fix is
+backported to the flask versions `1.1.2` and `2.0.0` and made available in new
+versions `1.1.2+cgr.1` and `2.0.0+cgr.1`. The package management tools consider
+this versions as newer and a compatible replacement automatically.
 
-## Technical details
+In some cases, multiple CVEs may be remediated in a specific library version.
+For example, `aiohttp` has fixes for both  CVE-2024-23334 and CVE-2024-30251 in
+the version `3.9.1+cgr.2`.
+
+## Technical Details
 
 Most organizations consume Chainguard Libraries for Python through a repository
 manager such as Cloudsmith, JFrog Artifactory or Sonatype Nexus Repository. For
@@ -72,16 +95,21 @@ https://libraries.cgr.dev/python/
 https://libraries.cgr.dev/python-remediated/
 ```
 
-The first index provides all Python libraries that we build from source, without remediated versions. The second index provides remediated libraries with high and critical CVE fixes applied to older versions. The separate indexes provide users the option to decide when they want to use remediated libraries. 
+The first index provides all Python libraries that Chainguard builds from
+source, without remediated versions. The second index provides remediated
+libraries with high and critical CVE fixes applied to older versions. The
+separate indexes provide the option to make remediated versions available for
+your development or opt out of using these versions completely and continue to
+use upstream versions only.
 
 Use the URLs with your [username and password retrieved with
 chainctl](/chainguard/libraries/access/) to access the Chainguard Libraries for
 Python repository manually with a browser.
 
 After successful login, you are redirected to the `simple` sub-context at
-`https://libraries.cgr.dev/python/simple/` or `https://libraries.cgr.dev/python-remediated/simple/` 
-that allows you to inspect the available packages. The top level contains 
-an alphabetical list of packages:
+`https://libraries.cgr.dev/python/simple/` or
+`https://libraries.cgr.dev/python-remediated/simple/` that allow you to inspect
+the available packages. The top level contains an alphabetical list of packages:
 
 ```
 2captcha-python


### PR DESCRIPTION
## Type of change

### What should this PR do?

* fix broken links and grammar issue
* add clarification on backports availability for specific version
* add config for Nexus and Cloudsmith

### Why are we making this change?

Docs needed to go live earlier but we also need to address the issues. 

* part of https://github.com/chainguard-dev/internal/issues/5394
* part of https://github.com/chainguard-dev/internal/issues/5393

### What are the acceptance criteria? 

Review

### How should this PR be tested?

I will follow up with anything after testing this myself .. we just need to get this out asap for now. 