### PR TITLE
Restructure Chainguard Repository docs slightly

### DIFF
--- a/content/chainguard/chainguard-repository/_index.md
+++ b/content/chainguard/chainguard-repository/_index.md
@@ -1,10 +1,10 @@
 ---
-title : "Chainguard OS"
+title : "Chainguard Repository"
 lead: ""
-description: "Chainguard OS Documentation"
+description: "Chainguard Repository Documentation"
 type: "article"
-date: 2025-07-03T08:48:23+00:00
-lastmod: 2025-07-03T08:48:23+00:00
+date: 2026-03-16T08:48:23+00:00
+lastmod: 2026-03-24T00:48:23+00:00
 draft: false
-weight: 030
+weight: 032
 ---

--- a/content/chainguard/chainguard-repository/_index.md
+++ b/content/chainguard/chainguard-repository/_index.md
@@ -1,65 +1,10 @@
 ---
-title : "Chainguard Repository"
-lead: "The Chainguard Repository is a single, policy-aware endpoint for all artifacts that Chainguard builds and distributes — libraries, containers, VMs, and OS."
-description: "Chainguard Repository Overview"
+title : "Chainguard OS"
+lead: ""
+description: "Chainguard OS Documentation"
 type: "article"
-date: 2026-03-16T08:48:23+00:00
-lastmod: 2026-03-17T00:48:23+00:00
+date: 2025-07-03T08:48:23+00:00
+lastmod: 2025-07-03T08:48:23+00:00
 draft: false
-weight: 032
+weight: 030
 ---
-
-The Chainguard Repository is a single, policy-aware endpoint for all artifacts that Chainguard builds and distributes. It gives your organization one place to pull open source artifacts, configure security policies that govern how they are consumed, and monitor coverage and policy enforcement across your environment.
-
-All artifacts served through the Chainguard Repository are either rebuilt by Chainguard from verifiable source in a SLSA L2-compliant build environment, or sourced from upstream public registries and protected by configurable policies. As Chainguard builds more artifacts from source, your organization's risk shrinks automatically — without any changes to your configuration or developer workflows.
-
-## Artifact types
-
-As of this writing, the Chainguard Repository contains the following artifact types:
-
-| Artifact type | Description |
-| ----- | ----- |
-| [Chainguard JavaScript Libraries](/chainguard/libraries/chainguard-repository/) | Open source language dependencies rebuilt from source for JavaScript (npm). |
-| [Chainguard OS Packages](/chainguard/chainguard-images/features/packages/private-apk-repos/#chainguard-os-packages) | The full set of packages built by Chainguard and used to create Chainguard containers. |
-
-
-## Endpoints
-
-Each artifact type is accessible via its own endpoint:
-
-| Artifact type | Endpoint |
-| ----- | ----- |
-| Libraries for JavaScript | `libraries.cgr.dev/javascript` |
-| OS Packages | `apk.cgr.dev/<organization-name>` |
-
-See each artifact type's documentation for authentication and configuration details.
-
-
-## Policies for Libraries
-
-The Chainguard Repository includes a policy engine that lets you define rules governing which artifacts can be consumed and under what conditions. Policies are configured once in the Chainguard Console and enforced automatically across your environment.
-
-For language dependencies, policies apply to both Chainguard-built packages and upstream packages served via the optional fallback to public registries (npm). Available policies include:
-
-* **Upstream fallback** — Control whether packages not yet built by Chainguard can be sourced from the upstream public registry.  
-* **Cooldown** — Block newly published upstream packages for a defined period before they can be pulled, giving the security community time to detect threats. A 7-day cooldown blocks 47% of malicious packages.
-
-All packages — whether Chainguard-built or sourced from upstream — are also scanned for malware before being served. Any package with a detected malware identifier is blocked.
-
-
-## Use case for OS Packages
-
-This is for large customers who already build their own container images from packages using tools like Bazel, Dockerfiles, and `rules_apko` and want to use a wider set of packages from Chainguard. Chainguard OS Packages makes over 400,000 built packages into your private APK repository.
-
-
-## **Console**
-
-The Chainguard Console is the central interface for configuring policies and monitoring artifact activity across your organization. Learn more in [Using the Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory/).
-
-Access the Console at [console.chainguard.dev](https://console.chainguard.dev).
-
-
-## **Learn more**
-
-* [Chainguard Repository for JavaScript Libraries](/chainguard/libraries/chainguard-repository/)  
-* [Chainguard OS Packages](/chainguard/chainguard-images/features/packages/private-apk-repos/#chainguard-os-packages/)

--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -1,5 +1,6 @@
 ---
-title : "Chainguard Repository"
+title : "Overview of Chainguard Repository"
+linktitle: "Overview"
 lead: "The Chainguard Repository is a single, policy-aware endpoint for all artifacts that Chainguard builds and distributes — libraries, containers, VMs, and OS."
 description: "Chainguard Repository Overview"
 type: "article"

--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -1,0 +1,65 @@
+---
+title : "Chainguard Repository"
+lead: "The Chainguard Repository is a single, policy-aware endpoint for all artifacts that Chainguard builds and distributes — libraries, containers, VMs, and OS."
+description: "Chainguard Repository Overview"
+type: "article"
+date: 2026-03-16T08:48:23+00:00
+lastmod: 2026-03-24T00:48:23+00:00
+draft: false
+weight: 010
+---
+
+The Chainguard Repository is a single, policy-aware endpoint for all artifacts that Chainguard builds and distributes. It gives your organization one place to pull open source artifacts, configure security policies that govern how they are consumed, and monitor coverage and policy enforcement across your environment.
+
+All artifacts served through the Chainguard Repository are either rebuilt by Chainguard from verifiable source in a SLSA L2-compliant build environment, or sourced from upstream public registries and protected by configurable policies. As Chainguard builds more artifacts from source, your organization's risk shrinks automatically — without any changes to your configuration or developer workflows.
+
+## Artifact types
+
+As of this writing, the Chainguard Repository contains the following artifact types:
+
+| Artifact type | Description |
+| ----- | ----- |
+| [Chainguard JavaScript Libraries](/chainguard/libraries/chainguard-repository/) | Open source language dependencies rebuilt from source for JavaScript (npm). |
+| [Chainguard OS Packages](/chainguard/chainguard-images/features/packages/private-apk-repos/#chainguard-os-packages) | The full set of packages built by Chainguard and used to create Chainguard containers. |
+
+
+## Endpoints
+
+Each artifact type is accessible via its own endpoint:
+
+| Artifact type | Endpoint |
+| ----- | ----- |
+| Libraries for JavaScript | `libraries.cgr.dev/javascript` |
+| OS Packages | `apk.cgr.dev/<organization-name>` |
+
+See each artifact type's documentation for authentication and configuration details.
+
+
+## Policies for Libraries
+
+The Chainguard Repository includes a policy engine that lets you define rules governing which artifacts can be consumed and under what conditions. Policies are configured once in the Chainguard Console and enforced automatically across your environment.
+
+For language dependencies, policies apply to both Chainguard-built packages and upstream packages served via the optional fallback to public registries (npm). Available policies include:
+
+* **Upstream fallback** — Control whether packages not yet built by Chainguard can be sourced from the upstream public registry.  
+* **Cooldown** — Block newly published upstream packages for a defined period before they can be pulled, giving the security community time to detect threats. A 7-day cooldown blocks 47% of malicious packages.
+
+All packages — whether Chainguard-built or sourced from upstream — are also scanned for malware before being served. Any package with a detected malware identifier is blocked.
+
+
+## Use case for OS Packages
+
+This is for large customers who already build their own container images from packages using tools like Bazel, Dockerfiles, and `rules_apko` and want to use a wider set of packages from Chainguard. Chainguard OS Packages makes over 400,000 built packages into your private APK repository.
+
+
+## **Console**
+
+The Chainguard Console is the central interface for configuring policies and monitoring artifact activity across your organization. Learn more in [Using the Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory/).
+
+Access the Console at [console.chainguard.dev](https://console.chainguard.dev).
+
+
+## **Learn more**
+
+* [Chainguard Repository for JavaScript Libraries](/chainguard/libraries/chainguard-repository/)  
+* [Chainguard OS Packages](/chainguard/chainguard-images/features/packages/private-apk-repos/#chainguard-os-packages/)


### PR DESCRIPTION
[ x] Check if this is a typo or other quick fix and ignore the rest :)

This changes from using just a directory and `_index.md` file by moving the content into an `overview.md` file and creating a new base `_index.md` that matches other sections (I copy/pasted/edited the one from Chainguard OS), just so that Hugo has things working consistently.