### PR TITLE
Add *.run.googleapis.com to egress allowlist for regional Cloud Run API

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -59,6 +59,7 @@ jobs:
           release-assets.githubusercontent.com:443
           rekor.sigstore.dev:443
           run.googleapis.com:443
+          *.run.googleapis.com:443
           sts.googleapis.com:443
           storage.googleapis.com:443
           timestamp.sigstore.dev:443


### PR DESCRIPTION
## Summary
- `gcloud run services update` uses regional endpoints (e.g., `us-central1-run.googleapis.com`)
- Only the global `run.googleapis.com` was in the harden-runner allowlist
- This caused a DNS resolution failure when deploying the MCP server to Cloud Run

## Test plan
- [ ] Merge and dispatch compile workflow
- [ ] Verify the deploy step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)