### PR TITLE
Libraries and CVE remediation in Console UI

### DIFF
--- a/content/chainguard/libraries/browse.md
+++ b/content/chainguard/libraries/browse.md
@@ -1,0 +1,100 @@
+---
+title: "Browsing Chainguard Libraries"
+linktitle: "Browsing"
+description: "Searching, browsing, and inspecting Chainguard Libraries in the console"
+type: "article"
+date: 2025-07-03T14:00:00+00:00
+lastmod: 2025-07-03T14:00:00+00:00
+draft: false
+tags: ["Chainguard Libraries"]
+menu:
+  docs:
+    parent: "libraries"
+weight: 007
+toc: true
+---
+
+Chainguard Libraries includes thousands of libraries and many more individual
+library versions and artifacts. Through the Chainguard Console, you can
+browse all available libraries and their versions, and inspect their
+characteristics before using them in your application development.
+
+## Access libraries in the Chainguard Console
+
+Log in to the Chainguard Console at
+[https://console.chainguard.dev/](https://console.chainguard.dev/).
+
+In the left-hand navigation under **Libraries**, expand **Ecosystems** to find
+links for browsing Chainguard's [**Java**](/chainguard/libraries/java/overview/)
+and [**Python**](/chainguard/libraries/python/overview/) libraries. 
+
+<a id="initial-display"></a>
+
+### Browse the libraries list
+
+When you open a specific ecosystem, you'll see a search input box and a list of
+libraries. Click any row to open the [library detail page](#library-page).
+
+The list includes the following columns:
+
+* **Name** - the full library name, excluding any version identifiers.
+    * Python library names are simple strings, such as `setuptools` or
+  `Flask-Admin`. 
+    * Java library names are the concatenation of the Maven
+  coordinate values `groupId` and `artifactId`, separated by `:`. Examples are
+  `org.springframework:spring-core` or `org.eclipse.jetty:jetty-http`.
+* **Latest version** - the latest released and available version of the library
+  and the total number of available versions.
+* **Updated** - The most recent date when any version of this library was built
+  and published by Chainguard.
+
+At the bottom of the page, see a total count of available libraries.
+
+<a id="search"></a>
+
+### Search the libraries list
+
+Use the **Search** text input at the top of the libraries list to
+narrow down the list and to locate a specific library.
+
+Click into a row to view a [specific library page](#library-page).
+
+<a id="library-page"></a>
+
+### View remediated libraries
+
+[CVE remediation](/chainguard/libraries/cve-remediation/) is available for a
+subset of Chainguard Libraries for Python. You can view remediated libraries in
+the Chainguard Console.
+
+In the Python libraries directory, click the **Remediated** tab to view a list
+of remediated libraries. Click into a library to see which versions have
+remediated CVEs.
+
+While viewing the list of remediated versions for a library, click into a
+version to view more details: which CVEs were remediated, the date that the
+version was patched, and links to additional resources. 
+
+Learn more about browsing remediations in [CVE remediation for Chainguard
+Libraries](/chainguard/libraries/cve-remediation/#about-cve-remediation).
+
+## Library page
+
+To access a library page, click on the row for a specific library in the search
+results or the [initial library list](#initial-display).
+
+On a library's page, use the search bar at the top to search for specific
+versions.
+
+The list of library versions includes the following columns:
+
+* **Version** - the version of the library. Library versions are strings.
+  Depending on the ecosystem and library they can follow naming patterns and
+  other restrictions that allow ordering by version.
+* **Size** - the size of the library.
+    * The displayed size reflects the primary file(s) only: `.jar`/`.pom` for
+      Java, and `.whl`/`.tar.gz` for Python. It is not an aggregation of all
+      files under a given version.
+* **Built** - The date when this version was built and published by Chainguard.
+
+Click on the column titles to change the **sort** order of the list.

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -70,7 +70,7 @@ You can:
 
 In the Chainguard Console, navigate to the Python libraries, then click the **Remediations** tab. Click into a library to see which versions have remediated CVEs.
 
-While viewing the list of remediated versions for a library, click into a version to view more details: which CVEs were remediated, the date that the version was patched, and links to additional resources. 
+Learn more in [Browsing Chainguard libraries](/chainguard/libraries/browse/).
 
 <a id="vex"></a>
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -51,13 +51,36 @@ versions only.
 
 <a id="vex"></a>
 
-## Public VEX feed
+## Browse libraries with CVE remediation
+
+Remediated libraries are published in a dedicated PyPI-compatible index: `https://libraries.cgr.dev/python-remediated/` (simple index at `https://libraries.cgr.dev/python-remediated/simple/`). 
+
+You can:
+- Browse them in the Chainguard Console
+- Use the public VEX feed to understand what has been remediated
+- View them in a browser at the simple index URL
+    - Learn more in [Python Overview > Manual access](/chainguard/libraries/python/overview/#manual-access).
+- Expose them to your developers via a repo manager 
+    - Learn more in the following pages:
+        - JFrog Artifactory
+        - Cloudsmith
+        - Sonatype Nexus
+
+
+### Browse remediations in the Chainguard Console
+
+In Chainguard, navigate to the Python libraries, then click the **Remediations** tab.
+
+
+### Public VEX feed
 
 Advisories for each CVE addressed in our remediated libraries are published via
 a public VEX feed at
 [https://libraries.cgr.dev/openvex/v1/all.json](https://libraries.cgr.dev/openvex/v1/all.json).
 Supported scanners and your own custom tooling can use this feed to identify and
 recognize remediated versions.
+
+To view more details on the CVE and versions of a library that have been remediated, identify the library then navigate to the URL. For example: `https://libraries.cgr.dev/openvex/v1/pypi/urllib3.openvex.json`. 
 
 ## Scanning remediated libraries
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -49,7 +49,6 @@ provides the option to make remediated versions available for your development
 or opt out of using these versions completely and continue to use upstream
 versions only.
 
-<a id="vex"></a>
 
 ## Browse libraries with CVE remediation
 
@@ -61,16 +60,19 @@ You can:
 - View them in a browser at the simple index URL
     - Learn more in [Python Overview > Manual access](/chainguard/libraries/python/overview/#manual-access).
 - Expose them to your developers via a repo manager 
-    - Learn more in the following pages:
-        - JFrog Artifactory
-        - Cloudsmith
-        - Sonatype Nexus
+    - Learn more in the Python global configuration docs:
+        - [JFrog Artifactory](/chainguard/libraries/python/global-configuration/#jfrog-artifactory)
+        - [Cloudsmith](/chainguard/libraries/python/global-configuration/#cloudsmith)
+        - [Sonatype Nexus](/chainguard/libraries/python/global-configuration/#sonatype-nexus-repository)
 
 
 ### Browse remediations in the Chainguard Console
 
-In Chainguard, navigate to the Python libraries, then click the **Remediations** tab.
+In the Chainguard Console, navigate to the Python libraries, then click the **Remediations** tab. Click into a library to see which versions have remediated CVEs.
 
+While viewing the list of remediated versions for a library, click into a version to view more details: which CVEs were remediated, the date that the version was patched, and links to additional resources. 
+
+<a id="vex"></a>
 
 ### Public VEX feed
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -66,9 +66,9 @@ You can:
         - [Sonatype Nexus](/chainguard/libraries/python/global-configuration/#sonatype-nexus-repository)
 
 
-### Browse remediations in the Chainguard Console
+### Browse remediated libraries in the Chainguard Console
 
-In the Chainguard Console, navigate to the Python libraries, then click the **Remediations** tab. Click into a library to see which versions have remediated CVEs.
+In the Chainguard Console, navigate to the Python libraries, then click the **Remediated** tab. Click into a library to see which versions have remediated CVEs.
 
 Learn more in [Browsing Chainguard libraries](/chainguard/libraries/browse/).
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -89,23 +89,19 @@ Python wheel files for standard and remediated package version.
 
 ## CVE remediation
 
-Chainguard Libraries for Python includes the [CVE
-Remediation](/chainguard/libraries/cve-remediation/) feature. Remediated
-libraries include an appended local version identifier of `+cgr.N`. Python
-package management tools interpret the `+cgr.N` suffix as a local version that
-takes precedence over versions without the version suffix during dependency
-resolution.
+Chainguard Libraries for Python includes [CVE
+Remediation](/chainguard/libraries/cve-remediation/), which backports security fixes into existing library versions without requiring you to upgrade. Remediated versions are published with a `+cgr.N` suffix — for example, `1.1.2+cgr.1`. Python package managers interpret the suffix as a local version that takes precedence over versions _without_ the suffix during dependency resolution. 
 
 For example, the `flask` library has a fix for CVE-2023-30861 available in the
 upstream codebase. Upon customer request for a specific version, the fix is
-backported to the flask versions `1.1.2` and `2.0.0` and made available in new
-versions `1.1.2+cgr.1` and `2.0.0+cgr.1`. Python package management tools
+backported to the flask versions `1.1.2` and `2.0.0`. These are made available in new
+versions: `1.1.2+cgr.1` and `2.0.0+cgr.1`. Python package management tools
 consider these local versions, such as `1.1.2+cgr.1` and `2.0.0+cgr.1`, as
 newer, compatible replacements automatically.
 
-In some cases, multiple CVEs may be remediated in a specific library version.
-For example, `aiohttp` has fixes for both CVE-2024-23334 and CVE-2024-30251 in
-the version `3.9.1+cgr.2`.
+When multiple CVEs are addressed in a single release, the build number increments accordingly. For example, `aiohttp 3.9.1+cgr.2` includes fixes for both CVE-2024-23334 and CVE-2024-30251.
+
+Learn more about browsing remediations in [CVE remediation for Chainguard Libraries](/chainguard/libraries/cve-remediation/#about-cve-remediation).
 
 ## CUDA-enabled libraries
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Content reorganization, new feature info about CVE browsing in Console

### What should this PR do?
- Update the CVE Remediation page to include information about browsing remediations in the Console
- Reorganize and reword content
- Note that this PR and https://github.com/chainguard-dev/edu/pull/2373 will need to be published alongside each other; information is cross-linked in each of these PRs. For example, one of the pages in this PR links to `chainguard/libraries/browse/` which will only exist when 2373 is merged.

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->