### PR TITLE
Clarify sources for Java libraries

### DIFF
--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -37,11 +37,10 @@ for Java also builds binaries for open source projects available in other
 repositories like the Google or Confluent repositories. This covers libraries
 not found on Maven Central, sourced from
 [Google](https://maven.google.com/web/index.html),
-[Oracle](https://maven.oracle.com),
+[Oracle](https://www.oracle.com/webfolder/application/maven/index.html),
 [JetBrains](https://www.jetbrains.com/intellij-repository/releases),
 [CERN](https://gitlab.cern.ch/),
-[Confluent](https://packages.confluent.io/maven/), [Gradle Plugin
-Portal](https://plugins.gradle.org/m2/), and other public artifact repositories.
+[Confluent](https://packages.confluent.io/maven/), [Gradle](https://plugins.gradle.org/m2/), and other public artifact repositories.
 Note that coverage is not exhaustive for any single repository; the index
 continues to grow, and any request for a missing library or version
 automatically triggers a process to provision the artifacts from relevant

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -28,16 +28,18 @@ Repository](https://central.sonatype.com/). It has been in operation for nearly
 20 years and hosts artifacts of all releases of most open source projects in the
 Java community. It is the default repository in all commonly used build tools
 from the Java community including [Apache Maven](https://maven.apache.org/),
-[Gradle](https://gradle.org/), and others and uses the Maven repository format.
-Chainguard Libraries for Java covers all open source artifacts from Maven
-Central.
+[Gradle](https://gradle.org/), and others, and uses the Maven repository format.
+Chainguard Libraries for Java covers a broad and growing set of artifacts from
+Maven Central.
 
-Chainguard Libraries for Java also builds binaries for many other open source
-projects available in other repositories or on code hosting platforms like
-GitHub. Examples include Google, Oracle, JetBrains, CERN, Apache, and many
-others. Any request for a library or library version missing in Chainguard
-Libraries automatically triggers a process to provision the artifacts from
-relevant sources if available. 
+While Maven Central is the primary upstream and reference repository, Chainguard
+Libraries for Java also builds binaries for open source projects available in
+other repositories and code hosting platforms like GitHub. This covers libraries
+not found on Maven Central, sourced from Google, Oracle, JetBrains, CERN,
+Apache, Confluent, Gradle plugins, and more. Note that coverage is not
+exhaustive for any single repository; the index continues to grow, and any
+request for a missing library or version automatically triggers a process to
+provision the artifacts from relevant sources if available. 
 
 You can use Chainguard Libraries for Java alongside third-party software
 repositories to create a single source of truth with your repository manager

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -32,14 +32,20 @@ from the Java community including [Apache Maven](https://maven.apache.org/),
 Chainguard Libraries for Java covers a broad and growing set of artifacts from
 Maven Central.
 
-While Maven Central is the primary upstream and reference repository, Chainguard
-Libraries for Java also builds binaries for open source projects available in
-other repositories and code hosting platforms like GitHub. This covers libraries
-not found on Maven Central, sourced from Google, Oracle, JetBrains, CERN,
-Apache, Confluent, Gradle plugins, and more. Note that coverage is not
-exhaustive for any single repository; the index continues to grow, and any
-request for a missing library or version automatically triggers a process to
-provision the artifacts from relevant sources if available. 
+While Maven Central is the primary reference repository, Chainguard Libraries
+for Java also builds binaries for open source projects available in other
+repositories like the Google or Confluent repositories. This covers libraries
+not found on Maven Central, sourced from
+[Google](https://maven.google.com/web/index.html),
+[Oracle](https://maven.oracle.com),
+[JetBrains](https://www.jetbrains.com/intellij-repository/releases),
+[CERN](https://gitlab.cern.ch/),
+[Confluent](https://packages.confluent.io/maven/), [Gradle Plugin
+Portal](https://plugins.gradle.org/m2/), and other public artifact repositories.
+Note that coverage is not exhaustive for any single repository; the index
+continues to grow, and any request for a missing library or version
+automatically triggers a process to provision the artifacts from relevant
+sources if available. 
 
 You can use Chainguard Libraries for Java alongside third-party software
 repositories to create a single source of truth with your repository manager

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -39,7 +39,7 @@ not found on Maven Central, sourced from
 [Google](https://maven.google.com/web/index.html),
 [Oracle](https://www.oracle.com/webfolder/application/maven/index.html),
 [JetBrains](https://www.jetbrains.com/intellij-repository/releases),
-[CERN](https://gitlab.cern.ch/),
+CERN,
 [Confluent](https://packages.confluent.io/maven/), [Gradle](https://plugins.gradle.org/m2/), and other public artifact repositories.
 Note that coverage is not exhaustive for any single repository; the index
 continues to grow, and any request for a missing library or version


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
clarify wording

### What should this PR do?
- Explains that Maven is the primary source, but other platforms are supported
- Add mention of Confluent and Gradle plugins to the list of other sources

### Why are we making this change?
Internal/customer feedback. [Slack thread here](https://chainguard-dev.slack.com/archives/C085187D8RE/p1767978789904909).
