### PR TITLE
Update chainctl example to remove redundant characters

### DIFF
--- a/content/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify.md
+++ b/content/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify.md
@@ -41,7 +41,7 @@ chainctl libraries verify [path...] [flags]
   chainctl libraries verify build/libs/*.jar build/libs/*.war
 
   # Analyze a local Python virtual environment
-  chainctl libraries verify ./venv/
+  chainctl libraries verify .venv/
 
   # Analyze with JSON output
   chainctl libraries verify -o json build/libs/*.jar


### PR DESCRIPTION
[X] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update chainctl command based on internal feedback that the `./` in `./venv/` was redundant