### PR TITLE
Move MCP IAM binding from Terraform to compile workflow

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -85,6 +85,11 @@ jobs:
       working-directory: ./iac
       run: |
         terraform init
+
+        # TODO: Remove after one successful apply.
+        # Forget IAM binding from state — moved to compile workflow.
+        terraform state rm 'google_cloud_run_v2_service_iam_member.mcp-server-is-unauthenticated["us-central1"]' || true
+
         terraform plan
         terraform apply -auto-approve
 

--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -285,6 +285,13 @@ jobs:
           --region us-central1 \
           --project "$PROJECT_ID"
 
+        # Allow unauthenticated access (CI terraform SA lacks setIamPolicy)
+        gcloud run services add-iam-policy-binding mcp-server \
+          --region us-central1 \
+          --member "allUsers" \
+          --role "roles/run.invoker" \
+          --project "$PROJECT_ID" || true
+
     - name: Upload bundle back to GCS for distribution
       env:
         COMMIT_SHA: ${{ github.sha }}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -118,15 +118,6 @@ resource "google_cloud_run_v2_service" "mcp-server" {
   }
 }
 
-resource "google_cloud_run_v2_service_iam_member" "mcp-server-is-unauthenticated" {
-  for_each = google_cloud_run_v2_service.mcp-server
-
-  project  = var.project_id
-  location = each.key
-  name     = each.value.name
-  role     = "roles/run.invoker"
-  member   = "allUsers"
-}
 
 resource "google_dns_managed_zone" "edu-zone" {
   project     = var.project_id


### PR DESCRIPTION
The cloud-run.yaml CI service account lacks run.services.setIamPolicy. Move the allUsers invoker binding to the compile workflow which uses a different service account. Also remove the resource from Terraform and clear it from state.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->