### PR TITLE
Remove command from Terraform, set it in gcloud deploy instead

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -281,6 +281,7 @@ jobs:
       run: |
         gcloud run services update mcp-server \
           --image "$REGISTRY_URL/$PROJECT_ID/$REPOSITORY/ai-docs:$COMMIT_SHA" \
+          --command "/usr/local/bin/serve-mcp-http" \
           --region us-central1 \
           --project "$PROJECT_ID"
 

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -90,8 +90,7 @@ resource "google_cloud_run_v2_service" "mcp-server" {
     service_account = google_service_account.chainguard-academy.email
 
     containers {
-      image   = var.mcp_image
-      command = ["/usr/local/bin/serve-mcp-http"]
+      image = var.mcp_image
 
       ports {
         container_port = 8080
@@ -114,6 +113,7 @@ resource "google_cloud_run_v2_service" "mcp-server" {
   lifecycle {
     ignore_changes = [
       template[0].containers[0].image,
+      template[0].containers[0].command,
     ]
   }
 }


### PR DESCRIPTION
The placeholder image (gcr.io/cloudrun/hello) doesn't have /usr/local/bin/serve-mcp-http, so Terraform can't boot the service on initial creation. Move the command to the gcloud deploy step and add it to ignore_changes so Terraform doesn't reset it.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->