### PR TITLE
Updating ctl auth pull-token commands to use new repo flag

### DIFF
--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -38,7 +38,7 @@ To create a pull token, use:
 chainctl auth pull-token
 ```
 
-One important flag you can pass to this command is the `--repository` flag, which allows you to specify the repository type to create the pull token for. For example, specifying `--repository=apk` will bind the pull-token identity to the `apk.pull` role, allowing the identity to download packages from the private APK repository of the parent organization.
+One important flag you can pass to this command is the `--repository` flag, which allows you to specify the repository type to create the pull token for. For example, specifying `--repository=apk` binds the pull-token identity to the `apk.pull` role, allowing the identity to download packages from the private APK repository of the parent organization.
 
 To configure a Docker credential helper, which will use a token to pull images when using Docker, use:
 

--- a/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
+++ b/content/chainguard/chainctl-usage/getting-started-with-chainctl.md
@@ -38,6 +38,8 @@ To create a pull token, use:
 chainctl auth pull-token
 ```
 
+One important flag you can pass to this command is the `--repository` flag, which allows you to specify the repository type to create the pull token for. For example, specifying `--repository=apk` will bind the pull-token identity to the `apk.pull` role, allowing the identity to download packages from the private APK repository of the parent organization.
+
 To configure a Docker credential helper, which will use a token to pull images when using Docker, use:
 
 ```shell

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -42,34 +42,24 @@ export CHAINGUARD_ORG=example.org
 Next, generate a pull token:
 
 ```shell
-chainctl auth pull-token --parent=${CHAINGUARD_ORG} -o env
+chainctl auth pull-token --repository=apk --parent=${CHAINGUARD_ORG} -o env
 ```
 
-The command outputs the credentials as `export` commands you can run to set them as environment variables:
+This `chainctl` command's `--repository=apk` flag creates a role binding to bind the pull token identity the `apk.pull` role, enabling the identity to download packages from the private APK repository of the parent organization.
+
+This command's output shows the pull token credentials:
 
 ```output
-export CHAINGUARD_IDENTITY_ID=<id>
-export CHAINGUARD_TOKEN=<token>
+Creating new APK registry pull-token in example.org
+
+To use this pull token in another environment, supply the following for Basic authorization:
+
+Username: <pull-token-id>
+
+Password: <pull-token-password>
 ```
 
-Run the first of these commands to create an environment variable for the identity:
-
-```shell
-export CHAINGUARD_IDENTITY_ID=<id>
-```
-
-Be sure to note both the identity and token values to use when you create a remote Artifactory repository in the next section.
-
-With the environment variables in place, create a role binding to bind the pull token identity the `apk.pull` role:
-
-```shell
-  chainctl iam role-bindings create \
-    --parent=${CHAINGUARD_ORG} \
-    --identity=${CHAINGUARD_IDENTITY_ID} \
-    --role=apk.pull
-```
-
-This enables the identity to download packages from the private APK repository of the organization.
+Be sure to note down both the `Username` and `Password` values returned by this command, as you will need these when setting up a remote Artifactory repository.
 
 
 ## Setting Up a Pull-Through Cache for a Private APK Repository
@@ -89,8 +79,8 @@ This takes you to a **Basic** configuration tab where you can enter the followin
 
 * **Repository Key** — This is a name used to identify your remote repository, for example `cg-private`.
 * **URL** — This must be set to `https://apk.cgr.dev/${CHAINGUARD_ORG}`, but with your organization's actual name in place of `${CHAINGUARD_ORG}`. For example, if your organization is named `example` use `https://apk.cgr.dev/example`.
-* **User Name** — This is used by Artifactory to authenticate to Chainguard and access your private APK repository. Use the pull token identity ID value you set to the `CHAINGUARD_IDENTITY_ID` variable.
-* **Password / Access Token** — This is used along with the user name to authenticate to Chainguard. Here, enter the value from `CHAINGUARD_TOKEN`. 
+* **User Name** — This is used by Artifactory to authenticate to Chainguard and access your private APK repository. Use the pull token `Username` value you generated with `chainctl` in the previous step.
+* **Password / Access Token** — This is used along with the user name to authenticate to Chainguard. Here, enter the `Password` value generated returned by the `chainctl auth pull-token` command in the previous section. 
 
 Then, navigate to the **Advanced** configuration tab and enter the following details:
 
@@ -130,7 +120,7 @@ If you aren't sure of these values, you can find them in the command from the **
 sudo sh -c "echo 'https://linky:<TOKEN>@example-server-name.jfrog.io/artifactory/cg-private/<BRANCH>/<REPOSITORY>'" >> /etc/apk/repositories
 ```
 
-In this example, the Artifactory username is `linky` and the hostname is `example-hostname`.
+In this example, the Artifactory username is `linky` and the hostname is `example-server-name`.
 
 > **Note**: If your Artifactory username is an email address, you must percent-encode the `@` sign, as in `export ARTIFACTORY_USERNAME=linky%40example.com`. Here, the Artifactory username is `linky@example.com`, but it must be entered into the environment variable as `linky%40example.com`. 
 

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -59,7 +59,7 @@ Username: <pull-token-id>
 Password: <pull-token-password>
 ```
 
-Be sure to note down both the `Username` and `Password` values returned by this command, as you will need these when setting up a remote Artifactory repository.
+Be sure to note down both the `Username` and `Password` values returned by this command, as you will need these when setting up a remote repository on Artifactory.
 
 
 ## Setting Up a Pull-Through Cache for a Private APK Repository

--- a/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
@@ -104,51 +104,6 @@ apk update
 
 Following that, you can proceed to search and install packages from your private APK repository.
 
-<a id="pull-token-automation"></a>
-
-## Pull Token for Authentication in Automated Workflows
-
-Use a pull token with a custom time to live (TTL) to authenticate to your
-private APK repository. The following example creates a pull token with a TTL of
-2190 hours, equivalent to 3 months, and produces an output with `export`
-commands to set environment variables `CHAINGUARD_IDENTITY_ID` for username and
-`CHAINGUARD_TOKEN` for password values and basic authentication use.
-
-```shell
-$ chainctl auth pull-token --ttl=2190h --output=env --parent=ORGANIZATION
-export CHAINGUARD_IDENTITY_ID=45a.....424eb0
-export CHAINGUARD_TOKEN=eeyJhbGciO..........WF0IjoxN
-```
-
-* `--ttl=2190d`: set the duration for the validity of the token, defaults to
-  `720h` (equivalent to 30 days), maximum valid value is `8760h` (equivalent to
-  365 days), valid unit strings range from nanoseconds to hours and are `ns`,
-  `us`, `ms`, `s`, `m`, and `h`.
-* `--output=env`: set the command output to use export commands for environment
-  variables.
-* `--parent=ORGANIZATION`: specify the parent organization for your account as
-  provided when requesting access and replace `ORGANIZATION`.
-
-Each invocation of the command creates a new identity with access rights as a
-pull token.
-
-Combine the call with `eval` to populate the environment variables directly by
-calling `chainctl`. The following example uses the default TTL value of 30 days,
-which is suitable for regular CI runs:
-
-```shell
-eval $(chainctl auth pull-token --output env --parent=ORGANIZATION)
-```
-
-The generated pull token can be provided in the `HTTP_AUTH` environment variable
-for accessing the private APK repository:
-
-```shell
-export HTTP_AUTH=basic:apk.cgr.dev:user:${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}
-```
-
-Now you can structure your CI workflow to utilize this variable for
-authentication against the APK repository.
 
 ## Searching for and Installing Packages
 
@@ -309,6 +264,58 @@ You'll get output similar to the following, indicating that the `wget` package w
 
 . . .
 ```
+
+<a id="pull-token-automation"></a>
+
+## Pull Token for Authentication in Automated Workflows
+
+Use a pull token with a custom time to live (TTL) to authenticate to your
+private APK repository. The following example creates a pull token with a TTL of
+2190 hours, equivalent to 3 months, and produces an output with `export`
+commands to set environment variables `CHAINGUARD_IDENTITY_ID` for username and
+`CHAINGUARD_TOKEN` for password values and basic authentication use.
+
+```shell
+chainctl auth pull-token --repository=apk --ttl=2190h --output=env --parent=ORGANIZATION
+```
+```output
+export CHAINGUARD_IDENTITY_ID=45a.....424eb0
+export CHAINGUARD_TOKEN=eeyJhbGciO..........WF0IjoxN
+```
+
+* `--repository=apk`: create a role binding to bind the pull token identity the 
+`apk.pull` role, enabling the identity to download packages from the private APK 
+repository of the parent organization.
+* `--ttl=2190d`: set the duration for the validity of the token, defaults to
+  `720h` (equivalent to 30 days), maximum valid value is `8760h` (equivalent to
+  365 days), valid unit strings range from nanoseconds to hours and are `ns`,
+  `us`, `ms`, `s`, `m`, and `h`.
+* `--output=env`: set the command output to use export commands for environment
+  variables.
+* `--parent=ORGANIZATION`: specify the parent organization for your account as
+  provided when requesting access and replace `ORGANIZATION`.
+
+Each invocation of the command creates a new identity with access rights as a
+pull token.
+
+Combine the call with `eval` to populate the environment variables directly by
+calling `chainctl`. The following example uses the default TTL value of 30 days,
+which is suitable for regular CI runs:
+
+```shell
+eval $(chainctl auth pull-token --output env --parent=ORGANIZATION)
+```
+
+The generated pull token can be provided in the `HTTP_AUTH` environment variable
+for accessing the private APK repository:
+
+```shell
+export HTTP_AUTH=basic:apk.cgr.dev:user:${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}
+```
+
+Now you can structure your CI workflow to utilize this variable for
+authentication against the APK repository.
+
 
 ## Troubleshooting
 

--- a/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
@@ -303,7 +303,7 @@ calling `chainctl`. The following example uses the default TTL value of 30 days,
 which is suitable for regular CI runs:
 
 ```shell
-eval $(chainctl auth pull-token --output env --parent=ORGANIZATION)
+eval $(chainctl auth pull-token --repository=apk --output env --parent=ORGANIZATION)
 ```
 
 The generated pull token can be provided in the `HTTP_AUTH` environment variable


### PR DESCRIPTION
## Type of change
**Documentation update**

Updates documentation for `chainctl auth pull-token` commands to use the new `--repository` flag.


### What should this PR do?
resolves https://github.com/chainguard-dev/internal/issues/5523

### Why are we making this change?
The `chainctl` CLI now supports a `--repository` flag that automatically creates the necessary role binding, simplifying the authentication workflow and reducing the number of commands  users need to run.

### What are the acceptance criteria?
- [ ] All `chainctl auth pull-token` commands include the `--repository=apk` flag
- [ ] Instructions accurately reflect the new simplified workflow
- [ ] Pull token credential output format is correctly documented

### How should this PR be tested?
1. Review the updated commands in both documentation files
2. Verify the new syntax matches current `chainctl` CLI behavior
3. Confirm the removal of the manual role-binding step is correct