### PR TITLE
Add documentation around retrieving FIPS image STIG results

### DIFF
--- a/content/chainguard/chainguard-images/features/image-stigs.md
+++ b/content/chainguard/chainguard-images/features/image-stigs.md
@@ -97,11 +97,9 @@ Note that this is a highly privileged container since we're scanning a container
 
 The results of the scan will be written to a new subdirectory named `out/` within the current working directory.  The `report.html` file will contain a human-readable report of the scan results, and the `results.xml` file will contain the raw results of the scan.
 
-### Retrieve a FIPS registry image's XCCDF report
+### Retrieve a registry FIPS image's XCCDF report
 
-Chainguard also scans each FIPS image with OpenSCAP using the latest release of the aforementioned [GPOS SRG](https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_GPOS_V3R2_SRG.zip) each time an image is built.
-
-Each OpenSCAP scan produces an XCCDF report and this report is included as a signed attestation for each FIPS image (similar to SBOMs), making them retrievable and verifiable.
+Chainguard also scans every FIPS image with OpenSCAP at build time using the latest release of the aforementioned [GPOS SRG](https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_GPOS_V3R2_SRG.zip). OpenSCAP scans produce both an HTML and XCCDF report and the latter is included as a signed attestation for each FIPS image (similar to SBOMs), making them retrievable and verifiable.
 
 [Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/) — a part of the Sigstore project — supports software artifact signing, verification, and storage in an [OCI (Open Container Initiative)](/open-source/oci/what-is-the-oci/) registry, as well as the retrieval of said artifacts. This tutorial outlines how you can use the `cosign` command to retrieve a Chainguard FIPS Container's XCCDF report.
 


### PR DESCRIPTION
## Type of change

We now attest our FIPS images with STIG results in the form of an XCCDF file. This can be retrieved just like an SBOM and has come up from customers fairly often.

### What should this PR do?

This PR adds a new section to the `image-stigs` article which documents how to retrieve the build-time XCCDF reports for FIPS imgaes.

<img width="2614" height="1606" alt="CleanShot 2025-11-06 at 10 09 35@2x" src="https://github.com/user-attachments/assets/19208b36-ab4f-4cae-8e3c-f515f2fb1a1d" />

### Why are we making this change?

Customers are asking how they can view the STIG results alluded to in the console.

### What are the acceptance criteria? 

The new section renders correctly and provides the command required to retrieve the new attestation.

### How should this PR be tested?

`npm install`/`npm run start` and then navigating to the appropriate page: `http://localhost:1313/chainguard/chainguard-images/features/image-stigs/#retrieve-a-fips-registry-images-xccdf-report`