### PR TITLE
Reorganize content on verifying and downloading SBOMs

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Retrieve SBOMs for Chainguard Containers"
-linktitle: "Retrieve SBOM"
+title: "How to Retrieve Attestations and SBOMs for Chainguard Containers"
+linktitle: "Retrieve Attestations and SBOMs"
 aliases: 
 - /chainguard/chainguard-images/retrieve-image-sboms
 - /chainguard/chainguard-images/images-features/retrieve-image-sboms
@@ -23,21 +23,24 @@ toc: true
 
 Chainguard provides a Software Bill of Materials (SBOM) with every container image, enabling complete transparency about package contents and dependencies for security and compliance requirements. These SBOMs are cryptographically signed and attached as attestations, making them retrievable and verifiable. By including only the minimum packages needed, Chainguard Containers reduce attack surface while the SBOM ensures you can verify exactly what's in each image.
 
-Even though they contain the minimum number of packages, there may come a time when you want to know exactly what's running inside of a certain Chainguard Container. For this reason, Chainguard includes a signed SBOM with each image in the form of a [software attestation](https://slsa.dev/attestation-model), allowing you to verify the contents and meet compliance requirements.
+Even though they contain the minimum number of packages, there may come a time when you want to know exactly what's running inside of a certain Chainguard Container. For this reason, Chainguard includes a signed SBOM with each image in the form of a [software attestation](https://slsa.dev/attestation-model), allowing you to verify the contents and meet compliance requirements. Chainguard publishes several different types of attestations; see the options under the [Available attestation types](#available-attestation-types) section on this page.
 
-[Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/) — a part of the Sigstore project — supports software artifact signing, verification, and storage in an [OCI (Open Container Initiative)](/open-source/oci/what-is-the-oci/) registry, as well as the retrieval of said artifacts. This tutorial outlines how you can use the `cosign` command to retrieve a Chainguard Container's SBOM. 
+## Retrieve a container image's attestation
+
+You can retrieve a container image's attestation in two ways:
+- [Using Cosign](#retrieve-a-container-image-attestation-via-cosign)
+    - [Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/) — a part of the Sigstore project — supports software artifact signing, verification, and storage in an [OCI (Open Container Initiative)](/open-source/oci/what-is-the-oci/) registry, as well as the retrieval of said artifacts.
+- [In the Chainguard Console](#retrieve-a-container-image-attestation-in-the-chainguard-console)
+
+### Prerequisites
+
+To retrieve an attestation via Cosign, you'll need the following installed on your local machine:
+
+* **Cosign**: Follow [our guide on installing Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) to configure it.
+* **jq**: Follow instructions on the [jq downloads page](https://jqlang.github.io/jq/download/) to set it up.
 
 
-## Prerequisites
-
-In order to follow this guide, you'll need the following installed on your local machine:
-
-* **Cosign** — to retrieve SBOMs associated with Chainguard Containers, check out [our guide on installing Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) to configure it.
-* **jq** — to process JSON, visit the [jq downloads](https://jqlang.github.io/jq/download/) page to set it up.
-
-
-## Using Cosign to retrieve an container image's SBOM
-
+### Retrieve a container image attestation via Cosign
 
 Cosign includes a `download attestation` command that allows you to retrieve a Chainguard Container's attestation over the command line. Different types of attestations are referenced by their **predicate type**. To authenticate these statements and verify the authenticity of the software producer, you can use [`cosign verify-attestation`](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/). 
 
@@ -55,18 +58,10 @@ Cosign returns the attestation in a signed envelope, with the SBOM stored as a b
 You can include the following flags when retrieving attestations:
 * The `--platform` flag, which selects the target platform for the image, such as `linux/amd64` or `linux/arm64`. 
     * This flag requires Cosign version 2.2.1 or newer.
-* The `--predicate-type` flag, required to specify which type of attestation to retrieve. 
-    * Chainguard publishes several different types of attestations. Not every image will have every predicate type; availability depends on the image and its build process. Available predicate types include:
-        * `https://apko.dev/image-configuration`: Available on all images.
-        * `https://slsa.dev/provenance/v1`: Available on all images.
-        * `https://spdx.dev/Document`: Available on all images.
-        * `https://chainguard.dev/end-of-life`: Only available on EOL images in grace period.
-        * `https://cyclonedx.org/bom`: Only available to customers, on new builds or rebuilds after January 29, 2026. Use `cyclonedx` as the predicate type flag's value.
-        * `https://chainguard.dev/helm-values/v1`: Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation.
-        * `https://chainguard.dev/attestation/syft/v1`: Not available on all images; this predicate is less common.
-        * `https://chainguard.dev/attestation/chart-lock/v1`: Only present for images where Helm chart locking is relevant.
+* The `--predicate-type` flag, required to specify which type of attestation to retrieve. You can use the full URI or the shorthand version as the value of the flag. See the [Available attestation types](#available-attestation-types) section for a list of options.
 
-## Image SBOMs in the Chainguard Console
+
+### Retrieve a container image attestation in the Chainguard Console
 
 You can also find container image SBOMs in the [Chainguard Console](https://console.chainguard.dev). After signing in to the Console and clicking either the **Public images** or, if available, **Organization images** you'll be presented with a list of images. Clicking on any of these will take you to the image's landing page. There, you can click on the [**SBOM** tab](/chainguard/chainguard-images/how-to-use/images-directory/#sbom-tab) to find and download the SBOM for the given image. 
 
@@ -77,6 +72,21 @@ The following example shows the **SBOM** tab for the `postgres` image.
 You can use the drop-down menu above the table to select which version and architecture of the image you want to view. You can also use the search box to find specific packages in the SBOM or use the button to the right of the search box to download the SBOM to your machine.
 
 Check out our guide on [using the Chainguard Containers Directory](/chainguard/chainguard-images/how-to-use/images-directory/) for more details.
+
+## Available attestation types
+
+Chainguard publishes several different types of attestations. Not every image will have every predicate type; availability depends on the image and its build process. Available predicate types include:
+
+| Attestation Type  | Description  | Availability  |
+| ----------------- | ------------ | ------------  |
+| `https://slsa.dev/provenance/v1` (`slsaprovenance1`)  	| The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. | Available on all images. |
+| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.   	| Available on all images. |
+| `https://spdx.dev/Document` (`spdx`,`spdxjson`)   	| Contains the image SBOM in SPDX format. | Available on all images.                                                            	|
+| `https://chainguard.dev/end-of-life`   	| End-of-life status. | Only available on EOL images in grace period. |
+| `https://cyclonedx.org/bom` (`cyclonedx`) |   Contains the image SBOM in CycloneDX format. 	| Only available to customers, on new builds or rebuilds after January 29, 2026. |
+| `https://chainguard.dev/helm-values/v1`   	| Contains Helm values for images with vetted upstream Helm charts. | Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation. |  
+| `https://chainguard.dev/attestation/chart-lock/v1`   	| Contains Helm chart-lock data for relevant images. | Only present for images where Helm chart locking is relevant. |
+| `https://chainguard.dev/attestation/syft/v1` |  Contains Syft-based SBOM attestation. 	| Not available on all images; this predicate is less common. |
 
 ## License Information and Source Code references
 

--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Retrieve Attestations and SBOMs for Chainguard Containers"
-linktitle: "Retrieve Attestations and SBOMs"
+title: "How to Retrieve SBOMs and attestations for Chainguard Containers"
+linktitle: "Retrieve SBOMs"
 aliases: 
 - /chainguard/chainguard-images/retrieve-image-sboms
 - /chainguard/chainguard-images/images-features/retrieve-image-sboms
@@ -77,16 +77,30 @@ Check out our guide on [using the Chainguard Containers Directory](/chainguard/c
 
 Chainguard publishes several different types of attestations. Not every image will have every predicate type; availability depends on the image and its build process. Available predicate types include:
 
-| Attestation Type         | Description  | Availability  |
-| :----------------------- | ------------ | ------------  |
-| `https://slsa.dev/provenance/v1` (`slsaprovenance1`)  	| The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. | Available on all images. |
-| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.   	| Available on all images. |
-| `https://spdx.dev/Document` (`spdx`,`spdxjson`)   	| Contains the image SBOM in SPDX format. | Available on all images.                                                            	|
-| `https://chainguard.dev/end-of-life`   	| End-of-life status. | Only available on EOL images in grace period. |
-| `https://cyclonedx.org/bom` (`cyclonedx`) |   Contains the image SBOM in CycloneDX format. 	| Only available to customers, on new builds or rebuilds after January 29, 2026. |
-| `https://chainguard.dev/helm-values/v1`   	| Contains Helm values for images with vetted upstream Helm charts. | Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation. |  
-| `https://chainguard.dev/attestation/chart-lock/v1`   	| Contains Helm chart-lock data for relevant images. | Only present for images where Helm chart locking is relevant. |
-| `https://chainguard.dev/attestation/syft/v1` |  Contains Syft-based SBOM attestation. 	| Not available on all images; this predicate is less common. |
+* **SLSA**: `https://slsa.dev/provenance/v1` (`slsaprovenance1`)
+    * The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment.
+    * Available on all images.
+* **apko**: `https://apko.dev/image-configuration`
+    * Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.
+    * Available on all images.
+* **SPDX**: `https://spdx.dev/Document` (`spdx`,`spdxjson`)
+    * Contains the image SBOM in SPDX format.
+    * Available on all images.
+* **Chainguard EOL**: `https://chainguard.dev/end-of-life`
+    * End-of-life status.
+    * Only available on EOL images in grace period.
+* **CycloneDX**: `https://cyclonedx.org/bom` (`cyclonedx`)
+    * Contains the image SBOM in CycloneDX format.
+    * Only available to customers, on new builds or rebuilds after January 29, 2026.
+* **Chainguard Helm values**: `https://chainguard.dev/helm-values/v1`
+    * Contains Helm values for images with vetted upstream Helm charts.
+    * Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation.
+* **Chainguard Helm chart-lock**: `https://chainguard.dev/attestation/chart-lock/v1`
+    * Contains Helm chart-lock data for relevant images.
+    * Only present for images where Helm chart locking is relevant.
+* **Syft**: `https://chainguard.dev/attestation/syft/v1`
+    * Contains Syft-based SBOM attestation.
+    * Not available on all images; this predicate is less common.
 
 ## License Information and Source Code references
 

--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -77,8 +77,8 @@ Check out our guide on [using the Chainguard Containers Directory](/chainguard/c
 
 Chainguard publishes several different types of attestations. Not every image will have every predicate type; availability depends on the image and its build process. Available predicate types include:
 
-| Attestation Type  | Description  | Availability  |
-| ----------------- | ------------ | ------------  |
+| Attestation Type         | Description  | Availability  |
+| :----------------------- | ------------ | ------------  |
 | `https://slsa.dev/provenance/v1` (`slsaprovenance1`)  	| The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. | Available on all images. |
 | `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.   	| Available on all images. |
 | `https://spdx.dev/Document` (`spdx`,`spdxjson`)   	| Contains the image SBOM in SPDX format. | Available on all images.                                                            	|

--- a/content/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
@@ -112,17 +112,7 @@ cosign verify \
 
 Attestations are signed metadata about the artifact, which can include SBOMs, vulnerability scans, or other custom predicates.
 
-The [attestations](https://slsa.dev/attestation-model) for a container image can be obtained and verified using Cosign. These are a few of the existing types:
-
-| Attestation Type  | Description  |
-| ----------------- | ------------ |
-| `https://slsa.dev/provenance/v1`   	| The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment. |
-| `https://apko.dev/image-configuration` | Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.   	|
-| `https://spdx.dev/Document`   	| Contains the image SBOM in SPDX format.                                                             	|
-
-To download an attestation, use the `cosign download attestation` command and provide both the `predicate-type` and the build `platform`. By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
-
-To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier. To illustrate, the following examples will obtain the SBOM for the requested image for the `linux/amd64` platform.
+The [attestations](https://slsa.dev/attestation-model) for a container image can be obtained and verified using Cosign or directly in the Chainguard Console. See [How to retrieve attestations and SBOMs for Chainguard Containers](/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/) for more information.
 
 ### Public Registry
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Small re-org of content and deduplication effort

### What should this PR do?
- Have the list of predicate types on only one page
- Clarify that you can use the full URI or the shorthand version in the `download` command
- From the "Verify containers" page, link out to info about downloading attestations
- Put attestation types into a table

### Why are we making this change?
Deduplicate info about predicate types and improve clarity

### What are the acceptance criteria? 
- Links should work
- Information should be accurate
- The table should be readable

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->