### PR TITLE
Add group ID retrieval instructions to Guardener prerequisites

### DIFF
--- a/content/chainguard/migration/the-guardener.md
+++ b/content/chainguard/migration/the-guardener.md
@@ -24,7 +24,7 @@ You interact with it through `chainctl agent dockerfile` commands. The AI runs s
 
 ## Prerequisites
 
-While The Guardener is in beta, your organization will need to join the waitlist. We’ll notify you once registration becomes available. You can sign up for the waitlist on the [The Guardener landing page](https://www.chainguard.dev/guardener).
+While The Guardener is in beta, your organization will need to join the waitlist. We’ll notify you once registration becomes available. You can sign up for the waitlist on [The Guardener landing page](https://www.chainguard.dev/guardener).
 
 Additionally, you will need the following in order to use The Guardener:
 
@@ -40,6 +40,25 @@ chainctl iam organizations list -o table
 
 chainctl iam role-bindings create --parent <group-id> --identity <identity> --role <role-with-repo.create>
 ```
+
+### Retrieving your organization's group ID
+
+The Guardener needs to know which Chainguard organization to reference when migrating Dockerfiles. For this reason, you must include your organization's group ID value in the `chainctl` commands you use to interact with the tool.
+
+Note that the group ID is **not** the name of your organization; it is a 40-character string used to identify your organization.
+
+To retrieve your organization's group ID value, run the following command:
+
+```shell
+chainctl iam organizations list -o table
+```
+```output
+                    ID                    |      NAME      |          DESCRIPTION          
+------------------------------------------|----------------|-------------------------------------
+ EXAMPLE05850c357EXAMPLE6e10d007c9EXAMPLE | example.com    | This is an example organization.
+```
+
+Your organization's group ID is the value that appears in the `ID` column of this command's output.
 
 
 ## Usage examples


### PR DESCRIPTION
## Type of change
**Documentation Update**
- Added a new "Retrieving your organization's group ID" subsection under Prerequisites
- Fixed duplicate "the The" phrasing on the waitlist sign-up link
- Made `chainctl iam organizations list` command consistent throughout the page

## What should this PR do?

Adds instructions for retrieving the Chainguard organization group ID, which users need to supply to all `chainctl agent dockerfile` commands when using The Guardener.

## Why are we making this change?

The page already referenced `--group <group-id>` in every usage example but gave users no guidance on how to find their group ID. This gap would cause confusion for users who are unfamiliar with the `chainctl` IAM commands.

## What are the acceptance criteria?

- The new "Retrieving your organization's group ID" subsection appears under Prerequisites
- The example output block renders correctly with the table formatting intact
- The `chainctl iam organizations list` command is consistent throughout the page

## How should this PR be tested?

1. Check the preview link and ensure the changes render correctly under the Prerequisites section
2. Verify the code block and output block in the new subsection display as expected
3. Confirm the table in the output block is readable and not garbled

🤖 Generated with [Claude Code](https://claude.com/claude-code)