### PR TITLE
Add *.pkg.dev to egress allowlist for Artifact Registry push

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -42,6 +42,7 @@ jobs:
         egress-policy: block
         allowed-endpoints: >
           api.github.com:443
+          *.pkg.dev:443
           *.r2.cloudflarestorage.com:443
           apk.cgr.dev:443
           cgr.dev:443


### PR DESCRIPTION
The compile workflow pushes to Artifact Registry but the AR domain was blocked by harden-runner egress policy.

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->