### PR TITLE
Revert "[AutoDocs] Update Platform Docs"

### DIFF
--- a/content/chainguard/administration/cloudevents/events-reference.md
+++ b/content/chainguard/administration/cloudevents/events-reference.md
@@ -4,7 +4,7 @@ lead: ""
 description: "Chainguard Events"
 type: "article"
 date: 2022-11-15T12:05:04
-lastmod: 2026-02-24T18:33:55
+lastmod: 2026-02-19T21:14:18
 draft: false
 tags: ["Platform", "Reference", "Product"]
 images: []
@@ -82,7 +82,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: cgr.dev
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of the repository being pulled from
-Ce-Time: 2026-02-24T18:33:55.425779136Z
+Ce-Time: 2026-02-19T21:14:18.471906226Z
 Ce-Type: dev.chainguard.registry.pull.v1
 Content-Length: 777
 Content-Type: application/json
@@ -112,7 +112,7 @@ User-Agent: Chainguard Enforce
     "tag": "The tag of the image being pulled",
     "type": "Type determines whether the object being pulled is a manifest or blob",
     "user_agent": "The user-agent of the client who pulled",
-    "when": "2026-02-24T18:33:55.424590"
+    "when": "2026-02-19T21:14:18.470647"
   }
 }
 ```
@@ -132,7 +132,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: cgr.dev
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of the repository being pushed to
-Ce-Time: 2026-02-24T18:33:55.424780857Z
+Ce-Time: 2026-02-19T21:14:18.470850612Z
 Ce-Type: dev.chainguard.registry.push.v1
 Content-Length: 707
 Content-Type: application/json
@@ -161,7 +161,7 @@ User-Agent: Chainguard Enforce
     "tag": "The tag of the image being pushed",
     "type": "Type determines whether the object being pushed is a manifest or blob",
     "user_agent": "The user-agent of the client who pushed",
-    "when": "2026-02-24T18:33:55.424565"
+    "when": "2026-02-19T21:14:18.470620"
   }
 }
 ```
@@ -181,7 +181,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/auth/v1/register
 Ce-Specversion: 1.0
 Ce-Subject: Chainguard UIDP
-Ce-Time: 2026-02-24T18:33:55.435155792Z
+Ce-Time: 2026-02-19T21:14:18.482665481Z
 Ce-Type: dev.chainguard.api.auth.registered.v1
 Content-Length: 154
 Content-Type: application/json
@@ -218,7 +218,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/events/v1/subscriptions
 Ce-Specversion: 1.0
 Ce-Subject: UIDP identifier of the subscription
-Ce-Time: 2026-02-24T18:33:55.43545715Z
+Ce-Time: 2026-02-19T21:14:18.472740759Z
 Ce-Type: dev.chainguard.api.events.subscription.created.v1
 Content-Length: 152
 Content-Type: application/json
@@ -254,7 +254,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/events/v1/subscriptions
 Ce-Specversion: 1.0
 Ce-Subject: UIDP identifier of the subscription to delete
-Ce-Time: 2026-02-24T18:33:55.435707063Z
+Ce-Time: 2026-02-19T21:14:18.473118381Z
 Ce-Type: dev.chainguard.api.events.subscription.deleted.v1
 Content-Length: 119
 Content-Type: application/json
@@ -290,7 +290,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP with which this account information is associated
-Ce-Time: 2026-02-24T18:33:55.426294241Z
+Ce-Time: 2026-02-19T21:14:18.477545236Z
 Ce-Type: dev.chainguard.api.iam.account_associations.created.v1
 Content-Length: 385
 Content-Type: application/json
@@ -334,7 +334,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP with which this account information is associated
-Ce-Time: 2026-02-24T18:33:55.426597132Z
+Ce-Time: 2026-02-19T21:14:18.477869809Z
 Ce-Type: dev.chainguard.api.iam.account_associations.updated.v1
 Content-Length: 336
 Content-Type: application/json
@@ -378,7 +378,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/account_associations
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the group whose associations will be deleted
-Ce-Time: 2026-02-24T18:33:55.428053964Z
+Ce-Time: 2026-02-19T21:14:18.47816563Z
 Ce-Type: dev.chainguard.api.iam.account_associations.deleted.v1
 Content-Length: 129
 Content-Type: application/json
@@ -414,7 +414,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/group_invites
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this invite resides
-Ce-Time: 2026-02-24T18:33:55.430656756Z
+Ce-Time: 2026-02-19T21:14:18.482892713Z
 Ce-Type: dev.chainguard.api.iam.group_invite.created.v1
 Content-Length: 145
 Content-Type: application/json
@@ -452,7 +452,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/group_invites
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2026-02-24T18:33:55.430947505Z
+Ce-Time: 2026-02-19T21:14:18.483103355Z
 Ce-Type: dev.chainguard.api.iam.group_invite.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -488,7 +488,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this group resides
-Ce-Time: 2026-02-24T18:33:55.433459859Z
+Ce-Time: 2026-02-19T21:14:18.482049835Z
 Ce-Type: dev.chainguard.api.iam.group.created.v1
 Content-Length: 169
 Content-Type: application/json
@@ -525,7 +525,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: group UIDP under which this group resides
-Ce-Time: 2026-02-24T18:33:55.433730431Z
+Ce-Time: 2026-02-19T21:14:18.482257471Z
 Ce-Type: dev.chainguard.api.iam.group.updated.v1
 Content-Length: 169
 Content-Type: application/json
@@ -562,7 +562,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/groups
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2026-02-24T18:33:55.433984602Z
+Ce-Time: 2026-02-19T21:14:18.48243927Z
 Ce-Type: dev.chainguard.api.iam.group.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -598,7 +598,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of identity
-Ce-Time: 2026-02-24T18:33:55.436046933Z
+Ce-Time: 2026-02-19T21:14:18.478452233Z
 Ce-Type: dev.chainguard.api.iam.identity.created.v1
 Content-Length: 329
 Content-Type: application/json
@@ -639,7 +639,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: The unique identifier of this specific identity
-Ce-Time: 2026-02-24T18:33:55.436306353Z
+Ce-Time: 2026-02-19T21:14:18.478729138Z
 Ce-Type: dev.chainguard.api.iam.identity.updated.v1
 Content-Length: 245
 Content-Type: application/json
@@ -677,7 +677,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identities
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the record
-Ce-Time: 2026-02-24T18:33:55.436583046Z
+Ce-Time: 2026-02-19T21:14:18.478970457Z
 Ce-Type: dev.chainguard.api.iam.identity.deleted.v1
 Content-Length: 92
 Content-Type: application/json
@@ -713,7 +713,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of identity provider
-Ce-Time: 2026-02-24T18:33:55.434229806Z
+Ce-Time: 2026-02-19T21:14:18.479319166Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.created.v1
 Content-Length: 378
 Content-Type: application/json
@@ -754,7 +754,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: The UIDP of the IAM group to nest this identity provider under
-Ce-Time: 2026-02-24T18:33:55.434558966Z
+Ce-Time: 2026-02-19T21:14:18.479586894Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.updated.v1
 Content-Length: 279
 Content-Type: application/json
@@ -792,7 +792,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/identityProviders
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the IdP
-Ce-Time: 2026-02-24T18:33:55.43483106Z
+Ce-Time: 2026-02-19T21:14:18.479867866Z
 Ce-Type: dev.chainguard.api.iam.identity_providers.deleted.v1
 Content-Length: 89
 Content-Type: application/json
@@ -828,7 +828,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UIDP of the Role to bind
-Ce-Time: 2026-02-24T18:33:55.428504639Z
+Ce-Time: 2026-02-19T21:14:18.474597001Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.created.v1
 Content-Length: 261
 Content-Type: application/json
@@ -868,7 +868,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings/batch
 Ce-Specversion: 1.0
 Ce-Subject: UID of this role binding, under a parent group UIDP
-Ce-Time: 2026-02-24T18:33:55.428828008Z
+Ce-Time: 2026-02-19T21:14:18.475446662Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.created.batch.v1
 Content-Length: 220
 Content-Type: application/json
@@ -909,7 +909,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UID of this role binding
-Ce-Time: 2026-02-24T18:33:55.429154142Z
+Ce-Time: 2026-02-19T21:14:18.476934349Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.updated.v1
 Content-Length: 173
 Content-Type: application/json
@@ -946,7 +946,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/iam/v1/rolebindings
 Ce-Specversion: 1.0
 Ce-Subject: UID of the record
-Ce-Time: 2026-02-24T18:33:55.430191194Z
+Ce-Time: 2026-02-19T21:14:18.477199002Z
 Ce-Type: dev.chainguard.api.iam.rolebindings.deleted.v1
 Content-Length: 91
 Content-Type: application/json
@@ -982,7 +982,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/repos
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific repository
-Ce-Time: 2026-02-24T18:33:55.431611976Z
+Ce-Time: 2026-02-19T21:14:18.480351436Z
 Ce-Type: dev.chainguard.api.platform.registry.repo.created.v1
 Content-Length: 243
 Content-Type: application/json
@@ -1022,7 +1022,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/repos
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific repository
-Ce-Time: 2026-02-24T18:33:55.432054606Z
+Ce-Time: 2026-02-19T21:14:18.480694274Z
 Ce-Type: dev.chainguard.api.platform.registry.repo.updated.v1
 Content-Length: 243
 Content-Type: application/json
@@ -1062,7 +1062,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/repos
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific repository
-Ce-Time: 2026-02-24T18:33:55.432334334Z
+Ce-Time: 2026-02-19T21:14:18.480932357Z
 Ce-Type: dev.chainguard.api.platform.registry.repo.deleted.v1
 Content-Length: 116
 Content-Type: application/json
@@ -1097,7 +1097,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/tags
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific tag
-Ce-Time: 2026-02-24T18:33:55.432591Z
+Ce-Time: 2026-02-19T21:14:18.481152647Z
 Ce-Type: dev.chainguard.api.platform.registry.tag.created.v1
 Content-Length: 197
 Content-Type: application/json
@@ -1134,7 +1134,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/tags
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific tag
-Ce-Time: 2026-02-24T18:33:55.432861882Z
+Ce-Time: 2026-02-19T21:14:18.481401029Z
 Ce-Type: dev.chainguard.api.platform.registry.tag.updated.v1
 Content-Length: 197
 Content-Type: application/json
@@ -1171,7 +1171,7 @@ Ce-Id: cloudevent generated UUID
 Ce-Source: https://console-api.enforce.dev/registry/v1/tags
 Ce-Specversion: 1.0
 Ce-Subject: The identifier of this specific tag
-Ce-Time: 2026-02-24T18:33:55.433063886Z
+Ce-Time: 2026-02-19T21:14:18.48168122Z
 Ce-Type: dev.chainguard.api.platform.registry.tag.deleted.v1
 Content-Length: 109
 Content-Type: application/json

--- a/content/chainguard/chainctl/chainctl-docs/chainctl.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl"
 slug: chainctl
 url: /chainguard/chainctl/chainctl-docs/chainctl/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth"
 slug: chainctl_auth
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-docker.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-docker.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth configure-docker"
 slug: chainctl_auth_configure-docker
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_configure-docker/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_delete-account.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_delete-account.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth delete-account"
 slug: chainctl_auth_delete-account
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_delete-account/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_login.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_login.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth login"
 slug: chainctl_auth_login
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_login/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_logout.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_logout.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth logout"
 slug: chainctl_auth_logout
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_logout/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth pull-token"
 slug: chainctl_auth_pull-token
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth pull-token create"
 slug: chainctl_auth_pull-token_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth pull-token list"
 slug: chainctl_auth_pull-token_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_status.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_status.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth status"
 slug: chainctl_auth_status
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_status/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_token.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_token.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth token"
 slug: chainctl_auth_token
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_token/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_auth_token_capabilities.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_auth_token_capabilities.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl auth token capabilities"
 slug: chainctl_auth_token_capabilities
 url: /chainguard/chainctl/chainctl-docs/chainctl_auth_token_capabilities/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config"
 slug: chainctl_config
 url: /chainguard/chainctl/chainctl-docs/chainctl_config/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_edit.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_edit.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config edit"
 slug: chainctl_config_edit
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_edit/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_reset.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_reset.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config reset"
 slug: chainctl_config_reset
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_reset/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_save.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_save.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config save"
 slug: chainctl_config_save
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_save/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_set.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_set.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config set"
 slug: chainctl_config_set
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_set/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_unset.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_unset.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config unset"
 slug: chainctl_config_unset
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_unset/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_validate.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_validate.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config validate"
 slug: chainctl_config_validate
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_validate/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_config_view.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_config_view.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl config view"
 slug: chainctl_config_view
 url: /chainguard/chainctl/chainctl-docs/chainctl_config_view/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_events.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_events.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl events"
 slug: chainctl_events
 url: /chainguard/chainctl/chainctl-docs/chainctl_events/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl events subscriptions"
 slug: chainctl_events_subscriptions
 url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl events subscriptions create"
 slug: chainctl_events_subscriptions_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl events subscriptions delete"
 slug: chainctl_events_subscriptions_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl events subscriptions list"
 slug: chainctl_events_subscriptions_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam"
 slug: chainctl_iam
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations"
 slug: chainctl_iam_account-associations
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations check"
 slug: chainctl_iam_account-associations_check
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations check aws"
 slug: chainctl_iam_account-associations_check_aws
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations check azure"
 slug: chainctl_iam_account-associations_check_azure
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations check gcp"
 slug: chainctl_iam_account-associations_check_gcp
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_describe.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_describe.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations describe"
 slug: chainctl_iam_account-associations_describe
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_describe/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations set"
 slug: chainctl_iam_account-associations_set
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations set aws"
 slug: chainctl_iam_account-associations_set_aws
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations set azure"
 slug: chainctl_iam_account-associations_set_azure
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations set gcp"
 slug: chainctl_iam_account-associations_set_gcp
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations unset"
 slug: chainctl_iam_account-associations_unset
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations unset aws"
 slug: chainctl_iam_account-associations_unset_aws
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations unset azure"
 slug: chainctl_iam_account-associations_unset_azure
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam account-associations unset gcp"
 slug: chainctl_iam_account-associations_unset_gcp
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam folders"
 slug: chainctl_iam_folders
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam folders delete"
 slug: chainctl_iam_folders_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_describe.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_describe.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam folders describe"
 slug: chainctl_iam_folders_describe
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_describe/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam folders list"
 slug: chainctl_iam_folders_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_folders_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam folders update"
 slug: chainctl_iam_folders_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities"
 slug: chainctl_iam_identities
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create"
 slug: chainctl_iam_identities_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create aws"
 slug: chainctl_iam_identities_create_aws
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create aws role"
 slug: chainctl_iam_identities_create_aws_role
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create aws user"
 slug: chainctl_iam_identities_create_aws_user
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_github.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_github.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create github"
 slug: chainctl_iam_identities_create_github
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_github/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities create gitlab"
 slug: chainctl_iam_identities_create_gitlab
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities delete"
 slug: chainctl_iam_identities_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_describe.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_describe.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities describe"
 slug: chainctl_iam_identities_describe
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_describe/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities list"
 slug: chainctl_iam_identities_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identities update"
 slug: chainctl_iam_identities_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identity-providers"
 slug: chainctl_iam_identity-providers
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identity-providers create"
 slug: chainctl_iam_identity-providers_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identity-providers delete"
 slug: chainctl_iam_identity-providers_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identity-providers list"
 slug: chainctl_iam_identity-providers_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam identity-providers update"
 slug: chainctl_iam_identity-providers_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam invites"
 slug: chainctl_iam_invites
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam invites create"
 slug: chainctl_iam_invites_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam invites delete"
 slug: chainctl_iam_invites_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_invites_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam invites list"
 slug: chainctl_iam_invites_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam organizations"
 slug: chainctl_iam_organizations
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam organizations delete"
 slug: chainctl_iam_organizations_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_describe.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_describe.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam organizations describe"
 slug: chainctl_iam_organizations_describe
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_describe/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam organizations list"
 slug: chainctl_iam_organizations_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam role-bindings"
 slug: chainctl_iam_role-bindings
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam role-bindings create"
 slug: chainctl_iam_role-bindings_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam role-bindings delete"
 slug: chainctl_iam_role-bindings_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam role-bindings list"
 slug: chainctl_iam_role-bindings_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam role-bindings update"
 slug: chainctl_iam_role-bindings_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles"
 slug: chainctl_iam_roles
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles capabilities"
 slug: chainctl_iam_roles_capabilities
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles capabilities list"
 slug: chainctl_iam_roles_capabilities_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles create"
 slug: chainctl_iam_roles_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles delete"
 slug: chainctl_iam_roles_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles list"
 slug: chainctl_iam_roles_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_iam_roles_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl iam roles update"
 slug: chainctl_iam_roles_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images"
 slug: chainctl_images
 url: /chainguard/chainctl/chainctl-docs/chainctl_images/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_advisories.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_advisories.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images advisories"
 slug: chainctl_images_advisories
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_advisories/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_advisories_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_advisories_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images advisories list"
 slug: chainctl_images_advisories_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_advisories_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_changelog.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_changelog.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images changelog"
 slug: chainctl_images_changelog
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_changelog/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_diff.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_diff.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images diff"
 slug: chainctl_images_diff
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_diff/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_entitlements.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_entitlements.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images entitlements"
 slug: chainctl_images_entitlements
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_entitlements/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_entitlements_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_entitlements_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images entitlements list"
 slug: chainctl_images_entitlements_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_entitlements_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_helm.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_helm.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images helm"
 slug: chainctl_images_helm
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_helm/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_helm_values.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_helm_values.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images helm values"
 slug: chainctl_images_helm_values
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_helm_values/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_history.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_history.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images history"
 slug: chainctl_images_history
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_history/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images list"
 slug: chainctl_images_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos"
 slug: chainctl_images_repos
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos build"
 slug: chainctl_images_repos_build
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos build apply"
 slug: chainctl_images_repos_build_apply
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_edit.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_edit.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos build edit"
 slug: chainctl_images_repos_build_edit
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_edit/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos build list"
 slug: chainctl_images_repos_build_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_logs.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_logs.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos build logs"
 slug: chainctl_images_repos_build_logs
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_logs/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_create.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos create"
 slug: chainctl_images_repos_create
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_create/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_delete.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos delete"
 slug: chainctl_images_repos_delete
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_delete/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos list"
 slug: chainctl_images_repos_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_repos_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images repos update"
 slug: chainctl_images_repos_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images tags"
 slug: chainctl_images_tags
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images tags list"
 slug: chainctl_images_tags_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags_resolve.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_images_tags_resolve.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl images tags resolve"
 slug: chainctl_images_tags_resolve
 url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags_resolve/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_libraries.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_libraries.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl libraries"
 slug: chainctl_libraries
 url: /chainguard/chainctl/chainctl-docs/chainctl_libraries/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl libraries verify"
 slug: chainctl_libraries_verify
 url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_packages.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_packages.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl packages"
 slug: chainctl_packages
 url: /chainguard/chainctl/chainctl-docs/chainctl_packages/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_packages_versions.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_packages_versions.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl packages versions"
 slug: chainctl_packages_versions
 url: /chainguard/chainctl/chainctl-docs/chainctl_packages_versions/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl packages versions list"
 slug: chainctl_packages_versions_list
 url: /chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_update.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_update.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl update"
 slug: chainctl_update
 url: /chainguard/chainctl/chainctl-docs/chainctl_update/

--- a/content/chainguard/chainctl/chainctl-docs/chainctl_version.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_version.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24T18:33:45Z
+date: 2026-02-19T21:14:08Z
 title: "chainctl version"
 slug: chainctl_version
 url: /chainguard/chainctl/chainctl-docs/chainctl_version/

--- a/static/api.json
+++ b/static/api.json
@@ -1904,45 +1904,6 @@
         },
         "type": "object"
       },
-      "chainguard.platform.matcher.MatchImageRequest": {
-        "properties": {
-          "arch": {
-            "title": "arch is the architecture (e.g., \"amd64\", \"arm64\")",
-            "type": "string"
-          },
-          "count": {
-            "format": "int32",
-            "title": "top_n is the maximum number of recommendations to return (default: 10)",
-            "type": "integer"
-          },
-          "distName": {
-            "title": "dist_name is the distribution name (e.g., \"debian\", \"ubuntu\", \"alpine\", \"wolfi\")",
-            "type": "string"
-          },
-          "distVersion": {
-            "title": "dist_version is the distribution version (e.g., \"1.2.3\", \"2.0-r2\")",
-            "type": "string"
-          },
-          "parentId": {
-            "title": "parent_id is the group id of the caller making the request",
-            "type": "string"
-          },
-          "sbom": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/chainguard.platform.matcher.SBOM"
-              }
-            ],
-            "title": "sbom is the SBOM data"
-          },
-          "threshold": {
-            "format": "double",
-            "title": "threshold is the minimum probability score (0-100) to report images (default: 50.0)",
-            "type": "number"
-          }
-        },
-        "type": "object"
-      },
       "chainguard.platform.matcher.MatchImageResponse": {
         "properties": {
           "images": {
@@ -7653,20 +7614,61 @@
       }
     },
     "/image-recommendation/v1/match": {
-      "post": {
+      "get": {
         "description": "MatchImage takes an sbom and returns a list of chainguard\nimages ranked by sbom similarity",
         "operationId": "ImageMatcher_MatchImage",
-        "requestBody": {
-          "content": {
-            "*/*": {
-              "schema": {
-                "$ref": "#/components/schemas/chainguard.platform.matcher.MatchImageRequest"
-              }
+        "parameters": [
+          {
+            "description": "parent_id is the group id of the caller making the request",
+            "in": "query",
+            "name": "parentId",
+            "schema": {
+              "type": "string"
             }
           },
-          "required": true,
-          "x-originalParamName": "body"
-        },
+          {
+            "description": "dist_name is the distribution name (e.g., \"debian\", \"ubuntu\", \"alpine\", \"wolfi\")",
+            "in": "query",
+            "name": "distName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "dist_version is the distribution version (e.g., \"bookworm\", \"jammy\")",
+            "in": "query",
+            "name": "distVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "arch is the architecture (e.g., \"amd64\", \"arm64\")",
+            "in": "query",
+            "name": "arch",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "top_n is the maximum number of recommendations to return (default: 10)",
+            "in": "query",
+            "name": "count",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "threshold is the minimum probability score (0-100) to report images (default: 50.0)",
+            "in": "query",
+            "name": "threshold",
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
Reverts chainguard-dev/edu#3019

For the API docs, the top level of the page displays, but if you click on anything like RoleBindings or a Schema, it displays an error. So, I'm reverting to the previous version while figuring out what went wrong. This way at least the page should work.