### PR TITLE
Remove temporary state rm for IAM binding

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -85,11 +85,6 @@ jobs:
       working-directory: ./iac
       run: |
         terraform init
-
-        # TODO: Remove after one successful apply.
-        # Forget IAM binding from state — moved to compile workflow.
-        terraform state rm 'google_cloud_run_v2_service_iam_member.mcp-server-is-unauthenticated["us-central1"]' || true
-
         terraform plan
         terraform apply -auto-approve
 


### PR DESCRIPTION
The IAM resource was successfully removed from state in the previous deploy. Clean up the one-time workaround.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->