### PR TITLE
Update section headings and titles to sentence case

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -1,5 +1,5 @@
 ---
-title: "Chainguard Libraries Access"
+title: "Chainguard Libraries access"
 linktitle: "Access"
 description: "Learn how to access Chainguard Libraries for enhanced security in Java and Python dependencies, including authentication and organization setup"
 type: "article"

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -1,6 +1,6 @@
 ---
-title: "CVE Remediation for Chainguard Libraries"
-linktitle: "CVE Remediation"
+title: "CVE remediation for Chainguard Libraries"
+linktitle: "CVE remediation"
 description: "An overview of the CVE remediation feature for Chainguard Libraries"
 type: "article"
 date: 2025-09-11
@@ -32,7 +32,7 @@ CVE remediation is available for a subset of [Chainguard Libraries for
 Python](/chainguard/libraries/python/overview/). If you want to request CVE
 remediation for additional libraries, reach out to your account team.
 
-## About CVE Remediation
+## About CVE remediation
 
 CVE remediation focuses on critical and high vulnerabilities. Chainguard
 backports fixes that are already available in the new versions of the upstream
@@ -51,7 +51,7 @@ versions only.
 
 <a id="vex"></a>
 
-## Public VEX Feed
+## Public VEX feed
 
 Advisories for each CVE addressed in our remediated libraries are published via
 a public VEX feed at
@@ -59,7 +59,7 @@ a public VEX feed at
 Supported scanners and your own custom tooling can use this feed to identify and
 recognize remediated versions.
 
-## Scanning Remediated Libraries
+## Scanning remediated libraries
 
 Chainguard works closely with scanner partners so that remediated versions are
 properly recognized in vulnerability reports. This ensures that teams can

--- a/content/chainguard/libraries/faq.md
+++ b/content/chainguard/libraries/faq.md
@@ -37,7 +37,7 @@ Levels for Software Artifacts (SLSA) website](https://slsa.dev/).
 The following examples are issues, attacks, and compromises that affect stages
 of the software supply chain for libraries across different language ecosystems:
 
-### Malicious GlueStack Packages
+### Malicious GlueStack packages
 
 * This May 2025 attack uploaded compromised packages to PyPI and npm that enable remote shell access and uploading files to compromised machines
 * Chainguard Libraries would have protected against this attack. First, the packages have invalid upstream source URLs so there was no source repository. In the case of the lone exception (a package with a valid source repository link), no code was present for Chainguard to build a valid package.

--- a/content/chainguard/libraries/how-libraries-help-developers.md
+++ b/content/chainguard/libraries/how-libraries-help-developers.md
@@ -1,6 +1,6 @@
 ---
 title: "How does Chainguard Libraries help developers?"
-linktitle: "How Libraries Help"
+linktitle: "How Chainguard Libraries helps"
 type: "article"
 description: "Interview with Dustin Kirkland about the benefits Chainguard Libraries provide to developers"
 date: 2025-08-02T16:00:00+00:00

--- a/content/chainguard/libraries/how-libraries-plug-into-workflow.md
+++ b/content/chainguard/libraries/how-libraries-plug-into-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: "How does Chainguard Libraries plug into a developer's workflow?"
-linktitle: "Libraries Developer Workflow"
+linktitle: "Developer workflow"
 type: "article"
 description: "Interview with Dustin Kirkland explaining how Chainguard Libraries integrate seamlessly into existing developer workflows"
 date: 2025-08-02T16:00:00+00:00

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Build Configuration"
-linktitle: "Build Configuration"
+title: "Build configuration"
+linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Global Configuration"
-linktitle: "Global Configuration"
+title: "Global configuration"
+linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Java in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00

--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -1,5 +1,5 @@
 ---
-title: "Management and Maintenance"
+title: "Management and maintenance"
 linktitle: "Management"
 description: "Learn how to manage and maintain Chainguard Libraries for Java, including dependency updates, verification, and monitoring security improvements"
 type: "article"
@@ -76,7 +76,7 @@ built in the Chainguard Factory from source, and is available at
 [manually download the file to
 compare](/chainguard/libraries/java/overview/#manual), if desired.
 
-## Increase Chainguard Library use
+## Increase Chainguard Libraries use
 
 The number of available artifacts in Chainguard Libraries for Java increases
 over time. If an artifact was already retrieved from the Maven Central

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Chainguard Libraries for Java Overview"
-linktitle: "Java Overview"
+title: "Chainguard Libraries for Java overview"
+linktitle: "Java overview"
 description: "Learn about Chainguard Libraries for Java, providing enhanced security for Maven dependencies through automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-03-25T08:04:00+00:00

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Build Configuration"
-linktitle: "Build Configuration  "
+title: "Build configuration"
+linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Global Configuration"
-linktitle: "Global Configuration  "
+title: "Global configuration"
+linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Chainguard Libraries for JavaScript Overview"
-linktitle: "JavaScript Overview"
+title: "Chainguard Libraries for JavaScript overview"
+linktitle: "JavaScript overview"
 description: "JavaScript libraries for your application development"
 type: "article"
 date: 2025-06-05T09:00:00+00:00

--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -1,6 +1,6 @@
 ---
-title: "Chainguard Libraries Network Requirements"
-linktitle: "Network Requirements"
+title: "Chainguard Libraries network requirements"
+linktitle: "Network requirements"
 description: "Learn the network requirements for accessing Chainguard Libraries, including domains needed for authentication, package downloads, and verification tools"
 type: "article"
 date: 2025-06-04T09:30:00+00:00
@@ -16,7 +16,7 @@ toc: true
 
 Chainguard Libraries require specific network access to ensure secure delivery of hardened Java and Python dependencies to your development environment. This guide details the domains and ports needed for authentication, package downloads, and verification tools.
 
-### Access for chainctl and Other Tools
+### Access for chainctl and other tools
 
 For initial configuration with chainctl as well as for verification of
 downloaded libraries with cosign and other tools, you must have HTTPS access to
@@ -29,7 +29,7 @@ the following domains:
 * `console.chainguard.dev` for the web console to administrate and use your
   Chainguard accounts.
 
-### Access for Libraries
+### Access for development tools
 
 Chainguard Libraries use is transparent for development efforts and typically
 requires no additional network access for workstations and other infrastructure

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Chainguard Libraries Overview"
-linktitle: "Libraries Overview"
+title: "Chainguard Libraries overview"
+linktitle: "Libraries overview"
 description: "Learn about Chainguard Libraries, providing enhanced security for 
     Java, JavaScript, and Python dependencies through automated patching and 
     comprehensive supply chain protection."
@@ -99,7 +99,7 @@ Chainguard Libraries is available for the following library ecosystems:
 * Python and the larger ecosystem with
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/)
 
-## Other Resources
+## Other resources
 
 * [Chainguard Libraries product page](https://www.chainguard.dev/libraries)
 * [Learning Lab for October 2025 on Chainguard Libraries for JavaScript and CVE

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Build Configuration"
-linktitle: "Build Configuration "
+title: "Build configuration"
+linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: "Global Configuration"
-linktitle: "Global Configuration "
+title: "Global configuration"
+linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00

--- a/content/chainguard/libraries/python/management.md
+++ b/content/chainguard/libraries/python/management.md
@@ -1,6 +1,6 @@
 ---
-title: "Management and Maintenance "
-linktitle: "Management "
+title: "Management and maintenance"
+linktitle: "Management"
 description: "Learn how to manage and maintain Chainguard Libraries for Python, including package updates, verification, and monitoring security improvements"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
@@ -20,7 +20,7 @@ Chainguard Libraries for Python operates transparently after completing the [glo
 The following sections detail optional management, maintenance, and auditing
 steps on the repository manager and the build tool.
 
-## Source Verification
+## Source verification
 
 You can verify what artifacts are retrieved from the Chainguard Libraries
 repository on a global level:
@@ -40,7 +40,7 @@ you can verify your libraries use in the following locations:
 * Libraries in your application bundles
 * Installed applications on your hosts or in your container images
 
-## Increase Chainguard Library Use
+## Increase Chainguard Libraries use
 
 The number of available artifacts in Chainguard Libraries for Python increases
 over time. If an artifact was already retrieved from the PyPI

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Chainguard Libraries for Python Overview"
-linktitle: "Python Overview "
+title: "Chainguard Libraries for Python overview"
+linktitle: "Python overview"
 description: "Learn about Chainguard Libraries for Python, providing enhanced security for PyPI packages through automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-04-09:04:00+00:00
@@ -35,7 +35,7 @@ sources if available. In combination with third-party software repository
 managers, you can use Chainguard Libraries for Python as a secure source of
 truth for your development process. 
 
-## Technical Details
+## Technical details
 
 Most organizations consume Chainguard Libraries for Python through a repository
 manager such as Cloudsmith, JFrog Artifactory, or Sonatype Nexus Repository. For
@@ -87,7 +87,7 @@ Python wheel files for standard and remediated package version.
 
 <a id="cve-remediation"></a>
 
-## CVE Remediation
+## CVE remediation
 
 Chainguard Libraries for Python includes the [CVE
 Remediation](/chainguard/libraries/cve-remediation/) feature. Remediated
@@ -148,7 +148,7 @@ must configure your package manager to pull NVIDIA components from an
 upstream source such as NVIDIA's index at https://pypi.nvidia.com, or from PyPI 
 where NVIDIA publishes them directly.
 
-## Runtime and Build Requirements
+## Runtime and build requirements
 
 The runtime requirements for Python artifacts available from Chainguard
 Libraries for Python are identical to the requirements of the original upstream
@@ -224,7 +224,7 @@ requirements apply:
 * The runtime environment's processor architecture must be `x86_64` or
   `aarch64`.
 
-### Behavior on Windows and MacOS
+### Behavior on Windows and macOS
 
 As a result of the requirements detailed in the preceding section, the developer
 experience on Windows and MacOS platforms is impacted. Chainguard only provides
@@ -245,7 +245,7 @@ Linux.
 
 <a id="manual"></a>
 
-## Manual Access
+## Manual access
 
 Use the URLs with your [username and password retrieved with
 chainctl](/chainguard/libraries/access/) to access the Chainguard Libraries for

--- a/content/chainguard/libraries/scanners.md
+++ b/content/chainguard/libraries/scanners.md
@@ -1,6 +1,6 @@
 ---
-title: "Vulnerability Scanners and Chainguard Libraries"
-linktitle: "Vulnerability Scanners"
+title: "Vulnerability scanners and Chainguard Libraries"
+linktitle: "Vulnerability scanners"
 description: "Details for using vulnerability scanners with Chainguard Libraries."
 type: "article"
 date: 2025-10-04T12:00:00+00:00
@@ -33,7 +33,7 @@ information on scanning containers, refer to our guide on [Working with
 Container Image
 Scanners](/chainguard/chainguard-images/staying-secure/working-with-scanners/).
 
-## Vulnerability Scanning
+## Vulnerability scanning
 
 Vulnerability scanning can be performed at various stages throughout the
 software development lifecycle. Scanning earlier in the process helps identify

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -1,5 +1,5 @@
 ---
-title: "Chainguard Libraries Verification"
+title: "Chainguard Libraries verification"
 linktitle: "Verification"
 description:
   "Learn how to verify libraries and packages are from Chainguard


### PR DESCRIPTION
## Summary

* Adjust to the new writing style guide 
* Update section headings and titles in Chainguard Libraries documentation to use sentence case
* Convert headings like "Other Resources" to "Other resources" while preserving proper nouns
* Maintain "Chainguard Libraries" product name and other proper nouns like "JFrog", "macOS"

used claude for initial blast and then modified and updated as needed. Also tested for render locally. Looks and reads much better.


