### PR TITLE
Add examples of auth with assumable ids using curl

### DIFF
--- a/content/chainguard/api/authentication.md
+++ b/content/chainguard/api/authentication.md
@@ -16,14 +16,14 @@ weight: 065
 
 There are several ways for users to interact with the Chainguard platform, with [`chainctl`](/chainguard/chainctl/) (Chainguard's command-line tool) and the [Chainguard Console](https://console.chainguard.dev/overview) (Chainguard's web interface) being the two most commonly-used methods. However, both of these require a human user to authenticate, and aren't useful for working with Chainguard resources programmatically.
 
-The [Chainguard SDK](https://github.com/chainguard-dev/sdk) serves to ease programmatic integration with the Chainguard platform. This guide highlights two examples from the SDK repository that show how to authenticate to the [Chainguard registry](/chainguard/chainguard-registry/overview/) using the `chainguard.dev/sdk/auth` and `chainguard.dev/sdk/auth/ggcr` packages. The first has you authenticate as a local user, while the second has you authenticate as an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/). 
+The [Chainguard SDK](https://github.com/chainguard-dev/sdk) serves to ease programmatic integration with the Chainguard platform. This guide highlights two examples from the SDK repository that show how to authenticate to the [Chainguard registry](/chainguard/chainguard-registry/overview/) using the `chainguard.dev/sdk/auth` and `chainguard.dev/sdk/auth/ggcr` packages. The first has you authenticate as a local user, while the second has you authenticate as an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/).
 
-For more information about the examples highlighted in this guide, refer to the [`examples` folder](https://github.com/chainguard-dev/sdk/tree/main/examples/registry) in the SDK repository.
+This page gives examples in Golang as well as using `curl`. For more information about the Golang examples, refer to the [`examples` folder](https://github.com/chainguard-dev/sdk/tree/main/examples/registry) in the SDK repository.
 
 
 ## Prerequisites
 
-To follow along with this guide you must have [Go installed](https://go.dev/doc/install) to run the provided examples, which are written in Golang.
+To follow along with this guide you must have [Go installed](https://go.dev/doc/install) to run the  examples provided by the SDK repository, which are written in Golang. Additional examples in `curl` are found just after the discussion of each Golang example.
 
 Additionally, it may help to run these examples from a temporary directory, like `/tmp` so the code is automatically removed from your system the next time it boots:
 
@@ -32,9 +32,11 @@ cd /tmp
 ```
 
 
-## Example 1 — Authenticate Using Local Credentials 
+## Example 1 — Authenticate using local credentials
 
 The first example from the SDK repository we will go over is the [`chainctl` example](https://github.com/chainguard-dev/sdk/tree/main/examples/registry/chainctl). This example shows how to use a token source backed by `chainctl` — Chainguard's command-line tool — to access the Chainguard registry using local credentials.
+
+### Example 1 in Golang
 
 The `chainctl` example consists of the following Go code in a `main.go` file (with comments removed):
 
@@ -105,9 +107,60 @@ This example doesn't really reflect a real-world use case, as users will general
 You can experiment with updating this example to retrieve information about a different Chainguard container image by changing the `cgr.dev/chainguard/static` value in the `main()` function. You could replace this with any Chainguard repository you have access to, and the example will return information about that image.
 
 
+### Example 1 using curl
+
+To authenticate using `curl` and the API, first authenticate directly with `chainctl`:
+
+```shell
+chainctl auth login
+```
+
+This will return output like the following:
+
+```response
+Opening browser to https://issuer.enforce.dev/oauth?audience=https%3A%2F%2Fconsole-api.enforce.dev&client_id=auth0&connection=google-oauth2&create_refresh_token=true&exit=redirect&redirect=http%3A%2F%2Flocalhost%3A44723%2Fcallback%3Ftoken%3Dtrue%26error%3Dtrue&skip_registration=true
+Opening in existing browser session.
+eyJhbGciOiJSUzI1NiIsImtpZCIiwibmFtZSI6SRi0IvgxPIlU8LfgLIk1hdHRoU5NmIxNzM3OGZlNzU51ZjczNTgxNTQ3ODU4OWM2MzNlZTQwZDUyOGMwYTAifQ.eyJhY3QiOnsiYXVkIjoiSHZxeTd5b0VoSThUWTF6WDlyUHJzZGNJbnREejl5aDIiLCJpc3MiOiJodHRwczovL2F1dGguY2hhaW5ndWFyZC5kZXYvIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMTUzMTIxMjYyNzg5NDAzNzAyMTgifSwiYXVkIjoiaHR0cHM6Ly9jb25zb2xlLWFwaS5lbmZvcmNlLmRldiIsImNhcCI6eyIwYWM3ZmY5MDU4NTBjMzU3MjNhN2YzNzZlMTBkMDA3Yzk1OGM0NWM4IjoiQUFBQUFBQUFBSHhFUWdCQWdJQkVTQWlJR0RCQWlxbGsiLCI0NWEwYzYxZWE2ZmQ5NzdmMDUwYzVmYjlhYzA2YTY5ZWVkNzY0NTk1IjoiQUFBQUFBQUFBSHpfOGdEeDRlRF9fZ25vLURCQl9fdHYiLCI1NWE1OGJjOGU0ZTNkZGNmNWJiZTczYWIwOTA4NzhmYTM1ZDBhNWE5IjoiQUFBQUFBQUFBSHpfOGdEeDRlRF9fZ25vLURCQl9fdHYiLCI3MjA5MDljOWY1Mjc5MDk3ZDg0N2FkMDJhMmYyNGJhOGY1OWRlMzZhIjoiQUFBQUFBQUFBSHhFUWdCQWdJQkVTQWlJR0RCQWlxbGsiLCI4ZDAwODEwYjBhMDI5NTU5ZTUyMzk5ODU1MDMxOTU4ZWY0OGJlNmM4IjoiQUFBQUFBQUFBSHhFUWdCQWdJQkVTQWlJR0RCQWlxbGsiLCI4ZGQwMGJjZmYyMjQzNGQ3YzEwMDdmZWY2Nzg5Mzk0NWU4YmNiNDM1IjoiQUFBQUFBQUFBRndBQUFBQUFBQUFBQUFBQUFBSUFBQUEiLCJhNzBkOTg5ZDgyMWJjMzE1ZmViYTlmYjU4NWQ0ZWNlMzVjODJjMjgyIjoiQUFBQUFBQUFBSHpfOGdEeDRlRF9fZ25vLURCQl9fdHYiLCJiMTkwNGI0MWU1Mzg1Yzk1ZGY3MDlhZjZhY2EzNTMwNTExMzgzZmVmIjoiQUFBQUFBQUFBSHhFUWdCQWdJQkVTQWlJR0RCQWlxbGsiLCJjYTQzOGQ3NmFjYmFkMDI5N2I3NzNkNjgzODkwZmJlNWQ5OWRiOGI1IjoiQUFBQUFBQUFBRzFFQWdBQUlBQVVDQUFBR1lBQmFBbGsiLCJjZTJkMTk4NGEwMTA0NzExNDI1MDMzNDBkNjcwNjEyZDYzZmZiOWY2IjoiQUFBQUFBQUFBSHhFUWdCQWdJQkVTQWlJR0RCQWlxbGsifSwiZW1haWwiOiJtYXR0aGV3LmhlbG1rZUBjaGFZTYwNDRjMDY5N2Y3ZlcmlmaWVkIjp0cnVlLCJleHAiOjE3NzM5MjYzNTcsImlhdCI6MTc3MzkyMjc1NywiaW50ZXJuYWwiOnsiZGVidWciOnRydWV9LCJpc3MiOiJodHRwczovL2lzc3Vlci5lbmZvcmNlLmRldiIsInN1YiI6IjY5MDkxMmNmM2U3Njk3OWVjYTVhYThjOWUyY2VmOTI3MDRhMTEyOTYiLCJ1cHN0cmVhbSI6eyJlbWFpbCI6Im1hdHRoZXcuaGVsbWtlQGNoYWluZ3VhcmQuZGV2ZXcgSGVsbWtlIiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS9hL0FDZzhvY0lERmdNeWZ4X2NOR2I0bGtwZ1VTbVA2WjlUSXg0NnZud3JtdDhEQmZYNkZYdmc2R009czk2LWMifX0.GnN8_oJwL3mgutHM3IoX65g8aYoEKmG0-dSHvlxXDYwB6cWpTlfNJKmkJjD5rT8exWnSiP_ibq9SZB7rA23pl17Gn0hdHH42lgKSKzdM6471E_Yz2cThxOKR4KrMDnI9UvIBrZ2cZ270WU21q0soIt5XBcEBTiZ1t2ehfvcVgSi4kq87pNQjF5esmeP71kiCQAtyQuEKKwLB-9ShIVJaSnmgjX3kWtOyXur9fBFXO7XBC6b9DKp3mzsc7JMyNE2UEKN5psHkprfARWa-MFYLsN4MKxo23CEUTOxmRaQzfznOdwDHwZgjN9tfp3RMqG6owvq5x4-H6OAIh6eKfVSadcBsgs2p__WpqPB66rZAt-J6E-NZlNzU51ZjczNTgxNTQ3ODU4tvNyqsxZhnN7rPv1Q0nc18e4JtYzIsBFr-SRi0IvgxPIlU8LfgLKI_CuZ3Uhk503M1lTlin2cPJi3DyDAc3xOeTr3NjSxJ2wOgUErgkZJg70aOoIpSV_4zRC_Qy8-aha-eICEEKs98yVw7GPSrPQpBBcIm0ud0pIM2e-33AVNG-D_mfA2chEZMxoFvZzZaF6xNv7v9r3TlyQ2m2mEJyt9qxkwgsoXaxHhHyjhEkfctP_4cNQ03ytwxqvo4o1SjsCTdo_CxdSOS2JMIvcpq-GDohWUZSAG
+```
+
+Then, retrieve an API token and use it to call the API:
+
+```shell
+curl -H "Authorization: Bearer $(chainctl auth token)" https://console-api.enforce.dev/iam/v1/groups | jq '.'
+```
+
+In our example, [we requested a list of groups the account belongs to](https://edu.chainguard.dev/chainguard/api/spec/#tag/groups/GET/iam/v1/groups). Then we piped the API response, which is in JSON, into `jq` to make it more easily readable by humans for our documentation sample. This will return output like the following, which has been edited for length:
+
+```response
+{
+  "items": [
+    {
+      "id": "<removed>",
+      "name": "chainguard.edu",
+      "description": "Developer Enablement images catalog",
+      "resourceLimits": {
+        "clusters": 0,
+        "idps": 0,
+        "repositories": 0
+      },
+      "verified": true
+    },
+    {
+      "id": "<removed>",
+      "name": "chainguard",
+      "description": "    This group holds the public Chainguard Images hosted under\n    cgr.dev/chainguard\n",
+      "resourceLimits": {},
+      "verified": true
+    }
+  ]
+}
+```
+
 ## Example 2 — Authenticate with an Assumed Identity 
 
 The [`exchange` example](https://github.com/chainguard-dev/sdk/tree/main/examples/registry/exchange) demonstrates how to exchange a token for an assumed identity to access the registry.
+
+### Example 2 in Golang
 
 This example consists of the following Go code in a `main.go` file (with comments removed):
 
@@ -179,6 +232,72 @@ Again, this example doesn't really reflect a real-world use case. Users will gen
 You can experiment with updating this example to authenticate by assuming an identity you created and retrieve the digest of a container image from your organization's private repository within the Chainguard registry.
 
 To do so, you will need an appropriately-configured assumable identity. You can create an assumable identity with the [`chainctl iam identities create` command](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create/).
+
+
+### Example 2 using curl
+
+First, login with chainctl using an OIDC token. Where the token comes from will differ by platform. Refer to our [Identity Provider samples](/chainguard/administration/custom-idps/idp-providers/) for some examples.
+
+```shell
+chainctl auth login --identity "<identity-id>" --identity-token /var/run/chainguard/oidc/oidc-token
+```
+
+Then, retrieve an API token and use it to call the API:
+
+```shell
+curl -H "Authorization: Bearer $(chainctl auth token)" https://console-api.enforce.dev/iam/v1/groups | jq '.'
+```
+
+In our example, [we requested a list of groups the account belongs to](https://edu.chainguard.dev/chainguard/api/spec/#tag/groups/GET/iam/v1/groups). Then we piped the API response, which is in JSON, into `jq` to make it more easily readable by humans for our documentation sample. This will return output like the following, which has been edited for length:
+
+```response
+{
+  "items": [
+    {
+      "id": "<removed>",
+      "name": "chainguard.edu",
+      "description": "Developer Enablement images catalog",
+      "resourceLimits": {
+        "clusters": 0,
+        "idps": 0,
+        "repositories": 0
+      },
+      "verified": true
+    },
+    {
+      "id": "<removed>",
+      "name": "chainguard",
+      "description": "    This group holds the public Chainguard Images hosted under\n    cgr.dev/chainguard\n",
+      "resourceLimits": {},
+      "verified": true
+    }
+  ]
+}
+```
+
+While using assumable identities with the API and API tokens, it is useful to use environment variables. Here's a high-level example of what you might do. Refer to your identity provider's documentation and [Assumable Identities](/chainguard/administration/assumable-ids/assumable-ids/) to learn more.
+
+Here are some sample environment variables:
+
+```shell
+# This is the UIDP of the assumable identity (refer to documentation)
+IDENTITY="<identity-id>"
+
+# Retrieve the OIDC token for your workload. How this is done will differ by platform.
+IDENTITY_TOKEN=$(cat /var/run/chainguard/oidc/oidc-token)
+
+# Exchange the OIDC token for a Chainguard API token. The token will be valid for an hour.
+API_TOKEN=$(curl -sSf \
+  -H "Authorization: Bearer $IDENTITY_TOKEN" \
+   "https://issuer.enforce.dev/sts/exchange?aud=https://console-api.enforce.dev&identity=$IDENTITY" \
+   | jq -r .token
+)
+
+# Use the API token
+curl -H "Authorization: Bearer ${API_TOKEN}" https://console-api.enforce.dev/registry/v1/repos
+```
+
+Refer to the [Assumable Identities documentation](/chainguard/administration/assumable-ids/assumable-ids/#using-the-chainguard-api) for another example of authentication using an assumed identity.
 
 
 ## Learn More

--- a/content/chainguard/api/authentication.md
+++ b/content/chainguard/api/authentication.md
@@ -275,7 +275,7 @@ In our example, [we requested a list of groups the account belongs to](https://e
 }
 ```
 
-While using assumable identities with the API and API tokens, it is useful to use environment variables. Here's a high-level example of what you might do. Refer to your identity provider's documentation and [Assumable Identities](/chainguard/administration/assumable-ids/assumable-ids/) to learn more.
+Using environment variables is helpful when working with assumable identities through the API and API tokens. Here's a high-level example of what you might do. Refer to your identity provider's documentation and [Assumable Identities](/chainguard/administration/assumable-ids/assumable-ids/) to learn more.
 
 Here are some sample environment variables:
 


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/internal/issues/5677

Our API authentication page uses Golang examples from the SDK repository. They are accurate. But, you have to both know Golang and set up a project to test them and figure out how they work. These additions use `curl` and really obvious actions. That should make it easier for customers to adapt to whatever context they are using.

I got these examples from @ribbybibby, so extra thanks for that!!