### PR TITLE
docs: Add Karpenter integration guide for Chainguard VMs

### DIFF
--- a/content/chainguard/vms/_index.md
+++ b/content/chainguard/vms/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Chainguard VMs"
+linkTitle: "Chainguard VMs"
+description: "Chainguard VMs offer a minimal and verifiable foundation for running ephemeral workloads in cloud and on-prem hypervisor deployments, designed to complement and extend the same secure-by-default philosophy found in Chainguard Containers"
+type: "article"
+date: 2025-10-21T08:04:00+00:00
+lastmod: 2025-10-21T15:09:59+00:00
+draft: false
+weight: 021
+---

--- a/content/chainguard/vms/faq.md
+++ b/content/chainguard/vms/faq.md
@@ -40,7 +40,7 @@ Chainguard VMs are based on [Chainguard OS](https://get.chainguard.dev/chainguar
 
 ## Which Linux kernel is used in Chainguard VMs?
 
-The Chainguard Factory tracks both the stable upstream and the latest LTS (for FIPS) versions of the kernel, building from source to provide the most up-to-date and patched versions.
+The [Chainguard Factory](/chainguard/factory/overview/) tracks both the stable upstream and the latest LTS (for FIPS) versions of the kernel, building from source to provide the most up-to-date and patched versions.
 
 ## Do Chainguard VMs support in-place upgrades?
 

--- a/content/chainguard/vms/faq.md
+++ b/content/chainguard/vms/faq.md
@@ -36,7 +36,7 @@ Application VMs come pre-packaged with popular backend applications running as s
 
 ## Which operating system is used by Chainguard VMs?
 
-Chainguard VMs are based on Chainguard OS, our minimal Linux distribution initially designed to run on containers and now extended to include a kernel and other components.
+Chainguard VMs are based on [Chainguard OS](https://get.chainguard.dev/chainguard-your-os-whitepaper-0), our minimal Linux distribution initially designed to run on containers and now extended to include a kernel and other components.
 
 ## Which Linux kernel is used in Chainguard VMs?
 

--- a/content/chainguard/vms/faq.md
+++ b/content/chainguard/vms/faq.md
@@ -1,0 +1,59 @@
+---
+title: "Chainguard VMs FAQ"
+linktitle: "FAQ"
+description: "Frequently asked questions about Chainguard VMs, including availability, supported ecosystems, compliance questions, and more"
+type: "article"
+date: 2025-10-21T08:04:00+00:00
+lastmod: 2025-10-21T15:09:59+00:00
+draft: false
+tags: ["Chainguard VMs", "FAQ"]
+menu:
+  docs:
+    parent: "vms"
+weight: 010
+toc: true
+---
+
+## Which platforms and hypervisors are Chainguard VMs available for?
+
+Chainguard VMs are available for AWS (EC2 and ECS/EKS), GCP (Compute Engine), and Azure Compute cloud environments, and also for on-prem solutions based on KVM such as QEmu, VMWare, Nutanix, among others.
+
+## What kinds of VMs are currently available?
+
+As part of our initial offering, we’re providing Container Host VMs, Base VMs, and Application VMs. This list should expand as we fine tune the product based on customer feedback.
+
+## What are Container Host VMs and which versions are available?
+
+Container Host VMs allow you to run containerized workloads on a hardened VM runtime. We currently offer container host VMs for AWS Container Services ECS and EKS, and also for native compute instances on AWS EC2, Google Compute Engine, and Azure Compute.
+
+## What are Base VMs and which versions are available?
+
+Base VMs are general purpose VMs that can be customized to suit your application needs. Current offerings include Chainguard Base, Java Base, and Python Base VM images available for native compute instances on AWS EC2, Google Compute Engine, and Azure Compute.
+
+## What are Application VMs and which versions are available?
+
+Application VMs come pre-packaged with popular backend applications running as systemd services. We currently offer Nginx, Jenkins, and Squid Proxy Application VMs available for native compute instances on AWS EC2, Google Compute Engine, and Azure Compute.
+
+## Which operating system is used by Chainguard VMs?
+
+Chainguard VMs are based on Chainguard OS, our minimal Linux distribution initially designed to run on containers and now extended to include a kernel and other components.
+
+## Which Linux kernel is used in Chainguard VMs?
+
+The Chainguard Factory tracks both the stable upstream and the latest LTS (for FIPS) versions of the kernel, building from source to provide the most up-to-date and patched versions.
+
+## Do Chainguard VMs support in-place upgrades?
+
+No, Chainguard VMs do not support in-place upgrades (e.g. via package upgrade). The upgrade strategy is based on node replacement.
+
+## Do Chainguard VMs support FIPS?
+
+Yes, Chainguard VMs support Kernel Independent FIPS.
+
+## How does FIPS work on VMs?
+
+Traditionally, FIPS in Virtual Machines is dependent on the Linux Kernel. That means that Linux Kernel’s entropy source and Cryptographic subsystem needs to be FIPS validated. Using a FIPS validated Linux Kernel allows VMs to provide FIPS graded cryptography for use cases like Disk Encryption, IPSec, KMSV, dm-verity, dm-integrity, etc.
+
+This is more relevant in on-prem environments.
+
+Chainguard VMs support kernel independent FIPS. This means that application workloads use a FIPS validated entropy source independent of the kernel. The advantage to this approach is that the certification of the entropy source does not need to be performed against a specific kernel, so customers can take advantage of new kernel features while remaining FIPS compliant. It also means that VMs no longer need to be booted in FIPS mode.  The disadvantage is that some low level operating system functions such as disk encryption, IPSEC etc.. are not able to use FIPS validated entropy. In clouds, disk volumes are encrypted and provided with FIPS validated entropy, as is network and filesystem encryption. In cloud, kernel independent FIPS is a more efficient way of servicing FIPS workloads in VMs.

--- a/content/chainguard/vms/faq.md
+++ b/content/chainguard/vms/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Chainguard VMs FAQ"
 linktitle: "FAQ"
-description: "Frequently asked questions about Chainguard VMs, including availability, supported ecosystems, compliance questions, and more"
+description: "Frequently asked questions about Chainguard VMs, including availability, supported ecosystems, compliance, and more"
 type: "article"
 date: 2025-10-21T08:04:00+00:00
 lastmod: 2025-10-21T15:09:59+00:00

--- a/content/chainguard/vms/karpenter-integration.md
+++ b/content/chainguard/vms/karpenter-integration.md
@@ -1,0 +1,297 @@
+---
+title: "Chainguard VMs with Karpenter"
+linktitle: "Karpenter"
+description: "Learn how to integrate Chainguard VMs with Karpenter for efficient node provisioning on AWS EKS using custom AMIs."
+type: "article"
+date: 2025-10-23T18:55:00+00:00
+lastmod: 2025-10-23T18:55:00+00:00
+draft: false
+tags: ["Chainguard VMs", "Karpenter", "AWS EKS", "AMI"]
+menu:
+  docs:
+    parent: "vms"
+weight: 005
+toc: true
+---
+
+## Introduction
+
+Chainguard VMs provide a secure, minimal foundation for running workloads in cloud environments. Integrating them with [Karpenter](https://karpenter.sh/) on AWS EKS allows for efficient, on-demand node provisioning using custom Chainguard AMIs. This guide covers the setup and configuration based on Karpenter v1.x, which uses `EC2NodeClass` for node management.
+
+Karpenter v1.x introduces `EC2NodeClass` to replace the deprecated `Provisioners` from earlier versions (e.g., v0.31 or older). This enables more flexible node configuration, including custom AMI selection and block device mappings.
+
+**Security Note**: This guide follows least privilege principles for IAM permissions. Always audit and minimize permissions after deployment, removing any unused access to maintain a secure posture.
+
+## Prerequisites
+
+- AWS EKS cluster with Karpenter installed (follow [official installation guide](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/))
+- AWS CLI configured with appropriate permissions
+- Access to a Chainguard AMI ID for your region (e.g., via Chainguard subscription)
+- Environment variables set: `CLUSTER_NAME`, `AWS_DEFAULT_REGION`, `KARPENTER_NAMESPACE`, `CUSTOM_AMI_ID`
+
+## AMI Verification
+
+Before configuring Karpenter, verify your Chainguard AMI details to ensure correct configuration:
+
+```bash
+# Verify AMI details (replace with your actual AMI ID and region)
+aws ec2 describe-images --image-ids ${CUSTOM_AMI_ID} --region ${AWS_DEFAULT_REGION} --query 'Images[*].{Name:Name,RootDeviceName:RootDeviceName,BlockDeviceMappings:BlockDeviceMappings,Architecture:Architecture,Description:Description}'
+```
+
+**Key details to verify:**
+- **Root Device Name**: Typically `/dev/sda1` for Chainguard AMIs
+- **Current Volume Size**: Default is usually 8Gi (you'll override this in Karpenter config)
+- **Architecture**: Ensure it matches your requirements (x86_64, arm64)
+- **Volume Type**: Usually gp3
+
+Example output:
+```json
+{
+  "Name": "chainguard-eks-1.32-dev-x86_64-20251024-0318",
+  "RootDeviceName": "/dev/sda1",
+  "BlockDeviceMappings": [
+    {
+      "DeviceName": "/dev/sda1",
+      "Ebs": {
+        "VolumeSize": 8,
+        "VolumeType": "gp3",
+        "Encrypted": false
+      }
+    }
+  ],
+  "Architecture": "x86_64",
+  "Description": "chainguard-eks-1.32-dev-x86_64-20251024-0318"
+}
+```
+
+## Installation
+
+Follow the [official Karpenter installation guide](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/) for the complete setup process. This section covers only the Chainguard-specific modifications needed.
+
+### Environment Variables
+
+Set these variables for your Chainguard integration:
+
+```bash
+export CLUSTER_NAME="your-cluster-name"
+export AWS_DEFAULT_REGION="us-west-2"
+export KARPENTER_VERSION="1.8.1"  # Use latest stable version
+export KARPENTER_NAMESPACE="karpenter"
+export CUSTOM_AMI_ID="ami-01f687414663bd721"  # Your Chainguard AMI ID
+```
+
+### IAM Permissions
+
+**Important**: The standard Karpenter CloudFormation stack may not include all permissions needed for custom AMI usage. Based on your setup, additional permissions might be required for the controller role.
+
+Add these permissions to your Karpenter controller role if you encounter access denied errors:
+
+```bash
+# Add basic permissions (if not already included in CloudFormation stack)
+aws iam put-role-policy --role-name "${CLUSTER_NAME}-karpenter" --policy-name "KarpenterEKS" --policy-document '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster",
+        "ec2:DescribeInstanceTypes"
+      ],
+      "Resource": [
+        "arn:aws:eks:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:cluster/${CLUSTER_NAME}",
+        "*"
+      ]
+    }
+  ]
+}'
+
+# Add comprehensive permissions for custom AMI operations
+aws iam put-role-policy \
+  --role-name "${CLUSTER_NAME}-karpenter" \
+  --policy-name "KarpenterCompletePermissions" \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }'
+```
+
+**Note**: Monitor CloudTrail logs for "Access Denied" errors and add only the minimum permissions needed for your specific environment.
+
+**Security**: Follow least privilege by auditing these permissions after deployment and removing any unused access.
+
+### NodeGroup Management
+
+The initial managed nodegroup created during cluster setup can coexist with Karpenter-managed nodes. For production clusters, consider keeping a small managed nodegroup for stability and core components. Only remove it if you want Karpenter to handle all node provisioning.
+
+## Configuration
+
+To integrate Chainguard VMs, configure a `NodePool` and `EC2NodeClass` in Karpenter. The key components are:
+
+- **amiSelectorTerms**: Specifies the custom Chainguard AMI.
+- **amiFamily: AL2023**: Enables automatic bootstrap generation, simplifying setup compared to `amiFamily: Custom`.
+- **blockDeviceMappings**: Defines the root volume size and type (e.g., 100Gi gp3 for the Chainguard AMI).
+
+Here's the example configuration:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r", "t"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: NotIn
+          values: ["metal"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: chainguard-eks
+  expireAfter: 720h  # 30 days
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: chainguard-eks
+spec:
+  amiFamily: AL2023
+  role: "KarpenterNodeRole-${CLUSTER_NAME}"
+  amiSelectorTerms:
+    - id: "${CUSTOM_AMI_ID}"
+  blockDeviceMappings:
+    - deviceName: /dev/sda1  # Chainguard AMI root device name (verify with: aws ec2 describe-images --image-ids <AMI_ID>)
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+```
+
+Apply the configuration using:
+
+```bash
+cat <<EOF | envsubst | kubectl apply -f -
+# Paste the YAML above
+EOF
+```
+
+## Key Learnings and Notes
+
+- **AMI Selection**: Use `amiSelectorTerms` to specify your Chainguard AMI. This is required for custom AMIs and ensures Karpenter provisions nodes with the correct image.
+- **amiFamily: AL2023**: This setting automatically handles the bootstrap process, making it easier than `amiFamily: Custom`, where you must manage bootstrapping manually.
+- **Block Device Mappings**: The `blockDeviceMappings` in `EC2NodeClass` allows customization of the root volume. For Chainguard AMIs, the `deviceName` is `/dev/sda1` (the AMI's root device name). You can specify the size (e.g., 100Gi) and volume type (gp3). Always verify the AMI's root device name before configuration using: `aws ec2 describe-images --image-ids <AMI_ID>`.
+- **Version Compatibility**: This setup is based on Karpenter v1.8. Older versions (e.g., v0.32) used `Provisioners`, which are deprecated. Ensure your cluster is updated for `EC2NodeClass` support.
+- **Node Expiration**: The `expireAfter: 720h` setting in the NodePool ensures nodes are replaced after 30 days, aligning with Chainguard VM best practices for node replacement over in-place upgrades.
+
+## Verification
+
+After applying the configuration, verify that nodes are provisioned correctly and the file system aligns with your settings.
+
+Check node details:
+
+```bash
+kubectl get nodes
+```
+
+To confirm the root volume size, query the node stats (replace with your node IP):
+
+```bash
+kubectl get --raw /api/v1/nodes/<node-ip>/proxy/stats/summary | jq '{node_fs: .node.fs, runtime_fs: .runtime.fs, rootfs: .node.rootfs}'
+```
+
+Expected output for a 100Gi volume:
+
+```json
+{
+  "node_fs": {
+    "time": "2025-10-22T22:58:07Z",
+    "availableBytes": 102086111232,
+    "capacityBytes": 106233311232,
+    "usedBytes": 4147200000,
+    "inodesFree": 51874115,
+    "inodes": 51904496,
+    "inodesUsed": 30381
+  },
+  "runtime_fs": null,
+  "rootfs": null
+}
+```
+
+The `capacityBytes` should reflect approximately 100Gi (106,233,311,232 bytes ≈ 100 GiB).
+
+## Troubleshooting
+
+### Common Issues
+
+- **Device Name Mismatch**: Always verify the Chainguard AMI's root device name before configuration. Chainguard AMIs typically use `/dev/sda1` as the root device. Verify using:
+  ```bash
+  # Check AMI details before configuration
+  aws ec2 describe-images --image-ids <AMI_ID> --region <region> --query 'Images[*].{RootDeviceName:RootDeviceName,BlockDeviceMappings:BlockDeviceMappings,ImageId:ImageId}'
+
+  # Alternative: Check from running instance
+  aws ec2 describe-instances --instance-ids <instance-id> --region <region> --query 'Reservations[*].Instances[*].{RootDeviceName:RootDeviceName,BDM:BlockDeviceMappings,ImageId:ImageId}'
+  ```
+
+- **NodeClaim Cleanup**: If nodes fail to provision, clean up stuck NodeClaims:
+  ```bash
+  kubectl get nodeclaims.karpenter.sh -A -o name | xargs -I{} kubectl delete {}
+  ```
+
+- **IAM Permissions**: Verify the Karpenter controller role has sufficient permissions for custom AMI operations. The standard CloudFormation stack may not include all permissions needed for custom AMI usage. Additional permissions might be required for `ec2:DescribeImages`, `ec2:DescribeInstances`, and other read-only operations. Check CloudTrail logs for "Access Denied" errors and add only the minimum required permissions following least privilege principles.
+
+### Verification Commands
+
+Check if Chainguard AMI is being used:
+```bash
+# Get node and instance mapping
+kubectl get nodes -o wide
+
+# Get instance ID and check AMI
+aws ec2 describe-instances --instance-ids <instance-id> --region <region> --query 'Reservations[*].Instances[*].ImageId' --output text
+```
+
+Check root volume configuration:
+```bash
+kubectl get --raw /api/v1/nodes/<node-ip>/proxy/stats/summary | jq '{node_fs: .node.fs, runtime_fs: .runtime.fs, rootfs: .node.rootfs}'
+```
+
+For more details on Karpenter, refer to the [official documentation](https://karpenter.sh/).

--- a/content/chainguard/vms/overview.md
+++ b/content/chainguard/vms/overview.md
@@ -1,0 +1,75 @@
+---
+title: "Chainguard VMs Overview"
+linktitle: "VMs Overview"
+description: "Chainguard VMs are designed for minimalism, security, and operational clarity."
+type: "article"
+date: 2025-10-21T08:04:00+00:00
+lastmod: 2025-10-21T15:09:59+00:00
+draft: false
+tags: ["Chainguard VMs", "Overview"]
+menu:
+  docs:
+    parent: "vms"
+weight: 001
+toc: true
+---
+
+Chainguard VMs offer a minimal and verifiable foundation for running ephemeral workloads in cloud and on-prem hypervisor deployments, designed to complement and extend the same secure-by-default philosophy found in [Chainguard Containers](https://edu.chainguard.dev/chainguard/chainguard-images/overview/). With a strong focus on rapid CVE remediation and a small attack surface, Chainguard VMs are purpose-built to service the target workload and include only the packages that are essential for its operation.
+
+Built in the Chainguard Factory, Chainguard VMs benefit from a highly automated, secure-by-design build pipeline that ensures consistent, reproducible artifacts. This streamlined process enables the delivery of VM images that are continuously updated to eliminate known vulnerabilities.
+
+## Why Chainguard VMs
+
+Unlike traditional virtual machines, which are often burdened with legacy components, unnecessary packages, and opaque dependency chains, Chainguard VMs are designed for minimalism, security, and operational clarity. Based on Chainguard OS, Chainguard VMs include a kernel that closely tracks the upstream Linux stable tree, ensuring timely updates and compatibility, along with a minimal `systemd` for service management. Consistent with the principle of minimalism, only the essential systemd units required to support the VM’s intended workload are included. Every component is fully traceable, with SLSA guarantees and SBOMs generated at every step, providing end-to-end transparency and helping prevent CVEs from ever entering your environment.
+
+For platform engineers and DevOps teams, this means:
+
+* **Fewer patching cycles**: With no unnecessary software to maintain, you reduce noise from non-actionable CVEs and focus only on what matters.
+* **Improved boot and runtime security**: Minimal, hardened images reduce the chances of privilege escalation, kernel exploits, and lateral movement.
+* **Operational consistency**: The same secure-by-default toolchain that powers Chainguard Containers now extends to your VMs, making it easier to manage and audit infrastructure uniformly across environments.
+
+## VMs and Containers Compared
+
+To understand the applicability of Chainguard VMs in your organization, it might be helpful to compare its features with Chainguard Containers. In a nutshell, the main differences come from the fact that Chainguard VMs boot from and run with their own hardened kernel as part of Chainguard OS, while Chainguard Containers rely on the host system's kernel.
+
+| Feature | Chainguard Container                                   | Chainguard VM                                                                               |
+| :---- |:-------------------------------------------------------|:--------------------------------------------------------------------------------------------|
+| Includes Kernel? | **No** – uses host’s kernel                            | **Yes** – ships and boots with its own hardened kernel                                      |
+| Environment | Userspace only, isolated via namespaces & cgroups      | Full OS, boots in VM with kernel, init, userspace                                           |
+| Boot Process | Starts from container entrypoint, no bootloader/kernel | Full bootloader → kernel → init system                                                      |
+| Security Boundaries | Dependent on host kernel isolation                     | Stronger isolation via hypervisor and custom kernel controls, secure boot, SELinux policies |
+| Use Case Focus | Microservices, CI/CD, ephemeral workloads              | Secure cloud workloads, edge VMs, kernel-level policy control, high performance             |
+
+## Chainguard VM Types
+
+We currently offer 3 distinct types of virtual machine images:
+
+* **Container Host:** a versatile option to run containerized workloads, protecting how you deploy containers on underlying hosts
+* **Base:** general purpose VM base images that can be customized to suit your application needs. Current offerings include Chainguard Base, Java Base, and Python Base.
+* **Application:** pre-packaged with popular backend applications running as systemd services. We currently offer Nginx, Jenkins, and Squid Proxy Application VMs.
+
+## Availability
+
+Chainguard VMs are currently available for the following platforms / hypervisors:
+
+* Google Cloud Platform (Compute Engine)
+* AWS (EC2, ECS, and EKS)
+* Microsoft Azure (Azure Compute)
+* QEMU/KVM (qcow2/raw)
+* VMware vSphere (VMDK)
+* Nutanix (qcow2/raw)
+
+Offering broad compatibility, Chainguard VMs allow for deployment in any environment, from public clouds to self-managed infrastructure. This flexibility facilitates one-click deployment across environments and helps prevent vendor lock-in.
+
+## Compliance and SLAs
+
+Chainguard VMs (running Chainguard OS) are intentionally designed to minimize risk, maximize transparency, and satisfy security standards such as CIS Benchmarks, FedRAMP, SOC 2, and others.
+
+* CVE remediation backed by an industry-leading SLA: 7 days for critical, 14 days for all others
+* Consistent, reproducible builds
+* Enterprise-grade support for multi-cloud and on-prem
+* Verifiable provenance for all included components
+
+## Learn More and Get Started
+
+Chainguard VMs are available through a subscription. To learn more and get started today, use [this form](https://get.chainguard.dev/vmearlyaccesswaitlist?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).

--- a/content/chainguard/vms/overview.md
+++ b/content/chainguard/vms/overview.md
@@ -30,7 +30,7 @@ For platform engineers and DevOps teams, this means:
 
 ## VMs and Containers Compared
 
-To understand the applicability of Chainguard VMs in your organization, it might be helpful to compare its features with Chainguard Containers. In a nutshell, the main differences come from the fact that Chainguard VMs boot from and run with their own hardened kernel as part of Chainguard OS, while Chainguard Containers rely on the host system's kernel.
+To understand the applicability of Chainguard VMs to your organization, it might be helpful to compare the features of Chainguard VMs to Chainguard Containers. In a nutshell, the main differences come from the fact that Chainguard VMs boot from and run with their own hardened kernel as part of Chainguard OS, while Chainguard Containers rely on the host system's kernel.
 
 | Feature | Chainguard Container                                   | Chainguard VM                                                                               |
 | :---- |:-------------------------------------------------------|:--------------------------------------------------------------------------------------------|


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Adding new documentation for Chainguard VM integration with Karpenter

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
This addresses the gap between the official Karpenter documentation (which focuses on standard AMIs) and the specific requirements for custom AMI integration. The documentation is based on real customer implementation experience and includes practical troubleshooting steps that aren't covered in the official Karpenter documentation, particularly around IAM permissions and AMI verification.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
A customer testing Chainguard EKS node VMs encountered challenges integrating with Karpenter autoscaler. I noticed that the current docs lack guidance for using Chainguard VMs with Karpenter. 

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->