### PR TITLE
fix(docs) correct npm env var substitution syntax in .npmrc example

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -196,7 +196,7 @@ with a specific prefix to a different registry:
 ```
 # .npmrc
 registry=https://libraries.cgr.dev/javascript/
-//libraries.cgr.dev/javascript/:_auth={$token}
+//libraries.cgr.dev/javascript/:_auth=${token}
 
 @your-org:registry=https://registry.npmjs.org/
 ```


### PR DESCRIPTION
## What

Fixes the `.npmrc` env var syntax in the scoped registry example in `content/chainguard/libraries/javascript/build-configuration.md` and the static docs bundle. `{$token}` → `${token}`.

## Why

npm's `.npmrc` env var substitution requires the dollar sign before the brace (`${VAR}`). The previous `{$token}` syntax is not recognized by npm and would be passed as a literal string, silently breaking authentication for any user who copied the snippet.

## References

- [npm docs: Environment Variables](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#environment-variables)