### PR TITLE
Docs: Split helm page

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -23,7 +23,7 @@ For organizations looking to deploy their Chainguard container images with Helm,
 
 > Chainguard also offers a limited set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. Learn more about these in [How to use Chainguard iamguarded Helm Charts](/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/).
 
-These community charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
+The community charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
 
 - Version streaming: Chainguard commits to supporting chart and image versions that match the latest upstream project chart. Within that latest chart we will support the associated image versions.
 - Testing policy: We test the latest charts with the supported version streams and functionally validate by deploying the Helm chart in its representative environment and exercising the various functionality of the chart(s). We’ll also continue publishing end-of-life (EOL) version streams as long as they continue to pass our functional validation.
@@ -31,49 +31,6 @@ These community charts have been tested by Chainguard to confirm they produce ex
 Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version adding an appended revision suffix for updates that include material changes to the chart; otherwise, tags will float based as their dependent images update. The OCI artifacts are signed and generate provenance attestations that link to the exact image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
 
 The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images.
-
-
-## Configuration Requirements
-
-If you are pulling container images directly from Chainguard, then you must set a `global.org` value. You don't need this if you are pulling from your own internal registry.
-
-You can set a `global.org` value using a `--set` flag during installation, as shown in this example:
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION"
-```
-
-Or in this example for iamguarded charts:
-
-```sh
-helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
-  --set "global.org=$ORGANIZATION"
-```
-
-Alternately, you can set this value in a YAML file:
-
-```yaml
-global:
-  org: $ORGANIZATION
-```
-
-In addition, users who mirror images to custom repositories should use `global.imageRegistry` to override the default `cgr.dev`. If you have a complex mirroring strategy, consult the chart’s `values.yaml` for individual image configuration options including `registry`, `repository`, `tag` and `digest`. Here’s a sample from the RabbitMQ `iamguarded` chart documentation:
-
-```yaml
-image:
-  registry: myregistry.example.com
-  repository: mirrored/rabbitmq-iamguarded
-  digest: sha256:... # Use specific digest instead of tag
-
-# OS Shell image for volume permissions
-volumePermissions:
-  enabled: true
-  image:
-    registry: myregistry.example.com
-    repository: mirrored/os-shell-iamguarded
-    digest: sha256:... # Use specific digest instead of tag
-```
 
 
 ## Authentication
@@ -161,14 +118,6 @@ helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
   --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
 ```
 
-Or for imguarded charts:
-
-```sh
-helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
-  --set "global.org=$ORGANIZATION" \
-  --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
-```
-
 
 When the install is successful, it returns a confirmation message, like this:
 
@@ -206,21 +155,10 @@ NOTES:
 
 If you manage access and permissions at cluster-wide and node-specific levels, these are some best practices to consider.
 
-**Pin to tag:** The best practice for community charts (not iamguarded) is to pin to the image tag, like this:
+**Pin to tag:** The best practice for community charts is to pin to the image tag, like this:
 
 ```sh
 helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana --version 10.5.13 \
-  --set "global.org=$ORGANIZATION"
-```
-
-For imguarded charts, instead pin to digest.
-
-
-**For iamguarded, pin to digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart digest to prevent unexpected updates:
-
-```sh
-helm install rabbitmq \ 
-oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
   --set "global.org=$ORGANIZATION"
 ```
 
@@ -229,26 +167,9 @@ oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
 
 ## Helm chart usage examples
 
-### Install with details passed in a flag
-
-To install a Helm chart using standard Helm commands and passing details as flag values in the command itself, add the flags and values at the end like this example, substituting your organization for `$ORGANIZATION`.
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION"
-```
-
-Or for imguarded charts:
-
-
-```sh
-helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
- --set "global.org=$ORGANIZATION"
-```
-
 ### Install with details in a file
 
-Alternatively, you can put values in a file, such as our `values.yaml` sample, and then refer to the file in your install command.
+You can put values in a file, such as our `values.yaml` sample, and then refer to the file in your install command by passing the detail in a flag.
 
 ```sh
 image:
@@ -264,12 +185,6 @@ helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
   --values ./values.yaml
 ```
 
-Or for imguarded charts:
-
-```sh
-helm install test oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
---values ./values.yaml
-```
 
 ### Installing on AWS Elastic Kubernetes Service (EKS) Auto Mode
 When installing on EKS Auto Mode, you may need to create a storage class for the Helm chart's pod(s). This can be done by creating a storage class:
@@ -293,19 +208,10 @@ You then pass the storage class's name to the `helm install` command. Here, we u
 
 ```sh
 helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION" \
   --set "global.imagePullSecrets[0].name=chainguard-pull-secret" \
   --set "persistence.storageClass=gp3-automode"
 ```
 
-Or, like this for iamguarded, using `rabbitmq` as an example:
-
-```sh
-helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
-  --set "global.org=$ORGANIZATION" \
-  --set "global.imagePullSecrets[0].name=chainguard-pull-secret" \
-  --set "persistence.storageClass=gp3-automode"
-```
 
 ## Troubleshooting 
 
@@ -317,22 +223,10 @@ To see the files, run:
 helm pull --untar oci://cgr.dev/$ORGANIZATION/charts/grafana \
 ```
 
-Or for imguarded charts:
-
-```sh
-helm pull --untar oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
-```
-
 To get the `values.yaml` so you can examine it, run:
 
 ```sh
 helm show values oci://cgr.dev/$ORGANIZATION/charts/grafana \
-```
-
-Or for imguarded charts:
-
-```sh
-helm show values oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
 ```
 
 See the [Helm commands documentation](https://helm.sh/docs/helm/) for more information.

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -21,7 +21,7 @@ toc: true
 
 For organizations looking to deploy their Chainguard container images with Helm, Chainguard provides upstream-produced Helm charts. These charts are available from the Chainguard Registry and are intended for customers who are either looking to get started with Helm or are looking for better, trusted alternatives to the public charts they may already be using.
 
-> Chainguard also offers a limited set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. Learn more about these in [How to use Chainguard iamguarded Helm Charts](/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/).
+> Chainguard also offers a limited set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. Learn more about these in [How to use Chainguard iamguarded Helm Charts](/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/).
 
 The community charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -21,7 +21,7 @@ toc: true
 
 Chainguard offers this limited iamguarded set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. The iamguarded charts are forked from upstream Bitnami charts, but now configured out-of-the box for use with Chainguard’s hardened container images. These charts only receive edits necessary to make them work with Chainguard container images and retain the intended functionality of the originals they are based on. Because the iamguarded charts are forks, they may be susceptible to breaking changes introduced by the upstream. In such cases, customers should plan to transition to a community-provided alternative (or an equivalent one from Chainguard) where possible.
 
-> For organizations looking to deploy their Chainguard container images with Helm and who don't need or want the iamguarded charts, Chainguard provides upstream-produced Helm charts, learn more about these in [How to use Chainguard Helm Charts](/chainguard-images/how-to-use/use-chainguard-helm-charts/).
+> For organizations looking to deploy their Chainguard container images with Helm and who don't need or want the iamguarded charts, Chainguard provides upstream-produced Helm charts, learn more about these in [How to use Chainguard Helm Charts](/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/).
 
 These iamguarded charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -1,36 +1,35 @@
 ---
-title: "How to Use Chainguard Helm Charts"
-linktitle: "Using Chainguard Helm Charts"
+title: "How to Use Chainguard iamguarded Helm Charts"
+linktitle: "Using Chainguard iamguarded Helm Charts"
 aliases:
 type: "article"
-description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
-lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
+description: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
+lead: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
 lastmod: 2026-01-29T08:49:31+00:00
 draft: false
-tags: ["Chainguard Containers", "Helm charts", "Product"]
+tags: ["Chainguard Containers", "Helm charts", "iamguarded", "Product"]
 images: []
 menu:
   docs:
     parent: "chainguard-images"
-weight: 050
+weight: 055
 toc: true
 ---
 
 [Helm](https://helm.sh) is a package manager for Kubernetes that simplifies the installation and management of applications by automating the creation of Kubernetes resources. Helm charts are reusable, versioned packages that define a collection of Kubernetes resources required to run an application or service. You use Helm to define, install, and perform upgrades to your applications on Kubernetes.
 
-For organizations looking to deploy their Chainguard container images with Helm, Chainguard provides upstream-produced Helm charts. These charts are available from the Chainguard Registry and are intended for customers who are either looking to get started with Helm or are looking for better, trusted alternatives to the public charts they may already be using.
+Chainguard offers this limited iamguarded set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. The iamguarded charts are forked from upstream Bitnami charts, but now configured out-of-the box for use with Chainguard’s hardened container images. These charts only receive edits necessary to make them work with Chainguard container images and retain the intended functionality of the originals they are based on. Because the iamguarded charts are forks, they may be susceptible to breaking changes introduced by the upstream. In such cases, customers should plan to transition to a community-provided alternative (or an equivalent one from Chainguard) where possible.
 
-> Chainguard also offers a limited set of Helm charts to go with a set of Chainguard-created containers labeled as iamguarded, designed specifically to support organizations migrating off of Bitnami. Learn more about these in [How to use Chainguard iamguarded Helm Charts](/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/).
+> For organizations looking to deploy their Chainguard container images with Helm and who don't need or want the iamguarded charts, Chainguard provides upstream-produced Helm charts, learn more about these in [How to use Chainguard Helm Charts](/chainguard-images/how-to-use/use-chainguard-helm-charts/).
 
-These community charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
+These iamguarded charts have been tested by Chainguard to confirm they produce expected deployment results using the following policies:
 
-- Version streaming: Chainguard commits to supporting chart and image versions that match the latest upstream project chart. Within that latest chart we will support the associated image versions.
-- Testing policy: We test the latest charts with the supported version streams and functionally validate by deploying the Helm chart in its representative environment and exercising the various functionality of the chart(s). We’ll also continue publishing end-of-life (EOL) version streams as long as they continue to pass our functional validation.
+- We only build the latest/mainline versions of iamguarded images and test them against the latest version of the corresponding iamguarded Helm charts.
 
 Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version adding an appended revision suffix for updates that include material changes to the chart; otherwise, tags will float based as their dependent images update. The OCI artifacts are signed and generate provenance attestations that link to the exact image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
 
-The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images.
+The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their iamguarded Chainguard container images.
 
 
 ## Configuration Requirements
@@ -38,13 +37,6 @@ The following is an instructional guide for Chainguard users that are looking fo
 If you are pulling container images directly from Chainguard, then you must set a `global.org` value. You don't need this if you are pulling from your own internal registry.
 
 You can set a `global.org` value using a `--set` flag during installation, as shown in this example:
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION"
-```
-
-Or in this example for iamguarded charts:
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -156,14 +148,6 @@ helm registry login cgr.dev \
 Reference the secret in your Helm installation:
 
 ```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION" \
-  --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
-```
-
-Or for imguarded charts:
-
-```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
   --set "global.org=$ORGANIZATION" \
   --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
@@ -173,32 +157,45 @@ helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
 When the install is successful, it returns a confirmation message, like this:
 
 ```sh
-Pulled: cgr.dev/chainguard.edu/charts/grafana:10.5.13
-Digest: sha256:2629f907b15f26c706b5668b5700340b851176a10f55cf709f89a3701f2b4220
-NAME: grafana
-LAST DEPLOYED: Thu Jan 29 08:19:23 2026
+Pulled: cgr.dev/chainguard-private/iamguarded-charts/rabbitmq:16.0.2
+Digest: sha256:cfc18fe651760c91c7596f7d9d44512b162f19e4bfd8ba81b5ff6cb6d8e61d6d
+NAME: rabbitmq
+LAST DEPLOYED: Mon Jun  9 08:35:39 2025
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
+TEST SUITE: None
 NOTES:
-1. Get your 'admin' user password by running:
+CHART NAME: rabbitmq
+CHART VERSION: 16.0.2
+APP VERSION: 4.1.0** Please be patient while the chart is being deployed **
 
-   kubectl get secret --namespace default grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+Credentials:
+    echo "Username      : user"
+    echo "Password      : $(kubectl get secret --namespace default rabbitmq -o jsonpath="{.data.rabbitmq-password}" | base64 -d)"
+    echo "ErLang Cookie : $(kubectl get secret --namespace default rabbitmq -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 -d)"
 
+Note that the credentials are saved in persistent volume claims and will not be changed upon upgrade or reinstallation unless the persistent volume claim has been deleted. If this is not the first installation of this chart, the credentials may not be valid.
+This is applicable when no passwords are set and therefore the random password is autogenerated. In case of using a fixed password, you should specify it when upgrading.
+More information about the credentials may be found at https://docs.iamguarded.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases.
 
-2. The Grafana server can be accessed via port 80 on the following DNS name from within your cluster:
+RabbitMQ can be accessed within the cluster on port 5672 at rabbitmq.default.svc.cluster.local
 
-   grafana.default.svc.cluster.local
+To access for outside the cluster, perform the following steps:
 
-   Get the Grafana URL to visit by running these commands in the same shell:
-     export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=grafana" -o jsonpath="{.items[0].metadata.name}")
-     kubectl --namespace default port-forward $POD_NAME 3000
+To Access the RabbitMQ AMQP port:
 
-3. Login with the password from step 1 and the username: admin
-#################################################################################
-######   WARNING: Persistence is disabled!!! You will lose your data when   #####
-######            the Grafana pod is terminated.                            #####
-#################################################################################
+    echo "URL : amqp://127.0.0.1:5672/"
+    kubectl port-forward --namespace default svc/rabbitmq 5672:5672
+
+To Access the RabbitMQ Management interface:
+
+    echo "URL : http://127.0.0.1:15672/"
+    kubectl port-forward --namespace default svc/rabbitmq 15672:15672
+
+WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
+  - resources
++info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 ```
 
 
@@ -206,23 +203,17 @@ NOTES:
 
 If you manage access and permissions at cluster-wide and node-specific levels, these are some best practices to consider.
 
-**Pin to tag:** The best practice for community charts (not iamguarded) is to pin to the image tag, like this:
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana --version 10.5.13 \
-  --set "global.org=$ORGANIZATION"
-```
-
-For imguarded charts, instead pin to digest.
-
-
-**For iamguarded, pin to digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart digest to prevent unexpected updates:
+**Pin to Digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart digest to prevent unexpected updates:
 
 ```sh
 helm install rabbitmq \ 
 oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
-  --set "global.org=$ORGANIZATION"
+     --set "global.org=$ORGANIZATION"
 ```
+
+**Review Default Values:** The chart provides security-minded defaults that are sensible but may not suit all use cases. Review the chart's `values.yaml` for the full range of configuration options and adjust as needed.
+
+**Use Image Pinning:** All `iamguarded` charts pin images to specific digests that have been tested for compatibility, ensuring reliable deployments.
 
 **Review Default Values:** The chart provides security-minded defaults that are sensible but may not suit all use cases. Review the chart's `values.yaml` for the full range of configuration options and adjust as needed.
 
@@ -232,14 +223,6 @@ oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
 ### Install with details passed in a flag
 
 To install a Helm chart using standard Helm commands and passing details as flag values in the command itself, add the flags and values at the end like this example, substituting your organization for `$ORGANIZATION`.
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION"
-```
-
-Or for imguarded charts:
-
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -253,25 +236,18 @@ Alternatively, you can put values in a file, such as our `values.yaml` sample, a
 ```sh
 image:
   registry: cgr.dev
-  repository: $ORGANIZATION/grafana # replace $ORGANIZATION
+  repository: $ORGANIZATION/rabbitmq # replace $ORGANIZATION
   tag: latest # pin to specific version instead of latest
 ```
 
 Then you refer to the file like this:
 
 ```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --values ./values.yaml
-```
-
-Or for imguarded charts:
-
-```sh
-helm install test oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
---values ./values.yaml
+helm install test oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq --values ./values.yaml
 ```
 
 ### Installing on AWS Elastic Kubernetes Service (EKS) Auto Mode
+
 When installing on EKS Auto Mode, you may need to create a storage class for the Helm chart's pod(s). This can be done by creating a storage class:
 
 ```sh
@@ -289,16 +265,7 @@ allowVolumeExpansion: true
 EOF
 ```
 
-You then pass the storage class's name to the `helm install` command. Here, we use `grafana` as an example:
-
-```sh
-helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
-  --set "global.org=$ORGANIZATION" \
-  --set "global.imagePullSecrets[0].name=chainguard-pull-secret" \
-  --set "persistence.storageClass=gp3-automode"
-```
-
-Or, like this for iamguarded, using `rabbitmq` as an example:
+You then pass the storage class's name to the `helm install` command. Here, we use `rabbitmq` as an example:
 
 ```sh
 helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
@@ -314,25 +281,13 @@ To check the Helm configuration, you can run `helm install` with `--dry-run` fla
 To see the files, run:
 
 ```sh
-helm pull --untar oci://cgr.dev/$ORGANIZATION/charts/grafana \
-```
-
-Or for imguarded charts:
-
-```sh
-helm pull --untar oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
+helm pull --untar oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq
 ```
 
 To get the `values.yaml` so you can examine it, run:
 
 ```sh
-helm show values oci://cgr.dev/$ORGANIZATION/charts/grafana \
-```
-
-Or for imguarded charts:
-
-```sh
-helm show values oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq
+helm show values oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq
 ```
 
 See the [Helm commands documentation](https://helm.sh/docs/helm/) for more information.


### PR DESCRIPTION
When I added the documentation for the new community Helm charts last week, I inserted those details into an existing page that was created for the iamguarded charts. That wasn't wrong, but it wasn't as clear as we hoped. Also, it would be useful to be able to link from READMEs to a docs page specific to the type of chart being perused, community or iamguarded.

So, this splits the page into two, one for community charts and one for iamguarded charts.

At the moment, everything in each page works and customers can be successful using them. However, the two charts have some detail differences that would be cool to capture in these pages. We may do this during this PR's review cycle or in future PRs, probably both.

I'm starting this review with @joshrwolf as he is the best SME on the Helm charts and we've already talked about me creating this PR.

Docs Team: please hold off on reviewing until Josh and I have finished refining based on his review. Thanks!