### PR TITLE
Fix MCP server HTTP transport startup

### DIFF
--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -640,9 +640,24 @@ async def main_stdio():
 def main_http(host: str, port: int):
     """Run the MCP server with Streamable HTTP transport."""
     import uvicorn
+    from contextlib import asynccontextmanager
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
 
     logger.info(f"Starting Chainguard AI Docs MCP Server (http) on {host}:{port}")
-    starlette_app = app.streamable_http_app()
+
+    session_manager = StreamableHTTPSessionManager(app=app)
+
+    @asynccontextmanager
+    async def lifespan(app):
+        async with session_manager.run():
+            yield
+
+    starlette_app = Starlette(
+        lifespan=lifespan,
+        routes=[Mount("/mcp", app=session_manager.handle_request)],
+    )
     uvicorn.run(starlette_app, host=host, port=port)
 
 


### PR DESCRIPTION
## Summary
- The MCP server container was failing to start on Cloud Run with `AttributeError: 'Server' object has no attribute 'streamable_http_app'`
- `streamable_http_app()` is a method on `FastMCP`, not the low-level `Server` class used by `mcp-server.py`
- Replace with `StreamableHTTPSessionManager` + Starlette routing, which is the correct approach for low-level `Server` instances

## Test plan
- [x] Built and ran container locally — server starts and responds to MCP `initialize` requests on `/mcp/`
- [ ] CI workflow `compile-ai-docs-from-gcs` deploys successfully to Cloud Run
- [ ] `mcp.edu.chainguard.dev` serves MCP responses instead of the Cloud Run placeholder page

🤖 Generated with [Claude Code](https://claude.com/claude-code)