### PR TITLE
Enabling Bootstrap icons via shortcode

### DIFF
--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -102,10 +102,9 @@ Chainguard Libraries is available for the following library ecosystems:
 ## Other resources
 
 * [Chainguard Libraries product page](https://www.chainguard.dev/libraries)
-* [Learning Lab for October 2025 on Chainguard Libraries for JavaScript and CVE
-  remediation for Python libraries](/software-security/learning-labs/ll202510/)
-* [Learning Lab for June 2025 on Chainguard Libraries for Python](/software-security/learning-labs/ll202506/)
-* [Learning Lab for May 2025 about Chainguard Libraries for Java](/software-security/learning-labs/ll202505/)
+* [{{< icon "play-circle-fill" >}} Learning Lab for October 2025 on Chainguard Libraries for JavaScript and CVE remediation for Python libraries](/software-security/learning-labs/ll202510/)
+* [{{< icon "play-circle-fill" >}} Learning Lab for June 2025 on Chainguard Libraries for Python](/software-security/learning-labs/ll202506/)
+* [{{< icon "play-circle-fill" >}} Learning Lab for May 2025 about Chainguard Libraries for Java](/software-security/learning-labs/ll202505/)
 
 Blog posts
 

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -1,0 +1,1 @@
+{{- $name := .Get 0 -}}<i class="bi bi-{{ $name }}" aria-hidden="true"></i>


### PR DESCRIPTION
## Type of Change
 **Documentation Update / New Feature**
Turns out Academy already imported Bootstrap icons. This PR adds a new icon Hugo shortcode that renders Bootstrap Icons inline via an `<i>` tag. Uses the shortcode to prefix Learning Lab links in the Libraries overview with a play-circle icon

## What should this PR do?

resolves https://github.com/chainguard-dev/internal/issues/5456                                                                                

## Why are we making this change?   

Learning Lab links lacked a visual cue to indicate they are video resources. Adding a Bootstrap play-circle icon before each Learning Lab link makes it immediately clear to readers that these resources are video-based content.

## What are the acceptance criteria?

- A Bootstrap play-circle icon renders inline before each Learning Lab link on the Libraries overview page
- The icon shortcode works without breaking page build or layout
- Icon is purely decorative (aria-hidden="true")                                                                                               
                                                                                                                                                 
## How should this PR be tested?

1. Check the preview link and navigate to the Libraries overview page (/chainguard/libraries/overview/)
2. Verify that a play-circle icon appears before each of the three Learning Lab links in the "Other resources" section   