### PR TITLE
network-requirements: document ip version

### DIFF
--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -24,19 +24,19 @@ Chainguard Containers do not call Chainguard services while running, so no netwo
 
 This table lists the DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Containers:
 
-| Hostname                | Port | Protocol | Notes                                           |
-| ----------------------- | ---- | -------- | ----------------------------------------------- |
-| cgr.dev                 | 443  | HTTPS    | Main container image registry                   |
-| console.chainguard.dev  | 443  | HTTPS    | Chainguard dashboard                            |
-| data.chainguard.dev     | 443  | HTTPS    | Console API endpoint                            |
-| console-api.enforce.dev | 443  | HTTPS    | Registry API endpoint                           |
-| enforce.dev             | 443  | HTTPS    | Registry authentication                         |
-| dl.enforce.dev          | 443  | HTTPS    | `chainctl` downloads                            |
-| issuer.enforce.dev      | 443  | HTTPS    | Registry STS (Security Token Service)           |
-| apk.cgr.dev             | 443  | HTTPS    | Package repository                              |
-| virtualapk.cgr.dev      | 443  | HTTPS    | Package repository                              |
-| packages.cgr.dev        | 443  | HTTPS    | Package repository (Extra packages)             |
-| packages.wolfi.dev      | 443  | HTTPS    | Package repository (Free containers)         |
+| Hostname                | Port | Protocol | IP      | Notes                                 |
+|-------------------------|------|----------|---------|---------------------------------------|
+| cgr.dev                 | 443  | HTTPS    | v4      | Main container image registry         |
+| console.chainguard.dev  | 443  | HTTPS    | v4      | Chainguard dashboard                  |
+| data.chainguard.dev     | 443  | HTTPS    | v4      | Console API endpoint                  |
+| console-api.enforce.dev | 443  | HTTPS    | v4      | Registry API endpoint                 |
+| enforce.dev             | 443  | HTTPS    | v4      | Registry authentication               |
+| dl.enforce.dev          | 443  | HTTPS    | v4      | `chainctl` downloads                  |
+| issuer.enforce.dev      | 443  | HTTPS    | v4      | Registry STS (Security Token Service) |
+| apk.cgr.dev             | 443  | HTTPS    | v4      | Package repository                    |
+| virtualapk.cgr.dev      | 443  | HTTPS    | v4      | Package repository                    |
+| packages.cgr.dev        | 443  | HTTPS    | v4      | Package repository (Extra packages)   |
+| packages.wolfi.dev      | 443  | HTTPS    | v4 & v6 | Package repository (Free containers)  |
 
 
 
@@ -46,10 +46,10 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 
 This table lists the third-party DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Containers:
 
-| Hostname                                                  | Port | Protocol | Notes                        |
-| --------------------------------------------------------- | ---- | -------- | ---------------------------- |
-| 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com | 443  | HTTPS    | Blob storage for *.cgr.dev   |
-| support.chainguard.dev                                    | 443  | HTTPS    | Support access for customers |
+| Hostname                                                  | Port | Protocol | IP      | Notes                        |
+|-----------------------------------------------------------|------|----------|---------|------------------------------|
+| 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com | 443  | HTTPS    | v4 & v6 | Blob storage for *.cgr.dev   |
+| support.chainguard.dev                                    | 443  | HTTPS    | v4      | Support access for customers |
 
 > Note that the `9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com` host is used to serve both image data and packages via `*.cgr.dev`.
 


### PR DESCRIPTION
We currently have a mix of ipv4 & ipv6 endpoints, document this.

Especially since we are about to gain ability to greenlight ipv6.
