### PR TITLE
Fix: Link to `configurable upstream fallback`

### DIFF
--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -60,7 +60,7 @@ There are two ways to access Chainguard Libraries: using an [artifact manager](#
 
 Configure credentials once in a tool like JFrog Artifactory, Sonatype Nexus, or Cloudsmith. This centralizes policy, logging, and fallback behavior, and is the safest approach for organizations with multiple teams and applications.
 
-Note that built-in [configurable upstream fallback](/libraries/javascript/overview/#upstream-fallback-policy-and-controls) is available for Chainguard Libraries for JavaScript via the Chainguard Repository, but not yet available for Chainguard Libraries for Python or Java. Before configuring your repository manager, consider how you want to handle packages that aren't available in the Chainguard registry:
+Note that built-in [configurable upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) is available for Chainguard Libraries for JavaScript via the Chainguard Repository, but not yet available for Chainguard Libraries for Python or Java. Before configuring your repository manager, consider how you want to handle packages that aren't available in the Chainguard registry:
 
 **Python and Java fallback approach**
 


### PR DESCRIPTION
- Fix: Link to `configurable upstream fallback`