### PR TITLE
Add info about using scoped packages for pnpm, Yarn, Yarn Classic

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -179,6 +179,7 @@ After adding this line, verify your lockfile reflects the
 correct resolved URLs: scoped packages should resolve to `registry.npmjs.org`
 and all other packages should resolve to `libraries.cgr.dev/javascript`.
 
+pnpm, Yarn, and Yarn Classic do not require this workaround.
 
 <a id="npm-minimal"></a>
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Updating info about using scoped packages alongside Chainguard Repository to include that the workaround doesn't apply to pnpm, Yarn, or Yarn Classic. Info specific to a workaround for npm was published in https://github.com/chainguard-dev/edu/pull/3103

### What should this PR do?
Explain how scoped packages work across the JavaScript build tools

### Why are we making this change?
For consistent information across tools

### What are the acceptance criteria? 
Content should be accurate. I manually tested scoped package routing behavior across npm, pnpm, Yarn Classic, and Yarn Berry by setting up minimal projects pointing at the Chainguard Libraries JavaScript registry and installing @types/node@18.16.0 as a proxy for a private scoped package. For each tool, tested whether per-scope registry config routes correctly to npm and lockfile behavior. npm is the only tool that requires `replace-registry-host=never` due to its lockfile URL-rewriting behavior. 

### How should this PR be tested?
Point a project at the Chainguard JS registry and install a scoped package, test how it routes to npm and whether the lockfile records tarball URLs that could be rewritten to the wrong registry 