### PR TITLE
Fix broken links (issue 3108)

### DIFF
--- a/content/chainguard/chainguard-images/about/catalog-starter.md
+++ b/content/chainguard/chainguard-images/about/catalog-starter.md
@@ -38,7 +38,7 @@ In the signup form, you can enter up to five non-FIPS images to be provisioned t
 
 ### 2. Integrate with your registry and pipelines
 
-After your organization is enabled, you're free to use the five images you selected however you like. For example, you can pull them into your CI/CD pipelines and runtime environments, or pull them through a third-party registry like [JFrog Artifactory](/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/). These container images are the same as those provided to Chainguard's paying customers, and are covered by Chainguard’s standard hardening, rebuild, and CVE-remediation processes, although they are not covered by [Chainguard's CVE SLA](https://www.chainguard.dev/legal/cve-policy).
+After your organization is enabled, you're free to use the five images you selected however you like. For example, you can pull them into your CI/CD pipelines and runtime environments, or pull them through a third-party registry like [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/). These container images are the same as those provided to Chainguard's paying customers, and are covered by Chainguard’s standard hardening, rebuild, and CVE-remediation processes, although they are not covered by [Chainguard's CVE SLA](https://www.chainguard.dev/legal/cve-policy).
 
 ### 3. Upgrade when you’re ready
 

--- a/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
@@ -32,7 +32,7 @@ Chainguard's private APK repositories are available to all Chainguard Containers
 
 Chainguard OS Packages is a beta offering for larger customers who already build their own images from packages using tools like Bazel, Dockerfiles, and rules\_apko, and want to use a wider set of packages from Chainguard. This includes over 400,000 packages that will be made available in a private APK repository. You are responsible for the image builds, the build tooling, validation, and compatibility while Chainguard builds the packages in the Chainguard Factory with complete SBOMs and our standard enterprise-grade, zero-CVE process.
 
-This beta offering is limited to those who want to use Chainguard-sourced packages in their existing, mature image building processes. Chainguard OS Packages are not currently available for use with [Chainguard Custom Assembly](/content/chainguard/chainguard-images/features/ca-docs/custom-assembly/).
+This beta offering is limited to those who want to use Chainguard-sourced packages in their existing, mature image building processes. Chainguard OS Packages are not currently available for use with [Chainguard Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/).
 
 
 ## Your repository address
@@ -154,7 +154,7 @@ Install the package with `apk add`:
 apk add wget
 ```
 
-Finally,run the same `apk policy` command you ran previously:
+Finally, run the same `apk policy` command you ran previously:
 
 ```container
 apk policy wget

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -360,7 +360,7 @@ docker build --no-cache
 
 ### Resolving checksum mismatches
 
-Before regenerating lock files, ensure your tool is configured to use Chainguard as the package index by following the [global configuration](chainguard/libraries/python/global-configuration/) or [direct access](/chainguard/libraries/python/build-configuration/#direct-access) documentation.
+Before regenerating lock files, ensure your tool is configured to use Chainguard as the package index by following the [global configuration](/chainguard/libraries/python/global-configuration/) or [direct access](/chainguard/libraries/python/build-configuration/#direct-access) documentation.
 
 To update your lock files and requirements with Chainguard's checksums:
 
@@ -410,7 +410,7 @@ Poetry 2.x:
 
 Repository managers such as JFrog Artifactory or Sonatype Nexus may continue serving cached PyPI artifacts even after the upstream index is changed. Clear the cache or invalidate the artifact to ensure the Chainguard-built package is fetched. 
 
-Before regenerating lock files, ensure your tool is configured to use Chainguard as the package index by following the [global configuration](link) or [direct access](link) documentation.
+Before regenerating lock files, ensure your tool is configured to use Chainguard as the package index by following the [global configuration](/chainguard/libraries/python/global-configuration/) or [direct access](/chainguard/libraries/python/build-configuration/#direct-access) documentation.
 
 >**Note:** While hash mismatches are expected for some tooling and
 configurations while migrating to Chainguard, you can verify the authenticity and provenance of Chainguard


### PR DESCRIPTION
## Type of change
**Documentation Update**
- Fixed broken link in `catalog-starter.md` (missing `/chainguard/` path prefix in Artifactory pull-through URL)
- Fixed broken link in `private-apk-repos/index.md` (spurious `/content/` prefix on Custom Assembly URL)
- Fixed two placeholder `(link)` URLs in `python/overview.md` (global configuration and direct access documentation links)

## What should this PR do?

resolves https://github.com/chainguard-dev/edu/issues/3108

## Why are we making this change?

Three pages contained broken links: one had an incorrect URL path prefix, one had a leftover `/content/` prefix that isn't part of the site's URL scheme, and one had unfilled `(link)` placeholders that were never replaced with real URLs.

## What are the acceptance criteria?

- All three previously broken URLs resolve to the correct pages
- No remaining `(link)` placeholder hrefs in `python/overview.md`
- The Artifactory pull-through, Custom Assembly, and Python Libraries configuration pages load correctly from their referring pages

## How should this PR be tested?

1. Check the preview link and verify the three changed pages render correctly
2. On the Catalog Starter page, confirm the JFrog Artifactory link navigates to the Artifactory pull-through guide
3. On the Private APK Repos page, confirm the Custom Assembly link resolves
4. On the Python Libraries overview page (sections "Resolving checksum mismatches" at two locations), confirm both the global configuration and direct access links are live