### PR TITLE
Remove cuda130 from Python overview

### DIFF
--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -124,7 +124,6 @@ GPU‑accelerated libraries, built for specific CUDA versions:
 https://libraries.cgr.dev/cu126/simple/
 https://libraries.cgr.dev/cu128/simple/
 https://libraries.cgr.dev/cu129/simple/
-https://libraries.cgr.dev/cu130/simple/
 ```
 
 Many Python package managers and repository managers support configuring 


### PR DESCRIPTION
[ X ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Removing cuda130 repo from the list in Python overview because it is currently empty and returns 403s https://github.com/chainguard-dev/customer-issues/issues/3093
