### PR TITLE
Bug: Fix `sitemaps.xml` and `ai-sitemap.json`

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -19,7 +19,7 @@ disableLanguages = ["de", "nl"]
 # defaultContentLanguageInSubdir = true
 # add redirects/headers
 [outputs]
-home = ["HTML", "RSS", "ALIASES", "REDIRECTS", "HEADERS", "TXT", "FULLTXT", "AIMETADATA", "AISITEMAP", "CONCEPTS"]
+home = ["HTML", "RSS", "ALIASES", "REDIRECTS", "HEADERS", "TXT", "FULLTXT", "AIMETADATA", "AISITEMAP", "CONCEPTS", "SITEMAP"]
 section = ["HTML", "RSS", "SITEMAP", "MD"]
 page = ["HTML", "MD"]
 # remove .{ext} from text/netlify

--- a/layouts/index.aisitemap.json
+++ b/layouts/index.aisitemap.json
@@ -1,5 +1,5 @@
-{{- $pages := where .Site.RegularPages "Type" "in" (slice "article" "blog" "education") -}}
-{{- $sections := where .Site.Sections "Section" "in" (slice "article" "blog" "education") -}}
+{{- $pages := .Site.RegularPages -}}
+{{- $sections := .Site.Sections -}}
 {
   "version": "1.0",
   "generated": {{ now.Format "2006-01-02T15:04:05Z07:00" | jsonify }},

--- a/layouts/index.sitemap.xml
+++ b/layouts/index.sitemap.xml
@@ -1,0 +1,22 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Site.Pages }}{{ if ne .Params.sitemap_exclude true }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}{{ end }}
+</urlset>


### PR DESCRIPTION
- Added modified doks `layouts/index.sitemap.xml`: Primary change is `.Data.Pages` -> `.Site.Pages` to work with repo version of hugo
- Updated the `config/_default/config.toml` configuration to include `SITEMAP` as an output format for the home page, ensuring the new XML sitemap is generated
- Modified `layouts/index.aisitemap.json` to include all sections and pages