### PR TITLE
Add Chainguard CIS Docker Benchmark Section 4 conformance documentation

### DIFF
--- a/content/compliance/cis-benchmarks.md
+++ b/content/compliance/cis-benchmarks.md
@@ -60,6 +60,19 @@ The Benchmark will then go into individual recommendations relating to the tool 
 Regarding this last bullet, [CIS Controls](https://www.cisecurity.org/controls) are more high-level recommendations than Benchmarks. CIS Benchmarks are best practices for specific tools, while CIS Controls are more simplified general recommendations that can be applied to a variety of technologies.
 
 
+## Chainguard Containers and the CIS Docker Benchmark
+
+Section 4 of the CIS Docker Benchmark — **"Container Images and Build File Configuration"** — is the section most relevant to Chainguard Containers. Chainguard container images are generally conformant with Section 4, with a few caveats:
+
+- **Benchmark 4.5 (Content Trust)**: Chainguard does not use [Docker Content Trust](https://docs.docker.com/engine/security/trust/). Instead, all images are signed with [Cosign](https://docs.sigstore.dev/cosign/overview/), which is more robust and accomplishes the same security objective. Because the benchmark prescribes Docker Content Trust specifically, whether Cosign satisfies this requirement in a formal audit is at the auditor's discretion.
+- **Benchmark 4.6 (HEALTHCHECK)**: Chainguard images do not include [Docker `HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) instructions. Docker health checks are not compatible with Kubernetes, where health checking is handled at the orchestration layer. Chainguard Containers do not meet this benchmark.
+- **Build-time recommendations (e.g., 4.9)**: Some benchmarks apply to how images are built rather than to the base image itself. Chainguard base images follow these recommendations internally, but compliance of any downstream image depends on the practices you follow when extending them.
+
+For all other Section 4 benchmarks, the security properties they describe (minimal footprint, non-root execution, trusted base images, and reduced attack surface) are core to what Chainguard Containers provide.
+
+If you have specific compliance questions or need documentation for an audit, [contact Chainguard](https://www.chainguard.dev/contact).
+
+
 ## Learn more
 
 By implementing CIS benchmarks, organizations not only improve their security against evolving cyber threats but also align with regulatory standards, ensuring compliance and minimizing risks. To explore the full range of benchmarks and start implementing these best practices, visit the [CIS website](https://www.cisecurity.org/cis-benchmarks) today.


### PR DESCRIPTION
## Type of change
**Documentation Update**
- Added new section to the CIS Benchmarks overview explaining how Chainguard Containers conform to Section 4 of the CIS Docker Benchmark

## What should this PR do?

resolves https://github.com/chainguard-dev/internal/issues/4569

## Why are we making this change?

The existing CIS Benchmarks page was purely conceptual and contained no information about Chainguard's conformance. A customer asked whether Chainguard images meet CIS Benchmarks and requested public-facing documentation they could share with their own customers.

## What are the acceptance criteria?

- A new "Chainguard Containers and the CIS Docker Benchmark" section is present on the page
- The section correctly describes Section 4 conformance, including the Cosign/4.5 caveat, the 4.6 HEALTHCHECK non-conformance, and the note about build-time recommendations
- Links to Docker Content Trust, Cosign, and Docker HEALTHCHECK docs are present and correct

## How should this PR be tested?

1. Check the preview link and navigate to `/software-security/compliance/cis-benchmarks/`
2. Verify the new section renders correctly and all links are functional