### PR TITLE
Updating Custom Assembly certs info

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md
@@ -1,0 +1,212 @@
+---
+title: "Adding Custom Certificates with Custom Assembly"
+linktitle: "Custom Certificates"
+type: "article"
+description: "How to add custom certificates to customized images with Custom Assembly."
+date: 2026-03-12T11:07:52+02:00
+lastmod: 2026-03-12T11:07:52+02:00
+draft: false
+tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
+images: []
+menu:
+  docs:
+    parent: "features"
+weight: 020
+toc: true
+---
+
+Many enterprise environments use internal certificate authorities (CAs) to issue certificates for internal services. These custom certificates need to be trusted by containers that communicate with the internal services. Custom Assembly allows you to build custom certificates directly into your container images, ensuring they trust your organization's internal services without requiring manual certificate mounting at runtime.
+
+> **Note**: If you are looking for a way to embed certificates at build time, refer to our guide on [How To Use incert to Create Container Images with Built-in Custom Certificates](/chainguard/chainguard-images/features/incert-custom-certs/).
+
+## Prerequisites and limitations
+
+Before getting started, you'll need the following:
+* Access to Chainguard's Custom Assembly tool, which is available to any organization with access to Production Chainguard Containers.
+* Permissions in your Chainguard organization to use Custom Assembly.
+  * Review the [Custom Assembly Permissions Requirements](https://edu.chainguard.dev/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements) for more information
+* [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) installed and configured.
+* One or more PEM-encoded certificate files that you want to add to your container.
+  * Each certificate must be a PEM-encoded string of an x509v3 certificate.
+  * Private keys must not be passed as a certificate, and will be rejected.
+  * The total size of all inlined certificates must not exceed 50 KB. Please reach out to your account team if there are any issues with this limit.
+
+
+Additionally, be aware of the following limitations when adding custom certificates:
+
+* Adding new certificates is currently only available through the API and `chainctl`.
+* Custom certificates are included in the image's provenance attestation but are not currently listed in the SBOM. They will appear in the apko configuration attestation.
+
+
+## Using `chainctl` to add custom certificates using Custom Assembly
+
+With Custom Assembly, you can add custom certificates to your Chainguard Containers using `chainctl images repos build edit` or `chainctl images repos build apply`. The process is similar to the process for [using Custom Assembly to add packages with `chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/).
+
+### Interactive usage
+
+You can add certificates interactively by running a command like the following:
+
+```shell
+chainctl image repos build edit --parent $ORGANIZATION --repo $CONTAINER
+```
+
+This will open your default text editor with the current configuration. This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
+
+In the editor, add one or more `certificates` sections with your custom certificates. Note that each entry must contain exactly one PEM block (`BEGIN CERTIFICATE` to `END CERTIFICATE`):
+
+```yaml
+contents:
+  packages:
+    - jq
+    - git
+    - curl
+
+certificates:
+  additional:
+    - name: internal-ca
+      content: |
+        -----BEGIN CERTIFICATE-----
+        BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+        ... (certificate content continues)
+        -----END CERTIFICATE-----
+    - name: partner-ca
+      content: |
+        Some descriptive text about this certificate's purpose
+        -----BEGIN CERTIFICATE-----
+        MIIDZTCCAk2gAwIBAgIJALT1VH+nSlnTMA0GCSqGSIb3DQEBCwUAMEYxCzAJBgNV
+        ... (certificate content continues)
+        -----END CERTIFICATE-----
+
+```
+
+Note that each certificate entry requires:
+
+* `name`: A descriptive name for the certificate (used for the filename).
+* `content`: The certificate in PEM format, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers.
+
+Optionally, you can also include descriptive text before the certificate block to document its purpose.
+
+Save your changes and close the editor. `chainctl` will display the changes and prompt for confirmation before applying them.
+
+This adds (concatenates) the provided inline certificates to the default truststore of the image in `/etc/ssl/certs/ca-certificates.crt`. It also writes them individually to `/usr/local/share/ca-certificates`, making them available for workflows that involve manually running `update-ca-certificates`.
+
+Alternatively, you can use the `--with-certificates` flag to pre-populate the `certificates.additional` section from a selected `.pem` file. Here is an example invocation that uses a `.pem` file named `certificates.pem`:
+
+```shell
+chainctl images repos build edit --with-certificates certificate.pem --parent $ORGANIZATION --repo $CONTAINER
+```
+
+As with the previous example, this will open up the configuration in your default editor. After saving and closing the editor, `chainctl` will prompt you to confirm the changes before applying them.
+
+### Non-interactive usage
+
+To add certificates without any interactivity, you can use the `apply` subcommand. This requires you to supply a YAML configuration file listing the certificates, like the example created with this command:
+
+```shell
+cat > cert.yaml <<EOF
+certificates:
+  additional:
+  - name: ca1
+    content: |
+      -----BEGIN CERTIFICATE-----
+      <certificate contents>
+      -----END CERTIFICATE-----
+EOF
+```
+
+Then include this file in the `apply` command by adding the `-f` argument:
+
+```shell
+chainctl image repos build apply --parent $ORGANIZATION --repo $CONTAINER -f cert.yaml --yes
+```
+
+This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:
+
+```output
+Image configuration changes:
+Legend: + to add, ~ to change, - to remove
+
+certificates.additional (+1, ~0, -0, final: 1):
+  + Name: ca1
+      Fingerprint:      CA:2F:ED:41:E8:A2:C9:D0:25:A2:8E:E5:0C:95:9B:E2
+                        15:10:F4:1E:72:B7:31:AA:B0:51:CD:AC:E9:F2:0C:51
+      SANs:             (none)
+      Issuer:           O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+      Expires:          2036-03-08 19:10:43 UTC
+      PublicKey:        RSA 2048-bit (ee878ed5)
+      Serial:           53:99:5e:47:8c:27:39:60:7b:fb:2b:17:77:ae:a2:01:03:1c:93:31
+      ExtKeyUsage:      (none)
+      KeyUsage:         (none)
+      BasicConstraints: CA:TRUE
+      Subject:          O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+
+
+Plan: 1 to add, 0 to change, 0 to remove
+```
+
+The non-interactive approach is particularly useful for CI/CD pipelines and automation.
+
+
+## Verifying that certificates were added
+
+Before following the steps below, ensure you have [`crane` installed](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md#installation).
+
+You can verify that your certificates are present in the system trust bundle by using `crane` to export the image filesystem, extract the system CA bundle from the archive, and write it to a local file for inspection:
+
+```shell
+crane export cgr.dev/my-org/my-custom-image:latest - | tar -xOf - etc/ssl/certs/ca-certificates.crt > ca-certificates.crt
+```
+After running this command, inspect the copied file locally to confirm that your certificate is present.
+
+
+## Changuard-managed certificate bundles
+
+Customers have the ability to add Chainguard-managed certificate bundles for certain regulated environments to their Custom Assembly images. These certificates are bundled into discrete packages that you can apply to customized images in bulk. You can add them to a customized image the same way you would add any other package with Custom Assembly, including with [`chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/) or in the [Chainguard Console](/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/). 
+
+The following example YAML configuration shows two certificate bundle packages added to an image:
+
+```yaml
+contents:
+  packages:
+  - ca-certificates-aws-rds-global
+  - ca-certificates-dod-wcf
+
+. . .
+```
+
+As of this writing, Chainguard offers the following certificate bundle packages for DoD and AWS environments:
+
+* `ca-certificates-aws-rds-global` — Any commercial AWS Region
+* `ca-certificates-aws-rds-govcloud-global` — AWS US GovCloud
+* `ca-certificates-dod-eca` — US DoD External Certificate Authority (ECA) PKI certificates
+* `ca-certificates-dod-wcf` — US DoD Web Content Filtering (WCF) PKI certificates
+
+
+## Troubleshooting
+
+### Certificate validation errors
+
+If you receive validation errors when adding certificates:
+
+* Verify that your certificate file contains only valid PEM-encoded certificate data
+* Check that there is no private key material in the file
+* Ensure the certificate has not expired
+* Verify that the total size of all certificates added is under 50KB
+
+### Applications not trusting custom certificates
+
+If applications within your container are not trusting your custom certificates:
+
+* Verify the certificate was added successfully by checking `/etc/ssl/certs/ca-certificates.crt`
+* Check that the certificate file exists in `/usr/local/share/ca-certificates/`
+* Ensure your application is configured to use the system truststore
+
+
+## Alternative: Using `incert` for certificate injection
+
+For scenarios where you need to add certificates to an existing image without using Custom Assembly, you can use [`incert`](/chainguard/chainguard-images/features/incert-custom-certs/), an open-source tool from Chainguard. However, we recommend using Custom Assembly over `incert` whenever possible, as this approach provides:
+
+* Automatic rebuilds when the base image is updated
+* Integration with Chainguard's security patching lifecycle
+* Provenance attestation for audit and compliance
+* No need to maintain your own build pipeline

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -83,7 +83,7 @@ chainctl image repo build apply -f build.yaml --parent $ORGANIZATION --repo $CON
 
 This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:
 
-```
+```output
 Applying build config to custom-assembly
   (*v1.CustomOverlay)(Inverse(protocmp.Transform, protocmp.Message{
       "@type": s"chainguard.platform.registry.CustomOverlay",
@@ -199,111 +199,6 @@ After saving and confirming these changes, Custom Assembly will add these five c
 
 Be aware that Custom Assembly blocks any environment variable that begins with `CHAINGUARD_` from being added or changed. This is to prevent conflicts with configuration details managed by Chainguard.
 
-## Adding custom certificates
-
-Many enterprise environments use internal certificate authorities (CAs) to issue certificates for internal services. These custom certificates need to be trusted by containers that communicate with the internal services. Custom Assembly allows you to build custom certificates directly into your container images, ensuring they trust your organization's internal services without requiring manual certificate mounting at runtime.
-
-> NOTE: If you are looking for a way to embed certificates at build time, see [How To Use incert to Create Container Images with Built-in Custom Certificates](/chainguard/chainguard-images/features/incert-custom-certs/).
-
-### Prerequisites and limitations
-
-Before getting started, you'll need:
-* Access to Chainguard's Custom Assembly tool, which is available to any organization with access to Production Chainguard Containers.
-* Permissions in your Chainguard organization to use Custom Assembly.
-  * Review the [Custom Assembly Permissions Requirements](https://edu.chainguard.dev/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements) for more information
-* [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) installed and configured.
-* One or more PEM-encoded certificate files that you want to add to your container.
-  * Each certificate must be a PEM-encoded string of an x509v3 certificate.
-  * Private keys must not be passed as a certificate, and will be rejected.
-  * The total size of all inlined certificates must not exceed 50 KB. Please reach out to your account team if there are any issues with this limit.
-
-
-Additionally, be aware of the following limitations when adding custom certificates:
-
-* Adding new certificates is currently only available via the API and chainctl.
-* Custom certificates are only concatenated to the ca-certificates.crt file, but not added to Java-specific truststores. This functionality is planned for a future release.
-* Custom certificates are included in the image's provenance attestation but are not currently listed in the SBOM. They will appear in the apko configuration attestation.
-
-### How to add custom certificates via Custom Assembly
-
-With Custom Assembly, you can add custom certificates to your Chainguard Containers using `chainctl images repos build edit` or `chainctl images repos build apply`. The process is similar the one outlined previously for adding packages.
-
-You can make these changes interactively using an editor as described below, or non-interactively by supplying a YAML configuration file with `-f <file>`. The non-interactive approach is particularly useful for CI/CD pipelines and automation.
-
-1. Run a command like the following:
-
-```shell
-chainctl image repos build edit --parent $ORGANIZATION --repo $CONTAINER
-```
-
-This will open your default text editor with the current configuration. This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
-
-Alternatively, you can use the `--with-certificates` flag to pre-populate the `certificates.additional` section from a selected `.pem` file. Here is an example invocation:
-
-```bash
-chainctl images repos build edit --with-certificates certs.pem --parent $ORGANIZATION --repo $CONTAINER
-```
-
-
-2. Add a `certificates` section with your custom certificates. Note that each entry must contain exactly one PEM block (`BEGIN CERTIFICATE` to `END CERTIFICATE`):
-
-```yaml
-contents:
-  packages:
-    - jq
-    - git
-    - curl
-
-certificates:
-  additional:
-    - name: internal-ca
-      content: |
-        -----BEGIN CERTIFICATE-----
-        MIIDXTCCAkWgAwIBAgIJAKL0UG+mRkmSMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-        BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-        ... (certificate content continues)
-        -----END CERTIFICATE-----
-    - name: partner-ca
-      content: |
-        Some descriptive text about this certificate's purpose
-        -----BEGIN CERTIFICATE-----
-        MIIDZTCCAk2gAwIBAgIJALT1VH+nSlnTMA0GCSqGSIb3DQEBCwUAMEYxCzAJBgNV
-        ... (certificate content continues)
-        -----END CERTIFICATE-----
-
-```
-Note that each certificate entry requires:
-
-* `name`: A descriptive name for the certificate (used for the filename).
-* `content`: The certificate in PEM format, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers.
-
-Optionally, you can also include descriptive text before the certificate block to document its purpose.
-
-3. Save and confirm your changes.
-
-After saving and closing the editor, `chainctl` will display the changes and prompt for confirmation before applying them.
-
-The provided inline certificates will be added (concatenated) to the default truststore of the image in `/etc/ssl/certs/ca-certificates.crt`. They will also be individually written to `/usr/local/share/ca-certificates` and will be available for workflows that involve manually running `update-ca-certificates`.
-
-### Verify that certificates were added
-
-Before following the steps below, ensure you have `crane` installed.
-
-You can verify that your certificates are present in the system trust bundle by using `crane` to export the image filesystem, extract the system CA bundle from the archive, and write it to a local file for inspection:
-
-```shell
-crane export cgr.dev/my-org/my-custom-image:latest - | tar -xOf - etc/ssl/certs/ca-certificates.crt > ca-certificates.crt
-```
-After running this command, inspect the copied file locally to confirm that your certificate is present.
-
-### Alternative: Using incert for certificate injection
-
-For scenarios where you need to add certificates to an existing image without using Custom Assembly, you can use [`incert`](/chainguard/chainguard-images/features/incert-custom-certs/), an open-source tool from Chainguard. However, we recommend using Custom Assembly over `incert` whenever possible, as this approach provides:
-
-* Automatic rebuilds when the base image is updated
-* Integration with Chainguard's security patching lifecycle
-* Provenance attestation for audit and compliance
-* No need to maintain your own build pipeline
 
 ## Retrieving Information about Custom Assembly Containers
 
@@ -333,7 +228,7 @@ chainctl image repo build logs --parent $ORGANIZATION --repo $REPO
 
 This command will prompt you to select the build report you want to view. These are organized in reverse chronological order by the time of each build:
 
-```
+```output
     Select a build report to view logs:
 
     Wed, 16 Apr 2025 16:36:52 PDT - Wed, 16 Apr 2025 16:37:08 PDT Success (18-dev, 18.20-dev, 18.20.8-dev)
@@ -358,32 +253,12 @@ This command will prompt you to select the build report you want to view. These 
 
 Highlight your chosen build report and select it by pressing `ENTER`. This will open up the build's logs:
 
-```
+```output
 2025-04-17T16:00:08-07:00[INFO]Building image with locked configuration: {Contents:{BuildRepositories:[] RuntimeRepositories:[https://apk.cgr.dev/45a0c61eEXAMPLEf050c5fb9ac06a69eed764595]
 ```
 
 ## Learn More
 
-The `chainctl` commands outlined in this guide show how you can interact with Chainguard's Custom Assembly tool from the command line.
+You can also use `chainctl` to add custom certificates to your Custom Assembly images. Refer to our guide on [Adding Custom Certificates with Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/#using-chainctl-to-add-custom-certificates-using-custom-assembly) for more information.
 
-You can also interact with Custom Assembly with the [Chainguard API](/chainguard/api/spec/). Our tutorial on [Using the Chainguard API to Manage Custom Assembly Resources](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/) outlines how to run a demo application that updates the configuration of a Custom Assembly container through the Chainguard API.
-
-### Troubleshooting
-
-#### Certificate validation errors
-
-If you receive validation errors when adding certificates:
-
-* Verify that your certificate file contains only valid PEM-encoded certificate data
-* Check that there is no private key material in the file
-* Ensure the certificate has not expired
-* Verify that the total size of all certificates added is under 50KB
-
-#### Applications not trusting custom certificates
-
-If applications within your container are not trusting your custom certificates:
-
-* Verify the certificate was added successfully by checking `/etc/ssl/certs/ca-certificates.crt`
-* Check that the certificate file exists in `/usr/local/share/ca-certificates/`
-* Ensure your application is configured to use the system truststore
-* For Java applications, note that custom Java truststore support is not yet available
+Additionally, you can interact with Custom Assembly with the [Chainguard API](/chainguard/api/spec/). Our tutorial on [Using the Chainguard API to Manage Custom Assembly Resources](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/) outlines how to run a demo application that updates the configuration of a Custom Assembly container through the Chainguard API.

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/index.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/index.md
@@ -112,6 +112,6 @@ You can also delete new container images that you've created with Custom Assembl
 
 ## Learn More
 
-You now have the knowledge to effectively manage Custom Assembly resources through the Chainguard console. This web interface provides a user-friendly way to customize container images by adding or removing packages, monitor build status, and review build logs without needing to use command-line tools.
+You can also use the Chainguard Console to add Chainguard-managed certificates to Custom Assembly images. Refer to our guide on [Adding Custom Certificates with Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/#changuard-managed-certificate-bundles) for more information. 
 
-Remember that customized images are rebuilt frequently, and build history is retained for 24 hours. For more advanced workflows or automation, consider exploring the [`chainctl` CLI tool](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/) or the [Chainguard API](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/) for programmatic access to Custom Assembly features.
+For more advanced workflows or automation, consider exploring the [`chainctl` CLI tool](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/) or the [Chainguard API](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/) for programmatic access to Custom Assembly features.

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -180,6 +180,5 @@ We encourage you to check out our resources on our other [Chainguard Containers 
 
 * [Unique Tags](/chainguard/chainguard-images/features/unique-tags/)
 * [CVE Visualizations](/chainguard/chainguard-images/features/cve_visualizations/)
-* [Custom Certificates](/chainguard/chainguard-images/features/incert-custom-certs/)
 
 Additionally, for more information on working with Chainguard Containers, refer to our docs on [How to Use Chainguard Containers](/chainguard/chainguard-images/how-to-use/).

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -172,9 +172,9 @@ In any case, you won't know whether a container image build fails until after it
 
 ## Learn More
 
-Custom Assembly allows customers to leverage Chainguard’s build infrastructure to produce container images tailored to their requirements. That means customers no longer have to stand up and maintain their own builds, saving costs in the form of infrastructure, engineering overhead, and complexity.
-
 This article provided a high-level overview of Custom Assembly. As a next step, we encourage you to checkout our guide on [managing Custom Assembly resources through the Chainguard Console](/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/). You can also interact with Custom Assembly using [`chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/) as well as [the Chainguard API](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/).
+
+You can also add custom certificates to Custom Assembly images. Refer to our guide on [Adding Custom Certificates with Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/) for more information. 
 
 We encourage you to check out our resources on our other [Chainguard Containers features](/chainguard/chainguard-images/features/), including the following:
 

--- a/content/chainguard/chainguard-images/features/incert-custom-certs.md
+++ b/content/chainguard/chainguard-images/features/incert-custom-certs.md
@@ -1,6 +1,6 @@
 ---
 title: "How To Use incert to Create Container Images with Built-in Custom Certificates"
-linktitle: "Custom Certificates"
+linktitle: "Custom Certs with incert"
 aliases: 
 - /chainguard/chainguard-images/working-with-images/incert-custom-certs/
 - /chainguard/chainguard-images/features/incert-custom-certs/
@@ -18,7 +18,7 @@ weight: 030
 toc: true
 ---
 
-> NOTE: If you are looking for a way to add certificates to existing Chainguard images, see [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/). 
+> NOTE: If you are looking for a way to add certificates to existing Chainguard images, check out our doc on [adding custom certificates with Custom Assembly](content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md). 
 
 In many enterprise settings, an organization will have its own certificate authority which it uses to issue certificates for its internal services. This is often for security or control reasons but could also be related to regulatory requirements. 
 

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -37,7 +37,7 @@ All Chainguard Containers are built with a consistent set of security and supply
 Chainguard Containers include features that allow you to customize images, manage updates, and meet security and compliance requirements across the container lifecycle:
 
 - [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/): Customize Chainguard images by adding packages, configuration files, and certificates using chainctl, without maintaining your own Dockerfiles.
-- Custom certificates: Add trusted certificates [to existing containers via Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/) (for organization-specific or environment-specific certificates) or by [using incert to build images with certificates embedded at build time](/chainguard/chainguard-images/features/incert-custom-certs/).
+- Custom certificates: Add trusted certificates [to existing containers via Custom Assembly](content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md) (for organization-specific or environment-specific certificates) or by [using incert to build images with certificates embedded at build time](/chainguard/chainguard-images/features/incert-custom-certs/).
 - [Packages](/chainguard/chainguard-images/features/packages/package-model/): Install and manage additional packages in Chainguard images while preserving Chainguard’s minimal, secure-by-default base images.
 - [EOL grace periods](/chainguard/chainguard-images/features/eol-gp-overview/): Control how end-of-life packages are handled in images to balance security requirements with operational stability.
 - [STIGs](/chainguard/chainguard-images/features/image-stigs/): Use DISA STIG–aligned images to support compliance-driven environments.


### PR DESCRIPTION
## Type of change                                                                                                                                  
   
**Documentation** — new content / content update                                                                                                    

This PR adds Adds a new dedicated page covering how to add custom certificates to Chainguard Container images using Custom Assembly, and moves that content out of the existing custom-assembly-chainctl.md guide.

## What should this PR do?

resolves https://github.com/chainguard-dev/internal/issues/5697

## Why are we making this change?

Custom certificate support in Custom Assembly was previously undocumented or buried. Splitting it into its own page (custom-assembly-certs.md) makes the feature easier to discover and keeps the chainctl guide focused.

## What are the acceptance criteria?

- New custom-assembly-certs.md page renders correctly and is accessible via the docs nav
- custom-assembly-chainctl.md no longer contains the certificate-specific content that was moved
- Cross-links between pages are accurate

## How should this PR be tested?

1. Check out the [preview link](https://deploy-preview-3070--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/)
    * The new content is located here: https://deploy-preview-3070--ornate-narwhal-088216.netlify.app/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/#changuard-managed-certificate-bundles
2. Confirm the new "Custom Certificates" page appears in the nav and loads correctly
3. Verify chainctl examples render without formatting issues
4. Check that links to/from the new page resolve correctly