### PR TITLE
Temporary: remove broken MCP service from Terraform state

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -86,6 +86,10 @@ jobs:
       run: |
         terraform init
 
+        # TODO: Remove this after one successful apply.
+        # Clears broken MCP service from state so Terraform can recreate it.
+        terraform state rm 'google_cloud_run_v2_service.mcp-server["us-central1"]' || true
+
         terraform plan
 
         terraform apply -auto-approve


### PR DESCRIPTION
## Summary

One-time `terraform state rm` to clear the broken MCP service resource from state. The initial creation failed (GHCR image rejected by Cloud Run) leaving a tainted resource with `deletion_protection=true` that Terraform can't destroy.

The `|| true` ensures it's a no-op if the resource is already gone. **Remove this line after one successful apply.**

## Test plan

- [ ] `cloud-run.yaml` terraform apply succeeds
- [ ] MCP service created with `gcr.io/cloudrun/hello` placeholder
- [ ] Follow-up PR to remove the `state rm` line