### PR TITLE
Add required description field to composite action metadata

### DIFF
--- a/.github/actions/integrate-platform-docs/action.yaml
+++ b/.github/actions/integrate-platform-docs/action.yaml
@@ -1,4 +1,5 @@
 name: Integrate Platform Docs
+description: Download and integrate platform docs from GCS into the academy content directory
 
 inputs:
   storage_bucket:


### PR DESCRIPTION
Actionlint requires a top-level `description` field in composite action metadata. The previous PR moved the action but missed this.
