### PR TITLE
Add chainctl entitlement command to JS library overview

### DIFF
--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -158,8 +158,18 @@ Repository](/chainguard/chainguard-repository/overview/). By default, the endpoi
 only Chainguard-built packages. When fallback is enabled, upstream packages are
 subject to additional security controls before being served.
 
-To enable or change upstream fallback configuration, contact your Chainguard
-account team or Chainguard support.
+### Enable the upstream repository
+
+To enable or change upstream fallback configuration, use the [`chainctl
+libraries entitlements`
+command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/).
+
+The following command creates or updates an entitlement to Chainguard Libraries
+for JavaScript and adds the npm upstream fallback policy:
+
+```bash
+chainctl libraries entitlements create --parent=example.com --ecosystems=JAVASCRIPT --policy=CHAINGUARD_AND_UPSTREAM
+```
 
 ### Fallback options
 The following options are available:


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to JS library overview page

### What should this PR do?
- Remove the instruction to contact Chainguard to enable upstream fallback, replace it with how to use chainctl to create an entitlement and update the upstream policy

### Why are we making this change?
Because customers can now self-serve this policy change

### What are the acceptance criteria? 
- Accurate command
- Accurate instructions

### How should this PR be tested?
Make sure the content appears as expected on the JS overview page