### PR TITLE
Fix actionlint: use fail_level and nofilter mode

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -54,4 +54,5 @@ jobs:
         with:
           actionlint_flags: ${{ steps.get_yamls.outputs.files }}
           level: error
-          fail_on_error: true
+          filter_mode: nofilter
+          fail_level: error


### PR DESCRIPTION
## Summary

- Replace deprecated `fail_on_error` with `fail_level: error` — only actual actionlint errors fail the check
- Use `filter_mode: nofilter` to prevent reviewdog from flooding annotations, which triggers a `##[error] Too many results` that fails the step regardless of finding severity

## Context

The ~40 pre-existing shellcheck warnings across workflows overflow GitHub's 50-annotation limit, causing reviewdog to emit an error annotation that fails the step even when there are zero actual actionlint errors.

## Test plan

- [ ] Actionlint check passes on this PR