### PR TITLE
network requirements: add http/2

### DIFF
--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -89,4 +89,6 @@ openssl s_client -cipher @SECLEVEL=2:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES
 
 One can also replace the `cgr.dev:443` with your own deployments.
 
-Many of the end-points require support for encrypted http/2 protocol. Some decrypting proxies might not support http/2. One known popular decrypting proxy Zscaler does not currently support encrypted http/2 traffic. One may need to reconfigure Zscaler to disable "Block Undecryptable Traffic" setting. Another alternative option is to configure direct (proxy-less) access to http/2 end-points and use `no_proxy=` environment variable. Please consult documentation of your proxy software.
+Many of the endpoints for Chainguard products require support for the encrypted [HTTP/2 protocol](https://http2.github.io/). Some decrypting proxies might not support HTTP/2. 
+
+Zscaler, a popular decrypting proxy, does not currently support encrypted HTTP/2 traffic. You may need to reconfigure Zscaler to disable its "Block Undecryptable Traffic" setting. Another option is to configure direct (proxyless) access to HTTP/2 endpoints and use the `no_proxy=` environment variable. Please consult your proxy software's documentation for guidance on adjusting these settings.

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -77,11 +77,16 @@ Containers and endpoints:
   - [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627) Extended Master Secret Extenstion support
 - Signatures using P-256 with SHA-256
 - Signatures using RSA-PSS with 2048 bits and SHA-256
+- Encrypted http/2 protocol must be supported, for example by proxies if any are in use
 
 The requirements can be approximately tested with the following OpenSSL client command:
 
 ```shell
-openssl s_client -cipher @SECLEVEL=2:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384 -ciphersuites TLS_AES_256_GCM_SHA384 -groups P-256 -connect HOST:PORT
+openssl s_client -cipher @SECLEVEL=2:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384 -ciphersuites TLS_AES_256_GCM_SHA384 -groups P-256 -alpn h2 -connect cgr.dev:443 < /dev/null
 ```
 
 > Note that in the case of TLSv1.2 connectivity you must check the output for `Extended master secret: yes`.
+
+One can also replace the `cgr.dev:443` with your own deployments.
+
+Many of the end-points require support for encrypted http/2 protocol. Some decrypting proxies might not support http/2. One known popular decrypting proxy Zscaler does not currently support encrypted http/2 traffic. One may need to reconfigure Zscaler to disable "Block Undecryptable Traffic" setting. Another alternative option is to configure direct (proxy-less) access to http/2 end-points and use `no_proxy=` environment variable. Please consult documentation of your proxy software.

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -77,7 +77,7 @@ Containers and endpoints:
   - [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627) Extended Master Secret Extenstion support
 - Signatures using P-256 with SHA-256
 - Signatures using RSA-PSS with 2048 bits and SHA-256
-- Encrypted http/2 protocol must be supported, for example by proxies if any are in use
+- Support for encrypted HTTP/2 is required, including by any proxies in use
 
 The requirements can be approximately tested with the following OpenSSL client command:
 

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -87,7 +87,7 @@ openssl s_client -cipher @SECLEVEL=2:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES
 
 > Note that in the case of TLSv1.2 connectivity you must check the output for `Extended master secret: yes`.
 
-One can also replace the `cgr.dev:443` with your own deployments.
+You can replace `cgr.dev:443` with your own deployments.
 
 Many of the endpoints for Chainguard products require support for the encrypted [HTTP/2 protocol](https://http2.github.io/). Some decrypting proxies might not support HTTP/2. 
 


### PR DESCRIPTION
Chainguard Containers product endpoints require http/2 support.

Add documentations for it, proxy guidance, and update the test command
to request http/2.
