### PR TITLE
Switch to ai-docs-bundle release tag

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Checkout edu repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # persist-credentials left enabled — this workflow needs git push
 
     - name: Authenticate to Google Cloud
       uses: step-security/google-github-auth@57c51210cb4d85d8a5d39dc4c576c79bd693f914 # v3.0.1
@@ -307,20 +308,14 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Org ruleset prevents tag deletion, so we update the existing release
-        # by replacing its assets rather than deleting and recreating it.
+        # Org ruleset makes releases immutable (can't delete assets).
+        # Use --clobber to overwrite existing assets in place.
+        TAG="ai-docs-bundle"
 
-        if gh release view ai-docs > /dev/null 2>&1; then
-          echo "Updating existing ai-docs release..."
+        if gh release view "$TAG" > /dev/null 2>&1; then
+          echo "Updating existing $TAG release..."
 
-          # Delete old assets so we can upload fresh ones
-          for asset in chainguard-ai-docs.tar.gz chainguard-ai-docs.md chainguard-ai-docs.zip \
-                       image-catalog.json checksums.txt mcp-server.py mcp-requirements.txt; do
-            gh release delete-asset ai-docs "$asset" -y 2>/dev/null || true
-          done
-
-          # Upload new assets
-          gh release upload ai-docs \
+          gh release upload "$TAG" --clobber \
             static/downloads/chainguard-ai-docs.tar.gz \
             static/downloads/chainguard-ai-docs.md \
             static/downloads/chainguard-ai-docs.zip \
@@ -329,10 +324,10 @@ jobs:
             scripts/mcp-server.py \
             scripts/mcp-requirements.txt
 
-          echo "✓ Release assets updated"
+          echo "Release assets updated"
         else
-          echo "Creating new ai-docs release..."
-          gh release create ai-docs \
+          echo "Creating new $TAG release..."
+          gh release create "$TAG" \
             static/downloads/chainguard-ai-docs.tar.gz \
             static/downloads/chainguard-ai-docs.md \
             static/downloads/chainguard-ai-docs.zip \
@@ -340,41 +335,6 @@ jobs:
             static/downloads/checksums.txt \
             scripts/mcp-server.py \
             scripts/mcp-requirements.txt \
-            --title "AI Documentation Bundle - Latest" \
-            --notes "Chainguard AI documentation bundle for use with AI coding assistants.
-
-        ## Download
-
-        \`\`\`bash
-        # Download the markdown file directly
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.md
-
-        # Or download the compressed bundle
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz
-        tar -xzf chainguard-ai-docs.tar.gz
-        \`\`\`
-
-        ## MCP Server (standalone)
-
-        \`\`\`bash
-        # Download the MCP server and requirements
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/mcp-server.py
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/mcp-requirements.txt
-        pip install -r mcp-requirements.txt
-
-        # Run with docs and catalog in the current directory
-        DOCS_PATH=chainguard-ai-docs.md CATALOG_PATH=image-catalog.json python3 mcp-server.py
-        \`\`\`
-
-        ## Container Distribution
-
-        \`\`\`bash
-        # Pull the container image
-        docker pull ghcr.io/chainguard-dev/ai-docs:latest
-
-        # Extract documentation to current directory
-        docker run --rm -v \$(pwd):/output ghcr.io/chainguard-dev/ai-docs:latest extract /output
-        \`\`\`
-
-        Generated: $(date -u '+%Y-%m-%d %H:%M UTC')"
+            --title "AI Documentation Bundle" \
+            --notes "Chainguard AI documentation bundle for use with AI coding assistants."
         fi

--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -299,28 +299,23 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Org ruleset prevents tag deletion, so we update the existing release
-        # by replacing its assets rather than deleting and recreating it.
+        # Org ruleset makes releases immutable (can't delete assets).
+        # Use --clobber to overwrite existing assets in place.
+        TAG="ai-docs-bundle"
 
-        if gh release view ai-docs > /dev/null 2>&1; then
-          echo "Updating existing ai-docs release..."
+        if gh release view "$TAG" > /dev/null 2>&1; then
+          echo "Updating existing $TAG release..."
 
-          # Delete old assets so we can upload fresh ones
-          for asset in chainguard-ai-docs.tar.gz chainguard-ai-docs.tar.gz.bundle; do
-            gh release delete-asset ai-docs "$asset" -y 2>/dev/null || true
-          done
-
-          # Upload new assets
-          gh release upload ai-docs \
+          gh release upload "$TAG" --clobber \
             "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz" \
             "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz.bundle"
 
           echo "Release assets updated"
         else
-          echo "Creating new ai-docs release..."
-          gh release create ai-docs \
+          echo "Creating new $TAG release..."
+          gh release create "$TAG" \
             "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz" \
             "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz.bundle" \
-            --title "AI Documentation Bundle - Latest" \
+            --title "AI Documentation Bundle" \
             --notes "Chainguard AI documentation bundle for use with AI coding assistants."
         fi

--- a/.github/workflows/compile-public-docs.yml
+++ b/.github/workflows/compile-public-docs.yml
@@ -183,69 +183,13 @@ jobs:
         cd static/downloads
         
         # Use a fixed tag for the latest release
-        TAG="ai-docs"
+        TAG="ai-docs-bundle"
         
-        # Delete old assets from existing release (org ruleset blocks tag deletion)
-        for asset in chainguard-ai-docs.tar.gz chainguard-ai-docs.tar.gz.bundle \
-                     chainguard-ai-docs.md.bundle checksums.txt; do
-          gh release delete-asset "$TAG" "$asset" -y 2>/dev/null || true
-        done
+        # Org ruleset makes releases immutable (can't delete assets).
+        # Use --clobber to overwrite existing assets in place.
 
-        # Create release notes
-        cat > release-notes.md << 'EOF'
-        # AI Documentation Bundle (Public)
-        
-        This release contains the compiled Chainguard public documentation bundle for use with AI assistants.
-        
-        ## Download Options
-        
-        | File | Description | Size |
-        |------|-------------|------|
-        | [chainguard-ai-docs.tar.gz](https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz) | Compressed bundle | ~1.7MB |
-        
-        ## Contents
-        - Complete public documentation from the edu repository
-        - Tutorials, guides, and reference documentation
-        - Compiled into a single markdown file for AI assistant consumption
-        
-        ## Verification
-        
-        To verify the signatures:
-        
-        ```bash
-        # Download files
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz.sig
-        curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz.crt
-        
-        # Verify tarball
-        cosign verify-blob \
-          --certificate chainguard-ai-docs.tar.gz.crt \
-          --signature chainguard-ai-docs.tar.gz.sig \
-          --certificate-identity-regexp ".*github.com/chainguard-dev/edu.*" \
-          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          chainguard-ai-docs.tar.gz
-        ```
-        
-        ## Usage with AI Assistants
-        
-        1. Download and extract the bundle
-        2. Open your AI assistant (Claude, ChatGPT, etc.)
-        3. Upload or paste the markdown file
-        4. Start asking questions about Chainguard!
-        
-        ## Checksums
-        
-        ```
-        $(cat checksums.txt)
-        ```
-        
-        _Last updated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")_
-        EOF
-        
-        # Upload assets to existing release, or create new if first time
         if gh release view "$TAG" > /dev/null 2>&1; then
-          gh release upload "$TAG" \
+          gh release upload "$TAG" --clobber \
             chainguard-ai-docs.tar.gz \
             chainguard-ai-docs.tar.gz.bundle \
             chainguard-ai-docs.md.bundle \
@@ -253,8 +197,7 @@ jobs:
         else
           gh release create "$TAG" \
             --title "AI Documentation Bundle - Latest" \
-            --notes-file release-notes.md \
-            --latest \
+            --notes "Chainguard AI documentation bundle for use with AI coding assistants." \
             chainguard-ai-docs.tar.gz \
             chainguard-ai-docs.tar.gz.bundle \
             chainguard-ai-docs.md.bundle \

--- a/content/ai-docs-security.md
+++ b/content/ai-docs-security.md
@@ -90,9 +90,9 @@ Example patterns we redact:
 
 ```bash
 # 1. Download files
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz.sig
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz.crt
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz.sig
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz.crt
 
 # 2. Verify signature
 cosign verify-blob \

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -44,7 +44,7 @@ Choose your preferred distribution method:
 
 | Format | Description | Verification |
 |--------|-------------|-------------|
-| [Latest Release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs) | Cryptographically signed documentation bundle (~1.7MB) | Includes Cosign signatures and certificates |
+| [Latest Release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) | Cryptographically signed documentation bundle (~1.7MB) | Includes Cosign signatures and certificates |
 
 ### Container Distribution
 
@@ -119,7 +119,7 @@ Add to your `claude_desktop_config.json`:
 - Searchable and queryable documentation
 - Perfect for automated workflows
 - Works with Claude Desktop, Cursor, and other MCP-compatible tools
-- Also available as a [standalone Python script](https://github.com/chainguard-dev/edu/releases/tag/ai-docs) (no Docker required)
+- Also available as a [standalone Python script](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) (no Docker required)
 
 [**Full MCP Server Documentation →**](/mcp-server-ai-docs/)
 
@@ -127,7 +127,7 @@ Add to your `claude_desktop_config.json`:
 
 ```bash
 # Download the documentation bundle from GitHub releases
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.tar.gz
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz
 
 # Extract the markdown file
 tar -xzf chainguard-ai-docs.tar.gz

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -221,14 +221,14 @@ latest, latest-dev, 3.13, 3.13-dev, ...
 
 ## Standalone Installation (without Docker)
 
-The MCP server is also available as a standalone Python script from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs):
+The MCP server is also available as a standalone Python script from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle):
 
 ```bash
 # Download the MCP server, requirements, docs, and catalog
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/mcp-server.py
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/mcp-requirements.txt
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/chainguard-ai-docs.md
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs/image-catalog.json
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/mcp-server.py
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/mcp-requirements.txt
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.md
+curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/image-catalog.json
 
 # Install dependencies
 pip install -r mcp-requirements.txt
@@ -256,7 +256,7 @@ To use this with Claude Desktop, update your configuration to point to the local
 
 ## Alternative: Static Documentation
 
-If you don't need MCP server functionality, you can download the documentation as a single markdown file from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs), or extract it from the container:
+If you don't need MCP server functionality, you can download the documentation as a single markdown file from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle), or extract it from the container:
 
 ```bash
 docker run --rm -v $(pwd):/output \


### PR DESCRIPTION
Switch to ai-docs-bundle release tag

The ai-docs release became immutable due to org-level ruleset, blocking both asset deletion and new uploads. Switch all workflows and content pages to a new ai-docs-bundle tag and use gh release upload --clobber for future updates.