### PR TITLE
Document 'Disable URL Normalization' option for Artifactory APK repositories

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "Tutorial for setting up remote Artifactory repositories as pull-through caches for apk packages from Chainguard's package repositories."
 date: 2024-11-14T15:56:52-07:00
-lastmod: 2025-08-28T15:56:52-07:00
+lastmod: 2025-09-24T06:00:00-07:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
@@ -91,6 +91,10 @@ This takes you to a **Basic** configuration tab where you can enter the followin
 * **URL** — This must be set to `https://apk.cgr.dev/${CHAINGUARD_ORG}`, but with your organization's actual name in place of `${CHAINGUARD_ORG}`. For example, if your organization is named `example` use `https://apk.cgr.dev/example`.
 * **User Name** — This is used by Artifactory to authenticate to Chainguard and access your private APK repository. Use the pull token identity ID value you set to the `CHAINGUARD_IDENTITY_ID` variable.
 * **Password / Access Token** — This is used along with the user name to authenticate to Chainguard. Here, enter the value from `CHAINGUARD_TOKEN`. 
+
+Then, navigate to the **Advanced** configuration tab and enter the following details:
+
+* **Disable URL Normalization** - This must be enabled because, in some cases, the normalization will invalidate the URLs that packages are served from.
 
 Click the **Create Remote Repository** button to create the remote repository and return to the **Repositories** page. 
 

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -94,7 +94,7 @@ This takes you to a **Basic** configuration tab where you can enter the followin
 
 Then, navigate to the **Advanced** configuration tab and enter the following details:
 
-* **Disable URL Normalization** - This must be enabled because, in some cases, the normalization will invalidate the URLs that packages are served from.
+* **Disable URL Normalization** — This must be enabled because, in some cases, the normalization will invalidate the URLs that packages are served from.
 
 Click the **Create Remote Repository** button to create the remote repository and return to the **Repositories** page. 
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

Documentation.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

Document an additional required setting when configuring a remote repository for our APK repositories in Artifactory.

### Why are we making this change?
<!-- What larger problem does this PR address? -->

Without this setting, Artifactory fails to pull packages with a `+` character in the checksum.

We use the checksum as the object name in Cloudflare and Artifactory's normalization seemingly mangles the URL encoding when it does its normalization. This results in a 403.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

🤷 

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->

1. Follow the steps as they are currently documented to set up a remote repository for a private or public APK repository.
2. Then try to add a package with a `+` in the checksum.

Here's an example. This must be ran from a `linux/amd64` container:
```
apk add curl=8.15.0-r5
```

You can also try to fetch it directly with curl:
```
curl -u "${ARTIFACTORY_CREDENTIALS}" 'https://chainguard.jfrog.io/artifactory/rob-best-virtualapk-chainguard/x86_64/curl-8.15.0-r5.apk'
```

You should get an error like:
```
{
  "errors" : [ {
    "status" : 404,
    "message" : "Forbidden; Path: 'rob-best-virtualapk-chainguard:x86_64/curl-8.15.0-r5.apk'"
  } ]
}
```

Enable 'Disable URL Normalization' and observe that the issue is resolved.