### PR TITLE
renumber page weights as maintenance

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/chainguard-directory/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/chainguard-directory/index.md
@@ -13,7 +13,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 005
+weight: 040
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/container-image-digests.md
+++ b/content/chainguard/chainguard-images/how-to-use/container-image-digests.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 037
+weight: 130
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/dev-containers/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/dev-containers/index.md
@@ -13,7 +13,7 @@ images: []
 menu:
   docs:
     parent: "how-to-use"
-weight: 27
+weight: 100
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/digestabot_frizbee.md
+++ b/content/chainguard/chainguard-images/how-to-use/digestabot_frizbee.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 040
+weight: 140
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/how-to-use-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use/how-to-use-chainguard-images.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 001
+weight: 010
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/images-directory/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/images-directory/index.md
@@ -12,7 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 003
+weight: 020
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/init-containers.md
+++ b/content/chainguard/chainguard-images/how-to-use/init-containers.md
@@ -12,7 +12,7 @@ images: []
 menu:
   docs:
     parent: "how-to-use"
-weight: 035
+weight: 110
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/minimal-runtime-images.md
+++ b/content/chainguard/chainguard-images/how-to-use/minimal-runtime-images.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 045
+weight: 160
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/proxy-and-cache/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/proxy-and-cache/index.md
@@ -13,7 +13,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 009
+weight: 060
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -16,7 +16,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 013
+weight: 080
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/static-base-image.md
+++ b/content/chainguard/chainguard-images/how-to-use/static-base-image.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 035
+weight: 120
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -13,7 +13,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 007
+weight: 050
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/use-with-openshift.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-with-openshift.md
@@ -11,7 +11,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 011
+weight: 070
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 015
+weight: 090
 toc: true
 ---
 

--- a/content/chainguard/chainguard-images/how-to-use/version-info-chainguard-images.md
+++ b/content/chainguard/chainguard-images/how-to-use/version-info-chainguard-images.md
@@ -15,7 +15,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 040
+weight: 150
 toc: true
 ---
 


### PR DESCRIPTION
[x ] Check if this is a typo or other quick fix and ignore the rest :)

As we've added pages over the years, the space between the weights of each page has been reduced to where in some cases it was impossible to add a page between two others. This spaces those weights out and leaves a spot for a soon-to-come new page.

To check, just make sure I don't have any duplicate weights. I've checked the order multiple times. Also, there is no `030` because that's where I'm going to put the new page in an upcoming PR.