### PR TITLE
Update Chainguard Libraries SLSA compliance to Level 3

### DIFF
--- a/content/compliance/slsa/slsa-chainguard.md
+++ b/content/compliance/slsa/slsa-chainguard.md
@@ -20,9 +20,9 @@ toc: true
 
 SLSA (pronounced "salsa"), or Supply chain Levels for Software Artifacts, is a security framework consisting of standards and controls that prevent tampering, improve integrity, and secure packages and infrastructure. It is described in depth in [What is SLSA?](/compliance/slsa/what-is-slsa/).
 
-Chainguard Containers and Guarded VMs are SLSA Level 3 compliant to provide confidence in the security of these products. Other Chainguard products, such as Chainguard Libraries, are SLSA Level 2 compliant and work is being done to bring them to level 3.
+All Chainguard products — including Chainguard Containers, Guarded VMs, and Chainguard Libraries — are SLSA Level 3 compliant to provide confidence in the security of these products.
 
-This page describes what we have done and are doing to bring Chainguard products into full SLSA Level 3 compliance.
+This page describes what we have done to bring Chainguard products into full SLSA Level 3 compliance.
 
 
 ## Isolated and Tamper-Resistant Builds


### PR DESCRIPTION
## Summary
- Chainguard Libraries are now SLSA Level 3 compliant, updating the docs to reflect this
- Removed "work is being done" language since Libraries have achieved L3 parity with Containers and VMs

## Test plan
- [ ] Verify the updated text renders correctly on the SLSA compliance page

🤖 Generated with [Claude Code](https://claude.com/claude-code)