### PR TITLE
Adding Annotations info + chainctl 'save-as' info

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -15,22 +15,22 @@ weight: 010
 toc: true
 ---
 
-Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) is a tool that allows customers to create customized containers with extra packages added. This enables customers to reduce their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs.
+Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) is a tool that allows customers to create customized containers with extra packages and annotations added. This enables customers to reduce their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs.
 
 You can use [`chainctl`, Chainguard's command-line interface tool](/chainguard/chainctl/), to further customize your Custom Assembly builds and retrieve information about them. This guide provides an overview of the relevant `chainctl` commands and outlines how you can edit the configuration of Custom Assembly containers, as well as retrieve a list of a customized image's builds and its build logs.
 
 > **Note**: This tutorial highlights using `chainctl` to interact with Custom Assembly resources. However, you can also interact with Custom Assembly using [the Chainguard console](/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/), as well as [the Chainguard API](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/).
 
 
-## Editing a Customized Container Image
+## Adding Packages to a Customized Container Image
 
 To edit one of your organization's Custom Assembly container images, you can run the `chainctl image repo build edit` command:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CUSTOMIZED_CONTAINER
+chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
 ```
 
-This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of your customized image. If you omit these arguments, `chainctl` will prompt you to select your organization and customized image interactively.
+This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
 
 This command will open up a file with your machine's default text editor. This file will contain a structure like the following:
 
@@ -54,7 +54,7 @@ Before applying the change, `chainctl` will outline the changes you made and pro
 -  - wget
 +  - bash
  
-Applying build config to custom-node
+Applying build config to $CONTAINER
 Are you sure?
 Do you want to continue? [y,N]:
 ```
@@ -78,32 +78,94 @@ EOF
 Then include this file in the `apply` command by adding the `-f` argument:
 
 ```shell
-chainctl image repo build apply -f build.yaml --parent chainguard.edu --repo custom-assembly --yes
+chainctl image repo build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
 ```
 
 This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:
 
 ```
 Applying build config to custom-assembly
-  (*v1.CustomOverlay)(Inverse(protocmp.Transform, protocmp.Message{
-  	"@type": s"chainguard.platform.registry.CustomOverlay",
-  	"contents": protocmp.Message{
-  		"@type": s"chainguard.platform.registry.ImageContents",
-  		"packages": []string{
-- 			"wolfi-base",
-+ 			"bash",
-- 			"go",
-+ 			"curl",
-+ 			"mysql",
-  		},
-  	},
-  }))
+  (*v1.CustomOverlay)(Inverse(protocmp.Transform, protocmp.Message{
+      "@type": s"chainguard.platform.registry.CustomOverlay",
+      "contents": protocmp.Message{
+          "@type": s"chainguard.platform.registry.ImageContents",
+          "packages": []string{
+-             "wolfi-base",
++             "bash",
+-             "go",
++             "curl",
++             "mysql",
+          },
+      },
+  }))
 
 Are you sure?
 Do you want to continue? [y,N]: 
 ```
 
 This approach is useful in cases where you would prefer to avoid any kind of interactivity, as in a CI/CD or other automation system.
+
+### Using the `--save-as` option
+
+> **Note**: The Custom Assembly `--save-as` option is currently in beta. [Contact us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) if you'd like to access this feature during the beta period.
+
+When customizing a Chainguard Container with Custom Assembly, you have the option to either customize the image itself or create a new image based on the original with your customizations applied to it.
+
+For example, say your organization has access to Chainguard's [`node` container image](https://images.chainguard.dev/directory/image/node/versions). If you use Custom Assembly to customize the `node` image without creating a new image, then the customizations applied to it will also apply to any users in your organization that are already consuming the image. Anyone who runs `docker pull cgr.dev/example.come/node` will download the customized image instead of the original, uncustomized one.
+
+By creating a new image with Custom Assembly, you can customize the image without impacting any of the users or workflows already consuming it. You could also create multiple customized images based on the `node` container image to support specific functions.
+
+To use `chainctl` to create new customized container images with Custom Assembly, you must include the `--save-as` option, like this:
+
+```shell
+chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER --save-as $NEW_NAME
+```
+
+The following example command will create a new image named `custom-node` after applying the customizations:
+
+```shell
+chainctl image repo build edit --parent example.com --repo node --save-as custom-node
+```
+
+Following this example, the new container image would be accessible from the following URL:
+
+```url
+cgr.dev/example.com/custom-node
+```
+
+Note that you **must** pass the new image's name when using the `--save-as` option; `chainctl` will return an error if you don't include a new name. Additionally, you can only use this option with the `edit` subcommand; you cannot create a new image declaratively using the `apply` subcommand.
+
+
+## Adding Custom Annotations
+
+Chainguard Containers include metadata in the form of *annotations* (also commonly referred to as "*labels*"). These annotations provide important information about the container image's origin, contents, and characteristics. 
+
+With Custom Assembly, you can add custom annotations to your Chainguard Containers using `chainctl`. The process is the same as the one outlined previously for adding packages. First run a command like the following:
+
+```shell
+chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+```
+
+In the text editor, add an `annotations` section to the bottom of the file like the following example:
+
+```
+contents:
+  packages:
+    - jq
+    - git
+    - curl
+
+annotations:
+  "com.example.team": "platform-team"
+  "com.example.build-timestamp": "2025-10-15T10:30:00Z"
+```
+
+After saving and confirming these changes, Custom Assembly will add two custom annotations to the container image.
+
+You can also apply custom annotations declaratively using the `apply` subcommand, as outlined previously.
+
+Note that Custom Assembly blocks `org.opencontainers` and `dev.chainguard` annotations from being changed. 
+
 
 ## Retrieving Information about Custom Assembly Containers
 
@@ -134,25 +196,25 @@ chainctl image repo build logs --parent $ORGANIZATION --repo $REPO
 This command will prompt you to select the build report you want to view. These are organized in reverse chronological order by the time of each build:
 
 ```
-	Select a build report to view logs:                                                                          	 
-                                                                                                                 	 
-	Wed, 16 Apr 2025 16:36:52 PDT - Wed, 16 Apr 2025 16:37:08 PDT Success (18-dev, 18.20-dev, 18.20.8-dev)       	 
-  > Wed, 16 Apr 2025 16:36:45 PDT - Wed, 16 Apr 2025 16:37:00 PDT Success (20-dev, 20.19-dev, 20.19.0-dev)       	 
-	Wed, 16 Apr 2025 16:36:42 PDT - Wed, 16 Apr 2025 16:36:52 PDT Success (18, 18.20, 18.20.8)                   	 
-	Wed, 16 Apr 2025 16:36:41 PDT - Wed, 16 Apr 2025 16:36:51 PDT Success (22-slim, 22.14-slim, 22.14.0-slim)    	 
-	Wed, 16 Apr 2025 16:36:32 PDT - Wed, 16 Apr 2025 16:36:57 PDT Success (22-dev, 22.14-dev, 22.14.0-dev)       	 
-	Wed, 16 Apr 2025 16:36:32 PDT - Wed, 16 Apr 2025 16:36:44 PDT Success (20-slim, 20.19-slim, 20.19.0-slim)    	 
-	Wed, 16 Apr 2025 16:36:29 PDT - Wed, 16 Apr 2025 16:36:41 PDT Success (23-slim, 23.11-slim, 23.11.0-slim)    	 
-	Wed, 16 Apr 2025 16:36:19 PDT - Wed, 16 Apr 2025 16:36:29 PDT Success (23, 23.11, 23.11.0, latest)           	 
-	Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:42 PDT Success (23-dev, 23.11-dev, 23.11.0-dev, latest-dev)
-	Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:31 PDT Success (20, 20.19, 20.19.0)                   	 
-	Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:31 PDT Success (22, 22.14, 22.14.0)                   	 
-	Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:18 PDT Success (18-slim, 18.20-slim, 18.20.8-slim)    	 
-	Wed, 16 Apr 2025 16:35:35 PDT - Wed, 16 Apr 2025 16:35:47 PDT Success                                        	 
-                                                                                                                 	 
-	••••••••••••••                                                                                               	 
-                                                                                                                 	 
-	↑/k up • ↓/j down • / filter • q quit • ? more  
+    Select a build report to view logs:                                                                               
+                                                                                                                      
+    Wed, 16 Apr 2025 16:36:52 PDT - Wed, 16 Apr 2025 16:37:08 PDT Success (18-dev, 18.20-dev, 18.20.8-dev)            
+  > Wed, 16 Apr 2025 16:36:45 PDT - Wed, 16 Apr 2025 16:37:00 PDT Success (20-dev, 20.19-dev, 20.19.0-dev)            
+    Wed, 16 Apr 2025 16:36:42 PDT - Wed, 16 Apr 2025 16:36:52 PDT Success (18, 18.20, 18.20.8)                        
+    Wed, 16 Apr 2025 16:36:41 PDT - Wed, 16 Apr 2025 16:36:51 PDT Success (22-slim, 22.14-slim, 22.14.0-slim)         
+    Wed, 16 Apr 2025 16:36:32 PDT - Wed, 16 Apr 2025 16:36:57 PDT Success (22-dev, 22.14-dev, 22.14.0-dev)            
+    Wed, 16 Apr 2025 16:36:32 PDT - Wed, 16 Apr 2025 16:36:44 PDT Success (20-slim, 20.19-slim, 20.19.0-slim)         
+    Wed, 16 Apr 2025 16:36:29 PDT - Wed, 16 Apr 2025 16:36:41 PDT Success (23-slim, 23.11-slim, 23.11.0-slim)         
+    Wed, 16 Apr 2025 16:36:19 PDT - Wed, 16 Apr 2025 16:36:29 PDT Success (23, 23.11, 23.11.0, latest)                
+    Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:42 PDT Success (23-dev, 23.11-dev, 23.11.0-dev, latest-dev)
+    Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:31 PDT Success (20, 20.19, 20.19.0)                        
+    Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:31 PDT Success (22, 22.14, 22.14.0)                        
+    Wed, 16 Apr 2025 16:36:09 PDT - Wed, 16 Apr 2025 16:36:18 PDT Success (18-slim, 18.20-slim, 18.20.8-slim)         
+    Wed, 16 Apr 2025 16:35:35 PDT - Wed, 16 Apr 2025 16:35:47 PDT Success                                             
+                                                                                                                      
+    ••••••••••••••                                                                                                    
+                                                                                                                      
+    ↑/k up • ↓/j down • / filter • q quit • ? more  
 
 ```
 

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -121,13 +121,13 @@ To use `chainctl` to create new customized container images with Custom Assembly
 chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER --save-as $NEW_NAME
 ```
 
-The following example command will create a new image named `custom-node` after applying the customizations:
+The following example command creates a new image named `custom-node` after applying the customizations:
 
 ```shell
 chainctl image repo build edit --parent example.com --repo node --save-as custom-node
 ```
 
-Following this example, the new container image would be accessible from the following URL:
+Once you run this example, the new container image would be accessible from the following URL:
 
 ```url
 cgr.dev/example.com/custom-node

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -138,7 +138,7 @@ Note that you **must** pass the new image's name when using the `--save-as` opti
 
 ## Adding Custom Annotations
 
-Chainguard Containers include metadata in the form of *annotations* (also commonly referred to as "*labels*"). These annotations provide important information about the container image's origin, contents, and characteristics. 
+Chainguard Containers include metadata in the form of *annotations*. These annotations provide important information about the container image's origin, contents, and characteristics. 
 
 With Custom Assembly, you can add custom annotations to your Chainguard Containers using `chainctl`. The process is the same as the one outlined previously for adding packages. First run a command like the following:
 

--- a/content/chainguard/chainguard-images/features/ca-docs/faq.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/faq.md
@@ -12,7 +12,7 @@ images: []
 menu:
   docs:
     parent: "features"
-    identifier: "Custom Assembly Introduction"
+    identifier: "Custom Assembly FAQs"
 weight: 002
 toc: true
 ---

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -124,15 +124,16 @@ Chainguard Containers follow the [Open Container Initiative (OCI) Image Specific
 * `org.opencontainers.image.vendor`: The distributing organization, always set to `Chainguard`
 * `org.opencontainers.image.created`: Timestamp indicating when the image was built; specifically, this annotation is calculated from the build time of the most recently built package within the container image
 
-In addition to the standard OCI annotations, Chainguard sets custom annotations (which begin with `dev.chainguard` instead of `org.opencontainers`) that provide additional context about the container image. However, the `dev.chainguard` labels are an internal implementation detail that support Chainguard platform features. They are not set universally across all Chainguard Containers and can change from time to time. 
+In addition to the standard OCI annotations, Chainguard sets custom annotations (which begin with `dev.chainguard` instead of `org.opencontainers`) that provide additional context about the container image:
+
+* `dev.chainguard.package.main`: The name of the primary package in the image. This may change between different versions of an image. In some situations, it may also be empty. 
 
 ### Retrieving annotation information
 
-You can inspect a Chainguard Container's annotations using the `docker inspect` command. The following example uses [`jq`](https://jqlang.org/), a command-line JSON processor, to filter the output to only show the `apko` image's annotations:
+You can inspect image annotations using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane). This section's examples uses [`jq`](https://jqlang.org/), a command-line JSON processor, to filter the output to only show the relevant information:
 
 ```shell
-docker pull cgr.dev/chainguard/apko:latest
-docker inspect cgr.dev/chainguard/apko:latest | jq '.[].Config.Labels'
+crane manifest cgr.dev/chainguard/apko:latest | jq -r .annotations
 ```
 
 This will output all the annotations set on the image:
@@ -148,13 +149,24 @@ This will output all the annotations set on the image:
 }
 ```
 
-You can also inspect image annotations using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane):
+Chainguard also sets these annotation values as *labels*. In the context of OCI specifications, labels are similar to annotations but the two are ultimately distinct. [This blog post](https://adrianmouat.com/posts/annotations-and-labels-in-container-images/) outlines the differences between the two.
+
+You can also inspect a Chainguard Container's labels using the `crane config` command:
 
 ```shell
 crane config cgr.dev/chainguard/apko:latest | jq '.config.Labels'
 ```
 
-This returns the same annotation information as the `docker inspect` command, but without requiring you to download the container image beforehand.
+This returns the same output as the previous `crane` command. 
+
+Lastly, you can use the `docker inspect` command to inspect a container image's labels:
+
+```shell
+docker pull cgr.dev/chainguard/apko:latest
+docker inspect cgr.dev/chainguard/apko:latest | jq '.[].Config.Labels'
+```
+
+Again, this returns the same information as before. However, using `docker inspect` requires you to download the container image beforehand.
 
 ### Adding container image annotations
 

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -130,7 +130,7 @@ In addition to the standard OCI annotations, Chainguard sets custom annotations 
 
 ### Retrieving annotation information
 
-You can inspect image annotations using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane). This section's examples uses [`jq`](https://jqlang.org/), a command-line JSON processor, to filter the output to only show the relevant information:
+You can inspect image annotations using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane). This section's examples use [`jq`](https://jqlang.org/), a command-line JSON processor, to filter the output to only show the relevant information:
 
 ```shell
 crane manifest cgr.dev/chainguard/apko:latest | jq -r .annotations
@@ -172,6 +172,6 @@ Again, this returns the same information as before. However, using `docker inspe
 
 OCI labels are specific to a container image, not to an entire layer. This means that for base images, annotation information is often overridden later on with more accurate details after the image has been ingested. For example, the `image.author` annotation might be reset to reflect the customer consuming the container image.
 
-Some users relabel their container images after they've been ingested. As an example, it may make sense add an annotation like `com.mycompany.image.source=chainguard` to your Chainguard Containers; this would allow you to filter for all the container images provided by Chainguard at `mycompany`. 
+Some users relabel their container images after they've been ingested. As an example, you may wish to add an annotation like `com.mycompany.image.source=chainguard` to your Chainguard Containers; this would allow you to filter for all the container images provided by Chainguard at `mycompany`. 
 
 Some package mirroring tools support this functionality, but we recommend using Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) tool to add custom annotations to your Chainguard Containers. Refer to our guide on [managing Custom Assembly resources with `chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#adding-custom-annotations-with-custom-assembly) for more information.


### PR DESCRIPTION
## Type of change
Documentation enhancement

This PR adds documentation for two new Custom Assembly features:
1. The `--save-as` option for creating derivative container images
2. Support for adding custom annotations to Chainguard Containers

It also adds a comprehensive "Annotations" section to the Chainguard Images overview page explaining OCI annotations and how to inspect them.

## What should this PR do?

resolves https://github.com/chainguard-dev/internal-dev/issues/20569

## Why are we making this change?

Customers need clear guidance on:
- How to create multiple customized variants of the same base image without impacting existing consumers
- How to add custom metadata/annotations to their containers for organizational tracking and filtering
- Understanding what annotations are set on Chainguard Containers and how to inspect them

These features provide more flexibility for organizations customizing Chainguard containers while maintaining separation of concerns.

## What are the acceptance criteria?

- [ ] Documentation accurately describes the `--save-as` functionality and its use cases
- [ ] Custom annotations documentation includes clear examples and explains restrictions
- [ ] New Annotations section in overview page covers both standard OCI and Chainguard-specific annotations
- [ ] Code examples are properly formatted and use consistent variable naming
- [ ] All internal links are valid and correctly formatted
- [ ] Content follows existing documentation style and tone

## How should this PR be tested?

1. Review the documentation for technical accuracy against the actual `chainctl` behavior
2. Verify that all command examples use consistent variable naming (`$ORGANIZATION`, `$CONTAINER`, etc.)
3. Check that internal links resolve correctly (especially links to Custom Assembly pages)
4. Confirm that the annotations examples match actual output from `docker inspect` and `crane config`
5. Ensure the new sections integrate smoothly with existing content flow

Preview links:

* [Annotations addition (Overview)](https://deploy-preview-2688--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/overview/#annotations)
* CA via `chainctl` updates:
    * [save-as option](https://github.com/chainguard-dev/internal-dev/issues/20569)
    * [custom annotations with CA](https://deploy-preview-2688--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#adding-custom-annotations) 