### PR TITLE
This exercise in the docs is currently broken

### DIFF
--- a/content/chainguard/fips/getting-started.md
+++ b/content/chainguard/fips/getting-started.md
@@ -85,7 +85,7 @@ Run the script in the FIPS container:
 ```bash
 docker run --rm -v $(pwd):/work -w /work \
   cgr.dev/ORGANIZATION/python-fips:latest \
-  python test_fips.py
+  test_fips.py
 ```
 
 You should see output like:


### PR DESCRIPTION
The entrypoint in the container image is `python`. There is no need for the command to be `python test_fips.py`. Running the command without `python` resulted in successful output:
```
SHA-256 hash: 8832699c6bbcc63001c75b098cb4499712bfc5680a1f517a9d5676abec8307bc 

OpenSSL version: OpenSSL 3.6.0 1 Oct 2025
FIPS cryptography is active
```

https://images.chainguard.dev/directory/image/python-fips/specifications

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->