### PR TITLE
fix typo in library verification

### DIFF
--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -80,7 +80,7 @@ organization using the `--parent` flag as follows, replacing
 `<your-organization>` with the name of your organization, with every command:
 
 ```sh
-chainctl libaries verify --parent <your-organization> /path/to/artifact.jar
+chainctl libraries verify --parent <your-organization> /path/to/artifact.jar
 ```
 
 To avoid the need for the additional parameter, you can configure a default


### PR DESCRIPTION
[x] Check if this is a typo or other quick fix and ignore the rest :)

Fix typo in command example.