### PR TITLE
Fix AI bundle release failure caused by immutable git tag

### DIFF
--- a/.github/workflows/compile-public-docs.yml
+++ b/.github/workflows/compile-public-docs.yml
@@ -154,8 +154,9 @@ jobs:
         # Use a fixed tag for the latest release
         TAG="ai-docs-latest"
         
-        # Delete existing release if it exists
-        gh release delete "$TAG" --yes || true
+        # Delete existing release and tag if they exist
+        gh release delete "$TAG" --yes 2>/dev/null || true
+        gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
         
         # Create release notes
         cat > release-notes.md << 'EOF'


### PR DESCRIPTION
EDIT:
WAIT! Hang on. I found something else. DO NOT MERGE yet

The fix in this PR won't work. The tag is protected by a repository ruleset — it truly cannot be deleted. The PR needs to be updated before merge.

Here's the full picture:

-  Root cause: **GitHub's** https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/ went GA in October 2025. At some point (likely recently per org policy), the `ai-docs-latest release` was published as `immutable`. Immutable releases lock the git tag permanently — even  deleting the release leaves the tag protected and unreusable. The "Monday, March 30th" timing likely aligns with chainguard-dev enabling an org-level ruleset  enforcing this.

Why the current fix fails: `gh api --method DELETE` on the tag returns `422 - Repository rule violations found / Cannot delete this tag. The tag is permanently locked.`

The real fix would probably be to switch to timestamped tags and rely on GitHub's `--latest` flag + the `stable /releases/latest/download/` redirect URL. The means a switch from a fixed `ai-docs-latest` tag to a timestamped tag (e.g., `ai-docs-20260403-142845`), using `--latest` on gh release create so that GitHub's `/releases/latest/download/` redirect always points to the newest one. BUT, what is out there relying on the existing tag?? Of course, if we can't make the immutable `ai-docs-latest` change what it points to, that's certainly a problem.

Here's what Claude Code says the workflow change should look like:

`workflows/compile-public-docs.yml` changes
```bash
 151        run: |
 152          cd static/downloads
 153
 154 -        # Use a fixed tag for the latest release
 155 -        TAG="ai-docs-latest"
 156 -
 157 -        # Delete existing release and tag if they exist
 158 -        gh release delete "$TAG" --yes 2>/dev/null || true
 159 -        gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
 160 -
 154 +        # Use a timestamped tag; GitHub's --latest flag + /releases/latest/download/ provides a stable URL
 155 +        TAG="ai-docs-$(date -u +%Y%m%d-%H%M%S)"
 156 +
 157          # Create release notes
 158          cat > release-notes.md << 'EOF'
 159          # AI Documentation Bundle (Public)
 164 -
 160 +
 161          This release contains the compiled Chainguard public documentation bundle for use with AI assistants.
 166 -
 162 +
 163          ## Download Options
 168 -
 164 +
 165          | File | Description | Size |
 166          |------|-------------|------|
 171 -        | [chainguard-ai-docs.tar.gz](https://github.com/chainguard-dev/edu/releases/download/ai-docs-latest/chainguard-ai-docs.tar.gz) | Compress
     -ed bundle | ~1.7MB |
 172 -
 167 +        | [chainguard-ai-docs.tar.gz](https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz) | Compressed bundl
     +e | ~1.7MB |
 168 +
 169          ## Contents
 170          - Complete public documentation from the edu repository
 171          - Tutorials, guides, and reference documentation
 172          - Compiled into a single markdown file for AI assistant consumption
 177 -
 173 +
 174          ## Verification
 179 -
 175 +
 176          To verify the signatures:
 181 -
 177 +
 178          ```bash
 179          # Download files
 184 -        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-latest/chainguard-ai-docs.tar.gz
 185 -        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-latest/chainguard-ai-docs.tar.gz.sig
 186 -        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-latest/chainguard-ai-docs.tar.gz.crt
 187 -
 180 +        curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz
 181 +        curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz.sig
 182 +        curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz.crt
 183 +
 184          # Verify tarball
 185          cosign verify-blob \
 186            --certificate chainguard-ai-docs.tar.gz.crt \
...
 189            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 190            chainguard-ai-docs.tar.gz
 191          ```
 196 -
 192 +
 193          ## Usage with AI Assistants
 198 -
 194 +
 195          1. Download and extract the bundle
 196          2. Open your AI assistant (Claude, ChatGPT, etc.)
 197          3. Upload or paste the markdown file
 198          4. Start asking questions about Chainguard!
 203 -
 199 +
 200          ## Checksums
 205 -
 201 +
 202          ```
 203          $(cat checksums.txt)
 204          ```
 209 -
 205 +
 206          _Last updated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")_
 207          EOF
 212 -
 213 -        # Create GitHub release (recreate with latest tag)
 208 +
 209 +        # Create GitHub release; --latest ensures /releases/latest/download/ always points here
 210          gh release create "$TAG" \
 211            --title "AI Documentation Bundle - Latest" \
 212            --notes-file release-notes.md \
```

I haven't yet updated the PR.

PREVIOUS THOUGHTS BELOW

Fixes https://github.com/chainguard-dev/edu/issues/3157

The build is failing because it finds the tag from the previously deleted file but not a file and the tag is marked as `immutable`.

This PR changes the workflow to delete the git tag ref via GitHub API before recreating the release, so the existing tag does not block gh release create with a 422 error. This should eliminate the error.

EDIT: It's the 422 error [on line 81 here](https://github.com/chainguard-dev/edu/actions/runs/23949685445/job/69853942671#step:12:82) that this PR should address and fix. The fix is straightforward, so it should do the trick. If the build still fails after merging, the next thing to check would be  whether the gh release delete step is actually finding and removing the release before the tag deletion runs — but the 422 error pointed clearly at the orphaned tag as the culprit.
