### PR TITLE
Explain CVE remediation for vendored dependencies

### DIFF
--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -49,6 +49,20 @@ provides the option to make remediated versions available for your development
 or opt out of using these versions completely and continue to use upstream
 versions only.
 
+### CVE remediation for vendored dependencies
+
+Some Python packages bundle compiled code written in other languages (such as Go
+or Rust) directly into their wheel. When a CVE exists in a dependency of that
+vendored code, Chainguard may apply a fix even when no CVE has been filed
+against the Python package itself.
+
+In these cases, Chainguard bumps the vulnerable dependency within the vendored
+code and publishes a new `+cgr.N` version of the package. Because the
+vulnerability exists at the vendored dependency level rather than the Python
+package level, no advisory entry is published in the VEX feed for these
+versions. However, scanners that inspect vendored binaries will reflect the fix
+in their results.
+
 
 ## Browse libraries with CVE remediation
 
@@ -57,6 +71,7 @@ Remediated libraries are published in a dedicated PyPI-compatible index: `https:
 You can:
 - Browse them in the Chainguard Console
 - Use the public VEX feed to understand what has been remediated
+    - This feed only covers backported Python-level CVEs, but does not include [vendored dependencies](#cve-remediation-for-vendored-dependencies).
 - View them in a browser at the simple index URL
     - Learn more in [Python Overview > Manual access](/chainguard/libraries/python/overview/#manual-access).
 - Expose them to your developers via a repo manager 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -51,9 +51,8 @@ versions only.
 
 ### CVE remediation for vendored dependencies
 
-Some Python packages bundle compiled code written in other languages (such as Go
-or Rust) directly into their wheel. When a CVE exists in a dependency of that
-vendored code, Chainguard may apply a fix even when no CVE has been filed
+Some Python packages bundle compiled code written in other languages (such as Go, Rust, or C/C++) directly into their wheel. When a CVE exists in a dependency of that
+vendored code, Chainguard may publish a remediated version even when no CVE has been filed
 against the Python package itself.
 
 In these cases, Chainguard bumps the vulnerable dependency within the vendored


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to library CVE remediations page

### What should this PR do?
Clarify how CVE remediations work for Python packages when a CVE exists in a dependency of vendored code

### Why are we making this change?
To prevent confusion if customers see +cgr.N versions of a package but no advisory in the VEX feed. [Thread here](https://chainguard-dev.slack.com/archives/C0962EGMS3F/p1775831600744599).

### What are the acceptance criteria? 
Content should clearly explain how this works

