### PR TITLE
Update chainctl info in Quickstart and Access

### DIFF
--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -435,7 +435,11 @@ chainctl iam ids rm --expired --parent=example
 
 <a id="entitlement"></a>
 
-## Verify entitlement
+## Manage library entitlement
+
+You can create, verify, list, and remove entitlement using [`chainctl libraries entitlement`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlement/).
+
+### Verify entitlement
 
 You can verify entitlements for your organization `example` with the following
 command:
@@ -459,9 +463,7 @@ Ecosystem Library Entitlements for example (45a0...764595)
 Contact your Chainguard account owner for confirmation or adjustments if
 necessary.
 
-<!-- Removed for now until we decide where this info should live. It is only accessible
-for administrators (so Chainguard internal), but they might also be an audience to
-read the docs - so TBD
+### Create entitlement
 
 As administrator you can create entitlements:
 
@@ -469,13 +471,14 @@ As administrator you can create entitlements:
 chainctl libraries entitlements create --ecosystems=java,python --parent=example
 ```
 
-Use the` --parent` option to specify the organization or select the organization
+Use the `--parent` option to specify the organization or select the organization
 when running the command.
 
-With the ID from listing the entitlements detailed in the preceding section, you
-can also remove a Chainguard Libraries entitlement:
+### Remove entitlement
+
+You can delete an ecosystem library entitlement from your organization:
 
 ```shell
-chainctl libraries entitlements rm ENTITLEMENT_ID
+chainctl libraries entitlements delete --ecosystem=LANGUAGE --parent=example
 ```
--->
+

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -435,13 +435,13 @@ chainctl iam ids rm --expired --parent=example
 
 <a id="entitlement"></a>
 
-## Manage library entitlement
+## Manage library entitlements
 
-You can create, list, and remove entitlements using [`chainctl libraries entitlement`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlement/).
+You can create, list, and remove entitlements using [`chainctl libraries entitlements`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlement/).
 
-### Create entitlement
+### Create entitlements
 
-As administrator you can create entitlements for one or more ecosystems:
+As administrator you can use [`chainctl libraries entitlements create`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for one or more ecosystems:
 
 ```shell
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT,JAVA,PYTHON --parent=example
@@ -455,6 +455,9 @@ To enable upstream fallback for JavaScript, use the `--policy` flag:
 ```bash
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT --policy=CHAINGUARD_AND_UPSTREAM --parent=example
 ```
+
+To update the policy on an existing entitlement, rerun the `create` command with the new `--policy` value.
+
 
 ### List entitlements
 
@@ -476,9 +479,9 @@ Ecosystem Library Entitlements for example (45a0...p7q)
  45a0c61a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q/56789abc67890 | PYTHON     | POLICY_CHAINGUARD
 ```
 
-### Remove entitlement
+### Remove entitlements
 
-You can delete an ecosystem library entitlement for a specific ecosystem from your organization:
+You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/): 
 
 ```shell
 chainctl libraries entitlements delete --ecosystem=JAVASCRIPT --parent=example

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -437,48 +437,50 @@ chainctl iam ids rm --expired --parent=example
 
 ## Manage library entitlement
 
-You can create, verify, list, and remove entitlement using [`chainctl libraries entitlement`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlement/).
+You can create, list, and remove entitlements using [`chainctl libraries entitlement`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlement/).
 
-### Verify entitlement
+### Create entitlement
 
-You can verify entitlements for your organization `example` with the following
-command:
+As administrator you can create entitlements for one or more ecosystems:
+
+```shell
+chainctl libraries entitlements create --ecosystems=JAVASCRIPT,JAVA,PYTHON --parent=example
+```
+
+Use the `--parent` option to specify the organization, or omit it to select the organization
+when running the command.
+
+To enable upstream fallback for JavaScript, use the `--policy` flag:
+
+```bash
+chainctl libraries entitlements create --ecosystems=JAVASCRIPT --policy=CHAINGUARD_AND_UPSTREAM --parent=example
+```
+
+### List entitlements
+
+You can verify entitlements for your organization `example` to verify which ecosystems are enabled and what policies are configured:
 
 ```shell
 chainctl libraries entitlements list --parent=example
 ```
 
-The output must include the desired ecosystem in the table:
+The output includes the ecosystem and configured policy in the table:
 
 ```output
-Ecosystem Library Entitlements for example (45a0...764595)
+Ecosystem Library Entitlements for example (45a0...p7q)
 
-                             ID                             | ECOSYSTEM
-------------------------------------------------------------+------------
-  45a...................................................2cf | JAVASCRIPT
-  45a....................................................e1 | JAVA
-  45a....................................................x6 | PYTHON
+                            ID                             | ECOSYSTEM  |             POLICY
+-----------------------------------------------------------|------------|--------------------------------
+ 45a0c61a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q/12345abc67890 | JAVASCRIPT | POLICY_CHAINGUARD_AND_UPSTREAM
+ 45a0c61a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q/45678abc67890 | JAVA       | POLICY_CHAINGUARD
+ 45a0c61a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q/56789abc67890 | PYTHON     | POLICY_CHAINGUARD
 ```
-
-Contact your Chainguard account owner for confirmation or adjustments if
-necessary.
-
-### Create entitlement
-
-As administrator you can create entitlements:
-
-```shell
-chainctl libraries entitlements create --ecosystems=java,python --parent=example
-```
-
-Use the `--parent` option to specify the organization or select the organization
-when running the command.
 
 ### Remove entitlement
 
-You can delete an ecosystem library entitlement from your organization:
+You can delete an ecosystem library entitlement for a specific ecosystem from your organization:
 
 ```shell
-chainctl libraries entitlements delete --ecosystem=LANGUAGE --parent=example
+chainctl libraries entitlements delete --ecosystem=JAVASCRIPT --parent=example
 ```
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -98,29 +98,29 @@ pages for instructions.
 
 ### Java 
 
-* **[Repository manager](/chainguard/libraries/java/global-configuration/)
-  (recommended)**: Configure your repository manager or build tool to use
+* [Repository manager](/chainguard/libraries/java/global-configuration/)
+  **(recommended)**: Configure your repository manager or build tool to use
   `https://libraries.cgr.dev/java/` as the first repository for artifact
   resolution, falling back to Maven Central for unavailable libraries. 
-* [Direct access](/chainguard/libraries/java/build-configuration/):
-      Configure your tool to retrieve artifacts directly from the Chainguard
-      Libraries for Java repository at `https://libraries.cgr.dev/java/`. Use
-      direct access for small teams or evaluations, or when you have an existing
-      repository configuration you can't change yet.
+* [Direct access](/chainguard/libraries/java/build-configuration/): Configure
+  your tool to retrieve artifacts directly from the Chainguard Libraries for
+  Java repository at `https://libraries.cgr.dev/java/`. Use direct access for
+  small teams or evaluations, or when you have an existing repository
+  configuration you can't change yet.
   
 Check out minimal example projects for
 [Maven](/chainguard/libraries/java/build-configuration/#minimal-example-project)
 and
-[Gradle](/chainguard/libraries/java/build-configuration/#minimal-example-project-1).
+[Gradle](/chainguard/libraries/java/build-configuration/#minimal-example-project-1) to understand how to use these repositories.
 
 ### Python
 
-* **[Repository manager](/chainguard/libraries/python/global-configuration/)
-  (recommended)**: Add Chainguard Libraries as a remote repository in your
+* [Repository manager](/chainguard/libraries/python/global-configuration/)
+  **(recommended)**: Add Chainguard Libraries as a remote repository in your
   repository manager, alongside PyPI as a fallback. 
 * [Direct access](/chainguard/libraries/python/build-configuration/): Configure
-      your tool to retrieve artifacts directly from the Chainguard Libraries for
-      Python. 
+  your tool to retrieve artifacts directly from the Chainguard Libraries for
+  Python. 
 
 Note that there are multiple repositories:
 * `https://libraries.cgr.dev/python/` with the simple index at
@@ -130,7 +130,7 @@ Note that there are multiple repositories:
   remediation](/chainguard/libraries/cve-remediation/)
 
 Check out minimal example projects for
-[uv](/chainguard/libraries/python/build-configuration/#uv-minimal) and [pip](/chainguard/libraries/python/build-configuration/#pip-minimal).
+[uv](/chainguard/libraries/python/build-configuration/#uv-minimal) and [pip](/chainguard/libraries/python/build-configuration/#pip-minimal) to understand how to use these repositories.
 
 > In addition to malware-resistance, Chainguard Libraries for Python includes
 > CVE remediation for select libraries. These patched versions help reduce known
@@ -140,14 +140,12 @@ Check out minimal example projects for
 
 ### JavaScript
 
-* **[Repository
+* [Repository
   manager](/chainguard/libraries/javascript/global-configuration/)
-  (recommended)**: Add the Chainguard Libraries registry as a remote repository
+  **(recommended)**: Add the Chainguard Libraries registry as a remote repository
   and configure it as the first choice for package resolution, with npm as a
   fallback only where necessary. 
-* [Direct access](/chainguard/libraries/javascript/build-configuration/):
-      Configure your `.npmrc` to use `https://libraries.cgr.dev/javascript/` as
-      the registry. 
+* [Direct access](/chainguard/libraries/javascript/build-configuration/): Configure your `.npmrc` to use `https://libraries.cgr.dev/javascript/` as the registry. 
 
 > **Note on upstream fallback for JavaScript**: The npm upstream fallback is
 > available as an opt-in setting for both repository manager or direct access
@@ -156,8 +154,8 @@ Check out minimal example projects for
 > Libraries product. The cooldown period and malware scanning provide a
 > supplemental baseline of protection to your own security practices, but you
 > are solely responsible for independently evaluating and validating all
-> upstream artifacts before use in your environment. 
-> Learn more about upstream
+> upstream artifacts before use in your environment.  
+> <br>Learn more about upstream
 > fallback policy and controls in the [JavaScript
 > overview](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls).
 
@@ -168,7 +166,7 @@ Check out minimal example projects for
 [Yarn
 Classic](/chainguard/libraries/javascript/build-configuration/#minimal-example-project-3),
 and
-[Bun](/chainguard/libraries/javascript/build-configuration/#minimal-example-project-4).
+[Bun](/chainguard/libraries/javascript/build-configuration/#minimal-example-project-4) to understand how to use these repositories.
 
 ## Step 4: Verify your libraries
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start for Chainguard Libraries"
+title: "Quick start for Chainguard Libraries"
 linktitle: "Quick Start"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
@@ -49,6 +49,8 @@ Before getting started:
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT
 ```
 The available `ecosystems` are `JAVASCRIPT`, `JAVA`, and `PYTHON`.
+
+Learn more about this command in the [chainctl documentation](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements/).
 
 ## Step 1: Choose your access method
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -57,8 +57,8 @@ Learn more about this command in the [chainctl documentation](/chainguard/chainc
 There are two ways to access Chainguard Libraries:
 
 - **Artifact manager (recommended)**: Configure credentials once in a tool like
- JFrog Artifactory, Sonatype Nexus, or Cloudsmith. All projects and developers automatically inherit the configuration. 
-    - This option is best for organizations with multiple teams.
+ JFrog Artifactory, Sonatype Nexus, or Cloudsmith. All projects and developers automatically inherit the configuration. This centralizes policy, logging, and fallback behavior.
+    - This option is the safest approach for organizations with multiple teams and applications.
 
 - **Direct access**: Configure authentication directly in each project's build
   configuration.
@@ -96,34 +96,41 @@ Once you have a pull token, you can configure your build tool. Configuration
 steps vary by build tool and ecosystem. See the ecosystem-specific documentation
 pages for instructions. 
 
-- **Java** 
-    - [Repository manager](/chainguard/libraries/java/global-configuration/):
-  Configure your repository manager or build tool to use
+### Java 
+
+* **[Repository manager](/chainguard/libraries/java/global-configuration/)
+  (recommended)**: Configure your repository manager or build tool to use
   `https://libraries.cgr.dev/java/` as the first repository for artifact
   resolution, falling back to Maven Central for unavailable libraries. 
-    - [Direct access](/chainguard/libraries/java/build-configuration/):
+* [Direct access](/chainguard/libraries/java/build-configuration/):
       Configure your tool to retrieve artifacts directly from the Chainguard
-      Libraries for Java repository at `https://libraries.cgr.dev/java/`.
+      Libraries for Java repository at `https://libraries.cgr.dev/java/`. Use
+      direct access for small teams or evaluations, or when you have an existing
+      repository configuration you can't change yet.
   
 Check out minimal example projects for
 [Maven](/chainguard/libraries/java/build-configuration/#minimal-example-project)
 and
 [Gradle](/chainguard/libraries/java/build-configuration/#minimal-example-project-1).
 
-- **Python** 
-    - [Repository manager](/chainguard/libraries/python/global-configuration/):
-  Add Chainguard Libraries as a remote repository in your repository manager,
-  alongside PyPI as a fallback. 
-    - [Direct access](/chainguard/libraries/python/build-configuration/):
-      Configure your tool to retrieve artifacts directly from the Chainguard
-      Libraries for Python. Note that there are multiple repositories:
-        - `https://libraries.cgr.dev/python/` with the simple index at
-          `https://libraries.cgr.dev/python/simple`
-        - `https://libraries.cgr.dev/python-remediated` with the simple index at
-          `https://libraries.cgr.dev/python-remediated/simple` for libraries
-          with [CVE remediation](/chainguard/libraries/cve-remediation/)
+### Python
 
-Check out a [minimal example project for uv](/chainguard/libraries/python/build-configuration/#minimal-example-project).
+* **[Repository manager](/chainguard/libraries/python/global-configuration/)
+  (recommended)**: Add Chainguard Libraries as a remote repository in your
+  repository manager, alongside PyPI as a fallback. 
+* [Direct access](/chainguard/libraries/python/build-configuration/): Configure
+      your tool to retrieve artifacts directly from the Chainguard Libraries for
+      Python. 
+
+Note that there are multiple repositories:
+* `https://libraries.cgr.dev/python/` with the simple index at
+  `https://libraries.cgr.dev/python/simple`
+* `https://libraries.cgr.dev/python-remediated` with the simple index at
+  `https://libraries.cgr.dev/python-remediated/simple` for libraries with [CVE
+  remediation](/chainguard/libraries/cve-remediation/)
+
+Check out minimal example projects for
+[uv](/chainguard/libraries/python/build-configuration/#uv-minimal) and [pip](/chainguard/libraries/python/build-configuration/#pip-minimal).
 
 > In addition to malware-resistance, Chainguard Libraries for Python includes
 > CVE remediation for select libraries. These patched versions help reduce known
@@ -131,14 +138,28 @@ Check out a [minimal example project for uv](/chainguard/libraries/python/build-
 > libraries have CVE remediation available in the Chainguard Console. CVE
 > remediation is currently available for Python libraries only.
 
-- **JavaScript** 
-    - [Repository manager](/chainguard/libraries/javascript/global-configuration/): Add the Chainguard Libraries registry as a remote
-  repository and configure it as the first choice for package resolution. 
-    - [Direct access](/chainguard/libraries/javascript/build-configuration/): Configure your `.npmrc` to use
-      `https://libraries.cgr.dev/javascript/` as the registry, with upstream npm
-      fallback available as an opt-in setting. Learn more about upstream
-      fallback policy and controls in the [JavaScript
-      overview](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls).
+### JavaScript
+
+* **[Repository
+  manager](/chainguard/libraries/javascript/global-configuration/)
+  (recommended)**: Add the Chainguard Libraries registry as a remote repository
+  and configure it as the first choice for package resolution, with npm as a
+  fallback only where necessary. 
+* [Direct access](/chainguard/libraries/javascript/build-configuration/):
+      Configure your `.npmrc` to use `https://libraries.cgr.dev/javascript/` as
+      the registry. 
+
+> **Note on upstream fallback for JavaScript**: The npm upstream fallback is
+> available as an opt-in setting for both repository manager or direct access
+> approaches, and is turned off by default. Upstream packages are proxied
+> directly from npm and are not rebuilt or authored by Chainguard as part of our
+> Libraries product. The cooldown period and malware scanning provide a
+> supplemental baseline of protection to your own security practices, but you
+> are solely responsible for independently evaluating and validating all
+> upstream artifacts before use in your environment. 
+> Learn more about upstream
+> fallback policy and controls in the [JavaScript
+> overview](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls).
 
 Check out minimal example projects for
 [npm](/chainguard/libraries/javascript/build-configuration/#minimal-example-project),
@@ -148,10 +169,6 @@ Check out minimal example projects for
 Classic](/chainguard/libraries/javascript/build-configuration/#minimal-example-project-3),
 and
 [Bun](/chainguard/libraries/javascript/build-configuration/#minimal-example-project-4).
-
-> **Note on upstream fallback for JavaScript**: The npm upstream fallback is opt-in and is turned off by
-> default. Upstream packages are proxied directly from npm and are not rebuilt or authored by Chainguard as part of our Libraries product. The cooldown period and malware scanning provide a supplemental baseline of protection to your own security practices, but you are solely responsible for independently evaluating and validating all upstream artifacts before use in your environment.
-
 
 ## Step 4: Verify your libraries
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Cross-linking to chainctl docs for the `libraries entitlements` command.

### What should this PR do?
- On both the "Quick start" and "Access" pages, link to the chainctl docs 
- Update the chainctl entitlements info on the "Access" page
- Make it clearer that repo manager is the recommended approach
- Update formatting of the "Configure your build tools" section

### Why are we making this change?
To provide additional info on the commands, make recommendations clearer
