### PR TITLE
assumable-ids: Add generic examples of assuming an identity

### DIFF
--- a/content/chainguard/administration/assumable-ids/assumable-ids.md
+++ b/content/chainguard/administration/assumable-ids/assumable-ids.md
@@ -144,7 +144,7 @@ chainctl iam identities delete <identity-name>
 For more detailed information on managing identities with `chainctl`, we encourage you to check out the [`chainctl` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities/).
 
 
-## Assuming an identity
+## Assuming an Identity
 
 Whether you create an identity with `chainctl` or with Terraform, Chainguard will generate a UIDP (unique identifier path) tied to the identity. You can retrieve a list of all the identities you've created — along with their UIDPs — with the following command.
 
@@ -157,8 +157,71 @@ chainctl iam identities ls -o table
   c95870ebffa72a258df087ea727ee92daf177e29/f067a9080d45a098 | sampleidentity | claim_match |             | example-group: viewer | https://token.actions.githubusercontent.com | n/a
 ```
 
-If a workflow is authorized to assume the identity — meaning that its token matches the `issuer` and `subject` specified for the identity — then it only needs to present this identification number in order to assume it.
+If a workflow is authorized to assume the identity — meaning that its token matches the `issuer` and `subject` specified for the identity — then it only needs to present this identification number and the token in order to assume it.
 
+There are a few different ways to do this.
+
+### Chainctl
+
+On some platforms, such as
+[GitHub](/chainguard/administration/assumable-ids/identity-examples/github-identity/)
+or Google Cloud Platform, `chainctl` should be able to detect your credentials
+transparently, meaning you only need to provide the identity's UIDP to login.
+
+```sh
+chainctl auth login --identity <identity-id>
+```
+
+Otherwise, you will need to provide the OIDC token explicitly. This can
+either be the raw token value or a path to the token on disk.
+
+```sh
+chainctl auth login --identity <identity-id> --identity-token <identity-token>
+```
+
+Once you're logged in, you should be able to perform the operations that the
+identity has permissions for. For instance, listing repositories.
+
+```sh
+chainctl image repo list
+```
+
+Or, you can use `chainctl auth token` to retrieve a bearer token that you can
+use directly with the Chainguard API.
+
+```sh
+curl -sSf \
+    -H "Authorization: Bearer $(chainctl auth token)" \
+    https://console-api.enforce.dev/registry/v1/repos \
+    | jq -r .items[].name
+```
+
+### API
+
+If you want to interact with the API directly, without any use of `chainctl`,
+then you can exchange your platform's OIDC token for a Chainguard API token
+yourself like this. Substituting `<identity-id>` and `<identity-token>` with the
+identity's UIDP and the OIDC token, respectively.
+
+```sh
+curl -sSf \
+    -H "Authorization: Bearer <identity-token>" \
+    "https://issuer.enforce.dev/sts/exchange?aud=https://console-api.enforce.dev&identity=<identity-id>" \
+    | jq -r .token
+```
+
+This will return a token for the Chainguard API that you can use for subsequent
+requests to the API. For instance, listing repositories.
+
+```sh
+curl -sSf \
+    -H "Authorization: Bearer <api-token>" \
+    https://console-api.enforce.dev/registry/v1/repos \
+    | jq -r .items[].name
+```
+
+The API token issued by `/sts/exchange` will be valid for up to an hour. You
+will need to fetch a new token after it has expired.
 
 ## Learn More
 

--- a/content/chainguard/administration/assumable-ids/assumable-ids.md
+++ b/content/chainguard/administration/assumable-ids/assumable-ids.md
@@ -161,33 +161,33 @@ If a workflow is authorized to assume the identity — meaning that its token ma
 
 There are a few different ways to do this.
 
-### Chainctl
+### Using `chainctl`
 
 On some platforms, such as
 [GitHub](/chainguard/administration/assumable-ids/identity-examples/github-identity/)
-or Google Cloud Platform, `chainctl` should be able to detect your credentials
-transparently, meaning you only need to provide the identity's UIDP to login.
+or Google Cloud Platform, `chainctl` is able to detect your credentials
+transparently. This means you only need to provide the identity's UIDP to log in, as in this example:
 
 ```sh
 chainctl auth login --identity <identity-id>
 ```
 
 Otherwise, you will need to provide the OIDC token explicitly. This can
-either be the raw token value or a path to the token on disk.
+either be the raw token value or a path to the token on disk:
 
 ```sh
 chainctl auth login --identity <identity-id> --identity-token <identity-token>
 ```
 
-Once you're logged in, you should be able to perform the operations that the
+Once you're logged in, you will be able to perform the operations that the
 identity has permissions for. For instance, listing repositories.
 
 ```sh
 chainctl image repo list
 ```
 
-Or, you can use `chainctl auth token` to retrieve a bearer token that you can
-use directly with the Chainguard API.
+Alternatively, you can use `chainctl auth token` to retrieve a bearer token that you can
+use directly with the Chainguard API:
 
 ```sh
 curl -sSf \
@@ -196,12 +196,12 @@ curl -sSf \
     | jq -r .items[].name
 ```
 
-### API
+### Using the Chainguard API
 
-If you want to interact with the API directly, without any use of `chainctl`,
-then you can exchange your platform's OIDC token for a Chainguard API token
-yourself like this. Substituting `<identity-id>` and `<identity-token>` with the
-identity's UIDP and the OIDC token, respectively.
+If you want to interact with the API directly without using `chainctl`, 
+you can exchange your platform's OIDC token for a Chainguard API token
+like in the following example. Be sure to substitute `<identity-id>` and `<identity-token>` with the
+identity's UIDP and the OIDC token, respectively:
 
 ```sh
 curl -sSf \
@@ -211,7 +211,7 @@ curl -sSf \
 ```
 
 This will return a token for the Chainguard API that you can use for subsequent
-requests to the API. For instance, listing repositories.
+requests to the API. For instance, listing repositories:
 
 ```sh
 curl -sSf \


### PR DESCRIPTION
We provide generic examples of creating an identity, but no tangible examples of assuming one.

This change adds generic instructions on how to assume an identity.

Most importantly, it adds an example of doing the exchange entirely via the API. This comes up a lot with customers who are writing their own implementations with our APIs and don't want to shell out to `chainctl` for authentication.