### PR TITLE
JS libraries Artifactory integrity issue with R2 redirects

### DIFF
--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -201,16 +201,27 @@ virtual repository.
 
 ### Advanced settings for redirect handling
 
-Chainguard Libraries uses Cloudflare R2 storage, meaning tarball downloads from `libraries.cgr.dev` return a 302 redirect to a different host. Without additional configuration, Artifactory may cache the redirect response instead of the actual tarball, causing npm integrity checksum failures at install time.
+Chainguard Libraries uses Cloudflare R2 storage, meaning tarball downloads from
+`libraries.cgr.dev` return a 302 redirect to a different host. Without
+additional configuration, Artifactory may cache the redirect response instead of
+the actual tarball, causing npm integrity checksum failures at install time.
 
 To prevent this:
 
-1. Apply the following settings to your Artifactory `javascript-chainguard` remote repository, within in the **Advanced** tab:
-    - **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD requests that may not be handled correctly by redirect-based registries.
-    - **Enable Lenient Host Authentication** — allows Artifactory to follow redirects across hosts (required since downloads redirect from `libraries.cgr.dev` to `*.r2.cloudflarestorage.com`).
-    - **Enable Cookie Management** - this setting is optional, but recommended by JFrog for remote repositories that involve redirects.
-2. Clear the corrupted cached tarballs: in Artifactory, right-click the `javascript-chainguard` repository and click **Zap Caches**, then re-run your install.
-    - Alternatively, you could also delete specific corrupted `.tgz` artifacts from the remote cache before re-running the install.
+1. Apply the following settings to your Artifactory `javascript-chainguard`
+   remote repository, within in the **Advanced** tab:
+    - **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD
+      requests that may not be handled correctly by redirect-based registries.
+    - **Enable Lenient Host Authentication** — allows Artifactory to follow
+      redirects across hosts (required since downloads redirect from
+      `libraries.cgr.dev` to `*.r2.cloudflarestorage.com`).
+    - **Enable Cookie Management** - this setting is optional, but recommended
+      by JFrog for remote repositories that involve redirects.
+2. Clear the corrupted cached tarballs: in Artifactory, right-click the
+   `javascript-chainguard` repository and click **Zap Caches**, then re-run your
+   install.
+    - Alternatively, you could delete specific corrupted `.tgz` artifacts from
+      the remote cache, rather than deleting all, before re-running the install.
 
 ### Build tool access
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -199,6 +199,19 @@ Use this setup for initial testing with Chainguard Libraries for JavaScript. For
 production usage add the `javascript-chainguard` repository to your production
 virtual repository.
 
+### Advanced settings for redirect handling
+
+Chainguard Libraries uses Cloudflare R2 storage, meaning tarball downloads from `libraries.cgr.dev` return a 302 redirect to a different host. Without additional configuration, Artifactory may cache the redirect response instead of the actual tarball, causing npm integrity checksum failures at install time.
+
+To prevent this:
+
+1. Apply the following settings to your Artifactory `javascript-chainguard` remote repository, within in the **Advanced** tab:
+    - **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD requests that may not be handled correctly by redirect-based registries.
+    - **Enable Lenient Host Authentication** — allows Artifactory to follow redirects across hosts (required since downloads redirect from `libraries.cgr.dev` to `*.r2.cloudflarestorage.com`).
+    - **Enable Cookie Management** - this setting is optional, but recommended by JFrog for remote repositories that involve redirects.
+2. Clear the corrupted cached tarballs: in Artifactory, right-click the `javascript-chainguard` repository and click **Zap Caches**, then re-run your install.
+    - Alternatively, you could also delete specific corrupted `.tgz` artifacts from the remote cache before re-running the install.
+
 ### Build tool access
 
 The following steps allow you to determine the URL and authentication details


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Add content on how to prevent JS checksum mismatches with Artifactory virtual repository

### What should this PR do?
Help customers prevent migration issues

### Why are we making this change?
Internal request / customer reported issue. [Slack thread here](https://chainguard-dev.slack.com/archives/C0962EGMS3F/p1773671606110999)

### What are the acceptance criteria? 
This content should be accurate. Working fix described here: https://github.com/chainguard-dev/customer-issues/issues/3217#issuecomment-4068348309

