### PR TITLE
[WIP] Add info about SBOM and SLSA files for JavaScript libraries

### DIFF
--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -101,3 +101,21 @@ Alternatively, you can use the token for direct access from a build tool as
 discussed in [Build
 configuration](/chainguard/libraries/javascript/build-configuration/).
 
+## SBOM and attestation files
+
+Chainguard Libraries for JavaScript include files that contain software bill of
+material (SBOM) information. Additional files attest details about build
+infrastructure with  the [Supply-chain Levels for Software Artifacts
+(SLSA)](https://slsa.dev/) provenance information.
+
+The related files for Chainguard Libraries for JavaScript are located separately
+from the registry and the packages themselves.
+
+More tbd
+
+From FAQ
+
+* SBOMs are available in SPDX format in the `sbom.spdx.json` file.
+* Provenance is available in the files: `putument.build.json`,
+  `putument.publish.json`, `build.provenance.json`, `provenance.json` ,
+  `rebuilder.provenance.json`, and  `source.provenance.json`.


### PR DESCRIPTION
Fix https://github.com/chainguard-dev/internal/issues/5430

Currently this is still incorrect since I could not find any files in the package tarballs directly or with npm and pnpm. I will work with @indexzero and @dakaneye to get more details and document. The current internal FAQ is wrong and I will update that as well