### PR TITLE
Update AWS assumable identity instructions to create identities with chainctl

### DIFF
--- a/content/chainguard/administration/assumable-ids/identity-examples/aws-ec2-identity.md
+++ b/content/chainguard/administration/assumable-ids/identity-examples/aws-ec2-identity.md
@@ -48,7 +48,7 @@ This will return information like the following:
 
 **From your local machine**, use this information to create an identity with `chainctl`:
 
-```
+```sh
 chainctl iam id create aws role aws-ec2-identity --aws-account-id=453EXAMPLE43 --aws-role-name=AmazonSSMRoleForInstancesQuickSetup --role=viewer
 ```
 

--- a/content/chainguard/administration/assumable-ids/identity-examples/aws-ec2-identity.md
+++ b/content/chainguard/administration/assumable-ids/identity-examples/aws-ec2-identity.md
@@ -28,7 +28,7 @@ To complete this guide, you will need the following.
 
 ## Create a Chainguard Assumable Identity
 
-To get started, you will need to retrieve some details about the AWS IAM user on your EC2 instance. You will use these details to create a Chainguard identity that the EC2 user will employ to authenticate to Chainguard.
+To get started, you will need to retrieve some details about the AWS IAM identity of your EC2 instance. You will use these details to create a Chainguard identity that the EC2 instance will employ to authenticate to Chainguard.
 
 Run the following command **from your EC2 instance**:
 
@@ -46,68 +46,15 @@ This will return information like the following:
 }
 ```
 
-**From your local machine**, use this information to create a JSON file named `id.json` which you'll use to define the identity your EC2 instance will use to authenticate to Chainguard:
+**From your local machine**, use this information to create an identity with `chainctl`:
 
-```shell
-cat > id.json <<EOF
-{
-   "name":"aws-ec2-identity",
-   "awsIdentity": {
-  	"aws_account" : "$ACCOUNT",
-  	"arnPattern"  : "$ARN",
-  	"userIdPattern" : "$USER-ID"
-   }
-}
-EOF
+```
+chainctl iam id create aws role aws-ec2-identity --aws-account-id=453EXAMPLE43 --aws-role-name=AmazonSSMRoleForInstancesQuickSetup --role=viewer
 ```
 
-Note that this identity definition specifies the name of the Chainguard identity as `aws-ec2-identity`. Be sure to change these placeholder values to reflect the output from the `aws sts get-caller-identity` command you ran on your EC2 instance.
-
-Next, use `chainctl` to authenticate to your Chainguard account:
-
-```shell
-chainctl auth login
-```
-
-After authenticating to Chainguard, you can create an identity that your EC2 instance will be able to assume. First though, you'll need to know the name of the Chainguard organization you want the assumable identity to be associated with.
-
-To retrieve a list of all the organizations you have access to, run the following command:
-
-```shell
-chainctl iam organizations ls -o table
-```
-
-Find the organization you want to use and copy the value from its `NAME` column exactly. You can then use this to create a new Chainguard identity.
-
-The following example uses the `id.json` file you created earlier as the identity definition and associates it with the `chainguard.edu` organization:
-
-```shell
-chainctl iam id create aws --filename id.json -oid --parent chainguard.edu
-```
-
-Be sure to change the `chainguard.edu` placeholder to reflect the name of your own Chainguard organization.
-
-This command will return a value like the following:
-
-```output
-. . .
-45a0cEXAMPLE977f050c5fb9ac06a69EXAMPLE95/2c5f7EXAMPLE3871
-```
-
-Note this value down, as you will need it in the next section when you authenticate to Chainguard from your EC2 instance using this identity.
-
-Before moving on, you must create a [role-binding](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to bind the identity stored in `$CHAINGUARD_IDENTITY` to a specific role:
-
-```shell
-chainctl iam rolebinding create --identity aws-ec2-identity --role viewer --parent chainguard.edu
-```
-
-This example binds the `aws-ec2-identity` to the `viewer` role, but you can bind it to any role you'd like. For a full list of available roles, you can run the `chainctl iam roles list` command.
-
-Again, be sure to change `chainguard.edu` to reflect the name of your own organization, and change `aws-ec2-identity` to the name of the identity you created previously, if different.
+In addition to creating the identity, this example binds the `aws-ec2-identity` to the `viewer` role, but you can bind it to any role you'd like. For a full list of available roles, you can run the `chainctl iam roles list` command.
 
 Following that, you can move on to the next section where you will authenticate to Chainguard from your EC2 instance using the identity you created.
-
 
 ## Authenticate from EC2 Using the Newly Created Identity
 

--- a/content/chainguard/administration/assumable-ids/identity-examples/aws-identity.md
+++ b/content/chainguard/administration/assumable-ids/identity-examples/aws-identity.md
@@ -32,21 +32,21 @@ This guide outlines two methods for creating an identity that can be assumed by 
 
 ### CLI
 
-This example creates an identity for an IAM role and binds it to the `registry.pull` role. Replace `<identity-name>` with the name you'd like to give the identity, `<account-id>` with your AWS account ID and `<role-name>` with the name of your IAM role.
+This example creates an identity for an IAM role and binds it to the `registry.pull` role. Replace `<identity-name>` with the name you'd like to give the identity, `<account-id>` with your AWS account ID, and `<role-name>` with the name of your IAM role.
 
-```
+```shell
 chainctl iam id create aws role <identity-name> --aws-account-id=<account-id> --aws-role-name=<role-name> --role=registry.pull
 ```
 
 For an IAM user, use this command. Replace `<identity-name>` with the name you'd like to give the identity, `<account-id>` with your AWS account ID and `<user-name>` with the name of your IAM user.
 
-```
+```shell
 chainctl iam id create aws user <identity-name> --aws-account-id=<account-id> --aws-user-name=<user-name> --role=registry.pull
 ```
 
 If your IAM resources are in the `aws-cn` or `aws-us-gov` [partitions](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html), you must specify that with the `--aws-partition` flag. For instance, for a role:
 
-```
+```shell
 chainctl iam id create aws role <identity-name> --aws-partition=aws-us-gov --aws-account-id=<account-id> --aws-role-name=<role-name> --role=registry.pull
 ```
 

--- a/content/chainguard/administration/assumable-ids/identity-examples/aws-identity.md
+++ b/content/chainguard/administration/assumable-ids/identity-examples/aws-identity.md
@@ -32,59 +32,33 @@ This guide outlines two methods for creating an identity that can be assumed by 
 
 ### CLI
 
-To begin, you will need to fetch the ID of the AWS IAM role or user that will be assuming the identity.
+This example creates an identity for an IAM role and binds it to the `registry.pull` role. Replace `<identity-name>` with the name you'd like to give the identity, `<account-id>` with your AWS account ID and `<role-name>` with the name of your IAM role.
 
-For an [IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html), fetch the ID with the following command. Make sure to replace `<role-name>` with the name of the role you want to assume the identity:
+```
+chainctl iam id create aws role <identity-name> --aws-account-id=<account-id> --aws-role-name=<role-name> --role=registry.pull
+```
+
+For an IAM user, use this command. Replace `<identity-name>` with the name you'd like to give the identity, `<account-id>` with your AWS account ID and `<user-name>` with the name of your IAM user.
+
+```
+chainctl iam id create aws user <identity-name> --aws-account-id=<account-id> --aws-user-name=<user-name> --role=registry.pull
+```
+
+If your IAM resources are in the `aws-cn` or `aws-us-gov` [partitions](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html), you must specify that with the `--aws-partition` flag. For instance, for a role:
+
+```
+chainctl iam id create aws role <identity-name> --aws-partition=aws-us-gov --aws-account-id=<account-id> --aws-role-name=<role-name> --role=registry.pull
+```
+
+These commands will return the identity's [UIDP (unique identity path)](/chainguard/administration/cloudevents/events-reference/#uidp-identifiers). Note this value down, as you'll need it to assume the identity later.
+
+If you need to retrieve the UIDP later on, you can always run the following `chainctl` command to list the identity.
 
 ```sh
-aws iam get-role --role-name <role-name> | jq -r '.Role.RoleId'
+chainctl iam identities list --name=<identity-name>
 ```
 
-This will return an ID like the following:
-
-```output
-AROAEXAMPLEC2UL7LUB
-```
-
-For an [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html), fetch its ID with this command. Again, be sure to replace `<user-name>` with the name of the AWS user you want to assume the identity:
-
-```sh
-aws iam get-user --user-name <user-name> | jq -r '.User.UserId'
-```
-```output
-AIDAEXAMPLEFUBLFJXS6B
-```
-
-Once you've got the ID, create a configuration file named `identity.json`. This will define the name of your identity and the patterns that dictate which AWS users and roles can assume it.
-
-For an IAM role, the contents of your `identity.json` file should look like this. Substitute `<account-id>` with your AWS account ID, `<role-name>` with the name of your role, and `<role-id>` with the role ID you just retrieved:
-
-```identity.json
-{
-    "name": "my-identity-name",
-    "awsIdentity": {
-        "aws_account" : "<account-id>",
-        "arnPattern"  : "^arn:aws:sts::<account-id>:assumed-role/<role-name>/(.+)$",
-        "userIdPattern" : "^<role-id>:(.+)$"
-    }
-}
-```
-
-For a user, the `identity.json` file should follow this format. Substitute `<account-id>` with your AWS account ID, `<user-name>` with the name of your user and `<user-id>` with the user ID you just retrieved:
-
-
-```identity.json
-{
-    "name": "my-identity-name",
-    "awsIdentity": {
-        "aws_account" : "<account-id>",
-        "arnPattern"  : "arn:aws:iam::<account-id>:user/<user-name>",
-        "userIdPattern" : "<user-id>"
-    }
-}
-```
-
-If you're unsure what the configuration of your assumable identity should look like, you can run `aws sts get-caller-identity` to get the details of the current AWS session. You must run this from the AWS environment you are trying to assume the identity from. For example, if you run this command from an EC2 instance with an assumed role, you might see output like this:
+If you're unsure which IAM identity your AWS resource is using, you can run `aws sts get-caller-identity` to get the details of the current AWS session. You must run this from the AWS environment you are trying to assume the identity from. For example, if you run this command from an EC2 instance with an assumed role, you might see output like this:
 
 ```sh
 aws sts get-caller-identity
@@ -97,25 +71,7 @@ aws sts get-caller-identity
 }
 ```
 
-You can translate this output into the assumable identity configuration described previously.
-
-Once the configuration is prepared, use `chainctl` to create the identity from `identity.json` and bind the `registry.pull` role to it. Substitute `<org-name>` with the name of your Chainguard organization.
-
-```sh
-chainctl iam identities create my-identity-name \
-    --parent=<org-name> \
-    --filename=identity.json \
-    --role=registry.pull \
-    -o id
-```
-
-This will return the identity's [UIDP (unique identity path)](/chainguard/administration/cloudevents/events-reference/#uidp-identifiers). Note this value down, as you'll need it to assume the identity later.
-
-If you need to retrieve the UIDP later on, you can always run the following `chainctl` command to list the identity.
-
-```sh
-chainctl iam identities list --name=my-identity-name
-```
+In this example, the role name is `AmazonSSMRoleForInstancesQuickSetup`.
 
 ### Terraform
 


### PR DESCRIPTION
We recently added commands to `chainctl` that massively simplify the process of creating identities for AWS.