### PR TITLE
Add regex example to github assumable IDs

### DIFF
--- a/content/chainguard/administration/assumable-ids/identity-examples/github-identity/index.md
+++ b/content/chainguard/administration/assumable-ids/identity-examples/github-identity/index.md
@@ -58,6 +58,15 @@ chainctl iam identities create github my-identity-name \
     --role registry.pull
 ```
 
+Regex is also available. For example creating an identity that can be assumed by multiple repositories and multiple branches.
+
+```sh
+chainctl iam identitie create github my-identity-name \
+    --github-repo='my-org/.*' \
+    --github-refs='refs/heads/main|master'
+    --role registry.pull
+```
+
 This will return the identity's
 [UIDP (unique identity path)](/chainguard/administration/cloudevents/events-reference/#uidp-identifiers).
 Note this value down, as you'll need it to set up the GitHub Actions workflow.


### PR DESCRIPTION
## Type of change
Example addition

### What should this PR do?
Customer was looking and only thought an assumable ID was per repo, didn't realize you could have a regex.

### Why are we making this change?
Make sure it's known that regex is available for the assumable ID creation (specifically under the github subcommand).

### What are the acceptance criteria? 
Just checking for wording.

### How should this PR be tested?
Can check the command, but it's the sample I use for customers.