### PR TITLE
Update custom-assembly.md with additional perms and --save-as updates

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -56,13 +56,13 @@ Custom Assembly is the officially supported method for extending Chainguard Cont
 
 ## Custom Assembly Permissions Requirements
 
-In order to build customized container images, you must have the appropriate permissions in relation to your Chainguard organization. Specifically, a Chainguard user must have a role with the `repo.update` capability to customize an existing image repository in place. Additionally, the `repo.create` is required if leveraging the `--save-as` feature to create a net new image repository. If you find yourself unable to customize container images with Custom Assembly, it may be that you don't have adequate permissions within your organization to do so.
+In order to build customized container images, you must have the appropriate permissions in relation to your Chainguard organization. Specifically, a Chainguard user must have a role with the `repo.update` capability to customize an existing image repository in place, and must have the `repo.create` to leverage the `--save-as` feature in ordr to create a net new image repository. If you find yourself unable to customize container images with Custom Assembly, it may be that you don't have adequate permissions within your organization to do so.
 
-As of this writing, only one of Chainguard's three main default roles (`viewer`, `editor`, and `owner`) has this capability: the `owner` role. 
+As of this writing, only one of Chainguard's three main default roles (`viewer`, `editor`, and `owner`) has these capabilities: the `owner` role. 
 
-This means that in order to use Custom Assembly, your account must be bound to the `owner` role, or to a custom role that also has the `repo.update` and optionally the `repo.create` capability.
+This means that in order to use Custom Assembly, your account must be bound to the `owner` role, or to a custom role that also has the `repo.update` and `repo.create` capabilities.
 
-To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` and `repo.create` capability:
+To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` and `repo.create` capabilities:
 
 ```shell
 chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_history.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -56,16 +56,16 @@ Custom Assembly is the officially supported method for extending Chainguard Cont
 
 ## Custom Assembly Permissions Requirements
 
-In order to build customized container images, you must have the appropriate permissions in relation to your Chainguard organization. Specifically, a Chainguard user must have a role with the `repo.update` capability. If you find yourself unable to customize container images with Custom Assembly, it may be that you don't have adequate permissions within your organization to do so.
+In order to build customized container images, you must have the appropriate permissions in relation to your Chainguard organization. Specifically, a Chainguard user must have a role with the `repo.update` capability to customize an existing image repository in place. Additionally, the `repo.create` is required if leveraging the `--save-as` feature to create a net new image repository. If you find yourself unable to customize container images with Custom Assembly, it may be that you don't have adequate permissions within your organization to do so.
 
 As of this writing, only one of Chainguard's three main default roles (`viewer`, `editor`, and `owner`) has this capability: the `owner` role. 
 
-This means that in order to use Custom Assembly, your account must be bound to the `owner` role, or to a custom role that also has the `repo.update` capability.
+This means that in order to use Custom Assembly, your account must be bound to the `owner` role, or to a custom role that also has the `repo.update` and optionally the `repo.create` capability.
 
-To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` capability:
+To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` and `repo.create` capability:
 
 ```shell
-chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.update,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
+chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_history.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
 ```
 
 After creating this custom role, you would need to bind it to any identities in your organization that you want to be able to manage Custom Assembly resources. Check out our [Overview of Roles and Role-bindings in Chainguard](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to learn more.


### PR DESCRIPTION


[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
Updates CA permissions information to align with current status of the feature.

### Why are we making this change?
1. build_history.list was not included in the example role, so an image could be customized in place, but users with this example role wouldn't be able to actually view the build history to explicitly confirm if their customization was successful.

2. with --save-as, repo.create is required because a net new image repo is created. I added some additional context about it towards the top of the permissions section and in the example role.

### What are the acceptance criteria? 
1. Review added language describing --save-as for readability.
2. Confirming custom role requiring repo.create for --save-as.
3. Confirm user can view build_history with the suggested custom role update.
@SharpRake

### How should this PR be tested?
1. Run the existing custom role example and attempt to view build_history and do --save-as. The expected result is that both operations will fail.
2. Run the suggested custom role in this PR and attempt to view build_history and do --save-as.  The expected result is that it both operations will work.