### PR TITLE
Add JS library SBOM retrieval command

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -214,7 +214,7 @@ directory:
 chainctl auth configure-npm --pull-token
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually.
+[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the latest version of `chainctl`.
 
 #### Verify authentication with npm ping
 
@@ -353,7 +353,7 @@ directory:
 chainctl auth configure-npm --pull-token
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. 
+[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. If this command returns an error, ensure that you are using the latest version of `chainctl`.
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -214,7 +214,7 @@ directory:
 chainctl auth configure-npm --pull-token
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the latest version of `chainctl`.
+[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
 #### Verify authentication with npm ping
 
@@ -353,7 +353,7 @@ directory:
 chainctl auth configure-npm --pull-token
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. If this command returns an error, ensure that you are using the latest version of `chainctl`.
+[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -150,6 +150,24 @@ Verified OK
 The `--certificate-oidc-issuer` and `--certificate-identity-regexp` flags confirm 
 the attestation was signed by Chainguard. 
 
+### Retrieve SBOMs
+
+Chainguard Libraries for JavaScript also include Software Bills of Materials (SBOMs) in SPDX format. 
+
+To check whether an SBOM is available for a package, use npm show with the dist.sboms field:
+
+```bash
+npm show PACKAGE@VERSION dist.sboms
+```
+
+To retrieve the SBOM directly:
+
+```bash
+curl -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.dev)" https://libraries.cgr.dev/javascript/-/npm/v1/sbom/spdx/PACKAGE@VERSION
+```
+
+Replace `PACKAGE` and `VERSION` with the package name and version (for example, `react-router` and `7.11.0`).
+
 ## Upstream fallback policy and controls
 
 Chainguard Libraries for JavaScript supports an optional built-in fallback to


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Add SBOM retrieval command to JS library docs, also note a troubleshooting step to update chainctl

### What should this PR do?
Explain how to retrieve SBOMs for JS libraries

### Why are we making this change?
Product update

### What are the acceptance criteria? 
Ensure the commands work as described and the content appears in the right location

### How should this PR be tested?
Review the deploy preview