### PR TITLE
Fix: DocSearch theme and section heading spacing

### DIFF
--- a/assets/js/docsearch.js
+++ b/assets/js/docsearch.js
@@ -5,7 +5,7 @@ docsearch({
   appId: "P6WD6RQSFQ",
   indexName: "chainguard",
   apiKey: "9846ce061788834124713a47b1cfd2f7",
-  theme: document.documentElement.hasAttribute("data-dark-mode") ? "dark" : "light",
+  theme: localStorage.getItem("theme") === "dark" ? "dark" : "light",
 });
 
 function openDocSearch() {

--- a/assets/scss/components/_typography-improvements.scss
+++ b/assets/scss/components/_typography-improvements.scss
@@ -117,27 +117,6 @@ h4 {
   }
 }
 
-// Navigation and sidebar text - keeping original spacing
-.docs-sidebar,
-.leftnav,
-#sidebar-default {
-  // Remove font size override to keep original
-  
-  .nav-link,
-  a {
-    // Keep original padding and line-height
-    font-weight: 450;
-    
-    &:hover {
-      font-weight: 500;
-    }
-    
-    &.active {
-      font-weight: 600;
-    }
-  }
-}
-
 // Table improvements
 table {
   font-size: var(--docs-small-font);

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -30,9 +30,9 @@
 
   {{ range $index, $section := sort .Site.Sections "Weight" }}
   {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-  <p class="sidebar-category text-uppercase">
+  <div class="sidebar-category text-uppercase">
     {{ .LinkTitle }}
-  </p>
+  </div>
   <div class="show" id="section-{{ md5 .LinkTitle }}">
     <ul class="btn-toggle-nav list-unstyled fw-normal small">
       {{ range where (where .Pages ".Params.unlisted" "!=" "true") ".Params.preview" "!=" true }}
@@ -43,7 +43,7 @@
       {{ if ne .Title "Videos" }}
       <li class="my-0 sidebar-item-list-item {{if $selected }} sidebar-item-list-item-selected {{ end }}">
         <div class="sidebar-item-top d-flex gap-1 justify-content-between align-items-center sidebar-item {{if $active }} sidebar-item-active {{ end }}">
-          <button class="{{if $active }} sidebar-item-active {{ end }} mx-0 border-0 bg-transparent d-flex align-items-center justify-content-between rounded sidebar-subcategory w-100 {{ if not $active }} collapsed {{ end }}" style="text-align:left" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .LinkTitle }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">
+          <button class="{{if $active }} sidebar-item-active {{ end }} mx-0 border-0 bg-transparent d-flex align-items-center justify-content-between rounded sidebar-subcategory w-100 {{ if not $active }} collapsed {{ end }}" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .LinkTitle }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">
             <a href="{{if $selected }}#{{ else }}{{ .Permalink }}{{ end }}" class="sidebar-item-top sidebar-item mx-0 p-0">
               <span>{{ .LinkTitle }}</span>
             </a>


### PR DESCRIPTION
- Use `localStorage` for setting DocSearch theme
- Remove unapplied font-weight nav styles
- Remove redundant inline style