### PR TITLE
Update docs on AI bundle: clarify GitHub release assets are static, update Quick Start to use container

### DIFF
--- a/content/ai-docs-security.md
+++ b/content/ai-docs-security.md
@@ -88,6 +88,8 @@ Example patterns we redact:
 
 ### Direct Download Verification
 
+> **Note:** The assets in this release are static and not updated automatically. These verification steps apply to the archived snapshot. For current documentation, use the container distribution.
+
 ```bash
 # 1. Download files
 curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -121,7 +121,7 @@ Add to your `claude_desktop_config.json`:
 - Searchable and queryable documentation
 - Perfect for automated workflows
 - Works with Claude Desktop, Cursor, and other MCP-compatible tools
-- Also available as a [standalone Python script](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) (no Docker required)
+- Also available as a [standalone Python script (static snapshot)](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) (no Docker required)
 
 [**Full MCP Server Documentation →**](/mcp-server-ai-docs/)
 

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -42,9 +42,11 @@ Choose your preferred distribution method:
 
 ### GitHub Release
 
+> **Note:** The assets in this release are static and not updated automatically. For current documentation, use the container distribution below.
+
 | Format | Description | Verification |
 |--------|-------------|-------------|
-| [Latest Release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) | Cryptographically signed documentation bundle (~1.7MB) | Includes Cosign signatures and certificates |
+| [Archived Bundle](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) | Static documentation bundle snapshot with Cosign signatures | Includes Cosign signatures and certificates |
 
 ### Container Distribution
 
@@ -126,11 +128,8 @@ Add to your `claude_desktop_config.json`:
 ### Quick Start
 
 ```bash
-# Download the documentation bundle from GitHub releases
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz
-
-# Extract the markdown file
-tar -xzf chainguard-ai-docs.tar.gz
+# Extract current documentation from the container image
+docker run --rm -v $(pwd):/output ghcr.io/chainguard-dev/ai-docs:latest extract /output
 
 # The extracted file 'chainguard-ai-docs.md' is ready to use with your AI assistant
 ```

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -242,7 +242,7 @@ latest, latest-dev, 3.13, 3.13-dev, ...
 
 ## Standalone Installation (without Docker)
 
-The MCP server is also available as a standalone Python script from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle):
+The MCP server is also available as a standalone Python script. These files are static snapshots from the [archived GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) and are not automatically updated. For current documentation, use the container distribution above.
 
 ```bash
 # Download the MCP server, requirements, docs, and catalog
@@ -311,7 +311,7 @@ Then configure your MCP client to connect to `http://localhost:8080/mcp/`.
 
 ## Alternative: Static Documentation
 
-If you don't need MCP server functionality, you can download the documentation as a single markdown file from the [GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle), or extract it from the container:
+If you don't need MCP server functionality, extract the documentation from the container:
 
 ```bash
 docker run --rm -v $(pwd):/output \


### PR DESCRIPTION
  ## Summary

  - Adds a note to the GitHub Release section warning that release assets are static and not automatically updated
  - Renames the release link from "Latest Release" to "Archived Bundle" to avoid implying freshness
  - Replaces the Quick Start curl command (which downloads from the frozen release) with the docker run ... extract
  command, which pulls from the live container image

Preview: https://deploy-preview-3268--ornate-narwhal-088216.netlify.app/developer-resources/#download-options

 ## Context

  The ai-docs-bundle GitHub Release is covered by an org ruleset that makes release assets immutable. The workflow attempts to update them on each build but fails silently (the step has continue-on-error: true), meaning users who download from the release get stale documentation. The container (ghcr.io/chainguard-dev/ai-docs:latest) is updated correctly on each build and is the right path for current docs.

  This PR updates the page to reflect that reality while a longer-term fix for the release update workflow is
  investigated.