### PR TITLE
perf: Query BigQuery once per day not 8000 times

### DIFF
--- a/tools/rumble/cmd/vulns.go
+++ b/tools/rumble/cmd/vulns.go
@@ -86,7 +86,7 @@ func (v *vulnsJson) generateJSON() error {
 	}
 
 	// Extract unique CVE IDs for enrichment
-	var cveRecords []interface{}
+	cveRecords := make([]interface{}, 0, len(vulnImageMap))
 	for vulnID := range vulnImageMap {
 		cveRecords = append(cveRecords, &grype.Cve{Vulnerability: vulnID})
 	}

--- a/tools/rumble/pkg/bigquery/bigquery.go
+++ b/tools/rumble/pkg/bigquery/bigquery.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	CveQueryType        = "cve"
-	ImageScanQueryType  = "scan"
-	LegacyScanQueryType = "legacyscan"
+	CveQueryType           = "cve"
+	ImageScanQueryType     = "scan"
+	LegacyScanQueryType    = "legacyscan"
+	VulnWithImagesQueryType = "vulnwithimages"
 )
 
 type BqClient struct {
@@ -48,6 +49,12 @@ type ImageScan struct {
 	Version       string
 	Type          string
 	Severity      string
+}
+
+type VulnWithImages struct {
+	Vulnerability string
+	Image         string
+	Time          string
 }
 
 func NewBqClient(project, db string) (BqClient, error) {
@@ -84,6 +91,8 @@ func (b *BqClient) Query(q *bigquery.Query, queryType string) ([]interface{}, er
 			values = &LegacyScan{}
 		case CveQueryType:
 			values = &grype.Cve{}
+		case VulnWithImagesQueryType:
+			values = &VulnWithImages{}
 		}
 		err := it.Next(values)
 		if err == iterator.Done {

--- a/tools/rumble/pkg/bigquery/queries.go
+++ b/tools/rumble/pkg/bigquery/queries.go
@@ -26,6 +26,17 @@ GROUP BY scan.time, scan.image
 ORDER BY scan.image, scan.time
 `
 
+	AllVulnsWithImagesQuery = `
+SELECT
+  vulns.vulnerability,
+  scan.image,
+  scan.time
+FROM ` + vulnsTable + ` AS vulns
+INNER JOIN ` + summaryTable + ` AS scan
+  ON scan.id = vulns.scan_id
+ORDER BY vulns.vulnerability, scan.image, scan.time
+`
+
 	LegacyCsvQuery = `
 SELECT
 	ROW_NUMBER() OVER (ORDER BY time),


### PR DESCRIPTION
BigQuery does a full table scan unless we select partitions. We're currently querying the `rumble_vulns` view once per vulnerability, which is quadratically expensive and costing us over $500 per day.

This changes the job to do one query, and moves the grouping logic into Go.

Since everything is already entirely in memory already, I don't expect this to cause OOMs.

We still query the local SQLite table once per vulnerability, since it works, doesn't show up on our cost bill, and I want to keep this fairly contained.

```sql
with 

base as (select * from `region-us.INFORMATION_SCHEMA.JOBS` where date(creation_time) = '2025-11-23')

select
  substr(query, 40),
  count(*) as num_queries,
  sum(total_bytes_billed) as total_bytes_billed,
  6 * sum(total_bytes_billed) / (pow(1024, 4)) as cost
from base
where user_email = 'github-chainguard-academy@chainguard-academy.iam.gserviceaccount.com'
group by 1
order by 4 desc
```

| query | num_queries |total_bytes_billed | cost |
| --- | --: | --: | --: |
| SELECT scan.image, scan.time as time | 7459 |97762042445824 | 533.4843578338623 |
| WITH ruuuumble AS (	SELECT scan.image, | 36 | 704013926400 | 3.8417816162109375 |
| SELECT DISTINCT vulnerability FROM `clo" | 1 | 13106151424 | 0.071519851684570312 |
| SELECT ROW_NUMBER() OVER (ORDER BY tim | 1 | 1669332992 | 0.0091094970703125 |

## Type of change

Performance optimization.

### What should this PR do?

Reduce the number of identical BigQuery queries.

### Why are we making this change?

To reduce BigQuery costs.

### How should this PR be tested?

After we merge the PR, we should trigger a manual run of the Rumble Vulnerability Data workflow.

- [ ] Does it succeed?
- [ ] Does it generate plausibly correct data? (Someone other than me will have to check this)
- [ ] Does it result in fewer queries and fewer total bytes billed? (I'll check the BigQuery logs)
