### PR TITLE
Quick update on JavaScript build config

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -155,8 +155,10 @@ npm init -y
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#env). Once
-the environment variables are set, the following steps configure registry
+detailed in the [access documentation](/chainguard/libraries/access/#env). For
+production use, set the config URL to either your organization's artifact
+manager alreaady in use, or directly to `libraries.cgr.dev/javascript`. Once the
+URL and environment variables are set, the following steps configure registry
 access with authentication in the `.npmrc` file in the current project
 directory:
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -157,7 +157,7 @@ npm init -y
 For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#env). For
 production use, set the config URL to either your organization's artifact
-manager alreaady in use, or directly to `libraries.cgr.dev/javascript`. Once the
+manager alreaady in use, or directly to `libraries.cgr.dev/javascript/`. Once the
 URL and environment variables are set, the following steps configure registry
 access with authentication in the `.npmrc` file in the current project
 directory:


### PR DESCRIPTION
[X] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
Under JavaScript Build Configuration > npm > Minimal example project, 
changed this
> For testing purposes, you can use direct access and environment variables as detailed in the [access documentation](https://edu.chainguard.dev/chainguard/libraries/access/#env). Once the environment variables are set, the following steps configure registry access with authentication in the .npmrc file in the current project directory:

to this

> For testing purposes, you can use direct access and environment variables as
detailed in the [access documentation](/chainguard/libraries/access/#env). For
production use, set the config URL to either your organization's artifact
manager alreaady in use, or directly to `libraries.cgr.dev/javascript`. Once the
URL and environment variables are set, the following steps configure registry
access with authentication in the `.npmrc` file in the current project
directory: