### PR TITLE
Revise stated roles for editors in IAM model

### DIFF
--- a/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
+++ b/content/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
@@ -28,7 +28,7 @@ There are a number of built-in roles in Chainguard's IAM model that customers ca
 
 `owner` is the role with the most privileges. An owner can create, delete, view (list), and modify (update) organizations, account associations, role-bindings, organization invitations, custom roles, role-bindings, and subscriptions. 
 
-`editor` is the role with read access and limited creation and modification access. An editor can create, delete, and view images, role-bindings, and subscriptions. Additionally, an editor can modify role-bindings and subscriptions. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources.
+`editor` is the role with read access and limited creation and modification access. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources. It can modify the state of event subscriptions, but cannot grant roles or permissions. Editors can also push and pull images, libraries, and APKs.
 
 `viewer` is a role that generally only has read-only access. That is, a viewer can list images, policies, organizations (and organization invites), records, roles and role-bindings, subscriptions, and account associations.
 


### PR DESCRIPTION
From Jon Namdar in Slack:

> Hi team - I'm looking for some clarification here referencing this link: https://edu.chainguard.dev/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/
> When the "Editor" role is defined, it says the following.
> editor is the role with read access and limited creation and modification access. An editor can create, delete, and view images, role-bindings, and subscriptions. Additionally, an editor can modify role-bindings and subscriptions. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources.
> 
> I don't believe the underlined portion is correct. [@justin.prince](https://chainguard.enterprise.slack.com/team/U09SPHJF9K4) and I did some testing in a registry, and I think editors can only view as noted in the following sentence.
> 
> We also compared it to the built in roles capabilities reference and it seems to support that an editor can't create, delete, etc. https://edu.chainguard.dev/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/

This PR is an attempt to fix the issue.

Current edits come from reading this code (thanks to Billy for the link) : https://github.com/chainguard-dev/mono/blob/5a3cec623238035d0f91af42eb7332a3b0b172a5/sdk/proto/capabilities/roles.go
See lines 59 and 101 for the start of code blocks that seem to apply.
