### PR TITLE
correcting incorrect extra-packages url

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -189,7 +189,7 @@ You also have access to the public `chainguard` and `extra-packages` repositorie
 You must create two remote repositories within Artifactory — one for each public package repo — by following the same steps as before. Enter the following details for these two remote repositories: 
 
 * **Repository Key** — This is the name used to identify your remote repository. Again, you can choose whatever names you like here but this guide's examples use the names `cg-chainguard` and `cg-extras`.
-* **URL** — This must be set to `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the `chainguard` repository and `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the `extra-packages` repository.
+* **URL** — This must be set to `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the `chainguard` repository and `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/extra-packages` for the `extra-packages` repository.
     * For both of these URLs, you need to replace the `<ORGANIZATION-ID>` placeholder with your Chainguard organization's UID. You can find this by running the `chainctl iam organizations list -o table`; the UID is the value in your organization's `ID` column. Alternatively, you can find it by checking the **Settings** ⇒ **General** page in the [Chainguard Console](https://console.chainguard.dev). 
 
 You **do not** need to set any values for the **User Name** or **Password / Access Token** fields, as the public repositories do not require authentication. Keep all the remaining fields set to their default values and click the **Create Remote Repository** button. This creates the remote repository and returns you to the **Repositories** page. 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Found our documentation duplicated the `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the extra-packages url

### What should this PR do?
This PR corrects the URL

### Why are we making this change?
Correcting our documentation to reflect correct url.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
Validate the URL compared to  /etc/apk/repositories on a Chainguard image
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
I don't think so.

### How should this PR be tested?
Validate the URL compared to what we have in /etc/apk/repositories on a Chainguard image