### PR TITLE
Clarify Network Requirements for libraries

### DIFF
--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -31,14 +31,14 @@ the following domains:
 
 ## Access for development tools
 
-Whether using a repository manager or accessing libraries directly, you must have HTTPS access to:
+Whether using a repository manager or accessing libraries directly, you must allow HTTPS access to:
 
 * `libraries.cgr.dev` for library access
 * `issuer.enforce.dev` for authentication
 
-When using a repository manager, configure these domains in your repository manager. Your workstations and build infrastructure typically require no additional network access, as libraries are served through your repository manager.
+When using a repository manager, allowlist these domains in your repository manager. Your workstations and build infrastructure typically require no additional network access, as libraries are served through your repository manager.
 
-If accessing Chainguard Libraries directly for testing with curl or builds, configure these domains on your workstation.
+If accessing Chainguard Libraries directly for testing with curl or builds, allowlist these domains on your workstation.
 
 ### Library storage locations
 

--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -14,12 +14,12 @@ weight: 003
 toc: true
 ---
 
-Chainguard Libraries require specific network access to ensure secure delivery of hardened Java and Python dependencies to your development environment. This guide details the domains and ports needed for authentication, package downloads, and verification tools.
+[Chainguard Libraries](/chainguard/libraries/overview/) require specific network access to ensure secure delivery of hardened dependencies to your development environment. This guide details the domains and ports needed for authentication, package downloads, and verification tools.
 
-### Access for chainctl and other tools
+## Access for chainctl and other tools
 
 For initial configuration with chainctl as well as for verification of
-downloaded libraries with cosign and other tools, you must have HTTPS access to
+downloaded libraries with cosign and other tools, you must allow HTTPS access to
 the following domains:
 
 * `dl.enforce.dev` for download and update of chainctl
@@ -29,17 +29,17 @@ the following domains:
 * `console.chainguard.dev` for the web console to administrate and use your
   Chainguard accounts.
 
-### Access for development tools
+## Access for development tools
 
-Chainguard Libraries use is transparent for development efforts and typically
-requires no additional network access for workstations and other infrastructure
-running builds because the libraries are provided by the repository manager as
-configured for [Java](/chainguard/libraries/java/global-configuration/) or
-[Python](/chainguard/libraries/python/global-configuration/).
+Whether using a repository manager or accessing libraries directly, you must have HTTPS access to:
 
-The repository manager application must have HTTPS access to the domain
-`libraries.cgr.dev` for library access and `issuer.enforce.dev` for
-authentication.
+* `libraries.cgr.dev` for library access
+* `issuer.enforce.dev` for authentication
 
-If you are accessing Chainguard Libraries directly for testing with curl or with
-a build tool, the used workstation must have identical access.
+When using a repository manager, configure these domains in your repository manager. Your workstations and build infrastructure typically require no additional network access, as libraries are served through your repository manager.
+
+If accessing Chainguard Libraries directly for testing with curl or builds, configure these domains on your workstation.
+
+### Library storage locations
+
+Chainguard Libraries are stored and served from Google Artifact Registry (GAR).

--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -31,12 +31,14 @@ the following domains:
 
 ## Access for development tools
 
-Whether using a repository manager or accessing libraries directly, you must allow HTTPS access to:
+When using a repository manager, ensure your network allows outbound HTTPS access 
+to the following domains from your repository manager. Your workstations and build 
+infrastructure typically require no additional network access, as libraries are 
+served through your repository manager. If accessing Chainguard Libraries directly 
+for testing with curl or builds, ensure your network allows outbound HTTPS access 
+to these domains from your workstation:
 
 * `libraries.cgr.dev` for library access
 * `issuer.enforce.dev` for authentication
 
-When using a repository manager, allowlist these domains in your repository manager. Your workstations and build infrastructure typically require no additional network access, as libraries are served through your repository manager.
-
-If accessing Chainguard Libraries directly for testing with curl or builds, allowlist these domains on your workstation.
 

--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -40,6 +40,3 @@ When using a repository manager, allowlist these domains in your repository mana
 
 If accessing Chainguard Libraries directly for testing with curl or builds, allowlist these domains on your workstation.
 
-### Library storage locations
-
-Chainguard Libraries are stored and served from Google Artifact Registry (GAR).


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Clarify existing content, add section about library storage locations

### What should this PR do?
- Rephrases the content under "Access for development tools" section
- Add that Chainguard Libraries are stored and served from GAR

### Why are we making this change?
[Internal questions](https://chainguard-dev.slack.com/archives/C085187D8RE/p1770330816117169) about where libraries are stored and feedback that the current docs imply you have to use a repo manager

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->