### PR TITLE
Update custom-assembly.md

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -65,7 +65,7 @@ This means that in order to use Custom Assembly (including `--save-as`), your ac
 To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` and `repo.create` capabilities:
 
 ```shell
-chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_history.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
+chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_report.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
 ```
 
 After creating this custom role, you would need to bind it to any identities in your organization that you want to be able to manage Custom Assembly resources. Check out our [Overview of Roles and Role-bindings in Chainguard](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to learn more.


### PR DESCRIPTION
Replace `build_history.list` capability (which doesn't exist) with the correct capability `build_report.list` for the custom-ca role.

[X ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Typo fix
### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Yes when customers copy the CA custom role it tries to add a capability that doesn't exist. Replaced `build_history.list` with the correct capability `build_report.list`

### Why are we making this change?
<!-- What larger problem does this PR address? -->
creating a custom ca role based off of our docs.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
review
### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
creating a custom ca role following the docs.