### PR TITLE
Updating stale Cosign docs

### DIFF
--- a/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
+++ b/content/open-source/sigstore/cosign/an-introduction-to-cosign.md
@@ -5,7 +5,7 @@ type: "article"
 lead: "A primer to signing software artifacts with Cosign"
 description: "Understanding Cosign, a project under Sigstore"
 date: 2022-07-19T08:49:31+00:00
-lastmod: 2024-07-29T15:12:18+00:00
+lastmod: 2025-12-26T15:16:50+01:00
 draft: false
 tags: ["Cosign", "Overview"]
 images: []
@@ -26,11 +26,13 @@ By signing software, you can authenticate that you are who you say you are, whic
 
 Software artifacts are distributed widely, can be incorporated into the software of other individuals and organizations, and are often updated throughout their life spans. End users and developers who build upon existing software are increasingly aware of the possibility of threats and vulnerabilities in packages, containers, and other artifacts. How can users and developers decide whether to use software created by others? One answer that has been increasingly gaining traction is *code signing*.
 
-While code signing is not new technology, the growing prevalence of software in our everyday lives coupled with a rising number of attacks like [SolarWinds](https://www.businessinsider.com/solarwinds-hack-explained-government-agencies-cyber-security-2020-12) and [Codecov](https://www.reuters.com/technology/codecov-hackers-breached-hundreds-restricted-customer-sites-sources-2021-04-19/) has created a more pressing need for solutions that build trust, prevent forgery and tampering, and ultimately lead to a more secure software supply chain. Similar in concept to a signature on a document that was signed in the presence of a notary or other professional who can certify your identity, a signature on a software artifact attests that you are who you say you are and that the code was not altered after signing. Instead of a recognized notary when you sign software, it is a recognized **certificate authority** (CA) that validates your identity. These checks that go through recognized bodies able to establish a developer’s identity support the root of trust that security relies on so that bad actors cannot compromise software.
+While code signing is not new technology, the growing prevalence of software in our everyday lives coupled with a rising number of attacks like [SolarWinds](https://www.businessinsider.com/solarwinds-hack-explained-government-agencies-cyber-security-2020-12) and [Codecov](https://www.reuters.com/technology/codecov-hackers-breached-hundreds-restricted-customer-sites-sources-2021-04-19/) has created a more pressing need for solutions that build trust, prevent forgery and tampering, and ultimately lead to a more secure software supply chain.
+
+Similar in concept to a signature on a document that was signed in the presence of a notary or other professional who can certify your identity, a signature on a software artifact attests that you are who you say you are and that the code was not altered after signing. Instead of a recognized notary when you sign software, it is a recognized **certificate authority** (CA) that validates your identity. These checks that go through recognized bodies able to establish a developer’s identity support the root of trust that security relies on so that bad actors cannot compromise software.
 
 Code signing involves a developer, software publisher, or entity (like an automated workload) digitally signing a software artifact to confirm their identity and ensure that the artifact was not tampered with since having been signed. Code signing has several implementations, and Cosign is one such implementation, but all code signing technology follows a similar process as Cosign.
 
-The recommended practice for a developer (or organization) looking to sign their code with Cosign is to use *keyless signing*. This process will first generate an ephemeral key pair which will then be used to create a digital signature for a given software artifact. A **key pair** is a combination of a signing key to sign data, and a verification key that is used to verify data signed with the corresponding signing key. With the `cosign sign` command, the developer will sign their software artifact, and that signature will be stored in the registry (if applicable). This signature can later be verified by others through searching for an artifact, finding its signature, and then verifying it.
+The recommended practice for a developer (or organization) looking to sign their code with Cosign is to use *keyless signing*. This process will first generate an ephemeral key pair which will then be used to create a digital signature for a given software artifact. A *key pair* is a combination of a signing key to sign data, and a verification key that is used to verify data signed with the corresponding signing key. With the `cosign sign` command, the developer will sign their software artifact, and that signature will be stored in the registry (if applicable). This signature can later be verified by others through searching for an artifact, finding its signature, and then verifying it.
 
 ## Keyless Signing
 
@@ -44,41 +46,31 @@ While keyless signing can be used by individuals in the same manner as long-live
 
 Cosign uses ephemeral keys and certificates, gets them signed automatically by the Fulcio root certificate authority, and stores these signatures in the [Rekor](/open-source/sigstore/rekor/) transparency log, which automatically provides an attestation at the time of creation.
 
-You can manually create a keyless signature with the following `cosign` command. In our example, we’ll use [Docker Hub](https://hub.docker.com/) to store the signature. If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`.
+You can manually create a keyless signature with the following `cosign` command. In our example, we’ll use [Docker Hub](https://hub.docker.com/) to store the signature. If you would like to follow along, ensure you are logged into Docker Hub on your local machine and that you have a Docker repository with an image available. The following example assumes a username of `docker-username` and a repository name of `demo-container`:
 
 ```sh
 cosign sign docker-username/demo-container
 ```
 
-You'll be taken through a workflow that requests you to grant permission to have your information stored permanently in transparency logs, and moves to a workflow with an OIDC provider.
+You'll be taken through a workflow that requests you to grant permission to have your information stored permanently in transparency logs, and moves to a workflow with an OIDC provider:
 
 ```output
-Generating ephemeral keys...
-Retrieving signed certificate...
+    The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+    Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+    This may include the email address associated with the account with which you authenticate your contractual Agreement.
+    This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
 
-	Note that there may be personally identifiable information associated with this signed artifact.
-	This may include the email address associated with the account with which you authenticate.
-	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
-
-By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
-Are you sure you would like to continue? [y/N]
+By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
+Are you sure you would like to continue? [y/N] y
 Your browser will now be opened to:
 ...
 ```
 
 At this point, a browser window will open and you will be directed to a page that asks you to log in to Sigstore. You can authenticate with GitHub, Google, or Microsoft. Note that the email address that is tied to these credentials will be permanently visible in the Rekor transparency log. This makes it publicly visible that you are the one who signed the given artifact, and helps others trust the given artifact. That said, it is worth keeping this in mind when choosing your authentication method. Once you log in and are authenticated, you’ll receive feedback of “`Sigstore Authentication Successful!`”, and you may now safely close the window.
 
-On the terminal, you’ll receive output that you were successfully verified, and you’ll get confirmation that the signature was pushed.
-
-```output
-Successfully verified SCT...
-tlog entry created with index:
-Pushing signature to: index.docker.io/docker-username/demo-container
-```
-
 If you followed along with Docker Hub, you can check the user interface of your repository and verify that you pushed a signature.
 
-You can then further verify that the keyless signature was successful by using `cosign verify` to check. You will need to know some information in order to verify the entry. You'll need to use the identity flags `--certificate-identity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command.
+You can then further verify that the keyless signature was successful by using `cosign verify` to check. You will need to know some information in order to verify the entry. You'll need to use the identity flags `--certificate-identity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command:
 
 ```sh
 cosign verify \
@@ -100,7 +92,7 @@ As part of the JSON output, you should get feedback on the issuer that you used 
 
 ## Cosign with Keys
 
-You can also use Cosign with long-lived key pairs. If you would like to follow along, please first [install Cosign](/open-source/sigstore/cosign/how-to-install-cosign/).
+You can also use Cosign with long-lived key pairs. If you would like to follow along, please first [install Cosign](/open-source/sigstore/cosign/how-to-install-cosign/):
 
 ```sh
 cosign generate-key-pair
@@ -113,7 +105,7 @@ Private key written to cosign.key
 Public key written to cosign.pub
 ```
 
-You can sign a container and store the signature in the registry with the cosign sign command.
+You can sign a container and store the signature in the registry with the cosign sign command:
 
 ```sh
 cosign sign --key cosign.key docker-username/demo-container
@@ -124,7 +116,7 @@ Enter password for private key:
 Pushing signature to: index.docker.io/sigstore-course/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
 
-Finally, you can verify a software artifact against a public key with the cosign verify command. This command will return 0 if at least one Cosign formatted signature for the given artifact is found that matches the public key. Any valid formats are printed to standard output in a JSON format.
+Finally, you can verify a software artifact against a public key with the cosign verify command. This command will return 0 if at least one Cosign formatted signature for the given artifact is found that matches the public key. Any valid formats are printed to standard output in a JSON format:
 
 ```sh
 cosign verify --key cosign.pub docker-username/demo-container
@@ -140,4 +132,3 @@ The following checks were performed on these signatures:
 You should now have some familiarity with the process of signing and verifying code in Cosign. For a more thorough tutorial, please review [How to Sign a Container with Cosign](/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign/).
 
 Code signing provides developers and others who release code a way to attest to their identity, and in turn, those who are consumers (whether end users or developers who incorporate existing code) can verify those signatures to ensure that the code is originating from where it is said to have originated, and check that that particular developer (or vendor) is trusted.
-

--- a/content/open-source/sigstore/cosign/cosign-manual-way.md
+++ b/content/open-source/sigstore/cosign/cosign-manual-way.md
@@ -16,6 +16,8 @@ weight: 007
 toc: true
 ---
 
+> **Note:** This tutorial is no longer actively maintained and may reference outdated versions of Cosign and related tools. While the underlying cryptographic concepts remain relevant, we recommend consulting the [current Cosign documentation](https://docs.sigstore.dev/cosign/overview/) for up-to-date usage guidance. This content is preserved for educational purposes and may still provide value for those interested in understanding the mechanics of software signing.
+
 When I first used [Cosign](https://github.com/sigstore/cosign), the software artifact signing CLI from the [Sigstore](https://www.sigstore.dev/) project, I was amazed at how painless signing and verifying could be.
 
 For example, in the three commands below we create a public/private key pair, sign the text file, upload it to the [Rekor](https://github.com/sigstore/rekor) transparency log, and verify the signature of the message.

--- a/content/open-source/sigstore/cosign/how-to-install-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-install-cosign.md
@@ -5,7 +5,7 @@ type: "article"
 lead: "Details for installing Cosign across operating systems to sign software artifacts"
 description: "Details for installing Cosign across operating systems"
 date: 2022-07-13T08:49:31+00:00
-lastmod: 2024-12-16T15:16:50+01:00
+lastmod: 2025-12-26T15:16:50+01:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -26,7 +26,7 @@ There are a few different ways to install Cosign to your local machine or remote
 
 Those who are running macOS locally may be familiar with Homebrew as a package manager. There is also a [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux) version for those running a Linux distribution. If you are using macOS and would like to leverage a package manager, you can review the [official documentation to install Homebrew](https://brew.sh/) to your machine.
 
-To install Cosign with Homebrew, run the following command.
+To install Cosign with Homebrew, run the following command:
 
 ```sh
 brew install cosign
@@ -36,19 +36,27 @@ To update Cosign in the future, you can run `brew upgrade cosign` to get the new
 
 ## Installing Cosign with Linux Package Managers
 
-Cosign is supported by the Arch Linux, Alpine Linux, and Nix package managers. On the [releases page](https://github.com/sigstore/cosign/releases), you’ll also find `.deb` and `.rpm` packages for manual download and installation.
+Cosign is supported by the Arch Linux, Alpine Linux, and Nix package managers.
 
-To install Cosign on Arch Linux, use the `pacman` package manager.
+You can check to ensure that Cosign is successfully installed using the `cosign version` command following installation. When you run the command, you should receive output that indicates the version you have installed.
+
+### Arch Linux
+
+To install Cosign on Arch Linux, use the `pacman` package manager:
 
 ```sh
 pacman -S cosign
 ```
 
-If you are using Alpine Linux or an Alpine Linux image, you can add Cosign with `apk`.
+### Alipne Linux
+
+If you are using Alpine Linux or an Alpine Linux image, you can add Cosign with `apk`:
 
 ```sh
 apk add cosign
 ```
+
+### NixOS
 
 For NixOS, you can install Cosign with the following command:
 
@@ -56,44 +64,54 @@ For NixOS, you can install Cosign with the following command:
 nix-env -iA nixpkgs.cosign
 ```
 
-And for NixOS Linux, you can install Cosign using `nixos.cosign` with the `nix-env` package manager.
+And for NixOS Linux, you can install Cosign using `nixos.cosign` with the `nix-env` package manager:
 
 ```sh
 nix-env -iA nixos.cosign
 ```
 
-For Ubuntu and Debian distributions, check the releases page and download the latest `.deb` package. At the time of this writing, this would be version 2.5.0. To install the `.deb` file, run:
+### `dpkg` and `rpm`
+
+On the [releases page](https://github.com/sigstore/cosign/releases), you’ll also find `.deb` and `.rpm` packages for manual download and installation.
+
+Both examples in this section assume you've found the latest version of Cosign and set it to an environment variable named `LATEST_VERSION`:
 
 ```sh
-sudo dpkg -i ~/Downloads/cosign_2.5.0_amd64.deb
+LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
+```
+
+For Ubuntu and Debian distributions, download and install the latest `.deb` package:
+
+```sh
+curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign_${LATEST_VERSION}_amd64.deb"
+sudo dpkg -i cosign_${LATEST_VERSION}_amd64.deb
 ```
 
 For CentOS and Fedora, download the latest `.rpm` package from the releases page and install Cosign with:
 
 ```sh
-rpm -ivh cosign-2.5.0-1.x86_64.rpm
+curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"
+sudo rpm -ivh cosign-${LATEST_VERSION}-1.x86_64.rpm
 ```
-
-You can check to ensure that Cosign is successfully installed using the `cosign version` command following installation. When you run the command, you should receive output that indicates the version you have installed.
 
 ## Installing Cosign with Go
 
-You can install Cosign using the Go package manager. Installing with Go will work across different operating systems and distributions. First, check that you have Go installed on your machine, and ensure that it is Go version `1.22.7` or later.
+You can install Cosign using the Go package manager. Installing with Go will work across different operating systems and distributions. First, check that you have Go installed on your machine, and ensure that it is Go version `1.22.7` or later:
 
 ```sh
 go version
 ```
 
 ```output
-go version go1.23.4 linux/amd64
+go version go1.25.4 linux/amd64
 ```
 
 If you run into an error or don’t receive output like the above, you’ll need to install Go in order to install Cosign with Go. Navigate to the official Go website in order to download the appropriate version of Go for your machine.
 
-With Go installed, you are ready to install Cosign using the following command.
+With Go installed, you are ready to install Cosign using the following command:
 
 ```sh
-go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+go install github.com/sigstore/cosign/v3/cmd/cosign@latest
 ```
 
 The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`.
@@ -102,10 +120,10 @@ The resulting binary from this installation will be placed at `$GOPATH/bin/cosig
 
 You can install Cosign with Go directly from the [Cosign GitHub releases page](https://github.com/sigstore/cosign/releases).
 
-At the time of writing, the newest release is [v2.5.0](https://github.com/sigstore/cosign/releases/tag/v2.5.0). You can download this version with the following command.
+At the time of writing, the newest release is [v3.0.2](https://github.com/sigstore/cosign/releases/tag/v3.0.2). You can download this version with the following command:
 
 ```sh
-go install github.com/sigstore/cosign/v2/cmd/cosign@v2.5.0
+go install github.com/sigstore/cosign/v2/cmd/cosign@v3.0.2
 ```
 
 The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`. Check the [release page]([Cosign GitHub releases page](https://github.com/sigstore/cosign/releases) for additional releases.
@@ -114,23 +132,22 @@ The resulting binary from this installation will be placed at `$GOPATH/bin/cosig
 
 Installing Cosign via its binary offers you greater control over your installation, but this method also requires you to manage your installation yourself. In order to install via binary, check for the most updated version in the open source GitHub repository for Cosign under the [releases page](https://github.com/sigstore/cosign/releases).
 
-You can use the `wget` command to install the most recent binary. In our example, the release we are installing is 2.5.0.
+You can use the `curl` command to install the most recent binary:
 
 ```sh
-wget "https://github.com/sigstore/cosign/releases/download/v2.5.0/cosign-linux-amd64"
+curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
 ```
 
-Next, move the Cosign binary to your bin folder.
+Next, move the Cosign binary to your bin folder:
 
 ```sh
 sudo mv cosign-linux-amd64 /usr/local/bin/cosign
 ```
 
-Finally, update permissions so that Cosign can execute within your filesystem.
+Finally, update permissions so that Cosign can execute within your filesystem:
 
 ```sh
 sudo chmod +x /usr/local/bin/cosign
 ```
 
 You’ll need to ensure that you keep Cosign up to date if you install via binary. You can always later opt to use a package manager to update Cosign in the future.
-

--- a/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign.md
@@ -5,7 +5,7 @@ type: "article"
 lead: "Container signing using Cosign"
 description: "Signing containers with Cosign"
 date: 2022-07-13T13:26:54+01:00
-lastmod: 2024-07-29T15:12:18+00:00
+lastmod: 2025-12-26T15:16:50+01:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -18,7 +18,7 @@ toc: true
 
 _An earlier version of this material was published in the [Cosign chapter](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/block-v1:LinuxFoundationX+LFS182x+2T2022+type@sequential+block@204b98f35bca48c194d1868e0356bef1/block-v1:LinuxFoundationX+LFS182x+2T2022+type@vertical+block@2f0ad9cb8f124a39ab555ac8bf1a114c) of the Linux Foundation [Sigstore course](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home)._
 
-Cosign is a tool you can use to sign software artifacts, which in turn allows you to verify that you are who you say you are, and instills trust across the software ecosystem. Signing software also allows people to understand the provenance of the software, and prevents tampering.
+Cosign is a tool you can use to sign software artifacts, which in turn allows you to verify that you are who you say you are, instilling trust across the software ecosystem. Signing software also allows people to understand the provenance of the software, and prevents tampering.
 
 Let’s step through signing a container with Cosign. We are using a container to provide a sense of how you may use Sigstore with containerized workloads, but the steps we are taking to sign a container are very similar to the steps that we would take to sign any other software artifact that can be published in a container registry, and we will discuss signing blobs a little later.
 
@@ -30,13 +30,13 @@ Additionally, you will need Cosign installed, which you can achieve by following
 
 ## Creating a Container
 
-You’ll now be creating a new container. Create a new directory within your user directory that is the same as your Docker username and, within that, a directory called `hello-container`. If you will be opting to use a registry other than Docker, feel free to use the relevant username for that registry.
+You’ll now be creating a new container. Create a new directory within your user directory that is the same as your Docker username and, within that, a directory called `hello-container`. If you will be opting to use a registry other than Docker, feel free to use the relevant username for that registry:
 
 ```sh
 mkdir -p ~/docker-username/hello-container
 ```
 
-Move into the directory.
+Move into the directory:
 
 ```sh
 cd ~/docker-username/hello-container
@@ -44,7 +44,7 @@ cd ~/docker-username/hello-container
 
 Let’s create the Dockerfile that describes the container. This will be essentially a “Hello, World” container for demonstration purposes.
 
-Use the text editor of your choice to create the Dockerfile. You can use [Visual Studio Code](https://code.visualstudio.com/) or a command line text editor like nano. Just ensure that the file is called exactly `Dockerfile` with a titlecase and no extension.
+Use the text editor of your choice to create the Dockerfile. You can use [Visual Studio Code](https://code.visualstudio.com/) or a command line text editor like nano. Just ensure that the file is called exactly `Dockerfile` with a titlecase and no extension:
 
 ```sh
 nano Dockerfile
@@ -63,7 +63,7 @@ Once you are satisfied that your Dockerfile is the same as the text above, you c
 
 ## Building and Running a Container
 
-Within the same `hello-container` directory, you can build the container. You should use the format `docker-username/image-name` to tag your image, since you'll be publishing it to a registry.
+Within the same `hello-container` directory, you can build the container. You should use the format `docker-username/image-name` to tag your image, since you'll be publishing it to a registry:
 
 ```sh
 docker build -t docker-username/hello-container .
@@ -71,25 +71,25 @@ docker build -t docker-username/hello-container .
 
 If you receive an error message or a “failed” message, check that your user is part of the `docker` group and that you have the right permissions to run Docker. For testing, you may also try to run the above command with `sudo`.
 
-You should get guidance in the output that your build was successful when you receive no errors.
+You should get guidance in the output that your build was successful when you receive no errors:
 
 ```output
 => => naming to docker.io/docker-username/hello-container
 ```
 
-At this point your container is built and you can verify that the container is working as expected by running the container.
+At this point your container is built and you can verify that the container is working as expected by running the container:
 
 ```sh
 docker run docker-username/hello-container
 ```
 
-You should receive the expected output of the echo message you added to the Dockerfile.
+You should receive the expected output of the echo message you added to the Dockerfile:
 
 ```output
 Hello, Cosign!
 ```
 
-You can further confirm that the Docker container is among your listed containers by listing all of your active containers.
+You can further confirm that the Docker container is among your listed containers by listing all of your active containers:
 
 ```sh
 docker ps -a
@@ -110,7 +110,7 @@ We will be publishing our container to the Docker registry. If you are opting to
 
 At this point, you can access the Docker container registry at [hub.docker.com](https://hub.docker.com/) and create a new repository under your username called `hello-container`. We will be making this public, but you can make it private if you prefer. If you are happy for it to be public, you can skip this step as the repository will be created when pushing the container. In any case, you can delete this once you are satisfied that you have signed the container.
 
-Once this is set up, you can push the container you created to the Docker Hub repository.
+Once this is set up, you can push the container you created to the Docker Hub repository:
 
 ```sh
 docker push docker-username/hello-container
@@ -122,34 +122,24 @@ You should be able to now access your published container via your Docker Hub ac
 
 Now that the container is in a registry (in our example, it is in Docker Hub), you are ready to sign the container and push that signature to the registry.
 
-You will call your registry user name and container name with the following `cosign` command. Note that we are signing the image in Docker Hub keylessly with Cosign.
+You will call your registry user name and container name with the following `cosign` command. Note that we are signing the image in Docker Hub keylessly with Cosign:
 
 ```sh
 cosign sign docker-username/hello-container
 ```
 
-You will be asked to verify that you agree with having your information in the transparency log and will be taken through an OIDC workflow.
+You will be asked to verify that you agree with having your information in the transparency log and will be taken through an OIDC workflow:
 
 ```output
-Generating ephemeral keys...
-Retrieving signed certificate...
+    The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+    Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+    This may include the email address associated with the account with which you authenticate your contractual Agreement.
+    This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
 
-	Note that there may be personally identifiable information associated with this signed artifact.
-	This may include the email address associated with the account with which you authenticate.
-	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
-
-By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
-Are you sure you would like to continue? [y/N]
+By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
+Are you sure you would like to continue? [y/N] y
 Your browser will now be opened to:
 ...
-```
-
-You’ll receive output indicating that the signature was pushed to the container registry.
-
-```output
-Successfully verified SCT...
-tlog entry created with index:
-Pushing signature to: index.docker.io/docker-username/hello-container
 ```
 
 In the case of Docker Hub, on the web interface there should be a SHA (secure hash algorithm) added to the tag, enabling you to confirm that your pushed signature was registered. We’ll now manually verify the signature with Cosign.
@@ -158,7 +148,7 @@ In the case of Docker Hub, on the web interface there should be a SHA (secure ha
 
 We’ll be demonstrating this on the container we just pushed to a registry, but you can also verify a signature on any other signed container using the same steps. While you will more likely be verifying signatures in workloads versus manually, it is still helpful to understand how everything works and is formatted.
 
-Let’s use Cosign to verify that the signature exists on the transparency log and matches our expected information. You will need to know some information in order to verify the entry. You'll need to use the identity flags `--certificate-identity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command.
+Let’s use Cosign to verify that the signature exists on the transparency log and matches our expected information. You will need to know some information in order to verify the entry. You'll need to use the identity flags `--certificate-identity` which corresponds to the email address of the signer, and `--certificate-oidc-issuer` which corresponds to the OIDC provider that the signer used. For example, a Gmail account using Google as the OIDC issuer, will be able to be verified with the following command:
 
 ```sh
 cosign verify \
@@ -169,7 +159,7 @@ cosign verify \
 
 Here, we are passing the public key contained in the cosign.pub file to the `cosign verify` command.
 
-You should receive output indicating that the Cosign claims were validated.
+You will receive output indicating that the Cosign claims were validated:
 
 ```output
 Verification for index.docker.io/docker-username/hello-container:latest --

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -32,9 +32,9 @@ We'll use the `apko_0.19.9_linux_arm64.tar.gz` tar archive from the `apko` [GitH
 
 There are three URLs from the list of assets on that page that you will need to copy:
 
-1. The release itself: `https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz`
-2. The signature file: `https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.sig`
-3. The public certificate: `https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.crt`
+1. The release itself: `https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz`
+2. The signature file: `https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz.sig`
+3. The public certificate: `https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz.crt`
 
 With these URLs, construct (or copy) the following command to verify the tar archive:
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -7,7 +7,7 @@ type: "article"
 description: "Use Cosign to verify non-container software artifacts"
 lead: "Cosign can verify software artifacts beyond containers"
 date: 2022-12-21T15:22:20+01:00
-lastmod: 2024-11-13T15:16:50+01:00
+lastmod: 2025-12-26T15:16:50+01:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -40,11 +40,11 @@ With these URLs, construct (or copy) the following command to verify the tar arc
 
 ```sh
 cosign verify-blob \
-  --signature https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.sig \
-  --certificate https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.crt \
+  --signature https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz.sig \
+  --certificate https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz.crt \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --certificate-identity "https://github.com/chainguard-dev/apko/.github/workflows/release.yaml@refs/tags/v0.19.9" \
-  https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz
+  --certificate-identity "https://github.com/chainguard-dev/apko/.github/workflows/release.yaml@refs/heads/main" \
+  https://github.com/chainguard-dev/apko/releases/download/v0.30.31/apko_0.30.31_linux_arm64.tar.gz
 ```
 
 Running the command may take a moment, but when it completes you will receive the following output:
@@ -56,27 +56,8 @@ Verified OK
 If any of the URLs are incorrect, if there was a problem with the `apko` release file, if the signature or certificate identity don't match, or if the release file was not signed, you will receive an error like the following:
 
 ```output
-Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest  &{Code:400 Message:verifying signature: invalid signature when validating ASN.1 encoded signature}
-main.go:74: error during command execution: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest  &{Code:400 Message:verifying signature: invalid signature when validating ASN.1 encoded signature}
-```
-
-You can also download the files and verify them locally:
-
-```sh
-curl -L -O https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz \
-  -O https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.sig \
-  -O https://github.com/chainguard-dev/apko/releases/download/v0.19.9/apko_0.19.9_linux_arm64.tar.gz.crt
-```
-
-You can then verify the files that you downloaded using Cosign:
-
-```sh
-cosign verify-blob \
-   --signature apko_0.19.9_linux_arm64.tar.gz.sig \
-   --certificate apko_0.19.9_linux_arm64.tar.gz.crt \
-   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-   --certificate-identity "https://github.com/chainguard-dev/apko/.github/workflows/release.yaml@refs/tags/v0.19.9" \
-   apko_0.19.9_linux_arm64.tar.gz
+Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest {"code":400,"message":"verifying signature: invalid signature when validating ASN.1 encoded signature"}
+error during command execution: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest {"code":400,"message":"verifying signature: invalid signature when validating ASN.1 encoded signature"}
 ```
 
 If you receive an error while verifying a binary with Cosign, then you know that there was a problem with creating the artifact, or that the file that you are verifying is corrupted or invalid. If that is the case, you should download a fresh copy and verify it again, or try a different version of the software with a working signature.


### PR DESCRIPTION
##  Type of change

Documentation update

This PR updates outdated Cosign documentation across 7 tutorial and reference pages. The changes refresh version numbers, URLs, examples, and commands to reflect current Cosign v3 and related tooling.

##  What should this PR do?

resolves https://github.com/chainguard-dev/edu/issues/2759
   
## Why are we making this change?

The existing Cosign documentation contained stale version references (Go 1.23 → 1.25, Cosign v2 → v3, outdated apko examples from v0.19.9 → v0.30.31) and needed formatting improvements to maintain accuracy and usefulness for users following the tutorials.

## What are the acceptance criteria?

[ ] All Cosign version references are updated to v3
[ ] Go version examples reflect current releases
[ ] apko example commands use latest stable release (v0.30.31)
[ ] Formatting improvements (colons, consistency) are applied throughout
[ ] Error message examples match current Cosign output format
[ ] All commands and examples are accurate and testable

## How should this PR be tested?

1. Review the 7 modified files for accuracy:
  •  an-introduction-to-cosign.md
  •  cosign-manual-way.md
  •  how-to-install-cosign.md
  •  how-to-sign-a-container-with-cosign.md
  •  how-to-sign-an-sbom-with-cosign.md
  •  how-to-sign-blobs-with-cosign.md
  •  how-to-verify-file-signatures-with-cosign.md
2. Verify installation commands reference correct Cosign v3 paths
3. Confirm apko example URLs and version numbers are valid
4. Check that formatting changes improve readability without altering meaning