### PR TITLE
Fix: use terraform import instead of state rm for MCP service

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -87,8 +87,9 @@ jobs:
         terraform init
 
         # TODO: Remove this after one successful apply.
-        # Clears broken MCP service from state so Terraform can recreate it.
-        terraform state rm 'google_cloud_run_v2_service.mcp-server["us-central1"]' || true
+        # Imports existing MCP service into state so Terraform can manage it.
+        terraform import 'google_cloud_run_v2_service.mcp-server["us-central1"]' \
+          "projects/$TF_VAR_project_id/locations/us-central1/services/mcp-server" || true
 
         terraform plan
 


### PR DESCRIPTION
## Summary
- The previous `terraform state rm` removed the MCP service from state, but the service still existed in GCP
- Terraform then tried to create a new one and got a 409 conflict ("Resource already exists")
- Replace `state rm` with `terraform import` to pull the existing GCP resource back into state so Terraform can manage it

## Test plan
- [ ] Verify `terraform import` succeeds in CI
- [ ] Verify `terraform plan` shows no unexpected changes after import
- [ ] Verify `terraform apply` completes successfully
- [ ] Remove the temporary import line in a follow-up PR after one successful apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)