### PR TITLE
Cleanup: Updated content link style

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -249,7 +249,7 @@ h2[id^="chainctl"] {
     display: flex;
     align-items: center;
     gap: 12px;
-    color: inherit;
+    text-decoration: none;
 }
 
 .pills-icon {
@@ -257,8 +257,8 @@ h2[id^="chainctl"] {
     padding: 4px;
     width: 28px !important;
     height: 28px !important;
-    border: 2px solid var(--pills-icon);
-    border-radius: 99px;
+    border: 1px solid var(--pills-icon);
+    border-radius: 4px;
     cursor: pointer;
     // Be under search overlay
     z-index: -1;
@@ -1201,8 +1201,8 @@ header .search-container {
     color: var(--tooltip-container-color) !important;
     border: none;
     padding: 0 8px;
-    height: 44px;
-    width: 44px;
+    height: 36px;
+    width: 36px;
 }
 
 .tooltip-container:hover .tooltip {
@@ -1443,6 +1443,7 @@ header .search-container {
 .docs-content.docs-content a:not(.tag),
 .card-link.card-link.card-link.card-link {
     color: var(--article-link-color);
+    text-decoration: underline;
 }
 
 [data-dark-mode] .docs-content.docs-content {

--- a/assets/scss/common/_theming.scss
+++ b/assets/scss/common/_theming.scss
@@ -1,6 +1,6 @@
 :root {
     --primary-1: #6226f0; // blurple (primary brand color)
-    --primary-2: #00a0eb; // aqua
+    --primary-2: #c0a8fd; // blurple (40)
     --primary-3: #0d161c; // ink (dark text)
     --primary-3-border: #0d161c1F;
     --secondary-1: #fdd5ff; // light fuschia

--- a/assets/scss/components/_typography-enhanced.scss
+++ b/assets/scss/components/_typography-enhanced.scss
@@ -122,8 +122,6 @@ a {
     &:hover {
         color: var(--secondary-2);
         text-decoration: underline;
-        text-decoration-thickness: 2px;
-        text-underline-offset: 2px;
     }
     
     &.link-underline {

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -115,7 +115,7 @@ Alternatively, you can use the token for direct access from a build tool as
 discussed in [Build
 configuration](/chainguard/libraries/java/build-configuration/).
 
-<a id="manual">
+<a id="manual"></a>
 
 ## Manual access
 


### PR DESCRIPTION
- Underline content links
- Updated color for links
- Reduce codeblock header height
- Fix `Manual access` anchor link in `Java` overview