### PR TITLE
Moving API Ref docs lower in left nav

### DIFF
--- a/content/chainguard/api/_index.md
+++ b/content/chainguard/api/_index.md
@@ -7,5 +7,5 @@ date: 2020-10-06T08:48:23+00:00
 lastmod: 2020-10-06T08:48:23+00:00
 draft: false
 images: []
-weight: 005
+weight: 033
 ---


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
@ltagliaferri thought the new location for the API Reference docs was a little out of place ([reference](https://chainguard-dev.slack.com/archives/C03H64P08UT/p1771181023564819)). I'm inclined to agree, and this PR moves it lower in the left-hand nav, while keeping it as a top-level item under `Product Docs`. 

This PR moves it below `Chainguard OS` but above `Administration`, which I think is a good compromise, but we can tweak this further as necessary.

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
n/a, quick fix

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Product docs should focus on flagship products. While we can and should start treating the API as a product of that level, the official products should probably come before it in the nav.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
LMK if you think this location is okay or if we should put it somewhere else.

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
Check the deploy preview ([link](https://deploy-preview-2980--ornate-narwhal-088216.netlify.app/chainguard/api/)), and let me know what you think.