### PR TITLE
Fix egress: use explicit us-central1-run.googleapis.com hostname

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -59,7 +59,7 @@ jobs:
           release-assets.githubusercontent.com:443
           rekor.sigstore.dev:443
           run.googleapis.com:443
-          *.run.googleapis.com:443
+          us-central1-run.googleapis.com:443
           sts.googleapis.com:443
           storage.googleapis.com:443
           timestamp.sigstore.dev:443


### PR DESCRIPTION
## Summary
- `*.run.googleapis.com` doesn't match `us-central1-run.googleapis.com` because it's a separate label under `googleapis.com`, not a subdomain of `run.googleapis.com`
- Replace the wildcard with the explicit hostname

## Test plan
- [ ] Merge and dispatch compile workflow
- [ ] Verify deploy step resolves DNS and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)