### PR TITLE
Add Amazon ECR pull-through cache guide

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/overview.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/overview.md
@@ -36,6 +36,7 @@ Chainguard does not offer an SLA for uptime for the Chainguard's registry. In or
 
 We currently provide documentation on how you can set up a pull-through cache for the Chainguard's registry on the following platforms:
 
+* [Amazon ECR](/chainguard/chainguard-registry/pull-through-guides/ecr-pull-through/)
 * [Google Artifact Registry](/chainguard/chainguard-registry/pull-through-guides/artifact-registry-pull-through/)
 * [JFrog Artifactory](/chainguard/chainguard-registry/pull-through-guides/artifactory/)
 * [Sonatype Nexus](/chainguard/chainguard-registry/pull-through-guides/nexus-pull-through/)

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/ecr-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/ecr-pull-through/index.md
@@ -1,0 +1,27 @@
+---
+title: "How to Set Up Pull Through from Chainguard's Registry to Amazon ECR"
+linktitle: "Amazon ECR"
+type: "article"
+description: "Overview of using Amazon ECR as a pull-through cache for Chainguard's registry."
+date: 2026-03-31T00:00:00+00:00
+lastmod: 2026-03-31T00:00:00+00:00
+draft: false
+tags: ["Chainguard Containers", "Registry"]
+images: []
+menu:
+  docs:
+    parent: "pull-through-guides"
+toc: true
+weight: 007
+---
+
+In March 2026, AWS [announced support](https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-ecr-pull-through-cache-chainguard/) for using Amazon Elastic Container Registry (ECR) as a pull-through cache for Chainguard's registry. This means you can configure ECR to automatically cache Chainguard container images, reducing your dependency on Chainguard's registry for production workloads.
+
+For setup and configuration instructions, refer to the official AWS documentation:
+
+* [Amazon ECR pull through cache rules](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+* [Pulling an image with a pull through cache rule](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-working-pulling.html)
+
+## Learn More
+
+You can review our [Registry Overview](/chainguard/chainguard-registry/overview/) to learn more about Chainguard's registry, or check out our [Containers documentation](/chainguard/chainguard-images/overview/) to learn more about Chainguard Containers.


### PR DESCRIPTION
## Type of change
**New Content**
- Added a new pull-through cache guide for Amazon ECR
- Added Amazon ECR to the pull-through platforms list in the Registry Overview

## What should this PR do?

resolves https://github.com/chainguard-dev/internal/issues/5759

## Why are we making this change?

AWS announced in March 2026 that Amazon ECR now supports pull-through caching for Chainguard's registry. We need a docs page that surfaces this announcement and directs users to the official AWS documentation, without duplicating setup instructions.

## What are the acceptance criteria?

- A new page exists under the pull-through guides section for Amazon ECR
- The page links to both relevant AWS documentation pages
- Amazon ECR appears in the pull-through platforms list on the Registry Overview page
- The page does not reproduce AWS setup/configuration steps

## How should this PR be tested?

1. Check the preview link and navigate to the Registry Overview — confirm Amazon ECR appears in the pull-through cache list with a working link
2. Navigate to the new Amazon ECR pull-through guide and confirm the AWS announcement link and both documentation links resolve correctly