### PR TITLE
Search: Fix list item spacing

### DIFF
--- a/assets/scss/components/_sidebar-search-fix.scss
+++ b/assets/scss/components/_sidebar-search-fix.scss
@@ -198,4 +198,7 @@
     svg {
         vertical-align: unset;
     }
+    ul li {
+        margin-bottom: unset;
+    }
 }


### PR DESCRIPTION
Fixes an instance of extra/unwanted spacing in DocSearch.