### PR TITLE
Fix actionlint: use github-check reporter

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -56,3 +56,4 @@ jobs:
           level: error
           filter_mode: nofilter
           fail_level: error
+          reporter: github-check


### PR DESCRIPTION
## Summary

Switch actionlint reviewdog reporter from `github-pr-check` (default) to `github-check`. The default reporter uses logging commands that hit GitHub's 50-annotation limit, emitting `##[error] Too many results` which fails the step even when there are zero actual actionlint errors. The `github-check` reporter uses the Checks API which handles more annotations cleanly.

## Test plan

- [ ] Actionlint check passes on this PR