### PR TITLE
AI docs bundle fix: switch AI docs releases to dated tags, and more

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -331,39 +331,51 @@ jobs:
         
         echo "✓ Bundle uploaded to GCS"
 
-    - name: Update GitHub Release
+    - name: Sign bundle files
       if: github.ref == 'refs/heads/main'
-      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
+      run: |
+        cd static/downloads
+        cosign sign-blob chainguard-ai-docs.tar.gz \
+          --yes \
+          --bundle=chainguard-ai-docs.tar.gz.bundle
+        cosign sign-blob chainguard-ai-docs.md \
+          --yes \
+          --bundle=chainguard-ai-docs.md.bundle
+        echo "Bundle files signed"
+
+    - name: Create GitHub Release
+      if: github.ref == 'refs/heads/main'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Org ruleset makes releases immutable (can't delete assets).
-        # Use --clobber to overwrite existing assets in place.
-        TAG="ai-docs-bundle"
+        TAG="ai-docs-$(date -u +%Y%m%d-%H%M%S)"
 
-        if gh release view "$TAG" > /dev/null 2>&1; then
-          echo "Updating existing $TAG release..."
+        gh release create "$TAG" \
+          --title "AI Documentation Bundle $TAG" \
+          --notes "Chainguard AI documentation bundle for use with AI coding assistants." \
+          --latest \
+          static/downloads/chainguard-ai-docs.tar.gz \
+          static/downloads/chainguard-ai-docs.tar.gz.bundle \
+          static/downloads/chainguard-ai-docs.md \
+          static/downloads/chainguard-ai-docs.md.bundle \
+          static/downloads/chainguard-ai-docs.zip \
+          static/downloads/image-catalog.json \
+          static/downloads/checksums.txt \
+          scripts/mcp-server.py \
+          scripts/mcp-requirements.txt
 
-          gh release upload "$TAG" --clobber \
-            static/downloads/chainguard-ai-docs.tar.gz \
-            static/downloads/chainguard-ai-docs.md \
-            static/downloads/chainguard-ai-docs.zip \
-            static/downloads/image-catalog.json \
-            static/downloads/checksums.txt \
-            scripts/mcp-server.py \
-            scripts/mcp-requirements.txt
+        echo "Release $TAG created"
 
-          echo "Release assets updated"
-        else
-          echo "Creating new $TAG release..."
-          gh release create "$TAG" \
-            static/downloads/chainguard-ai-docs.tar.gz \
-            static/downloads/chainguard-ai-docs.md \
-            static/downloads/chainguard-ai-docs.zip \
-            static/downloads/image-catalog.json \
-            static/downloads/checksums.txt \
-            scripts/mcp-server.py \
-            scripts/mcp-requirements.txt \
-            --title "AI Documentation Bundle" \
-            --notes "Chainguard AI documentation bundle for use with AI coding assistants."
-        fi
+    - name: Clean up old releases
+      if: github.ref == 'refs/heads/main'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Keep only the 10 most recent dated releases; delete older ones
+        gh release list --limit 100 --json tagName,createdAt \
+          | jq -r '[.[] | select(.tagName | test("^ai-docs-[0-9]{8}-[0-9]{6}$"))] | sort_by(.createdAt) | reverse | .[10:] | .[].tagName' \
+          | while read -r tag; do
+              echo "Deleting old release: $tag"
+              gh release delete "$tag" --yes --cleanup-tag
+            done
+        echo "Release cleanup complete"

--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -286,29 +286,3 @@ jobs:
         fi
 
 
-    - name: Update GitHub Release
-      if: (github.event.inputs.create_release == 'true' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Org ruleset makes releases immutable (can't delete assets).
-        # Use --clobber to overwrite existing assets in place.
-        TAG="ai-docs-bundle"
-
-        if gh release view "$TAG" > /dev/null 2>&1; then
-          echo "Updating existing $TAG release..."
-
-          gh release upload "$TAG" --clobber \
-            "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz" \
-            "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz.bundle"
-
-          echo "Release assets updated"
-        else
-          echo "Creating new $TAG release..."
-          gh release create "$TAG" \
-            "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz" \
-            "$TEMP_BUILD_DIR/chainguard-ai-docs.tar.gz.bundle" \
-            --title "AI Documentation Bundle" \
-            --notes "Chainguard AI documentation bundle for use with AI coding assistants."
-        fi

--- a/.github/workflows/compile-public-docs.yml
+++ b/.github/workflows/compile-public-docs.yml
@@ -170,35 +170,6 @@ jobs:
         
         echo "Security scan passed - no secrets detected"
 
-    - name: Create release
-      if: (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true') || github.event_name == 'push'
-      continue-on-error: true  # Org ruleset makes release assets immutable; container/GCS are primary distribution
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd static/downloads
-        
-        # Use a fixed tag for the latest release
-        TAG="ai-docs-bundle"
-        
-        # Org ruleset makes releases immutable (can't delete assets).
-        # Use --clobber to overwrite existing assets in place.
-
-        if gh release view "$TAG" > /dev/null 2>&1; then
-          gh release upload "$TAG" --clobber \
-            chainguard-ai-docs.tar.gz \
-            chainguard-ai-docs.tar.gz.bundle \
-            chainguard-ai-docs.md.bundle \
-            checksums.txt
-        else
-          gh release create "$TAG" \
-            --title "AI Documentation Bundle - Latest" \
-            --notes "Chainguard AI documentation bundle for use with AI coding assistants." \
-            chainguard-ai-docs.tar.gz \
-            chainguard-ai-docs.tar.gz.bundle \
-            chainguard-ai-docs.md.bundle \
-            checksums.txt
-        fi
 
     - name: Login to GHCR
       if: github.ref == 'refs/heads/main'

--- a/content/ai-docs-security.md
+++ b/content/ai-docs-security.md
@@ -88,12 +88,10 @@ Example patterns we redact:
 
 ### Direct Download Verification
 
-> **Note:** The assets in this release are static and not updated automatically. These verification steps apply to the archived snapshot. For current documentation, use the container distribution.
-
 ```bash
 # 1. Download files
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.tar.gz.bundle
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.tar.gz.bundle
 
 # 2. Verify signature (using cosign v3 bundle format)
 cosign verify-blob \

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -42,11 +42,9 @@ Choose your preferred distribution method:
 
 ### GitHub Release
 
-> **Note:** The assets in this release are static and not updated automatically. For current documentation, use the container distribution below.
-
 | Format | Description | Verification |
 |--------|-------------|-------------|
-| [Archived Bundle](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) | Static documentation bundle snapshot with Cosign signatures | Includes Cosign signatures and certificates |
+| [Latest Release](https://github.com/chainguard-dev/edu/releases/latest) | Cryptographically signed documentation bundle | Includes Cosign signatures and certificates |
 
 ### Container Distribution
 
@@ -121,7 +119,7 @@ Add to your `claude_desktop_config.json`:
 - Searchable and queryable documentation
 - Perfect for automated workflows
 - Works with Claude Desktop, Cursor, and other MCP-compatible tools
-- Also available as a [standalone Python script (static snapshot)](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) (no Docker required)
+- Also available as a [standalone Python script](https://github.com/chainguard-dev/edu/releases/latest) (no Docker required)
 
 [**Full MCP Server Documentation →**](/mcp-server-ai-docs/)
 

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -242,14 +242,14 @@ latest, latest-dev, 3.13, 3.13-dev, ...
 
 ## Standalone Installation (without Docker)
 
-The MCP server is also available as a standalone Python script. These files are static snapshots from the [archived GitHub release](https://github.com/chainguard-dev/edu/releases/tag/ai-docs-bundle) and are not automatically updated. For current documentation, use the container distribution above.
+The MCP server is also available as a standalone Python script from the [latest GitHub release](https://github.com/chainguard-dev/edu/releases/latest):
 
 ```bash
 # Download the MCP server, requirements, docs, and catalog
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/mcp-server.py
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/mcp-requirements.txt
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/chainguard-ai-docs.md
-curl -LO https://github.com/chainguard-dev/edu/releases/download/ai-docs-bundle/image-catalog.json
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/mcp-server.py
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/mcp-requirements.txt
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/chainguard-ai-docs.md
+curl -LO https://github.com/chainguard-dev/edu/releases/latest/download/image-catalog.json
 
 # Install dependencies
 pip install -r mcp-requirements.txt


### PR DESCRIPTION
fix: switch AI docs releases to dated tags, consolidate release creation in GCS workflow

Summary

  - Replaces the frozen ai-docs-bundle release tag with dated tags (ai-docs-YYYYMMDD-HHMMSS), which are not subject to
   the org immutable releases ruleset
  - Adds cosign blob signing (.bundle files) to the GCS workflow, matching the signing that previously only existed in
   the other two workflows
  - Removes release creation from compile-public-docs.yml and compile-docs.yml — the GCS workflow is now the sole
  release creator, as it's the only workflow with complete content from all source repositories
  - Adds a cleanup step to retain only the 10 most recent dated releases
  - Updates all user-facing download URLs in three content pages from hardcoded /releases/download/ai-docs-bundle/ to
  /releases/latest/download/, which GitHub redirects to the most recent --latest release

  Context

  The ai-docs-bundle GitHub Release tag was covered by an org immutable releases ruleset. gh release upload --clobber
  silently failed on every run (the step had continue-on-error: true), leaving release assets permanently frozen while
   the container and GCS continued updating correctly. The security team confirmed there is no way to create a per-tag
   exemption without disabling the ruleset entirely.

  Testing (has been done)

  - Compilation pipeline validated: triggered workflow_dispatch on this branch against chainguard-dev/edu — completed
  successfully, confirming GCS authentication, all-repo download, compilation, and GCS upload are unaffected by these
  changes
  - Cleanup logic validated: tested the jq filter locally with a simulated 12-release + ai-docs-bundle input —
  correctly identified the 2 oldest dated releases for deletion, left the 10 most recent untouched, and ignored
  ai-docs-bundle entirely
  - Release creation and signing steps are gated on if: github.ref == 'refs/heads/main' and cannot be fully exercised
  pre-merge; the logic uses standard gh release create with a guaranteed-unique timestamped tag, which cannot
  encounter the immutability error

