### PR TITLE
Deploy MCP server to Cloud Run

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -3,10 +3,10 @@ name: Compile AI Documentation Bundle from GCS
 on:
   schedule:
     - cron: '0 2 * * 0'  # Weekly on Sundays at 2 AM
-  
+
   repository_dispatch:
     types: [ai-docs-source-updated]
-  
+
   workflow_dispatch:
     inputs:
       create_release:
@@ -17,6 +17,10 @@ on:
         options:
           - 'true'
           - 'false'
+
+concurrency:
+  group: compile-ai-docs-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write  # For creating/updating releases
@@ -52,6 +56,7 @@ jobs:
           pypi.org:443
           raw.githubusercontent.com:443
           rekor.sigstore.dev:443
+          run.googleapis.com:443
           sts.googleapis.com:443
           storage.googleapis.com:443
           timestamp.sigstore.dev:443
@@ -248,10 +253,21 @@ jobs:
           echo "ERROR: Failed to capture image digest from docker push"
           exit 1
         fi
-        docker push "ghcr.io/$REPO_OWNER/ai-docs:$COMMIT_SHA"
+        docker push "ghcr.io/$REPO_OWNER/ai-docs:$COMMIT_SHA" || { echo "ERROR: Failed to push SHA-tagged image"; exit 1; }
 
         # Sign container image by immutable digest
         cosign sign --yes "ghcr.io/$REPO_OWNER/ai-docs@$DIGEST"
+
+    - name: Deploy MCP server to Cloud Run
+      if: github.ref == 'refs/heads/main'
+      env:
+        REPO_OWNER: ${{ github.repository_owner }}
+        COMMIT_SHA: ${{ github.sha }}
+      run: |
+        gcloud run services update mcp-server \
+          --image "ghcr.io/$REPO_OWNER/ai-docs:$COMMIT_SHA" \
+          --region us-central1 \
+          --project chainguard-academy
 
     - name: Upload bundle back to GCS for distribution
       env:

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -294,13 +294,13 @@ To connect Claude Desktop to a remote MCP server, use the `url` field instead of
 }
 ```
 
-For a Cloud Run or other hosted deployment, replace `localhost:8080` with your service URL:
+The Chainguard-hosted MCP server is available at `mcp.edu.chainguard.dev` — no Docker or local setup required:
 
 ```json
 {
   "mcpServers": {
     "chainguard-docs": {
-      "url": "https://your-cloud-run-service.run.app/mcp"
+      "url": "https://mcp.edu.chainguard.dev/mcp"
     }
   }
 }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -67,6 +67,66 @@ resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthent
   member   = "allUsers"
 }
 
+resource "google_cloud_run_v2_service" "mcp-server" {
+  for_each = module.networking.regional-networks
+
+  project  = var.project_id
+  name     = "mcp-server"
+  location = each.key
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  launch_stage = "BETA"
+
+  template {
+    vpc_access {
+      network_interfaces {
+        network    = each.value.network
+        subnetwork = each.value.subnet
+      }
+      egress = "ALL_TRAFFIC"
+    }
+
+    service_account = google_service_account.chainguard-academy.email
+
+    containers {
+      image   = var.mcp_image
+      command = ["/usr/local/bin/serve-mcp-http"]
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          memory = "512Mi"
+          cpu    = "1"
+        }
+      }
+    }
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 3
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "mcp-server-is-unauthenticated" {
+  for_each = google_cloud_run_v2_service.mcp-server
+
+  project  = var.project_id
+  location = each.key
+  name     = each.value.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
 resource "google_dns_managed_zone" "edu-zone" {
   project     = var.project_id
   name        = "edu-chainguard-dev"
@@ -94,6 +154,9 @@ module "serverless-gclb" {
   public-services = {
     "edu.chainguard.dev" = {
       name = var.name
+    }
+    "mcp.edu.chainguard.dev" = {
+      name = "mcp-server"
     }
   }
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -17,3 +17,9 @@ variable "image" {
   description = "The container image to deploy."
   type        = string
 }
+
+variable "mcp_image" {
+  description = "The container image for the MCP HTTP server. Managed by CI after initial creation."
+  type        = string
+  default     = "ghcr.io/chainguard-dev/ai-docs:latest"
+}

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -452,10 +452,17 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
             text="Error: Documentation not loaded. Please check server logs."
         )]
 
+    # Input length limits to prevent CPU DoS on string operations
+    MAX_INPUT_LEN = 500
+    MAX_RESULTS_CAP = 20
+
     try:
         if name == "search_docs":
-            query = arguments.get("query", "")
-            max_results = arguments.get("max_results", 5)
+            query = arguments.get("query", "")[:MAX_INPUT_LEN]
+            try:
+                max_results = min(int(arguments.get("max_results", 5)), MAX_RESULTS_CAP)
+            except (ValueError, TypeError):
+                max_results = 5
 
             results = docs_index.search(query, max_results)
 
@@ -474,7 +481,7 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
             return [TextContent(type="text", text=response)]
 
         elif name == "get_image_docs":
-            image_name = arguments.get("image_name", "")
+            image_name = arguments.get("image_name", "")[:MAX_INPUT_LEN]
             docs = docs_index.get_image_docs(image_name)
 
             if docs:
@@ -489,7 +496,8 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
                 )]
 
         elif name == "list_images":
-            filter_term = arguments.get("filter")
+            raw_filter = arguments.get("filter")
+            filter_term = raw_filter[:MAX_INPUT_LEN] if raw_filter else None
 
             # Use catalog if available for richer results
             if catalog.available:
@@ -524,7 +532,7 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
             return [TextContent(type="text", text=security_docs)]
 
         elif name == "get_tool_docs":
-            tool_name = arguments.get("tool_name", "")
+            tool_name = arguments.get("tool_name", "")[:MAX_INPUT_LEN]
             docs = docs_index.get_tool_docs(tool_name)
 
             if docs:
@@ -539,7 +547,7 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
                 )]
 
         elif name == "find_package_equivalent":
-            package = arguments.get("package", "")
+            package = arguments.get("package", "")[:MAX_INPUT_LEN]
             distro = arguments.get("distro")
             if not catalog.available:
                 return [TextContent(
@@ -567,7 +575,7 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
                 )]
 
         elif name == "check_image_freshness":
-            image_name = arguments.get("image_name", "")
+            image_name = arguments.get("image_name", "")[:MAX_INPUT_LEN]
             result = catalog.check_live_image(image_name)
 
             response = f"# Image Check: {image_name}\n\n"
@@ -588,10 +596,10 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
             )]
 
     except Exception as e:
-        logger.error(f"Error handling tool call {name}: {e}")
+        logger.error(f"Error handling tool call {name}: {e}", exc_info=True)
         return [TextContent(
             type="text",
-            text=f"Error: {str(e)}"
+            text="An internal error occurred. Please try again or adjust your query."
         )]
 
 


### PR DESCRIPTION
## Summary

  - Add Cloud Run service, public IAM binding, and GCLB entry for `mcp.edu.chainguard.dev` so users can connect to the MCP server with just a URL — no Docker required
  - Add `gcloud run services update` step to the compile workflow to deploy SHA-pinned images after each build
  - Harden the MCP server's public attack surface: cap `max_results`, truncate all user inputs, suppress internal error details
  - Add workflow concurrency control and exit guard on SHA-tagged image push

 ## How it works

Two CI workflows share one Terraform state. `cloud-run.yaml` runs `terraform apply` on every push to main and creates the `mcp-server` Cloud Run service. `compile-ai-docs-from-gcs.yaml` builds the container image and deploys it via `gcloud run services update`. The `lifecycle { ignore_changes }` block on the image field prevents Terraform from reverting the CI-deployed image.

## Changes

  | File | What |
  |---|---|
  | `iac/variables.tf` | Add `mcp_image` variable with `:latest` default (so `cloud-run.yaml` doesn't need to set it) |
  | `iac/main.tf` | Cloud Run service, IAM `allUsers` binding, `mcp.edu.chainguard.dev` in GCLB `public services` |
  | `.github/workflows/compile-ai-docs-from-gcs.yaml` | Deploy step, `run.googleapis.com` in harden-runner, concurrency block, push error guard |
  | `scripts/mcp-server.py` | Input length caps (500 chars), `max_results` cap (20), generic error messages to callers |
  | `content/mcp-server-ai-docs.md` | Replace placeholder URL with `https://mcp.edu.chainguard.dev/mcp` |

## What happens on merge

  1. Push to main triggers `cloud-run.yaml` → `terraform apply` creates the service and GCLB entry
  2. SSL cert provisions for `mcp.edu.chainguard.dev` (15-60 min)
  3. Next compile workflow run (weekly or manual dispatch) deploys a SHA-pinned image via `gcloud`

## Verify

  - [ ] `cloud-run.yaml` workflow succeeds (`terraform plan` will fail immediately if `ignore_changes` path is invalid)
  - [ ] `mcp.edu.chainguard.dev` DNS resolves
  - [ ] After SSL provisioning: `curl https://mcp.edu.chainguard.dev/mcp`
  - [ ] Manually dispatch compile workflow to test the deploy step
  - [ ] Test from Claude Desktop with `"url": "https://mcp.edu.chainguard.dev/mcp"`

## Follow-ups

  - Deploy by signed digest instead of mutable tag (C1 from security review)
  - Catalog allowlist before live `cgr.dev` registry calls (H4)
  - Dedicated service account for MCP service (H5)
  - Hash-pinned Python dependencies in `mcp-requirements.txt` (M1)