### PR TITLE
update rumble bigquery to fetch 31 days only

### DIFF
--- a/tools/rumble/pkg/bigquery/bigquery.go
+++ b/tools/rumble/pkg/bigquery/bigquery.go
@@ -8,7 +8,6 @@ package cgbigquery
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/chainguard-dev/edu/tools/rumble/pkg/grype"
@@ -55,7 +54,7 @@ type ImageScan struct {
 type VulnWithImages struct {
 	Vulnerability string
 	Image         string
-	Time          time.Time
+	Dates         []string
 }
 
 func NewBqClient(project, db string) (BqClient, error) {

--- a/tools/rumble/pkg/grype/grype.go
+++ b/tools/rumble/pkg/grype/grype.go
@@ -178,7 +178,6 @@ func (d *GrypeDB) ExtractCVEs(allVulnRecords []interface{}) ([]Vuln, error) {
 		}
 		vulns = append(vulns, v)
 	}
-
 	// now distro-specific URLs like security.debian.org, people.ubuntu.com
 	for _, r := range altVulnIDs {
 		row = d.DB.QueryRow(altVulnIDquery, r)
@@ -193,6 +192,5 @@ func (d *GrypeDB) ExtractCVEs(allVulnRecords []interface{}) ([]Vuln, error) {
 		}
 		vulns = append(vulns, v)
 	}
-
 	return vulns, nil
 }


### PR DESCRIPTION
The vulnerability comparison and CVE pages like https://edu.chainguard.dev/chainguard/chainguard-images/vuln-comparison/node/ are failing to update. It turns out we have 70,000,000+ rows of data and querying them all is.. not optimal..

Since the pages are broken, I think we should land this to get them updating again. I ran this locally to update the cloud storage buckets with fresh data and the charts are current again.