### PR TITLE
Fix typos and improve clarity in PCI DSS documentation

### DIFF
--- a/content/compliance/pci-dss-4/pci-dss-chainguard.md
+++ b/content/compliance/pci-dss-4/pci-dss-chainguard.md
@@ -37,17 +37,17 @@ STIG-hardened FIPS images are pre-configured container images that have been sec
 
 One of the main requirements of PCI DSS is to maintain a vulnerability management program. PCI DSS requires you to scan for vulnerabilities once every three months (Requirement 11.3.1) and triage and address all vulnerabilities (Requirement 11.3.11). Chainguard protects you from malicious attacks by supplying you with images where CVEs have already been dealt with, removing vulnerabilities for you.
 
-PCI DCC requires that you catalog and classify vulnerabilities bespoke and third-party software (Requirements 6.3.1 and 6.3.2). You must fix all critical and high vulnerabilities and have a plan of action for the rest (Requirement 11.4.4). Chainguard does that for you.
+PCI DSS requires that you catalog and classify vulnerabilities bespoke and third-party software (Requirements 6.3.1 and 6.3.2). You must fix all critical and high vulnerabilities and have a plan of action for the rest (Requirement 11.4.4). Chainguard does that for you.
 
 Vulnerability scanners can be noisy and sifting through false positives while cataloging true vulnerabilities can be tedious work. Providing justifications for vulnerabilities that aren't applicable takes time, and that is after investigating them thoroughly.
 
 Chainguard Containers are carefully engineered to contain low-to-no CVEs. Organizations can use them as their source to build their applications on. The benefits of our solution are:
 
 - **You’re secured by default** : Our images contain low-to-no CVEs. Check out our [Images Directory](https://images.chainguard.dev) yourself. ‍
-- [**Extensive scanner partnerships**](https://www.chainguard.dev/scanners): We partner with the industry-leading scanners such as Snyk, Crowdstrike, and Wiz. ‍
+- **Extensive scanner partnerships**: We partner with industry-leading scanners such as Snyk, Crowdstrike, Wiz, [and many others](https://www.chainguard.dev/scanners).
 - **SBOM for all Chainguard Containers**: Get full transparency into the packages actually used in our images and ultimately run in your environment. ‍
 - **Less ongoing human overhead**: Every new Chainguard Container version is carefully scanned and any addressable CVEs are fixed. ‍
--  **Trust in our industry leading [CVE SLA]**(https://www.chainguard.dev/cve-sla): We are committed to supplying secure software and commit to fixing CVEs so you don’t have to.
+-  **Trust in our industry-leading CVE SLA**: We are committed to supplying secure software and commit to fixing CVEs [quickly](https://www.chainguard.dev/cve-sla) so you don’t have to.
 
 
 ## Browse all CMMC 2.0 Articles


### PR DESCRIPTION
1. PCI DSS, not PCI DCC.
2. industry-leading should have a hyphen
3. One of the hyperlinks isn't visible from the docs page since the text is bolded
4. One of the hyperlinks had a markdown issue so wouldn't render, and for the same reason as #2, shouldn't be embedded in the bold text.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->