### PR TITLE
Document support of npm ping

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -177,7 +177,7 @@ coreutils versions included in most operating systems.
 Before installing packages, you can verify that authentication is configured correctly by running:
 
 ```bash
-chainguard-with-upstream npm ping --userconfig .npmrc
+npm ping --userconfig .npmrc
 ```
 
 A successful respoonse looks like:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -172,6 +172,24 @@ Note that the trailing slash in the registry URL is required, and that setting
 npm. The `-w 0` option for `base64` is required and supported by the GNU
 coreutils versions included in most operating systems.
 
+#### Verify authentication with npm ping
+
+Before installing packages, you can verify that authentication is configured correctly by running:
+
+```bash
+chainguard-with-upstream npm ping --userconfig .npmrc
+```
+
+A successful respoonse looks like:
+```bash
+npm notice PING https://libraries.cgr.dev/javascript/
+npm notice PONG 1065ms
+```
+
+The PONG response confirms that your credentials are valid and the registry is reachable. If the command fails, check that the .npmrc file exists in the current directory and that your token has not expired.
+
+#### Add dependencies for the project
+
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Add mention of using `npm ping` as it is now a supported way to verify auth

### What should this PR do?
Add information about using `npm ping` to the npm minimal project example. It seemed like the best location to add this information since users following the example would be likely to need an auth check before adding dependencies.

### What are the acceptance criteria? 
Content should be clear and accurate and on a page/section where it makes sense.

### How should this PR be tested?
In a directory with a .npmrc configured to point to `https://libraries.cgr.dev/javascript/` with valid credentials, run `npm ping --userconfig .npmrc` and confirm you get a `PONG` response