### PR TITLE
Regex example in Assumable IDs overview

### DIFF
--- a/content/chainguard/administration/assumable-ids/assumable-ids.md
+++ b/content/chainguard/administration/assumable-ids/assumable-ids.md
@@ -130,6 +130,21 @@ chainctl iam identities create <identity-name> \
 
 As with Terraform, you must provide `chainctl` with certain information about the identity you want to create, including the issuer and subject of the identity, the role-bindings associated with the identity (if any), and the organization under which the identity should be created.
 
+Be aware that you can use regular expressions to create an identity that matches claims using a pattern. The following example passes pattern expressions to the `--identity-issuer-pattern` and `--subject-pattern` flags:
+
+```shell
+chainctl iam identities create <identity-name> \
+    --identity-issuer-pattern="https://*.mycompany\.com" \ 
+    --subject-pattern="^\d{4}$"
+```
+
+You can use the following `chainctl` flags to match claims to patterns:
+
+* `--audience-pattern`: A pattern to match the audience of the identity.
+* `--claim-pattern`: A comma-separated list of `claim:pattern` pairs of custom claims to match the identity.
+* `--identity-issuer-pattern`: A pattern to match the issuer of the identity.
+* `--subject-pattern`: A pattern to match the subject of the identity.
+
 You can change an existing identity with the `update` command. The following example would update the identity's issuer.
 
 ```sh


### PR DESCRIPTION
## Type of change                                                                                                                                  
                                                                                                                                                  
Add documentation for regex-based identity matching flags (--identity-issuer-pattern, --subject-pattern, --audience-pattern, --claim-pattern) to the Assumable IDs overview 

## What should this PR do?                                                                                                                         
resolves https://github.com/chainguard-dev/internal/issues/5739

## Why are we making this change?                                                                                                               

Users creating identities with chainctl had no guidance that claims can be matched using regex patterns, making this capability undiscoverable. 
   
## What are the acceptance criteria?                                                                                                               
                                                                                                                                               
- The new section appears in the Assumable IDs overview with a working code example                                                             
- All four --*-pattern flags are listed and described                                                                                        
                                                                                                                                                  
## How should this PR be tested?

Navigate to the [Assumable IDs overview page](https://deploy-preview-3100--ornate-narwhal-088216.netlify.app/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl) and verify the new regex example and flag list render correctly.