### PR TITLE
Hide MCP docs from nav and add prominent callout

### DIFF
--- a/content/chainguard/mcp-server-ai-docs.md
+++ b/content/chainguard/mcp-server-ai-docs.md
@@ -9,6 +9,12 @@ lastmod: 2026-01-02T21:00:00+00:00
 draft: false
 images: []
 weight: 600
+menu:
+  main:
+    identifier: "mcp-server-ai-docs"
+    parent: ""
+    weight: 9999
+    hidden: true
 ---
 
 ## Overview

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -27,6 +27,12 @@ A comprehensive collection of Chainguard documentation including:
 
 ## Download AI Documentation Bundle
 
+<div style="background-color: #e3f2fd; border-left: 4px solid #2196F3; padding: 20px; border-radius: 4px; margin: 20px 0;">
+  <h3 style="margin-top: 0;">🚀 New: MCP Server Support</h3>
+  <p>Run the container as an <strong>MCP (Model Context Protocol) server</strong> for searchable, on-demand access to Chainguard documentation in AI assistants and IDEs.</p>
+  <p><a href="/chainguard/mcp-server-ai-docs/" style="font-weight: bold; text-decoration: none;">→ Full MCP Server Documentation</a></p>
+</div>
+
 Choose your preferred distribution method:
 
 <div style="background-color: var(--blockquote-background); border-left: 4px solid #4CAF50; padding: 16px; border-radius: 4px; margin: 20px 0;">


### PR DESCRIPTION
## Overview

The MCP server documentation is currently showing in the left navigation, which adds clutter. This PR hides it from the nav while adding a prominent callout box at the top of the developer-resources page to ensure discoverability.

## Changes

### Hidden from Navigation
- Added  config with  to MCP docs frontmatter
- Page remains fully accessible via direct link
- Follows same pattern as 

### Prominent Callout Box
- Added blue callout box at top of "Download AI Documentation Bundle" section
- Highlights the new MCP server feature
- Direct link to full MCP documentation
- Positioned before distribution method options for maximum visibility

## Visual Impact

The callout box will appear prominently:


## Benefits

- **Cleaner navigation**: Reduces clutter in left sidebar
- **Better discoverability**: Prominent callout highlights new feature
- **Focused experience**: Users see MCP docs when looking for AI documentation tools
- **Consistent pattern**: Matches approach used for other linked-only pages

## Related

- Merged PR #2870 (MCP server implementation)
- Addresses feedback about nav visibility