### PR TITLE
Use Artifact Registry for MCP server Cloud Run image

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -258,16 +258,31 @@ jobs:
         # Sign container image by immutable digest
         cosign sign --yes "ghcr.io/$REPO_OWNER/ai-docs@$DIGEST"
 
+    - name: Push container image to Artifact Registry
+      if: github.ref == 'refs/heads/main'
+      env:
+        REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+        REPOSITORY: ${{ secrets.REPOSITORY }}
+        COMMIT_SHA: ${{ github.sha }}
+      run: |
+        gcloud auth configure-docker "${REGISTRY_URL%%/*}" --quiet
+        AR_IMAGE="$REGISTRY_URL/$PROJECT_ID/$REPOSITORY/ai-docs"
+        docker tag "ghcr.io/${{ github.repository_owner }}/ai-docs:$COMMIT_SHA" "$AR_IMAGE:$COMMIT_SHA"
+        docker push "$AR_IMAGE:$COMMIT_SHA" || { echo "ERROR: Failed to push to Artifact Registry"; exit 1; }
+
     - name: Deploy MCP server to Cloud Run
       if: github.ref == 'refs/heads/main'
       env:
-        REPO_OWNER: ${{ github.repository_owner }}
+        REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+        REPOSITORY: ${{ secrets.REPOSITORY }}
         COMMIT_SHA: ${{ github.sha }}
       run: |
         gcloud run services update mcp-server \
-          --image "ghcr.io/$REPO_OWNER/ai-docs:$COMMIT_SHA" \
+          --image "$REGISTRY_URL/$PROJECT_ID/$REPOSITORY/ai-docs:$COMMIT_SHA" \
           --region us-central1 \
-          --project chainguard-academy
+          --project "$PROJECT_ID"
 
     - name: Upload bundle back to GCS for distribution
       env:

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -21,5 +21,5 @@ variable "image" {
 variable "mcp_image" {
   description = "The container image for the MCP HTTP server. Managed by CI after initial creation."
   type        = string
-  default     = "ghcr.io/chainguard-dev/ai-docs:latest"
+  default     = "gcr.io/cloudrun/hello"
 }


### PR DESCRIPTION
## Summary

- Change `mcp_image` Terraform default from `ghcr.io/chainguard-dev/ai-docs:latest` to `gcr.io/cloudrun/hello` — Cloud Run rejects GHCR images
- Add Artifact Registry push step in compile workflow using existing `REGISTRY_URL`/`PROJECT_ID`/`REPOSITORY` secrets
- Deploy MCP server from AR image instead of GHCR

## Context

Cloud Run only supports images from GCR, Artifact Registry, and Docker Hub. The initial deploy in #3203 used a GHCR image which Cloud Run rejected. The `gcr.io/cloudrun/hello` placeholder lets Terraform create the service; the first compile workflow run replaces it with the real wolfi-based `ai-docs` image from AR.

## Test plan

- [ ] `cloud-run.yaml` terraform apply succeeds (creates MCP service with placeholder image)
- [ ] Manually dispatch compile workflow to verify AR push and `gcloud run services update`