### PR TITLE
Remove temporary state rm/delete from cloud-run workflow

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -85,16 +85,7 @@ jobs:
       working-directory: ./iac
       run: |
         terraform init
-
-        # TODO: Remove this after one successful apply.
-        # Clears broken MCP service from state so Terraform can recreate it.
-        terraform state rm 'google_cloud_run_v2_service.mcp-server["us-central1"]' || true
-        # Delete the broken service from GCP so Terraform can create it fresh.
-        gcloud run services delete mcp-server \
-          --region us-central1 --project "$TF_VAR_project_id" --quiet || true
-
         terraform plan
-
         terraform apply -auto-approve
 
     - name: Post failure notice to Slack


### PR DESCRIPTION
The MCP service was successfully created in GCP. Remove the one-time cleanup lines so they don't destroy it on the next push to main.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->