### PR TITLE
Add further documentation on Disable URL Normalization in index.md

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -184,19 +184,25 @@ There, you will find the `sed` package listed, along with any other packages you
 
 ## Configuring Pull-Through Caches for Chainguard's Public Repositories
 
-You also have access to the public `chainguard` and `extra-packages` repositories. Also, because these repositories are public, they do not require authentication. To set up a pull-through cache for these package repositories on Artifactory, you can follow the same procedure outlined previously for the private APK repository.
+You also have access to the public `chainguard` and `extra-packages` repositories. Because these repositories are public, they do not require authentication. To set up a pull-through cache for these package repositories on Artifactory, you can follow the same procedure outlined previously for the private APK repository.
 
-You must create two remote repositories within Artifactory — one for each public package repo — by following the same steps as before. Enter the following details for these two remote repositories: 
+You must create two remote repositories within Artifactory — one for each public package repo — by following the same steps as before:
+
+1. On the Repositories page, click the **Create a Repository** button.
+2. Select the **Remote** option.
+3. In the **Select Package Type** window, select **Alpine**.
+
+Enter the following details for the two remote repositories: 
 
 * **Repository Key** — This is the name used to identify your remote repository. Again, you can choose whatever names you like here but this guide's examples use the names `cg-chainguard` and `cg-extras`.
 * **URL** — This must be set to `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the `chainguard` repository and `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/extra-packages` for the `extra-packages` repository.
     * For both of these URLs, you need to replace the `<ORGANIZATION-ID>` placeholder with your Chainguard organization's UID. You can find this by running the `chainctl iam organizations list -o table`; the UID is the value in your organization's `ID` column. Alternatively, you can find it by checking the **Settings** ⇒ **General** page in the [Chainguard Console](https://console.chainguard.dev). 
 
-You **do not** need to set any values for the **User Name** or **Password / Access Token** fields, as the public repositories do not require authentication. Keep all the remaining fields set to their default values and click the **Create Remote Repository** button. This creates the remote repository and returns you to the **Repositories** page. 
+You **do not** need to set any values for the **User Name** or **Password / Access Token** fields, as the public repositories do not require authentication.
 
-In both remote repositories created, navigate to the **Advanced** configuration tab and enter the following details:
+Next, for both repositories, navigate to the **Advanced** configuration tab and check the **Disable URL Normalization** option. This will prevent URL normalization from invalidating the URLs that packages are served from.
 
-* **Disable URL Normalization** — This must be enabled because, in some cases, the normalization will invalidate the URLs that packages are served from.
+Keep all the remaining fields set to their default values and click the **Create Remote Repository** button. This creates the remote repository and returns you to the **Repositories** page. 
 
 After creating both repositories, generate and retrieve a token for each one as you did for the `cg-private` remote repository:
 
@@ -250,7 +256,7 @@ If you run into issues when trying to pull from Chainguard's package repositorie
     * If necessary, ensure that you've set the correct UID for your organization in the URL field.
 * It may help to [clear the Artifactory cache](https://jfrog.com/help/r/artifactory-cleanup-best-practices/clearing-an-oversized-cache).
 * It could be that your Artifactory repository was misconfigured. In this case, create and configure a new Remote Artifactory repository to test with.
-* If you see `package mentioned in index not found`, it usually means Artifactory or a CDN is normalizing/rewriting APK URLs (stripping query strings, collapsing path segments, or altering tokens), so enable Artifactory's **"Disable URL Normalization"** to preserve exact filenames and tokens. 
+* If your output returns `package mentioned in index not found`, it usually means Artifactory or a CDN is normalizing or rewriting APK URLs (often by stripping query strings, collapsing path segments, or altering tokens). To prevnt this, ensure that Artifactory's **Disable URL Normalization** option is checked in order to preserve exact filenames and tokens. 
 
 
 ## Learn More

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -194,6 +194,10 @@ You must create two remote repositories within Artifactory — one for each publ
 
 You **do not** need to set any values for the **User Name** or **Password / Access Token** fields, as the public repositories do not require authentication. Keep all the remaining fields set to their default values and click the **Create Remote Repository** button. This creates the remote repository and returns you to the **Repositories** page. 
 
+In both remote repositories created, navigate to the **Advanced** configuration tab and enter the following details:
+
+* **Disable URL Normalization** — This must be enabled because, in some cases, the normalization will invalidate the URLs that packages are served from.
+
 After creating both repositories, generate and retrieve a token for each one as you did for the `cg-private` remote repository:
 
 1. On the Repositories page, find both remote repositories you just created.
@@ -246,6 +250,7 @@ If you run into issues when trying to pull from Chainguard's package repositorie
     * If necessary, ensure that you've set the correct UID for your organization in the URL field.
 * It may help to [clear the Artifactory cache](https://jfrog.com/help/r/artifactory-cleanup-best-practices/clearing-an-oversized-cache).
 * It could be that your Artifactory repository was misconfigured. In this case, create and configure a new Remote Artifactory repository to test with.
+* If you see `package mentioned in index not found`, it usually means Artifactory or a CDN is normalizing/rewriting APK URLs (stripping query strings, collapsing path segments, or altering tokens), so enable Artifactory's **"Disable URL Normalization"** to preserve exact filenames and tokens. 
 
 
 ## Learn More


### PR DESCRIPTION
Add Disable URL normalization in docs under under Pull Through for Public repos and Debugging section for more visibility and instruction

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
PR clarifies the cause of the package mentioned in index not found error when using Artifactory as a pull-through cache for Chainguard APK repos

### Why are we making this change?
Users and myself just found out about this and have been confused. That confusion leads to misconfigured remote repos and failed apk downloads. I have included this setting under Pull Through Cache for Public Repos and added to Debugging to prevent further problems associated with this setting. 

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->