### PR TITLE
Change owner of AutoDocs Update Platform Docs PRs

### DIFF
--- a/.github/workflows/autodocs-platform.yaml
+++ b/.github/workflows/autodocs-platform.yaml
@@ -85,7 +85,7 @@ jobs:
           documentation
           platform
           automated
-        assignees: erikaheidi
+        assignees: matthewhelmke
 
     - name: Post failure notice to Slack
       uses: step-security/action-slack-notify@e04c77a65bae8b6c0373478a1cb8fd7e012637e6 # v2.3.5


### PR DESCRIPTION
[ x] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Changes whose name is attached to AutoDocs platform update PRs.

### What should this PR do?
Removes `erikaheidi` and inserts `matthewhelmke`

### Why are we making this change?
Doing this as part of https://github.com/chainguard-dev/internal/issues/5662
