### PR TITLE
Add deletion_protection=false to MCP server Cloud Run service

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -75,7 +75,8 @@ resource "google_cloud_run_v2_service" "mcp-server" {
   location = each.key
   ingress  = "INGRESS_TRAFFIC_ALL"
 
-  launch_stage = "BETA"
+  launch_stage          = "BETA"
+  deletion_protection   = false
 
   template {
     vpc_access {


### PR DESCRIPTION
## Summary

Terraform is trying to replace the broken initial MCP service (created with the rejected GHCR image) but Cloud Run's default `deletion_protection` blocks the destroy step. Add `deletion_protection = false` so Terraform can recreate the service with the correct `gcr.io/cloudrun/hello` placeholder.

## Test plan

- [ ] `cloud-run.yaml` terraform apply succeeds