### PR TITLE
Fix CI workflow failures  

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -284,6 +284,7 @@ jobs:
 
     - name: Update GitHub Release
       if: github.ref == 'refs/heads/main'
+      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -296,6 +296,7 @@ jobs:
 
     - name: Update GitHub Release
       if: (github.event.inputs.create_release == 'true' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/compile-public-docs.yml
+++ b/.github/workflows/compile-public-docs.yml
@@ -177,6 +177,7 @@ jobs:
 
     - name: Create release
       if: (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true') || github.event_name == 'push'
+      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
## Summary
  - Remove the "Commit and push changes" step from the GCS compile workflow — compiled docs are already distributed via container (GHCR), GCS, and GitHub Release, making the git push redundant (and it fails due to branch protection requiring PRs)
  - Add `continue-on-error: true` to the GitHub Release upload step in all 3 compile workflows — org ruleset makes release assets immutable, so `--clobber` fails on subsequent runs; container and GCS are the primary distribution channels

## Test plan
  - [ ] Trigger `compile-ai-docs-from-gcs` via `workflow_dispatch` and verify it completes green
  - [ ] Trigger `compile-public-docs` via push and verify it completes green
  - [ ] Verify container `ghcr.io/chainguard-dev/ai-docs:latest` is still built and pushed
  - [ ] Verify GCS upload still succeeds