### PR TITLE
Disable workflow jobs in forks

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -25,6 +25,7 @@ permissions:
   
 jobs:
   compile-docs:
+    if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest
     environment: documentation
     

--- a/.github/workflows/compile-docs-on-webhook.yml
+++ b/.github/workflows/compile-docs-on-webhook.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   compile-docs:
+    if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest
     environment: documentation  # Use environment protection rules
     

--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -27,6 +27,7 @@ permissions:
   
 jobs:
   compile-docs:
+    if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest
     environment: documentation  # Use environment protection rules
     

--- a/.github/workflows/compile-public-docs.yml
+++ b/.github/workflows/compile-public-docs.yml
@@ -30,6 +30,7 @@ permissions:
   
 jobs:
   compile-and-release:
+    if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/export-edu-docs-to-gcs.yaml
+++ b/.github/workflows/export-edu-docs-to-gcs.yaml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   export-docs:
+    if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## Summary

- Adds `if: github.repository == 'chainguard-dev/edu'` to all workflow jobs that were missing it
- Prevents unintended runs in forks (deployments, GCS uploads, container pushes, GitHub releases, secret access)

## Workflows updated

- `compile-docs.yml`
- `compile-docs-on-webhook.yml`
- `compile-public-docs.yml`
- `compile-ai-docs-from-gcs.yaml`
- `export-edu-docs-to-gcs.yaml`

The remaining 6 workflows already had this condition in place.

## Test plan

- [ ] Verify workflows still run normally on pushes to `main` in this repo
- [ ] Confirm jobs are skipped when triggered from a fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)