### PR TITLE
update helm doc for new community charts

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -85,7 +85,7 @@ volumePermissions:
 You will need to authenticate to pull charts. These instructions explain how to use charts and images with the `cgr.dev` repository. If you have mirrored or copied the charts and images to an organization-specific registry, you will need to adapt these instructions to authenticate to your registry, as appropriate.
 
 This section presents multiple authentication methods:
-- Use Helm values with `gloal.imagePullSecrets`
+- Use Helm values with `global.imagePullSecrets`
 - Deploy a Chainguard Helm chart using a Kubernetes pull secret
 - Use cluster node-scoped registry permissions
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -1,12 +1,12 @@
 ---
-title: "How to Use Chainguard iamguarded Helm Charts"
+title: "How to Use Chainguard Helm Charts"
 linktitle: "Using Chainguard Helm Charts"
 aliases:
 type: "article"
-description: "A primer on how to use the Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
-lead: "A primer on how to use the Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
+description: "A primer on how to use Chainguard-produced Helm charts to deploy Chainguard container images, including iamguarded Helm charts"
+lead: "A primer on how to use Chainguard-produced Helm charts to deploy Chainguard container images, including iamguarded Helm charts"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2025-07-11T08:49:31+00:00
+lastmod: 2026-01-29T08:49:31+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "iamguarded", "Product"]
 images: []
@@ -17,13 +17,24 @@ weight: 050
 toc: true
 ---
 
-[Helm](https://helm.sh) is the package manager for Kubernetes that simplifies the installation and management of applications by automating the creation of Kubernetes resources. Helm charts are reusable, versioned packages that define a collection of Kubernetes resources required to run an application or service. You use Helm to define, install, and perform upgrades to your applications on Kubernetes.
+[Helm](https://helm.sh) is a package manager for Kubernetes that simplifies the installation and management of applications by automating the creation of Kubernetes resources. Helm charts are reusable, versioned packages that define a collection of Kubernetes resources required to run an application or service. You use Helm to define, install, and perform upgrades to your applications on Kubernetes.
 
-Previously, Chainguard created containers specially designed for compatibility with community Helm charts to deliver added benefits to customers already using those charts. We are now publishing our own collection of Helm charts, labeled as “iamguarded,” that come configured out-of-the box for use with Chainguard container images.
+For organizations looking to deploy their Chainguard container images with Helm, Chainguard provides upstream-produced Helm charts. These charts are available from the Chainguard Registry and are intended for customers who are either looking to get started with Helm or are looking for better, trusted alternatives to the public charts they may already be using.
 
-Chainguard’s `iamguarded`-labeled Helm charts take the place of the earlier methods and the charts are pulled directly from Chainguard. This new experience makes the provenance of these charts clear, and comes with the added benefit that they are designed to work with your Chainguard images.
+Chainguard also offers a limited set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. The iamguarded charts are forked from upstream Bitnami charts, but now configured out-of-the box for use with Chainguard’s hardened container images. These charts only receive edits necessary to make them work with Chainguard container images and retain the intended functionality of the originals they are based on.
 
-The following is an instructional guide for Chainguard users that were previously using community charts with Chainguard images to migrate over to the new `iamguarded` charts as well as for those who wish to begin using Chainguard's `iamguarded` Helm charts.
+These charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies.
+
+- For the community charts:
+  - Version streaming: Chainguard commits to supporting chart and image versions that match the latest upstream project chart. Within that latest chart we will support the associated image versions.
+  - Testing policy: We test the latest charts with the supported version streams and functionally validate by deploying various versions of Kubernetes clusters, deploying the Helm chart, and functionally validating it in its representative environment by exercising the various functionality of the chart(s). We’ll also continue publishing end-of-life (EOL) version streams as long as they continue to pass our functional validation.
+
+- For the iamguarded charts:
+  - We only build the latest/mainline versions of iamguarded images and test them against the latest version of the corresponding iamguarded Helm charts.
+
+For both types, Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version with an appended revision suffix for updates that include new image digests but no template changes. The OCI artifacts are signed and generate provenance attestations that link to the exact source commit and image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
+
+The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images. There are both similarities and differences for installing the two types of charts. The differences are labeled where they occur.
 
 
 ## Configuration Requirements
@@ -31,6 +42,13 @@ The following is an instructional guide for Chainguard users that were previousl
 If you are pulling container images directly from Chainguard, then you must set a `global.org` value. You don't need this if you are pulling from your own internal registry.
 
 You can set a `global.org` value using a `--set` flag during installation, as shown in this example:
+
+```sh
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
+  --set "global.org=$ORGANIZATION"
+```
+
+Or in this example for iamguarded charts:
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -139,7 +157,15 @@ helm registry login cgr.dev \
   --password=$HELMPASS
 ```
 
-Reference the secret in your Helm installation.
+Reference the secret in your Helm installation:
+
+```sh
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
+  --set "global.org=$ORGANIZATION" \
+  --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
+```
+
+Or for imguarded charts:
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -151,45 +177,32 @@ helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
 When the install is successful, it returns a confirmation message, like this:
 
 ```sh
-Pulled: cgr.dev/chainguard-private/iamguarded-charts/rabbitmq:16.0.2
-Digest: sha256:cfc18fe651760c91c7596f7d9d44512b162f19e4bfd8ba81b5ff6cb6d8e61d6d
-NAME: rabbitmq
-LAST DEPLOYED: Mon Jun  9 08:35:39 2025
+Pulled: cgr.dev/chainguard.edu/charts/grafana:10.5.13
+Digest: sha256:2629f907b15f26c706b5668b5700340b851176a10f55cf709f89a3701f2b4220
+NAME: grafana
+LAST DEPLOYED: Thu Jan 29 08:19:23 2026
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
-TEST SUITE: None
 NOTES:
-CHART NAME: rabbitmq
-CHART VERSION: 16.0.2
-APP VERSION: 4.1.0** Please be patient while the chart is being deployed **
+1. Get your 'admin' user password by running:
 
-Credentials:
-    echo "Username      : user"
-    echo "Password      : $(kubectl get secret --namespace default rabbitmq -o jsonpath="{.data.rabbitmq-password}" | base64 -d)"
-    echo "ErLang Cookie : $(kubectl get secret --namespace default rabbitmq -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 -d)"
+   kubectl get secret --namespace default grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 
-Note that the credentials are saved in persistent volume claims and will not be changed upon upgrade or reinstallation unless the persistent volume claim has been deleted. If this is not the first installation of this chart, the credentials may not be valid.
-This is applicable when no passwords are set and therefore the random password is autogenerated. In case of using a fixed password, you should specify it when upgrading.
-More information about the credentials may be found at https://docs.iamguarded.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases.
 
-RabbitMQ can be accessed within the cluster on port 5672 at rabbitmq.default.svc.cluster.local
+2. The Grafana server can be accessed via port 80 on the following DNS name from within your cluster:
 
-To access for outside the cluster, perform the following steps:
+   grafana.default.svc.cluster.local
 
-To Access the RabbitMQ AMQP port:
+   Get the Grafana URL to visit by running these commands in the same shell:
+     export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=grafana" -o jsonpath="{.items[0].metadata.name}")
+     kubectl --namespace default port-forward $POD_NAME 3000
 
-    echo "URL : amqp://127.0.0.1:5672/"
-    kubectl port-forward --namespace default svc/rabbitmq 5672:5672
-
-To Access the RabbitMQ Management interface:
-
-    echo "URL : http://127.0.0.1:15672/"
-    kubectl port-forward --namespace default svc/rabbitmq 15672:15672
-
-WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
-  - resources
-+info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+3. Login with the password from step 1 and the username: admin
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Grafana pod is terminated.                            #####
+#################################################################################
 ```
 
 
@@ -197,24 +210,40 @@ WARNING: There are "resources" sections in the chart not set. Using "resourcesPr
 
 If you manage access and permissions at cluster-wide and node-specific levels, these are some best practices to consider.
 
-**Pin to Digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart digest to prevent unexpected updates:
+**Pin to tag:** The best practice for community charts (not iamguarded) is to pin to the image tag, like this:
+
+```sh
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana --version 10.5.13 \
+  --set "global.org=$ORGANIZATION"
+```
+
+For imguarded charts, instead pin to digest.
+
+
+**For iamguarded, pin to digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart digest to prevent unexpected updates:
 
 ```sh
 helm install rabbitmq \ 
 oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
-     --set "global.org=$ORGANIZATION"
+  --set "global.org=$ORGANIZATION"
 ```
 
 **Review Default Values:** The chart provides security-minded defaults that are sensible but may not suit all use cases. Review the chart's `values.yaml` for the full range of configuration options and adjust as needed.
-
-**Use Image Pinning:** All `iamguarded` charts pin images to specific digests that have been tested for compatibility, ensuring reliable deployments.
 
 
 ## Helm chart usage examples
 
 ### Install with details passed in a flag
 
-To install an `iamguarded` Helm chart using standard Helm commands and passing details as flag values in the command itself, add the flags and values at the end like this example, substituting your organization for `$ORGANIZATION`.
+To install a Helm chart using standard Helm commands and passing details as flag values in the command itself, add the flags and values at the end like this example, substituting your organization for `$ORGANIZATION`.
+
+```sh
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
+  --set "global.org=$ORGANIZATION"
+```
+
+Or for imguarded charts:
+
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -228,14 +257,22 @@ Alternatively, you can put values in a file, such as our `values.yaml` sample, a
 ```sh
 image:
   registry: cgr.dev
-  repository: $ORGANIZATION/rabbitmq # replace $ORGANIZATION
+  repository: $ORGANIZATION/grafana # replace $ORGANIZATION
   tag: latest # pin to specific version instead of latest
 ```
 
 Then you refer to the file like this:
 
 ```sh
-helm install test oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq --values ./values.yaml
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
+  --values ./values.yaml
+```
+
+Or for imguarded charts:
+
+```sh
+helm install test oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
+--values ./values.yaml
 ```
 
 ### Installing on AWS Elastic Kubernetes Service (EKS) Auto Mode
@@ -256,7 +293,16 @@ allowVolumeExpansion: true
 EOF
 ```
 
-You then pass the storage class's name to the `helm install` command. Here, we use `rabbitmq` as an example:
+You then pass the storage class's name to the `helm install` command. Here, we use `grafana` as an example:
+
+```sh
+helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
+  --set "global.org=$ORGANIZATION" \
+  --set "global.imagePullSecrets[0].name=chainguard-pull-secret" \
+  --set "persistence.storageClass=gp3-automode"
+```
+
+Or, like this for iamguarded, using `rabbitmq` as an example:
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -272,13 +318,25 @@ To check the Helm configuration, you can run `helm install` with `--dry-run` fla
 To see the files, run:
 
 ```sh
-helm pull --untar oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq
+helm pull --untar oci://cgr.dev/$ORGANIZATION/charts/grafana \
+```
+
+Or for imguarded charts:
+
+```sh
+helm pull --untar oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
 ```
 
 To get the `values.yaml` so you can examine it, run:
 
 ```sh
-helm show values oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq
+helm show values oci://cgr.dev/$ORGANIZATION/charts/grafana \
+```
+
+Or for imguarded charts:
+
+```sh
+helm show values oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
 ```
 
 See the [Helm commands documentation](https://helm.sh/docs/helm/) for more information.

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -27,12 +27,12 @@ These charts have been tested by Chainguard to confirm they produce expected dep
 
 - For the community charts:
   - Version streaming: Chainguard commits to supporting chart and image versions that match the latest upstream project chart. Within that latest chart we will support the associated image versions.
-  - Testing policy: We test the latest charts with the supported version streams and functionally validate by deploying various versions of Kubernetes clusters, deploying the Helm chart, and functionally validating it in its representative environment by exercising the various functionality of the chart(s). We’ll also continue publishing end-of-life (EOL) version streams as long as they continue to pass our functional validation.
+  - Testing policy: We test the latest charts with the supported version streams and functionally validate by deploying the Helm chart, and functionally validating it in its representative environment by exercising the various functionality of the chart(s). We’ll also continue publishing end-of-life (EOL) version streams as long as they continue to pass our functional validation.
 
 - For the iamguarded charts:
   - We only build the latest/mainline versions of iamguarded images and test them against the latest version of the corresponding iamguarded Helm charts.
 
-For both types, Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version with an appended revision suffix for updates that include new image digests but no template changes. The OCI artifacts are signed and generate provenance attestations that link to the exact source commit and image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
+For both types, Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version adding an appended revision suffix for updates that include material changes to the chart; otherwise, tags will float based as their dependent images update. The OCI artifacts are signed and generate provenance attestations that link to the exact image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
 
 The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images. There are both similarities and differences for installing the two types of charts. The differences are labeled where they occur.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

Chainguard is adding a new set of Helm charts that will be more extensive than the existing iamguarded charts. This PR modifies the existing Helm chart docs page to be inclusive of the new set while retaining needed information about the iamguarded charts.

## Type of change
Fixes #2935 

## What should this PR do?
The feature releases tomorrow. The PR is being created today to provide one last review opportunity before it must go live.

## What are the acceptance criteria?
Docs-team: Is this clear? Up to our standards?

Engineering/product: Already reviewed in draft in google doc

Note that the UI elements of the new Helm chart addition were not yet available when this was written, so the documentation will be updated further when those updates are out.