### PR TITLE
versions: add a section that describes how to retrieve version metadata

### DIFF
--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -132,20 +132,19 @@ To help in situations like this, Chainguard offers an end-of-life grace period f
 ## Inspecting the Product Release Lifecycle
 
 There are a number of ways that you can inspect and understand the version
-lifecycle of your Chainguard images.
+lifecycle of your Chainguard Containers.
 
 ### List Active Tags
 
 You can retrieve the list of tags that are being actively maintained for a
-Chainguard image from the output of `chainctl image repo list`.
+Chainguard cointainer image from the output of `chainctl image repo list`.
 
-For instance, this command lists the tags that are currently active for
-`python`.
+For instance, the following command lists the tags that are currently active for
+`python`:
 
 ```sh
 chainctl image repo list --repo=python -o json | jq -r '.items[].activeTags'
 ```
-
 ```output
 [
   "3",
@@ -196,17 +195,12 @@ chainctl image repo list --repo=python -o json | jq -r '.items[].activeTags'
 You can list the version information for packages that have multiple release
 tracks with `chainctl package versions list`.
 
-For instance, this command lists the active release tracks for the `python`
-package. The output also includes the date when the version will become EOL, as
-well as the date after which it will no longer be covered by the EOL grace
-period.
+The following `chainctl` command lists the active release tracks for the `python`
+package:
 
 ```sh
 chainctl package versions list python --show-active
 ```
-
-The output should look like this.
-
 ```output
  VERSION |  EOL DATE  | EOL GRACE PERIOD END DATE
 ---------|------------|---------------------------
@@ -217,17 +211,21 @@ The output should look like this.
  3.14    | 2030-10-31 | 2031-05-01
 ```
 
+This output also includes the date when the version will become EOL, as
+well as the date after which it will no longer be covered by the EOL grace
+period.
+
 Refer to the [`chainctl`
 documentation](/chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list/)
-for the full list of options that can be provided to the command.
+for the full list of options that can be passed to the command.
 
 ### EOL Grace Period API
 
 The [EOL Grace Period
 API](/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)
-provides lifecycle information about a Chainguard image's tags.
+provides lifecycle information about a Chainguard container image's tags.
 
-For instance, this snippet retrieves EOL data for the `python` image.
+For instance, the following snippet retrieves EOL data for the `python` image:
 
 ```sh
 REPO_ID=$(chainctl images repos list --repo=python --parent=${ORGANIZATION} -o json | jq -r '.items[0].id')
@@ -237,7 +235,7 @@ curl -H "Authorization: Bearer $(chainctl auth token)" \
     | jq '.'
 ```
 
-The output should look like this.
+This command will return output like the following:
 
 ```output
 {
@@ -268,11 +266,11 @@ The output should look like this.
 }
 ```
 
-This tells you whether a tag is active, whether it is eligible for an EOL grace
-period and whether it is currently within its grace period.
+This output tells you whether a tag is active, whether it is eligible for an EOL grace
+period, and whether it is currently within its grace period.
 
 For full instructions on how to use the API and interpret its output, refer to
-[this page]((/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)).
+[our overview of the EOL grace period]((/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)).
 
 ### Refer to endoflife.date
 

--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2024-12-17T08:49:31+00:00
+lastmod: 2025-11-28T06:30:00+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -24,36 +24,36 @@ toc: true
 * Rapidly applying upstream patches to current releases — you can read more about this in our blog post, “[How Chainguard fixes vulnerabilities before they're detected](https://www.chainguard.dev/unchained/how-chainguard-fixes-vulnerabilities?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)”
 * Applying Chainguard patches to OSS software
 
-Upstream projects are updated frequently for many reasons, including to combat CVEs, and Chainguard ensures that the most up-to-date software is available in all Chainguard Containers. Additionally, Chainguard often identifies CVEs and other issues before scanners can detect them, so Chainguard may offer a patch to a vulnerable dependency to support Chainguard Containers with few-to-zero vulnerabilities. 
+Upstream projects are updated frequently for many reasons, including to combat CVEs, and Chainguard ensures that the most up-to-date software is available in all Chainguard Containers. Additionally, Chainguard often identifies CVEs and other issues before scanners can detect them, so Chainguard may offer a patch to a vulnerable dependency to support Chainguard Containers with few-to-zero vulnerabilities.
 
-The best way to mitigate vulnerabilities is to continually update to the latest patched releases of software, but testing and updating can take time and effort. To support flexibility and user choice, Chainguard aims to offer multiple versions of a Chainguard Container that provide the lowest number of vulnerabilities realistically possible. 
+The best way to mitigate vulnerabilities is to continually update to the latest patched releases of software, but testing and updating can take time and effort. To support flexibility and user choice, Chainguard aims to offer multiple versions of a Chainguard Container that provide the lowest number of vulnerabilities realistically possible.
 
-This document provides an overview of Chainguard’s approach to updates, releases, and versions within Chainguard Containers. For more specific guidance, please [contact us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement). 
+This document provides an overview of Chainguard’s approach to updates, releases, and versions within Chainguard Containers. For more specific guidance, please [contact us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).
 
 ## Open Source Release Tracks
 
-In order to understand how Chainguard releases Chainguard Containers, it’s first important to understand how different open source projects version and release software. This is because Chainguard Containers are built on open source software. There are generally two open source approaches: multiple releases across different versions, or a single release track. In rare cases, open source projects don’t follow a release pattern at all. 
+In order to understand how Chainguard releases Chainguard Containers, it’s first important to understand how different open source projects version and release software. This is because Chainguard Containers are built on open source software. There are generally two open source approaches: multiple releases across different versions, or a single release track. In rare cases, open source projects don’t follow a release pattern at all.
 
 ### Multiple Releases Maintained by a Given Open Source Project
 
 Popular open source projects often provide maintenance for a number of release tracks concurrently. For example, Java, Go, Postgres, and Kubernetes patch multiple release versions, each on their own defined maintenance schedule. For these types of projects, Chainguard will maintain every version track of the upstream software that receives updates from the project.
 
-### Single Release Track Maintained by a Given Open Source Project 
+### Single Release Track Maintained by a Given Open Source Project
 
 Many open source projects support only a single stream of releases that are continuously incremented; often, this is simply the latest release. In the case of a single release track, any security fix that is published will only be applied to the most recent release of the project, and the project release tags will be updated to indicate a new version is available. For this type of project, Chainguard only warrants that the latest release of the software and its corresponding version tags have the most up-to-date patches available.
 
 ## What Chainguard Supports and Maintains for Chainguard Containers
 
-There are several scenarios that define what Chainguard agrees to maintain regarding software versions in the [Chainguard Containers Directory](/chainguard/chainguard-images/how-to-use/images-directory/). All container images that Chainguard currently supports are those with upstream software that is still supported and maintained, and Chainguard patches and rebuilds these Containers daily. If you have purchased a container image during its lifecycle that is no longer being supported upstream, you will still be able to access this Container, _but_ Chainguard will not be patching or rebuilding this Container and it will start to accrue CVEs. It is recommended to upgrade to an actively maintained version. 
+There are several scenarios that define what Chainguard agrees to maintain regarding software versions in the [Chainguard Containers Directory](/chainguard/chainguard-images/how-to-use/images-directory/). All container images that Chainguard currently supports are those with upstream software that is still supported and maintained, and Chainguard patches and rebuilds these Containers daily. If you have purchased a container image during its lifecycle that is no longer being supported upstream, you will still be able to access this Container, _but_ Chainguard will not be patching or rebuilding this Container and it will start to accrue CVEs. It is recommended to upgrade to an actively maintained version.
 
-The table provides some example scenarios to help illustrate our approach. 
+The table provides some example scenarios to help illustrate our approach.
 
-| **Category**	| **Example** | **Maintained Upstream Releases** | **Chainguard Patches** | **Chainguard No Longer Patches** | 
+| **Category**	| **Example** | **Maintained Upstream Releases** | **Chainguard Patches** | **Chainguard No Longer Patches** |
 |---------------|-------------|----------------------------------|------------------------|----------------------------------|
 | **Multiple Release Tracks** | [Go](https://images.chainguard.dev/directory/image/go/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)       | 1.23, 1.22                 | `:latest`, 1, 1.23, 1.22 | 1.23.old, 1.22.old, 1.21 and below |
-|                             | [Python](https://images.chainguard.dev/directory/image/python/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 3.13, 3.12, 3.11, 3.10, 3.9 | `:latest`, 3, 3.9 and above | 3.8 and below, 3.8.old, 3.9.old, 3.10.old, 3.11.old, 3.12.old | 
-|                             | [Postgres](https://images.chainguard.dev/directory/image/postgres/version?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 17, 16, 15, 14, 13         | `:latest`, 17, 16, 15, 14, 13 | 12 (EOL November 21, 2024) and below | 
-| **Single Release Track**    | [Cosign](https://images.chainguard.dev/directory/image/cosign/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 2                          | `:latest`, 2, 2.4 | 2.3, 2.2, 2.1, 2.0, 1.x, 0.x | 
+|                             | [Python](https://images.chainguard.dev/directory/image/python/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 3.13, 3.12, 3.11, 3.10, 3.9 | `:latest`, 3, 3.9 and above | 3.8 and below, 3.8.old, 3.9.old, 3.10.old, 3.11.old, 3.12.old |
+|                             | [Postgres](https://images.chainguard.dev/directory/image/postgres/version?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 17, 16, 15, 14, 13         | `:latest`, 17, 16, 15, 14, 13 | 12 (EOL November 21, 2024) and below |
+| **Single Release Track**    | [Cosign](https://images.chainguard.dev/directory/image/cosign/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 2                          | `:latest`, 2, 2.4 | 2.3, 2.2, 2.1, 2.0, 1.x, 0.x |
 |                             | [Bank-Vaults](https://images.chainguard.dev/directory/image/bank-vaults/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 1 | `:latest`, 1 | Any previous version tag
 | **No Release Track**        | [envoyproxy/ratelimit](https://images.chainguard.dev/directory/image/envoy-ratelimit/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | No versioned releases | `:latest` | Any previous version tag |
 
@@ -62,14 +62,14 @@ The table provides some example scenarios to help illustrate our approach.
 
 ## What Chainguard Container Versions to Expect
 
-When you use freely-available [Chainguard Starter Containers](/chainguard/chainguard-images/about/images-categories/#starter-containers), you will have access to the `:latest` version of any Container available to the public. In some cases, you will also have access to the `:latest-dev` version, which includes a shell and package manager. For example, the Python container image has both `cgr.dev/chainguard/python:latest` and `cgr.dev/chainguard/python:latest-dev`. Many of the programming languages have these options available, including the Java JDK and JRE containers, PHP, Go, Node, Ruby, and Rust. 
+When you use freely-available [Chainguard Starter Containers](/chainguard/chainguard-images/about/images-categories/#starter-containers), you will have access to the `:latest` version of any Container available to the public. In some cases, you will also have access to the `:latest-dev` version, which includes a shell and package manager. For example, the Python container image has both `cgr.dev/chainguard/python:latest` and `cgr.dev/chainguard/python:latest-dev`. Many of the programming languages have these options available, including the Java JDK and JRE containers, PHP, Go, Node, Ruby, and Rust.
 
-If you are using our enterprise Chainguard Production Containers, you will have access to more versions. The Chainguard approach is as follows: 
+If you are using our enterprise Chainguard Production Containers, you will have access to more versions. The Chainguard approach is as follows:
 
-* For **multiple-release track projects**, you will have access to major and minor versions that are actively maintained. 
+* For **multiple-release track projects**, you will have access to major and minor versions that are actively maintained.
 * For **single-release track projects**, you will receive the `:latest` tag as well as every versioned tag that is released over time.
 
-Chainguard Containers use *floating tags*. This means that a container image's tag always points to the most recent build or version within a version stream, rather than a fixed, immutable image. For example, `python:3.19` will always point to the latest version of that version stream (`3.13.9`, as of this writing), even if older tags like `3.13.8` and `3.13.7` are available. 
+Chainguard Containers use *floating tags*. This means that a container image's tag always points to the most recent build or version within a version stream, rather than a fixed, immutable image. For example, `python:3.19` will always point to the latest version of that version stream (`3.13.9`, as of this writing), even if older tags like `3.13.8` and `3.13.7` are available.
 
 ## Chainguard Patches and Maintenance
 
@@ -95,14 +95,14 @@ Bear in mind that Chainguard's Containers, although minimal, will almost always 
 
 Put simply, when you opt in to pulling `go:1.21.3-r2`, you're opting in to a consistent version of Go, and potentially floating versions of all the other packages. This means you get CVE fixes as well as patch, and minor, and even major version releases of bash, and every other package the image contains.
 
-It’s important to note that using epoch tags to "lock" to specific images is discouraged, as even specific epoch tags can change over time and may introduce breaking or functional changes. For true immutability, use [image digests](/chainguard/chainguard-images/how-to-use/container-image-digests/) instead. 
+It’s important to note that using epoch tags to "lock" to specific images is discouraged, as even specific epoch tags can change over time and may introduce breaking or functional changes. For true immutability, use [image digests](/chainguard/chainguard-images/how-to-use/container-image-digests/) instead.
 
 You can learn more about our approach by reviewing our [blog on Chainguard's container image tagging philosophy](https://www.chainguard.dev/unchained/chainguards-image-tagging-philosophy-enabling-high-velocity-updates-pt-1-of-3?utm=docs).
 
 
 ## Wolfi Packages in Chainguard Containers
 
-Chainguard Containers only contain packages that are either built and maintained internally by Chainguard or packages from the [Wolfi Project](https://github.com/wolfi-dev). These packages follow the same conventions of minimalism and rapid updates as Chainguard Containers. 
+Chainguard Containers only contain packages that are either built and maintained internally by Chainguard or packages from the [Wolfi Project](https://github.com/wolfi-dev). These packages follow the same conventions of minimalism and rapid updates as Chainguard Containers.
 
 Starting in March of 2024, Chainguard will maintain one version of each Wolfi package at a time. These will track the latest version of the upstream software in the package. Chainguard will end patch support for previous versions of packages in Wolfi. Existing packages will not be removed from Wolfi and you may continue to use them, but be aware that older packages will no longer be updated and will accrue vulnerabilities over time. The tools we use to build packages and container images remain freely available and open source in Wolfi.
 
@@ -116,7 +116,7 @@ If you are a Chainguard Production Containers user, Chainguard vulnerability and
 
 ## End of Life and End of Support Software
 
-When an open source application version is no longer maintained by the upstream project or has otherwise met its end of life (EOL), Chainguard will generally no longer provide patches to that software. While the Chainguard Production Containers organization directory will continue to have previously purchased container images available, new builds will no longer be published and vulnerabilities are expected to accumulate in those Containers over time. It is recommended to move to an up-to-date, actively maintained version. 
+When an open source application version is no longer maintained by the upstream project or has otherwise met its end of life (EOL), Chainguard will generally no longer provide patches to that software. While the Chainguard Production Containers organization directory will continue to have previously purchased container images available, new builds will no longer be published and vulnerabilities are expected to accumulate in those Containers over time. It is recommended to move to an up-to-date, actively maintained version.
 
 For software applications that maintain multiple concurrent release tracks, Chainguard will endeavor to provide [reasonable notice](/chainguard/chainguard-images/features/eol-notifications/) when a particular software release version is expected to reach EOL status, thus no longer updated.
 
@@ -128,3 +128,155 @@ No EOL notice will be provided for single-release applications where the only su
 There are cases where an organization may want to continue using a container image after it has reached end-of-life. This could be because an image reaches EOL before the organization's release schedule, or perhaps later image versions have one or more issues that prevent the organization from upgrading.
 
 To help in situations like this, Chainguard offers an end-of-life grace period for eligible Containers, allowing customers access to new builds of container images whose primary package has entered its end-of-life phase for up to six months after they have reached EOL. Refer to our [overview of the EOL Grace Period](/chainguard/chainguard-images/features/eol-gp-overview/) for more information.
+
+## Inspecting the Product Release Lifecycle
+
+There are a number of ways that you can inspect and understand the version
+lifecycle of your Chainguard images.
+
+### List Active Tags
+
+You can retrieve the list of tags that are being actively maintained for a
+Chainguard image from the output of `chainctl image repo list`.
+
+For instance, this command lists the tags that are currently active for
+`python`.
+
+```sh
+chainctl image repo list --repo=python -o json | jq -r '.items[].activeTags'
+```
+
+```output
+[
+  "3",
+  "3-dev",
+  "3.10",
+  "3.10-dev",
+  "3.10.19",
+  "3.10.19-dev",
+  "3.10.19-r2",
+  "3.10.19-r2-dev",
+  "3.11",
+  "3.11-dev",
+  "3.11.14",
+  "3.11.14-dev",
+  "3.11.14-r2",
+  "3.11.14-r2-dev",
+  "3.12",
+  "3.12-dev",
+  "3.12.12",
+  "3.12.12-dev",
+  "3.12.12-r2",
+  "3.12.12-r2-dev",
+  "3.13",
+  "3.13-dev",
+  "3.13.9",
+  "3.13.9-dev",
+  "3.13.9-r2",
+  "3.13.9-r2-dev",
+  "3.14",
+  "3.14-dev",
+  "3.14.0",
+  "3.14.0-dev",
+  "3.14.0-r8",
+  "3.14.0-r8-dev",
+  "3.9",
+  "3.9-dev",
+  "3.9.25",
+  "3.9.25-dev",
+  "3.9.25-r0",
+  "3.9.25-r0-dev",
+  "latest",
+  "latest-dev"
+]
+```
+
+### List Package Version Information
+
+You can list the version information for packages that have multiple release
+tracks with `chainctl package versions list`.
+
+For instance, this command lists the active release tracks for the `python`
+package. The output also includes the date when the version will become EOL, as
+well as the date after which it will no longer be covered by the EOL grace
+period.
+
+```sh
+chainctl package versions list python --show-active
+```
+
+The output should look like this.
+
+```output
+ VERSION |  EOL DATE  | EOL GRACE PERIOD END DATE
+---------|------------|---------------------------
+ 3.10    | 2026-10-31 | 2027-05-01
+ 3.11    | 2027-10-31 | 2028-05-01
+ 3.12    | 2028-10-31 | 2029-05-01
+ 3.13    | 2029-10-31 | 2030-05-01
+ 3.14    | 2030-10-31 | 2031-05-01
+```
+
+Refer to the [`chainctl`
+documentation](/chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list/)
+for the full list of options that can be provided to the command.
+
+### EOL Grace Period API
+
+The [EOL Grace Period
+API](/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)
+provides lifecycle information about a Chainguard image's tags.
+
+For instance, this snippet retrieves EOL data for the `python` image.
+
+```sh
+REPO_ID=$(chainctl images repos list --repo=python --parent=${ORGANIZATION} -o json | jq -r '.items[0].id')
+
+curl -H "Authorization: Bearer $(chainctl auth token)" \
+    "https://console-api.enforce.dev/registry/v1/eoltags?uidp.childrenOf=${REPO_ID}" \
+    | jq '.'
+```
+
+The output should look like this.
+
+```output
+{
+  "items": [
+    ...
+    {
+      "id": "326bcde5903252f3ae2fe01c691b5a50f7046b5d/256c7780003faa0a/f37adb295422587a",
+      "name": "3.10.16-r4-dev",
+      "mainPackageName": "python",
+      "tagStatus": "TAG_INACTIVE",
+      "mainPackageVersion": {
+        "eolDate": "2026-10-31",
+        "exists": true,
+        "fips": false,
+        "legacyLts": "",
+        "lts": false,
+        "releaseDate": "2021-10-04",
+        "version": "3.10",
+        "eolBroken": false,
+        "latestVersion": "",
+        "versionSource": null
+      },
+      "graceStatus": "GRACE_ELIGIBLE",
+      "gracePeriodExpiryDate": null
+    },
+    ...
+  ]
+}
+```
+
+This tells you whether a tag is active, whether it is eligible for an EOL grace
+period and whether it is currently within its grace period.
+
+For full instructions on how to use the API and interpret its output, refer to
+[this page]((/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)).
+
+### Refer to endoflife.date
+
+The [endoflife.date](https://endoflife.date) website lists the release tracks
+and product lifecycles of many Open Source projects. Generally the information
+on this site will align with the lifecycle of the corresponding Chainguard
+image.

--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -270,7 +270,7 @@ This output tells you whether a tag is active, whether it is eligible for an EOL
 period, and whether it is currently within its grace period.
 
 For full instructions on how to use the API and interpret its output, refer to
-[our overview of the EOL grace period]((/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api)).
+[our overview of the EOL grace period](/chainguard/chainguard-images/features/eol-gp-overview/#using-the-eol-grace-period-api).
 
 ### Refer to endoflife.date
 


### PR DESCRIPTION
Customers often want to know how they can identify the images and tags that are currently maintained in their organization.

This change adds a section to the Product Release Lifecycle page that describes some methods for retrieving lifecycle information.