### PR TITLE
Update notifications page as beta matures

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
@@ -17,7 +17,7 @@ weight: 030
 toc: true
 ---
 
-You can use the [Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory) to configure how **Chainguard** is permitted to send notifications about things like breaking changes to users in your organization. The feature includes options to allow notifications to be sent in-app to the Activity Center on the user’s Overview page in the Chainguard Console, via email, and using Slack.
+You can use the [Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory) to configure how **Chainguard** is permitted to send notifications about things like breaking changes to users in your organization. The feature includes options to allow notifications to be sent in-app to the Activity Center on the user’s Overview page in the Chainguard Console, via Slack, and for customers who are opted in, via email.
 
 These notifications are different from [Chainguard Events](/chainguard/administration/cloudevents/) as Chainguard Notifications are sent by Chainguard’s customer success representatives.
 
@@ -31,7 +31,7 @@ The in-app notifications are set up automatically and currently have no configur
 
 Slack requires you to establish the connection between our Chainguard Notifications Slack app and your company Slack workspace by completing the Slack OAuth flow that initiates when you connect Slack the first time.
 
-Some customers have access email notifications. When enabled, you have control over which email notifications are sent. You are also able to set one or more additional email addresses to receive notifications for your organizations; these are called forwarding addresses.
+Some customers have access to email notifications. When enabled, you have control over which email notifications are sent. You are also able to set one or more additional email addresses to receive notifications for your organizations; these are called forwarding addresses.
 
 
 ## Set up Slack for Chainguard Notifications
@@ -82,6 +82,8 @@ Include the private channel in your actions in the next section.
 
 
 ## Manage email notifications
+
+Email notifications are not yet available to all customers.
 
 To perform this task, you must use a user account for the Chainguard Console that is configured with the *owner* role for the organization. Then, follow these steps:
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
@@ -6,7 +6,7 @@ type: "article"
 description: "A primer on how to configure Chainguard Notifications"
 lead: "A primer on how to configure Chainguard Notifications in the Chainguard Console"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2025-07-11T08:49:31+00:00
+lastmod: 2026-03-20T08:49:31+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -17,36 +17,22 @@ weight: 030
 toc: true
 ---
 
-You can use the [Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory) to configure how Chainguard is permitted to send notifications about things like breaking changes to users in your organization. The feature is rolling out with options to allow notifications to be sent in-app to the user’s Overview page in the Chainguard Console, via email, and using Slack.
+You can use the [Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory) to configure how **Chainguard** is permitted to send notifications about things like breaking changes to users in your organization. The feature includes options to allow notifications to be sent in-app to the Activity Center on the user’s Overview page in the Chainguard Console, via email, and using Slack.
 
 These notifications are different from [Chainguard Events](/chainguard/administration/cloudevents/) as Chainguard Notifications are sent by Chainguard’s customer success representatives.
 
 ## Prerequisites and limitations
 
-This feature is currently in private beta. If you would like to participate, please [reach out to our Customer Support team](https://www.chainguard.dev/contact?utm=docs). To use the feature:
+This feature is currently in beta.
 
-- You must use a user account for the Chainguard Console that is configured with the *owner* role for your organization.
-- There are two feature flags which must be turned on, `notificationsBeta` and `emailNotifications`. These flags are not available to you until Chainguard enables your access.
+Notifications are currently limited to messages related to a small set of topics like breaking changes, incidents, and product lifecycle changes like end-of-life (EOL) and new releases.
 
-Notifications are currently limited to messages related to breaking changes. In the future, this will expand to include notifications about topics like incidents, new releases, and end of life for specific images.
+The in-app notifications are set up automatically and currently have no configuration options.
 
-The in-app and email notifications can be set up for you by Chainguard when you opt in to enabling the notifications feature, but you have control over which email notifications are sent. You are also able to set one or more additional email addresses to receive notifications for your organizations; these are called forwarding addresses.
+Slack requires you to establish the connection between our Chainguard Notifications Slack app and your company Slack workspace by completing the Slack OAuth flow that initiates when you connect Slack the first time.
 
-Slack requires you to establish the connection between our Chainguard Notifications Slack app and your company Slack workspace by completing the Slack OAuth flow.
+Some customers have access email notifications. When enabled, you have control over which email notifications are sent. You are also able to set one or more additional email addresses to receive notifications for your organizations; these are called forwarding addresses.
 
-## Manage email notifications
-
-To perform this task, you must use a user account for the Chainguard Console that is configured with the *owner* role for the organization. Then, follow these steps:
-
-1. In the Chainguard Console, open **Settings \> Notifications**.
-
-1. Next to the **Email** section heading, click **Edit**.
-  You can then change settings for what notification topics will be sent and to whom, either an individual or perhaps to an email alias for a group.
-
-1. When you are done, click **Save changes**.
-
-<center><img src="notifications-email.png" alt="Screenshot showing the Email section of the Chainguard Console's Settings > Notifications page." style="width:700px;"></center>
-<br /> 
 
 ## Set up Slack for Chainguard Notifications
 
@@ -56,7 +42,7 @@ Make sure you are logged into both the console and to your Slack workspace on th
 
 To set this up, follow these steps:
 
-1. In the Chainguard Console, open **Settings \> Notifications**.
+1. In the Chainguard Console, open **Settings \> Activity Center**.
 
 1. Next to the **Integrations** section heading, click **Edit**.
 
@@ -88,7 +74,23 @@ Include the private channel in your actions in the next section.
 ### Set up notifications in a public or private channel
 
 1. Click into the **Slack Channels** box under the **Slack** subheading on the **Notifications** page in the console. You will be shown the list of channels available for the Chainguard Notifications app to use. Select the channel(s) where you want these notifications to be posted.
+
 > NOTE: Private channels will not appear here unless you first complete the preliminary step in the previous section.
 
 <center><img src="notifications-integrations.png" alt="Screenshot showing the Integrations section of the Chainguard Console's Settings > Notifications page." style="width:700px;"></center>
+<br />
+
+
+## Manage email notifications
+
+To perform this task, you must use a user account for the Chainguard Console that is configured with the *owner* role for the organization. Then, follow these steps:
+
+1. In the Chainguard Console, open **Settings \> Activity Center**.
+
+1. Next to the **Email** section heading, click **Edit**.
+  You can then change settings for what notification topics will be sent and to whom, either an individual or perhaps to an email alias for a group.
+
+1. When you are done, click **Save changes**.
+
+<center><img src="notifications-email.png" alt="Screenshot showing the Email section of the Chainguard Console's Settings > Notifications page." style="width:700px;"></center>
 <br />


### PR DESCRIPTION
Closes https://github.com/chainguard-dev/internal/issues/5754

The beta is moving from private to public and there have been minor tweaks. This PR
- Captures those changes
- Adjusts verbiage to account for the change in availability
- Moves Email to the end as it is not going to be available to everyone immediately (or perhaps may end up limited to just some subset of users); even if it isn't available at all right now, this revision should give enough info for users who don't see it to just shrug that off as something not available to them today rather than something broken