### PR TITLE
Re-organize Library Access content, add direct access vs repo manager section

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -37,8 +37,7 @@ direct access.
 
 **Artifact manager**
 
-Configure credentials once in your artifact manager, such
-as Artifactory or Nexus, then all projects and developers automatically inherit
+If your organization uses an artifact manager such as JFrog Artifactory or Sonatype Nexus, you can set up and configure credentials once per language ecosystem. Then, all projects and developers automatically inherit
 the configuration. This option is recommended for organizations with multiple
 teams, and provides centralized access controls and consistent uptime. 
 

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -18,20 +18,49 @@ Chainguard Libraries provide controlled access to security-enhanced Java and
 Python dependencies through the unified Chainguard platform authentication
 system. This guide explains how to set up access for your organization.
 
-If you are not a Chainguard user yet, a new Chainguard account must be created
-and configured for access to Chainguard Libraries.
+## Getting started
 
-If you are already a Chainguard user, the Chainguard account owner in your
+### Prerequisites
+
+- Ensure you have access to Chainguard Libraries. 
+    - If you are not a Chainguard user yet, a new Chainguard account must be
+created and configured for access to Chainguard Libraries.
+    - If you are already a Chainguard user, the Chainguard account owner in your
 organization can grant access to Chainguard Libraries.
+- Confirm the name of your organization so you can use it with the `--parent`
+parameter to specify your organization when running commands with `chainctl`.
 
-In both cases, confirm the name of the organization so you can use it with the
-`--parent` parameter to specify the organization.
+### Direct access vs. artifact manager
 
-## Initial authentication
+Chainguard Libraries supports two approaches to access: an artifact manager or
+direct access. 
+
+**Artifact manager**
+
+Configure credentials once in your artifact manager, such
+as Artifactory or Nexus, then all projects and developers automatically inherit
+the configuration. This option is recommended for organizations with multiple
+teams, and provides centralized access controls and consistent uptime. 
+
+**Direct access**
+
+Set up authentication directly in each project's build
+configuration. This option allows for faster initial setup, but it does not
+allow for global configuration. It requires configuration per project and
+workstation, which creates more overhead as you scale across teams and projects.
+
+Both approaches require pull tokens for authentication; see [Pull token
+characteristics and use](#pull-token-characteristics-and-use) for more information. 
+
+> NOTE: For Python users, the [Chainguard keyring
+provider](#python-keyring-provider) uses short-lived credentials and is the
+preferred method where your environment supports it. 
+
+### Initial authentication
 
 Once your user account is created and access is confirmed, [install the
 Chainguard Control `chainctl` command line
-tool](/chainguard/chainctl-usage/how-to-install-chainctl/) and login to your
+tool](/chainguard/chainctl-usage/how-to-install-chainctl/) and log in to your
 account:
 
 ```shell
@@ -46,64 +75,19 @@ Successfully exchanged token.
 Valid! Id: 8a4141a........7d9904d98c
 ```
 
-<a id name="python-keyring"></a>
-
-## Python keyring provider
-
-Python users can leverage the [Chainguard keyring implementation](https://github.com/chainguard-dev/keyrings-chainguard-libraries) to provide short-lived credentials from supported environments, such as local development and CI/CD platforms that can use [assumable identities](/chainguard/administration/assumable-ids/assumable-ids/).
-
-Where possible, Chainguard recommends using short-lived credentials to access Chainguard Libraries.
-
-To set up the keyring, install the `keyrings-chainguard-libraries` package:
-
-```shell
-pip install keyrings-chainguard-libraries
-```
-
-*Note:* If you haven't set up access to Chainguard Libraries for Python, the above command installs the package from PyPI. After installing and configuring Chainguard Libraries for Python, you can get the private package again, to get the package built by Chainguard. To re-install the package:
-
-```
-pip install keyrings-chainguard-libraries --ignore-installed --no-cache-dir
-```
-
-Once the keyring package is installed, when you request to install packages from Chainguard Libraries for Python, the keyring automatically retrieves short-lived credentials for you, using `chainctl`.
-
-To use the keyring with a project `uv`, install the keyring:
-
-```shell
-uv pip install keyrings-chainguard-libraries
-```
-
-*Note:* If you haven't set up access to Chainguard Libraries for Python, the above command installs the package from PyPI. After installing and configuring Chainguard Libraries for Python, you can get the private package again, to get the package built by Chainguard. To re-install the package:
-
-```shell
-uv pip install keyrings-chainguard-libraries --reinstall --no-cache
-```
-
-By default, [uv disables keyring auth](https://docs.astral.sh/uv/reference/settings/#keyring-provider).
-
-To enable it in the global uv.toml:
-
-```toml
-keyring-provider = "subprocess"
-```
-
-To enable it in a project-specific pyproject.toml:
-
-```toml
-[tool.uv]
-keyring-provider = "subprocess"
-```
-
 <a id name="pull-token"></a>
 
-## Pull token for libraries
+## Creating pull tokens for libraries
 
 Pull tokens are separate identities with an assigned role to access the
-repositories from Chainguard Libraries. You can create the pull tokens with the
-chainctl command or using the Chainguard console.
+repositories from Chainguard Libraries. You can create the pull tokens:
+- With [the chainctl command](#creating-pull-tokens-with-chainctl), or 
+- [Using the Chainguard
+  console](#creating-pull-tokens-with-the-chainguard-console).
 
-For environments where short-lived credentials are not suitable, such as some CI/CD platforms, you can generate a pull token, which provides longer-lived access to Chainguard Libraries.
+For environments where short-lived credentials are not suitable, such as some
+CI/CD platforms, you can generate a pull token, which provides longer-lived
+access to Chainguard Libraries.
 
 To create a pull token you must have the relevant [entitlement](#entitlement)
 for the ecosystem and the `libraries.java.pull_token_creator`,
@@ -120,12 +104,11 @@ command:
 chainctl auth pull-token --repository=java --parent=example --ttl=8670h
 ```
 
-* `--repository=java`: retrieve the token for use with [Chainguard
-  Libraries for Java](/chainguard/libraries/java/overview/). Use `python` for a
-  token to use [Chainguard Libraries for
-  Python](/chainguard/libraries/python/overview/) and `javascript` for a token to
-  use [Chainguard Libraries for
-  JavaScript](/chainguard/libraries/python/overview/).
+* `--repository=java`: retrieve the token for use with [Chainguard Libraries for
+  Java](/chainguard/libraries/java/overview/). Use `python` for a token to use
+  [Chainguard Libraries for Python](/chainguard/libraries/python/overview/) and
+  `javascript` for a token to use [Chainguard Libraries for
+  JavaScript](/chainguard/libraries/javascript/overview/).
 * `--parent=example`: specify the parent organization for your account as
   provided when requesting access to Chainguard Libraries and replace `example`.
 * `--ttl=8670h`: set the duration for the validity of the token, defaults to
@@ -151,7 +134,30 @@ Username: 45a.....424eb0
 Password: eyJhbGciO..........WF0IjoxN
 ```
 
-### Pull token characteristics and use
+### Creating pull tokens with the Chainguard console
+
+Follow these steps to create a pull tokens for Chainguard Libraries in the
+Chainguard console:
+
+1. Use your authentication details to access the console at
+  [https://console.chainguard.dev/](https://console.chainguard.dev/).
+2. In the left-hand navigation, click **Overview**.
+3. Click the **Manage pull tokens** tab, then click **Create access token**.
+    - Alternatively, select **Access Tokens** from the menu at the top of the
+      **Settings** page.
+4. Configure the access token:
+    - **Name**: Provide a name. The name can later be used to locate the token
+  in the list.
+    - **Description**: Optionally provide a description of the token.
+    - **Access**: Choose the library that this token should access.
+    - **Expiration**: Set an expiration date for the token. The default is 30
+      days.
+5. Click **Create token**.
+6. When the username and password values are displayed, note these values in a
+   secure location, as you will need them for pull token use. These values will
+   not be displayed again.
+
+## Pull token characteristics and use
 
 The returned username and password combination is a new credential set in the
 organization that is independent of the account used to create and retrieve the
@@ -168,61 +174,22 @@ for basic authentication. Note that the actual returned values are much longer.
 > risk and ensure reliability, we recommend proxying the repositories through
 > your own artifact repository whenever possible.
 
-Refer to the following resources for more specific information for your needs:
+For artifact manager setup, see the global configuration guides:
+* [Java](/chainguard/libraries/java/global-configuration/)
+* [JavaScript](/chainguard/libraries/javascript/global-configuration/)
+* [Python](/chainguard/libraries/python/global-configuration/)
 
-* [Repository manager configuration with
-  Java](/chainguard/libraries/java/global-configuration/)
-* [Build tool and direct access configuration with
-  Java](/chainguard/libraries/java/build-configuration/)
-* [Repository manager configuration with
-  JavaScript](/chainguard/libraries/javascript/global-configuration/)
-* [Build tool and direct access configuration with
-  JavaScript](/chainguard/libraries/javascript/build-configuration/)
-* [Repository manager configuration with
-  Python](/chainguard/libraries/python/global-configuration/)
-* [Build tool and direct access configuration with
-  Python](/chainguard/libraries/python/build-configuration/)
-
-### Creating pull tokens with the Chainguard console
-
-Follow these steps to create a pull tokens for Chainguard Libraries in the
-Chainguard console:
-
-1. Use your authentication details to access the console at
-  [https://console.chainguard.dev/](https://console.chainguard.dev/).
-2. In the left-hand navigation, click **Overview**.
-3. Click the **Manage pull tokens** tab, then click **Create access token**.
-    - Alternatively, select **Access Tokens** from the menu at the top of the **Settings** page.
-4. Configure the access token:
-    - **Name**: Provide a name. The name can later be used to locate the
-  token in the list.
-    - **Description**: Optionally provide a description of the token.
-    - **Access**: Choose the library that this token should access.
-    - **Expiration**: Set an expiration date for the token. The default is 30 days.
-5. Click **Create token**.
-6. When the username and password values are displayed, note these values in a secure location, as you will need them for pull token use. These values will not be displayed again.
-
-### Verification
-
-Use the credentials for manual testing in a browser or with a script and curl if
-you know the URL for a specific library artifact. Refer to the following
-sections for more details:
-
-* [Technical details and manual testing for Java
-  libraries](/chainguard/libraries/java/overview/#technical-details)
-* [Technical details and manual testing for JavaScript
-  libraries](/chainguard/libraries/javascript/overview/#technical-details)
-* [Technical details and manual testing for Python
-  libraries](/chainguard/libraries/python/overview/#technical-details)
-* [Use environment variables](#env)
-* [.netrc for authentication](#netrc)
+For direct access, see the build configuration guides:
+* [Java](/chainguard/libraries/java/build-configuration/)
+* [JavaScript](/chainguard/libraries/javascript/build-configuration/)
+* [Python](/chainguard/libraries/python/build-configuration/)
 
 <a name="env"></a>
 
-## Use environment variables
+### Use environment variables for pull token credentials
 
-Using environment variables for username and password is more secure than
-hard coding the values in configuration files. In addition, you can use the same
+Using environment variables for username and password is more secure than hard
+coding the values in configuration files. In addition, you can use the same
 configuration and files for all users to simplify setup and reduce errors.
 
 Use the `env` environment output option to create a snippet for a new token
@@ -258,7 +225,7 @@ tool configuration with environment variable placeholders:
 
 <a id="netrc"></a>
 
-## .netrc for authentication
+### .netrc for authentication
 
 [curl](https://curl.se/) and a number of other tools support configuration of
 username and password authentication details for a specific domain in the
@@ -296,52 +263,84 @@ password CHAINGUARD_PYTHON_TOKEN
 
 Note that the long string for the password value must use only one line.
 
-<a id="entitlement"></a>
+<a id name="python-keyring"></a>
 
-## Verify entitlement
+## Python keyring provider
 
-You can verify entitlements for your organization `example` with the following
-command:
+Python users can leverage an alternative to pull tokens. The [Chainguard keyring
+implementation](https://github.com/chainguard-dev/keyrings-chainguard-libraries)
+provides short-lived credentials from supported environments, such as local
+development and CI/CD platforms that can use [assumable
+identities](/chainguard/administration/assumable-ids/assumable-ids/).
 
-```shell
-chainctl libraries entitlements list --parent=example
-```
+Where possible, Chainguard recommends using short-lived credentials to access
+Chainguard Libraries.
 
-The output must include the desired ecosystem in the table:
-
-```output
-Ecosystem Library Entitlements for example (45a0...764595)
-
-                             ID                             | ECOSYSTEM
-------------------------------------------------------------+------------
-  45a...................................................2cf | JAVASCRIPT
-  45a....................................................e1 | JAVA
-  45a....................................................x6 | PYTHON
-```
-
-Contact your Chainguard account owner for confirmation or adjustments if
-necessary.
-
-<!-- Removed for now until we decide where this info should live. It is only accessible
-for administrators (so Chainguard internal), but they might also be an audience to
-read the docs - so TBD
-
-As administrator you can create entitlements:
+To set up the keyring, install the `keyrings-chainguard-libraries` package:
 
 ```shell
-chainctl libraries entitlements create --ecosystems=java,python --parent=example
+pip install keyrings-chainguard-libraries
 ```
 
-Use the` --parent` option to specify the organization or select the organization
-when running the command.
+*Note:* If you haven't set up access to Chainguard Libraries for Python, the
+above command installs the package from PyPI. After installing and configuring
+Chainguard Libraries for Python, you can get the private package again, to get
+the package built by Chainguard. To re-install the package:
 
-With the ID from listing the entitlements detailed in the preceding section, you
-can also remove a Chainguard Libraries entitlement:
+```
+pip install keyrings-chainguard-libraries --ignore-installed --no-cache-dir
+```
+
+Once the keyring package is installed, when you request to install packages from
+Chainguard Libraries for Python, the keyring automatically retrieves short-lived
+credentials for you, using `chainctl`.
+
+To use the keyring with a project `uv`, install the keyring:
 
 ```shell
-chainctl libraries entitlements rm ENTITLEMENT_ID
+uv pip install keyrings-chainguard-libraries
 ```
--->
+
+*Note:* If you haven't set up access to Chainguard Libraries for Python, the
+above command installs the package from PyPI. After installing and configuring
+Chainguard Libraries for Python, you can get the private package again, to get
+the package built by Chainguard. To re-install the package:
+
+```shell
+uv pip install keyrings-chainguard-libraries --reinstall --no-cache
+```
+
+By default, [uv disables keyring
+auth](https://docs.astral.sh/uv/reference/settings/#keyring-provider).
+
+To enable it in the global uv.toml:
+
+```toml
+keyring-provider = "subprocess"
+```
+
+To enable it in a project-specific pyproject.toml:
+
+```toml
+[tool.uv]
+keyring-provider = "subprocess"
+```
+
+### Verification
+
+Use the credentials for manual testing in a browser or with a script and curl if
+you know the URL for a specific library artifact. Refer to the following
+sections for more details:
+
+* [Technical details and manual testing for Java
+  libraries](/chainguard/libraries/java/overview/#technical-details)
+* [Technical details and manual testing for JavaScript
+  libraries](/chainguard/libraries/javascript/overview/#technical-details)
+* [Technical details and manual testing for Python
+  libraries](/chainguard/libraries/python/overview/#technical-details)
+* [Use environment variables](#env)
+* [.netrc for authentication](#netrc)
+
 
 <a id="pull-token-management"></a>
 
@@ -351,8 +350,9 @@ Pull tokens are separate identities with username and password that are used for
 access to Chainguard Libraries. The tokens have a limited Time to Live (TTL)
 with a default of 30 days and a maximum TTL of 365 days.
 
-As a result, pull tokens become invalid after the TTL and are flagged as expired.
-For your use of Chainguard Libraries you must replace the token with a new one.
+As a result, pull tokens become invalid after the TTL and are flagged as
+expired. For your use of Chainguard Libraries you must replace the token with a
+new one.
 
 Expired tokens can no longer be used for access to Chainguard Libraries, but
 otherwise do not cause any issues and continue to exist until you delete them.
@@ -435,3 +435,50 @@ flag to remove all expired pull tokens:
 ```shell
 chainctl iam ids rm --expired --parent=example
 ```
+
+<a id="entitlement"></a>
+
+## Verify entitlement
+
+You can verify entitlements for your organization `example` with the following
+command:
+
+```shell
+chainctl libraries entitlements list --parent=example
+```
+
+The output must include the desired ecosystem in the table:
+
+```output
+Ecosystem Library Entitlements for example (45a0...764595)
+
+                             ID                             | ECOSYSTEM
+------------------------------------------------------------+------------
+  45a...................................................2cf | JAVASCRIPT
+  45a....................................................e1 | JAVA
+  45a....................................................x6 | PYTHON
+```
+
+Contact your Chainguard account owner for confirmation or adjustments if
+necessary.
+
+<!-- Removed for now until we decide where this info should live. It is only accessible
+for administrators (so Chainguard internal), but they might also be an audience to
+read the docs - so TBD
+
+As administrator you can create entitlements:
+
+```shell
+chainctl libraries entitlements create --ecosystems=java,python --parent=example
+```
+
+Use the` --parent` option to specify the organization or select the organization
+when running the command.
+
+With the ID from listing the entitlements detailed in the preceding section, you
+can also remove a Chainguard Libraries entitlement:
+
+```shell
+chainctl libraries entitlements rm ENTITLEMENT_ID
+```
+-->

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -32,7 +32,7 @@ parameter to specify your organization when running commands with `chainctl`.
 
 ### Direct access vs. artifact manager
 
-Chainguard Libraries supports two approaches to access: an artifact manager or
+There are two approaches to access: Using an artifact manager or
 direct access. 
 
 **Artifact manager**

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -263,6 +263,21 @@ password CHAINGUARD_PYTHON_TOKEN
 
 Note that the long string for the password value must use only one line.
 
+### Verification
+
+Use the credentials for manual testing in a browser or with a script and curl if
+you know the URL for a specific library artifact. Refer to the following
+sections for more details:
+
+* [Technical details and manual testing for Java
+  libraries](/chainguard/libraries/java/overview/#technical-details)
+* [Technical details and manual testing for JavaScript
+  libraries](/chainguard/libraries/javascript/overview/#technical-details)
+* [Technical details and manual testing for Python
+  libraries](/chainguard/libraries/python/overview/#technical-details)
+* [Use environment variables](#env)
+* [.netrc for authentication](#netrc)
+
 <a id name="python-keyring"></a>
 
 ## Python keyring provider
@@ -325,22 +340,6 @@ To enable it in a project-specific pyproject.toml:
 [tool.uv]
 keyring-provider = "subprocess"
 ```
-
-### Verification
-
-Use the credentials for manual testing in a browser or with a script and curl if
-you know the URL for a specific library artifact. Refer to the following
-sections for more details:
-
-* [Technical details and manual testing for Java
-  libraries](/chainguard/libraries/java/overview/#technical-details)
-* [Technical details and manual testing for JavaScript
-  libraries](/chainguard/libraries/javascript/overview/#technical-details)
-* [Technical details and manual testing for Python
-  libraries](/chainguard/libraries/python/overview/#technical-details)
-* [Use environment variables](#env)
-* [.netrc for authentication](#netrc)
-
 
 <a id="pull-token-management"></a>
 

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -136,7 +136,7 @@ Password: eyJhbGciO..........WF0IjoxN
 
 ### Creating pull tokens with the Chainguard console
 
-Follow these steps to create a pull tokens for Chainguard Libraries in the
+Follow these steps to create a pull token for Chainguard Libraries in the
 Chainguard console:
 
 1. Use your authentication details to access the console at


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Mostly re-organized existing content and added one new section

### What should this PR do?
- Re-organize content on the Library "Access" page to make it flow better
- Update some header names
- Add new section about using an artifact manager vs direct access and improve findability of links to build config/global config for each ecosystem

### Why are we making this change?
Internal feedback ([slack thread here](https://chainguard-dev.slack.com/archives/C085187D8RE/p1770040151929359)) regarding the findability of content relating to each ecosystem.

### What are the acceptance criteria? 
- Content should make sense in this new order
- New headers should make sense
- The direct access vs artifact manager section should be accurate

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->