### PR TITLE
Fix typos on Java page

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -308,7 +308,7 @@ cd maven-example
 
 Add a dependency on `com.google.guava:guava` to the `<dependencies>` section of
 `pom.xml`. Open the file and insert the following before the closing
-`</dependencies>` tag::
+`dependencies` tag:
 
 ```xml
 <dependency>


### PR DESCRIPTION
[X] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
apparently trying to style `</` as code turns it into a sideways arrow? Rephrasing something to work around that