### PR TITLE
Add minimal example project for Gradle Java libraries

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -523,8 +523,8 @@ repositories {
     maven {
         url = uri("https://libraries.cgr.dev/java/")
         credentials {
-            username = providers.environmentVariable("CHAINGUARD_JAVA_IDENTITY_ID").orNull
-            password = providers.environmentVariable("CHAINGUARD_JAVA_TOKEN").orNull
+            username = "$System.env.CHAINGUARD_JAVA_IDENTITY_ID"
+            password = "$System.env.CHAINGUARD_JAVA_TOKEN"
         }
     }
     mavenCentral()
@@ -602,13 +602,37 @@ repositories {
 }
 ```
 
-Build the project and verify the downloaded packages. The project generated in this example includes `com.google.guava:guava` as a dependency via the
-version catalog in `gradle/libs.versions.toml`, so guava is downloaded from
-Chainguard Libraries as part of the build:
+Build the project:
 
 ```bash
 ./gradlew app:assemble
-find ~/.gradle/caches/modules-2/files-2.1/com.google.guava -name "*.jar" | sort
+```
+
+The project generated in this example includes `com.google.guava:guava` as a dependency via the
+version catalog in `gradle/libs.versions.toml`, so guava is downloaded from
+Chainguard Libraries as part of the build. 
+
+Following the build, find the guava jar declared in the version catalog at:
+
+```bash
+~/.gradle/caches/modules-2/files-2.1/com.google.guava
+```
+
+#### Verify the project works as expected
+
+To verify the artifact was built by Chainguard, use `chainctl`. In this example,
+we use `find` to locate the jar and then pipe it to `chainctl`:
+
+```bash
+find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava \
+  -name "*.jar" | head -1 | xargs chainctl libraries verify --parent your-org
+```
+
+A successfully verified artifact produces output similar to the following:
+
+```bash
+Artifact: ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/33.5.0-jre/.../guava-33.5.0-jre.jar
+Verification Coverage: 100.00%
 ```
 
 Adjust the repository URL to use your repository manager and add any other

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -435,24 +435,14 @@ desired packages for further testing.
 [Gradle](https://gradle.org/) is a commonly used build tool in the Java
 ecosystem.
 
-### Refresh or remove Gradle caches
+### Step 1: Remove Gradle caches
 
 Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
-Java you must refresh dependencies or delete that local cache so that libraries
+Java you must delete that local cache so that libraries
 are downloaded again. By default the cache is located in a hidden
 `~/.gradle/caches` directory in your users home directory. 
 
-If you are updating an existing Gradle project to use Chainguard Libraries for
-Java, refresh the dependencies so Gradle re-resolves artifacts from the updates
-repositories:
-
-```bash
-./gradlew --refresh-dependencies build
-```
-
-This forces Gradle to ignore cached dependencies and retrieve them again from the configured repositories.
-
-If issues persist, remove the local cache:
+Use the following command to delete it:
 
 ```bash
 rm -rf ~/.gradle/caches/
@@ -472,7 +462,7 @@ repositories {
 If this configuration is used, ensure you [delete the local Maven repository as
 well](#remove-maven-caches). 
 
-### Change Gradle configuration
+### Step 2: Change Gradle configuration
 
 Before running a new build you must configure access to the Chainguard Libraries
 for Java. If the administrator for your organization’s repository manager

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -435,14 +435,26 @@ desired packages for further testing.
 [Gradle](https://gradle.org/) is a commonly used build tool in the Java
 ecosystem.
 
-### Remove Gradle caches
+### Refresh or remove Gradle caches
 
 Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
-Java you must delete that local cache so that libraries are downloaded again. By
-default the cache is located in a hidden `.gradle/.cache` directory in your
-users home directory. Use the following command to delete it:
+Java you must refresh dependencies or delete that local cache so that libraries
+are downloaded again. By default the cache is located in a hidden
+`~/.gradle/caches` directory in your users home directory. 
 
-```shell
+If you are updating an existing Gradle project to use Chainguard Libraries for
+Java, refresh the dependencies so Gradle re-resolves artifacts from the updates
+repositories:
+
+```bash
+./gradlew --refresh-dependencies build
+```
+
+This forces Gradle to ignore cached dependencies and retrieve them again from the configured repositories.
+
+If issues persist, remove the local cache:
+
+```bash
 rm -rf ~/.gradle/caches/
 ```
 
@@ -457,7 +469,7 @@ repositories {
 }
 ```
 
-If this configuration is used, ensure to [delete the local Maven repository as
+If this configuration is used, ensure you [delete the local Maven repository as
 well](#remove-maven-caches). 
 
 ### Change Gradle configuration
@@ -477,7 +489,10 @@ separately.
 A typical setup removes the direct reference to Maven Central `mavenCentral()`
 and any other repositories, and adds a replacement definition with the URL of the
 repository group or virtual repository from your repository manager
-`https://repo.example.com/group/` and any applicable authentication details:
+`https://repo.example.com/group/` and any applicable authentication details.
+
+Open `app/build.gradle` and update the `repositories` block to include the following repository. Ensure it is located above the `mavenCentral` repository and any
+other repositories:
 
 ```groovy
 repositories {
@@ -490,7 +505,8 @@ repositories {
     }
 }
 ```
->Note: Do not store credentials directly in build files; use environment variables or local Gradle properties instead.
+>Note: Do not store credentials directly in build files; use environment
+>variables or local Gradle properties instead.
 
 Example URLs for repository managers:
 
@@ -503,27 +519,14 @@ Example URLs for repository managers:
 
 If your organization does not use a repository manager you can configure the
 Chainguard Libraries for Java repository with the credentials from [Chainguard
-Libraries access](/chainguard/libraries/access/) replacing the placeholders
-`CHAINGUARD_JAVA_IDENTITY_ID` and `CHAINGUARD_JAVA_TOKEN`. Ensure that the
-Chainguard repository is located above the `mavenCentral` repository and any
-other repositories:
+Libraries access](/chainguard/libraries/access/). The following `repositories` block demonstrates
+the recommended method of using [environment
+variables](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials)
+for your pull token credentials. 
 
-```groovy
-repositories {
-    maven {
-        url = uri("https://libraries.cgr.dev/java/")
-        credentials {
-            username = "CHAINGUARD_JAVA_IDENTITY_ID"
-            password = "CHAINGUARD_JAVA_TOKEN"
-        }
-    }
-    mavenCentral()
-}
-```
->This example uses placeholders. It is not recommended to hardcode credentials.
-
-Alternatively configure [environment
-variables](/chainguard/libraries/access/#env) and access the values:
+Open `app/build.gradle` and update the `repositories` block to include the
+Chainguard repository. Ensure it is located above the `mavenCentral` repository
+and any other repositories:
 
 ```groovy
 repositories {
@@ -567,7 +570,6 @@ allprojects {
   }
 }
 ```
->Use HTTP repositories only in trusted environments. HTTPS is recommended.
 
 ### Minimal example project
 
@@ -621,11 +623,16 @@ Following the build, find the guava jar declared in the version catalog at:
 #### Verify the project works as expected
 
 To verify the artifact was built by Chainguard, use `chainctl`. In this example,
-we use `find` to locate the jar and then pipe it to `chainctl`:
+we first use `find` to locate the jar:
 
 ```bash
-find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava \
-  -name "*.jar" | head -1 | xargs chainctl libraries verify --parent your-org
+find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava -name "*.jar" | sort
+```
+
+Then copy the exact path to the jar and verify it with `chainctl`: 
+
+```bash
+chainctl libraries verify --parent your-org /full/path/to/guava-<version>.jar
 ```
 
 A successfully verified artifact produces output similar to the following:

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -299,7 +299,16 @@ details must remain within the settings file.
 Use the following steps to create a minimal example project for Maven with Chainguard Libraries for Java. For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
 
-**1. Create a new Maven project**
+**1. Remove the Maven cache**
+
+Remove the Maven cache as described in the [Remove Maven
+caches](#step-1-remove-maven-caches) section.
+
+**2. Create a new Maven project**
+
+This command generates a new Maven project from the `archetype` template, sets
+the group ID and artifact ID, creates a full project structure, and then moves
+into the generated project directory:
 
 ```bash
 mvn archetype:generate \
@@ -311,9 +320,7 @@ mvn archetype:generate \
 cd maven-example
 ```
 
-This command generates a new Maven project from the `archetype` template, sets the group ID and artifact ID, creates a full project structure, and then moves into the generated project directory.
-
-**2. Add a dependency to pom.xml**
+**3. Add a dependency to pom.xml**
 
 Add a dependency on `com.google.guava:guava` to the `<dependencies>` section of
 `pom.xml`. Open the file and insert the following before the closing
@@ -327,7 +334,7 @@ Add a dependency on `com.google.guava:guava` to the `<dependencies>` section of
 </dependency>
 ```
 
-**3. Configure credentials**
+**4. Configure credentials**
 
 Once the environment variables are set, configure credentials in `~/.m2/settings.xml`:
 
@@ -398,7 +405,7 @@ cat > ~/.m2/settings.xml << EOF
 EOF
 ```
 
-**4. Build the project**
+**5. Build the project**
 
 Then build the project:
 

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -90,6 +90,15 @@ rm -rf ~/.m2/repository
 
 ### Step 2: Configure access 
 
+Before running a new build you must configure access to the Chainguard Libraries
+for Java. There are two options for configuring Maven to use Chainguard
+Libraries:
+
+* Repository manager — routes all artifact requests through your organization's
+  Artifactory, Nexus, or Cloudsmith instance
+* Direct access — configures Chainguard Libraries directly in
+  `~/.m2/settings.xml`, without a repository manager
+
 #### Configure access with a repository manager
 
 Before running a new build you must configure access to Chainguard Libraries
@@ -481,10 +490,22 @@ well](#remove-maven-caches).
 ### Step 2: Change Gradle configuration
 
 Before running a new build you must configure access to the Chainguard Libraries
-for Java. If the administrator for your organization’s repository manager
-created a new repository or virtual repository or group repository, you must
-update your Gradle configuration. Artifact download in Gradle can be configured
-in an [`init`
+for Java. There are three options for configuring Gradle to use Chainguard
+Libraries:
+
+* Repository manager — routes all artifact requests through your organization's
+  Artifactory, Nexus, or Cloudsmith instance
+* Direct access — configures Chainguard Libraries as a repository in your build
+  file, without a repository manager
+* An [`init`
+script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
+— applies the repository configuration globally to all Gradle projects on a
+machine
+
+If the administrator for your organization’s repository manager created a new
+repository or virtual repository or group repository, you must update your
+Gradle configuration. Artifact download in Gradle can be configured in an
+[`init`
 script](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script)
 using the repositories definition. Each project can also [declare
 repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -480,29 +480,20 @@ repository group or virtual repository from your repository manager
 ```groovy
 repositories {
     maven {
-        name = 'repoManager'
-        credentials(PasswordCredentials)
         url = uri("https://repo.example.com/group/")
+        credentials {
+            username = "YOUR_USERNAME_FOR_REPOSITORY_MANAGER"
+            password = "YOUR_PASSWORD"
+        }
     }
 }
 ```
-
-Store credentials outside of version control in `~/.gradle/gradle.properties`, using the repository `name` as the prefix::
-
-```
-repoManagerUsername=YOUR_USERNAME_FOR_REPOSITORY_MANAGER
-repoManagerPassword=YOUR_PASSWORD
-```
->Note: Gradle derives the credential property names automatically from the
-repository name. For a repository named `repoManager`, it looks for
-`repoManagerUsername` and `repoManagerPassword` in Gradle properties.
 
 Example URLs for repository managers:
 
 * Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/java-all/maven/`
 * JFrog Artifactory: `https://example.jfrog.io/artifactory/java-all/`
 * Sonatype Nexus: `https://repo.example.com:8443/repository/java-all/`
-
 
 If your organization does not use a repository manager you can configure the
 Chainguard Libraries for Java repository with the credentials from [Chainguard
@@ -514,24 +505,17 @@ other repositories:
 ```groovy
 repositories {
     maven {
-        url = 'https://libraries.cgr.dev/java/'
+        url = uri("https://libraries.cgr.dev/java/")
         credentials {
-            username = providers.gradleProperty('CHAINGUARD_JAVA_IDENTITY_ID').get()
-            password = providers.gradleProperty('CHAINGUARD_JAVA_TOKEN').get()
+            username = "CHAINGUARD_JAVA_IDENTITY_ID"
+            password = "CHAINGUARD_JAVA_TOKEN"
         }
     }
     mavenCentral()
 }
 ```
 
-Store credentials in `~/.gradle/gradle.properties`:
-
-```
-chainguardJavaUsername=YOUR_JAVA_IDENTITY_ID
-chainguardJavaPassword=YOUR_JAVA_TOKEN
-```
-
-Alternatively, you can configure [environment
+Alternatively configure [environment
 variables](/chainguard/libraries/access/#env) and access the values:
 
 ```groovy

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -440,7 +440,7 @@ ecosystem.
 Gradle uses a local cache of libraries. When adopting Chainguard Libraries for
 Java you must delete that local cache so that libraries
 are downloaded again. By default the cache is located in a hidden
-`~/.gradle/caches` directory in your users home directory. 
+`~/.gradle/caches` directory in your user's home directory. 
 
 Use the following command to delete it:
 
@@ -481,8 +481,9 @@ and any other repositories, and adds a replacement definition with the URL of th
 repository group or virtual repository from your repository manager
 `https://repo.example.com/group/` and any applicable authentication details.
 
-Open `app/build.gradle` and update the `repositories` block to include the following repository. Ensure it is located above the `mavenCentral` repository and any
-other repositories:
+Open `app/build.gradle` and update the `repositories` block to include the
+following repository. Ensure it is located above the `mavenCentral` repository
+and any other repositories:
 
 ```groovy
 repositories {
@@ -495,7 +496,7 @@ repositories {
     }
 }
 ```
->Note: Do not store credentials directly in build files; use environment
+> **Note**: Do not store credentials directly in build files; use environment
 >variables or local Gradle properties instead.
 
 Example URLs for repository managers:
@@ -566,17 +567,16 @@ allprojects {
 Use the following steps to create a minimal example project for Gradle with Chainguard Libraries for Java. For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
 
-**Step 1: Clear the cache**
+**1. Clear the cache**
 
 Clear the Gradle cache as described in the [Remove Gradle caches](#step-1-remove-gradle-caches) section.
 
-**Step 2: Create the example project**
+**2. Create the example project**
 
-Run the following command:
+Create a project directory and navigate to it:
 
 ```bash
-mkdir gradle-example
-cd gradle-example
+mkdir gradle-example && cd $_
 gradle init --type java-application --dsl groovy \
   --project-name gradle-example \
   --package com.example \
@@ -584,11 +584,17 @@ gradle init --type java-application --dsl groovy \
   --no-split-project
 ```
 
-**Step 3: Edit app/build.gradle**
+**3. Edit app/build.gradle**
+
+Open `app/build.gradle` in a text editor. For example, to open it in `nano`:
+
+```bash
+nano app/build.gradle
+```
 
 Edit the `repositories` block in `app/build.gradle` to point to Chainguard and use the environment variables for your pull token credentials:
 
-```groovy
+```app/build.gradle
 repositories {
     maven {
         url = 'https://libraries.cgr.dev/java/'
@@ -601,7 +607,7 @@ repositories {
 }
 ```
 
-**Step 4: Build the project**
+**4. Build the project**
 
 Run the following command:
 
@@ -613,9 +619,9 @@ The project generated in this example includes `com.google.guava:guava` as a dep
 version catalog in `gradle/libs.versions.toml`, so guava is downloaded from
 Chainguard Libraries as part of the build. 
 
-Following the build, find the guava jar declared in the version catalog at:
+Following the build, you can find the guava jar declared in the version catalog at:
 
-```bash
+```
 ~/.gradle/caches/modules-2/files-2.1/com.google.guava
 ```
 

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -472,10 +472,12 @@ using the repositories definition. Each project can also [declare
 repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
 separately.
 
+#### Using a repository manager 
+
 A typical setup removes the direct reference to Maven Central `mavenCentral()`
 and any other repositories, and adds a replacement definition with the URL of the
 repository group or virtual repository from your repository manager
-`https://repo.example.com/group/` and any applicable authentication details.
+`https://repo.example.com/group/` and any applicable authentication details:
 
 ```groovy
 repositories {
@@ -488,12 +490,16 @@ repositories {
     }
 }
 ```
+>Note: Do not store credentials directly in build files; use environment variables or local Gradle properties instead.
 
 Example URLs for repository managers:
 
 * Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/java-all/maven/`
 * JFrog Artifactory: `https://example.jfrog.io/artifactory/java-all/`
 * Sonatype Nexus: `https://repo.example.com:8443/repository/java-all/`
+
+
+#### Direct access to Chainguard Libraries
 
 If your organization does not use a repository manager you can configure the
 Chainguard Libraries for Java repository with the credentials from [Chainguard
@@ -514,6 +520,7 @@ repositories {
     mavenCentral()
 }
 ```
+>This example uses placeholders. It is not recommended to hardcode credentials.
 
 Alternatively configure [environment
 variables](/chainguard/libraries/access/#env) and access the values:
@@ -523,15 +530,17 @@ repositories {
     maven {
         url = uri("https://libraries.cgr.dev/java/")
         credentials {
-            username = "$System.env.CHAINGUARD_JAVA_IDENTITY_ID"
-            password = "$System.env.CHAINGUARD_JAVA_TOKEN"
+            username = providers.environmentVariable("CHAINGUARD_JAVA_IDENTITY_ID").orNull
+            password = providers.environmentVariable("CHAINGUARD_JAVA_TOKEN").orNull
         }
     }
     mavenCentral()
 }
 ```
 
-The following listing shows a valid `init.gradle` file. It wraps the
+#### Using an init script
+
+The following listing shows a valid `init.gradle` file that applies the repository configuration globally using `~/.gradle/init.gradle`. It wraps the
 `repositories` element with `allprojects` so that the scope of the file affects
 all projects built locally with Gradle. It also allows for downloads for plugins
 and build scripts from the remote URL using `buildscript`. Lastly the example
@@ -558,6 +567,7 @@ allprojects {
   }
 }
 ```
+>Use HTTP repositories only in trusted environments. HTTPS is recommended.
 
 ### Minimal example project
 
@@ -577,25 +587,15 @@ For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
 
 
-Once the environment variables are set, configure credentials in `~/.gradle/gradle.properties`:
-
-```bash
-cat >> ~/.gradle/gradle.properties << EOF
-chainguardJavaUsername=${CHAINGUARD_JAVA_IDENTITY_ID}
-chainguardJavaPassword=${CHAINGUARD_JAVA_TOKEN}
-EOF
-```
-
-Edit the `repositories` block in `app/build.gradle` to point to Chainguard
-Libraries:
+Once the environment variables are set, edit the `repositories` block in `app/build.gradle` to point to Chainguard and use your environment variables:
 
 ```groovy
 repositories {
     maven {
         url = 'https://libraries.cgr.dev/java/'
         credentials {
-            username = providers.gradleProperty('chainguardJavaUsername').get()
-            password = providers.gradleProperty('chainguardJavaPassword').get()
+            username = providers.environmentVariable("CHAINGUARD_JAVA_IDENTITY_ID").orNull
+            password = providers.environmentVariable("CHAINGUARD_JAVA_TOKEN").orNull
         }
     }
     mavenCentral()

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -76,7 +76,7 @@ with username and password from a pull token as detailed in
 [Apache Maven](https://maven.apache.org/) is the most widely used build tool in
 the Java ecosystem. Dependencies are declared in a `pom.xml` file and resolved from remote repositories.
 
-### Remove Maven caches
+### Step 1: Remove Maven caches
 
 Maven caches downloaded artifacts in a local repository. When adopting Chainguard Libraries
 for Java you must delete that local cache so that libraries are re-downloaded
@@ -88,7 +88,9 @@ following command to delete it:
 rm -rf ~/.m2/repository
 ```
 
-### Configure access via a repository manager
+### Step 2: Configure access 
+
+#### Configure access with a repository manager
 
 Before running a new build you must configure access to Chainguard Libraries
 for Java. If your organization uses a repository manager, configure a global mirror in `~/.m2/settings.xml` that routes all artifact requests through it. 
@@ -158,7 +160,7 @@ activated profile.
 </settings>
 ```
 
-#### Setting credentials for the server
+**Setting credentials for the server**
 
 If your repository manager requires authentication, you must specify credentials
 for the server. The `id` value in the server element must match the `id` value
@@ -206,7 +208,7 @@ If the administrator only re-configured the existing repository group or virtual
 repository, you can trigger a build to initiate use of Chainguard Libraries for
 Java.
 
-### Configure direct access
+#### Configure direct access
 
 If you are not using a repository manager at your organization, you can
 configure access to the Chainguard Libraries for Java repository directly.
@@ -294,7 +296,10 @@ details must remain within the settings file.
 
 ### Minimal example project
 
-Use the following steps to create a minimal example project for Maven with Chainguard Libraries for Java.
+Use the following steps to create a minimal example project for Maven with Chainguard Libraries for Java. For testing purposes, you can use direct access and environment variables as
+detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
+
+**1. Create a new Maven project**
 
 ```bash
 mvn archetype:generate \
@@ -305,6 +310,10 @@ mvn archetype:generate \
   -DinteractiveMode=false
 cd maven-example
 ```
+
+This command generates a new Maven project from the `archetype` template, sets the group ID and artifact ID, creates a full project structure, and then moves into the generated project directory.
+
+**2. Add a dependency to pom.xml**
 
 Add a dependency on `com.google.guava:guava` to the `<dependencies>` section of
 `pom.xml`. Open the file and insert the following before the closing
@@ -318,9 +327,7 @@ Add a dependency on `com.google.guava:guava` to the `<dependencies>` section of
 </dependency>
 ```
 
-For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
-
+**3. Configure credentials**
 
 Once the environment variables are set, configure credentials in `~/.m2/settings.xml`:
 
@@ -390,6 +397,8 @@ cat > ~/.m2/settings.xml << EOF
 </settings>
 EOF
 ```
+
+**4. Build the project**
 
 Then build the project:
 
@@ -657,7 +666,7 @@ desired packages for further testing.
 [Bazel](https://bazel.build/) is a fast, scalable, and extensible build tool
 commonly used in large-scale projects.
 
-### Remove Bazel caches
+### Step 1: Remove Bazel caches
 
 Bazel uses a cache to store downloaded artifacts. When adopting Chainguard
 Libraries for Java, you must delete this cache to ensure that libraries are
@@ -673,7 +682,9 @@ The [Bazel documentation on output
 directories](https://bazel.build/remote/output-directories) contains further
 details.
 
-### Change Bazel configuration
+### Step 2: Change Bazel configuration
+
+#### Using a repository manager 
 
 Before running a new build, you must configure access to Chainguard Libraries
 for Java. If the administrator for your organization’s repository manager
@@ -721,6 +732,8 @@ Example URLs for repository managers:
 * Cloudsmith: https://dl.cloudsmith.io/basic/exampleorg/java-all/maven/
 * JFrog Artifactory: https://example.jfrog.io/artifactory/java-all/
 * Sonatype Nexus: https://repo.example.com:8443/repository/java-all/
+
+#### Using direct access
 
 If your organization does not use a repository manager, you can configure the
 Chainguard Libraries for Java repository directly, and include the Maven Central

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -563,7 +563,16 @@ allprojects {
 
 ### Minimal example project
 
-Use the following steps to create a minimal example project for Gradle with Chainguard Libraries for Java.
+Use the following steps to create a minimal example project for Gradle with Chainguard Libraries for Java. For testing purposes, you can use direct access and environment variables as
+detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
+
+**Step 1: Clear the cache**
+
+Clear the Gradle cache as described in the [Remove Gradle caches](#step-1-remove-gradle-caches) section.
+
+**Step 2: Create the example project**
+
+Run the following command:
 
 ```bash
 mkdir gradle-example
@@ -575,11 +584,9 @@ gradle init --type java-application --dsl groovy \
   --no-split-project
 ```
 
-For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
+**Step 3: Edit app/build.gradle**
 
-
-Once the environment variables are set, edit the `repositories` block in `app/build.gradle` to point to Chainguard and use your environment variables:
+Edit the `repositories` block in `app/build.gradle` to point to Chainguard and use the environment variables for your pull token credentials:
 
 ```groovy
 repositories {
@@ -594,7 +601,9 @@ repositories {
 }
 ```
 
-Build the project:
+**Step 4: Build the project**
+
+Run the following command:
 
 ```bash
 ./gradlew app:assemble

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -480,20 +480,29 @@ repository group or virtual repository from your repository manager
 ```groovy
 repositories {
     maven {
+        name = 'repoManager'
+        credentials(PasswordCredentials)
         url = uri("https://repo.example.com/group/")
-        credentials {
-            username = "YOUR_USERNAME_FOR_REPOSITORY_MANAGER"
-            password = "YOUR_PASSWORD"
-        }
     }
 }
 ```
+
+Store credentials outside of version control in `~/.gradle/gradle.properties`, using the repository `name` as the prefix::
+
+```
+repoManagerUsername=YOUR_USERNAME_FOR_REPOSITORY_MANAGER
+repoManagerPassword=YOUR_PASSWORD
+```
+>Note: Gradle derives the credential property names automatically from the
+repository name. For a repository named `repoManager`, it looks for
+`repoManagerUsername` and `repoManagerPassword` in Gradle properties.
 
 Example URLs for repository managers:
 
 * Cloudsmith: `https://dl.cloudsmith.io/basic/exampleorg/java-all/maven/`
 * JFrog Artifactory: `https://example.jfrog.io/artifactory/java-all/`
 * Sonatype Nexus: `https://repo.example.com:8443/repository/java-all/`
+
 
 If your organization does not use a repository manager you can configure the
 Chainguard Libraries for Java repository with the credentials from [Chainguard
@@ -505,17 +514,24 @@ other repositories:
 ```groovy
 repositories {
     maven {
-        url = uri("https://libraries.cgr.dev/java/")
+        url = 'https://libraries.cgr.dev/java/'
         credentials {
-            username = "CHAINGUARD_JAVA_IDENTITY_ID"
-            password = "CHAINGUARD_JAVA_TOKEN"
+            username = providers.gradleProperty('CHAINGUARD_JAVA_IDENTITY_ID').get()
+            password = providers.gradleProperty('CHAINGUARD_JAVA_TOKEN').get()
         }
     }
     mavenCentral()
 }
 ```
 
-Alternatively configure [environment
+Store credentials in `~/.gradle/gradle.properties`:
+
+```
+chainguardJavaUsername=YOUR_JAVA_IDENTITY_ID
+chainguardJavaPassword=YOUR_JAVA_TOKEN
+```
+
+Alternatively, you can configure [environment
 variables](/chainguard/libraries/access/#env) and access the values:
 
 ```groovy
@@ -523,8 +539,8 @@ repositories {
     maven {
         url = uri("https://libraries.cgr.dev/java/")
         credentials {
-            username = "$System.env.CHAINGUARD_JAVA_IDENTITY_ID"
-            password = "$System.env.CHAINGUARD_JAVA_TOKEN"
+            username = providers.environmentVariable("CHAINGUARD_JAVA_IDENTITY_ID").orNull
+            password = providers.environmentVariable("CHAINGUARD_JAVA_TOKEN").orNull
         }
     }
     mavenCentral()
@@ -558,6 +574,61 @@ allprojects {
   }
 }
 ```
+
+### Minimal example project
+
+Use the following steps to create a minimal example project for Gradle with Chainguard Libraries for Java.
+
+```bash
+mkdir gradle-example
+cd gradle-example
+gradle init --type java-application --dsl groovy \
+  --project-name gradle-example \
+  --package com.example \
+  --no-incubating \
+  --no-split-project
+```
+
+For testing purposes, you can use direct access and environment variables as
+detailed in the [access documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
+
+
+Once the environment variables are set, configure credentials in `~/.gradle/gradle.properties`:
+
+```bash
+cat >> ~/.gradle/gradle.properties << EOF
+chainguardJavaUsername=${CHAINGUARD_JAVA_IDENTITY_ID}
+chainguardJavaPassword=${CHAINGUARD_JAVA_TOKEN}
+EOF
+```
+
+Edit the `repositories` block in `app/build.gradle` to point to Chainguard
+Libraries:
+
+```groovy
+repositories {
+    maven {
+        url = 'https://libraries.cgr.dev/java/'
+        credentials {
+            username = providers.gradleProperty('chainguardJavaUsername').get()
+            password = providers.gradleProperty('chainguardJavaPassword').get()
+        }
+    }
+    mavenCentral()
+}
+```
+
+Build the project and verify the downloaded packages. The project generated in this example includes `com.google.guava:guava` as a dependency via the
+version catalog in `gradle/libs.versions.toml`, so guava is downloaded from
+Chainguard Libraries as part of the build:
+
+```bash
+./gradlew app:assemble
+find ~/.gradle/caches/modules-2/files-2.1/com.google.guava -name "*.jar" | sort
+```
+
+Adjust the repository URL to use your repository manager and add any other
+desired packages for further testing.
 
 <a id="bazel"></a>
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Adding minimal example project for Java libraries with Gradle

### What should this PR do?
- Add minimal example project
- Update existing env vars example to use Gradle's recommended format

### Why are we making this change?
For consistency across libraries docs, we're adding minimal example projects

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?
Follow the steps to create the example