### PR TITLE
Update doc to reflect new working procedure for authentication using pull token in automated workflow

### DIFF
--- a/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
@@ -310,7 +310,7 @@ The generated pull token can be provided in the `HTTP_AUTH` environment variable
 for accessing the private APK repository:
 
 ```shell
-export HTTP_AUTH=basic:apk.cgr.dev:${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}
+export HTTP_AUTH=basic::${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}
 ```
 
 Now you can structure your CI workflow to utilize this variable for


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Document Update.

### What should this PR do?
Update doc to reflect new working procedure for authentication using pull token in automated workflow.

### Why are we making this change?
- Old doc does not work.
- [Customer reported issue](https://chainguardhelp.zendesk.com/agent/tickets/6504) and has been investigated by engineering using [GH2780](https://github.com/chainguard-dev/customer-issues/issues/2780#issuecomment-3559467118)

### What are the acceptance criteria? 
- The [doc](https://edu.chainguard.dev/chainguard/chainguard-images/features/packages/private-apk-repos/#pull-token-for-authentication-in-automated-workflows) has references for `chainctl auth token` and `chainctl auth pull-token`
- The docs around `chainctl auth token` is good and does not need any change.
- This change is only necessary for reference around `chainctl auth pull-token`, which mistakenly add `apk.cgr.dev` in HTTP_AUTH and needs to be dropped to get working. If not done, it results in `Permission denied` as noted in [engineering ticket GH2780](https://github.com/chainguard-dev/customer-issues/issues/2780)

### How should this PR be tested?
```
]$ eval $(chainctl auth pull-token --output env --parent=optum.com)
]$ export HTTP_AUTH="basic::${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}"
]$ echo $HTTP_AUTH|wc
       1       1    1025
]$ 
]$ chainctl iam role-bindings create --parent=optum.com --identity="$CHAINGUARD_IDENTITY_ID" --role=apk.pull
]$ docker run -it --rm -e "HTTP_AUTH=$HTTP_AUTH" cgr.dev/optum.com/chainguard-base
bf2b509d3040:/# echo https://apk.cgr.dev/optum.com >> /etc/apk/repositories
bf2b509d3040:/# apk update
bf2b509d3040:/# apk search --no-cache jre
```