### PR TITLE
Updates to AI security doc.

### DIFF
--- a/content/ai-docs-security.md
+++ b/content/ai-docs-security.md
@@ -98,31 +98,12 @@ curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-latest/
 cosign verify-blob \
   --certificate chainguard-ai-docs.tar.gz.crt \
   --signature chainguard-ai-docs.tar.gz.sig \
-  --certificate-identity-regexp ".*" \
+  --certificate-identity "https://github.com/chainguard-dev/edu/.github/workflows/compile-public-docs.yml@refs/heads/main" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   chainguard-ai-docs.tar.gz
 
-# 3. Extract and verify contents
+# 3. Extract contents
 tar -xzf chainguard-ai-docs.tar.gz
-./verification.sh
-```
-
-### Container Verification
-
-```bash
-# 1. Verify container signature
-cosign verify ghcr.io/chainguard-dev/ai-docs:latest \
-  --certificate-identity-regexp ".*" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-# 2. Inspect without running
-docker create --name temp ghcr.io/chainguard-dev/ai-docs:latest
-docker cp temp:/docs/checksums.txt .
-docker rm temp
-
-# 3. Verify and extract
-docker run --rm ghcr.io/chainguard-dev/ai-docs:latest verify
-docker run --rm -v $(pwd):/output ghcr.io/chainguard-dev/ai-docs:latest extract /output
 ```
 
 ## Build Frequency


### PR DESCRIPTION
This PR improves the verification of the download by adding the name of action (otherwise any action could have signed, including non-chainguard ones).

I deleted section with verification script, as there is no indication of where to get this file and we've already verified it's authenticity. If the script exists and works, we should add it back.

I also deleted the container section as verification failed and I'm unsure of the use case -- why would you pull the container rather than the .gz? Happy to add back and test if we can get this working and there's a valid use case.

## Type of change
Update to docs following testing.

### What should this PR do?
Improve verification and remove unused flow.

### Why are we making this change?
Allow users to effectively verify download.

### What are the acceptance criteria? 
@ltagliaferri to check this is correct!

### How should this PR be tested?
Please test verification passes.