### PR TITLE
Reorder regular and remediated repos in Python example

### DIFF
--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -205,12 +205,13 @@ Note that `pip` supports installing Python libraries from one main repository
 URL specified with `index-url` and one or more additional repositories specified
 with `extra-index-url` without any specific prioritization beyond resolving
 semantic versions. The following example uses authentication from a local
-`.netrc` file and direct access to Chainguard Libraries including remediated
-package versions:
+`.netrc` file and places the remediated repository first as the primary source,
+falling back to the standard Chainguard Libraries repository when a remediated
+version is not available: 
 
 ```
---index-url https://libraries.cgr.dev/python/simple/
---extra-index-url https://libraries.cgr.dev/python-remediated/simple/
+--index-url https://libraries.cgr.dev/python-remediated/simple/
+--extra-index-url https://libraries.cgr.dev/python/simple/
 ```
 
 If you are using `pip` and prefer to pull from multiple repositories while


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Clarify docs based on [internal feedback](https://chainguard-dev.slack.com/archives/C085187D8RE/p1773771854731199)/best practices

### What should this PR do?
Make it more obvious that you should list the remediated repo first to ensure it takes precedence

### Why are we making this change?
Internal feedback

