### PR TITLE
Add manual npmrc config instructions to JavaScript build config

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -256,7 +256,7 @@ chainctl auth configure-npm
 
 Alternatively, you can configure the `.npmrc` file manually:
 
-{{< details "Configure .npmcr manually" >}}
+{{< details "Configure .npmrc manually" >}}
 The following steps configure registry
 access with authentication in the `.npmrc` file in the current project
 directory:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -276,7 +276,7 @@ coreutils versions included in most operating systems.
 
 **Example .npmrc file**
 
-```.npmrc
+```
 registry=https://libraries.cgr.dev/javascript/
 //libraries.cgr.dev/javascript/:_auth=aWRlbnRpdHktaWQ6dG9rZW4=
 ```

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -226,6 +226,11 @@ and all other packages should resolve to `libraries.cgr.dev/javascript`.
 
 ### Minimal example project
 
+For testing purposes, you can use direct access and environment variables as
+detailed in the [access documentation](/chainguard/libraries/access/#env). 
+
+**1. Create a JavaScript project**
+
 Use the following steps to create a minimal example project for npm with
 Chainguard Libraries for JavaScript.
 
@@ -235,21 +240,49 @@ cd npm-example
 npm init -y
 ```
 
-For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#env). 
+**2. Configure the .npmrc file**
 
-Once
-the environment variables are set, run the following command to configure registry
+Once the environment variables are set, configure the `.npmrc` file. 
+
+Run the following command to configure registry
 access and authentication in the `.npmrc` file in the current project
 directory:
 
 ```shell
-chainctl auth configure-npm --pull-token
+chainctl auth configure-npm
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
-#### Verify authentication with npm ping
+Alternatively, you can configure the `.npmrc` file manually:
+
+{{< details "Configure .npmcr manually" >}}
+The following steps configure registry
+access with authentication in the `.npmrc` file in the current project
+directory:
+
+```shell
+export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
+
+npm config set registry https://libraries.cgr.dev/javascript/ --location=project
+npm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
+```
+
+Note that the trailing slash in the registry URL is required, and that setting
+`username` and `_password` instead of `auth` with a token does not work with
+npm. The `-w 0` option for `base64` is required and supported by the GNU
+coreutils versions included in most operating systems.
+{{< /details >}}
+
+**Example .npmrc file**
+
+```.npmrc
+registry=https://libraries.cgr.dev/javascript/
+//libraries.cgr.dev/javascript/:_auth=aWRlbnRpdHktaWQ6dG9rZW4=
+```
+The value of `auth` is the base64 encoding of `identity-id:token`, including the `/` character in the username.
+
+**3. Verify authentication with npm ping**
 
 Before installing packages, you can verify that authentication is configured correctly by running:
 
@@ -265,7 +298,7 @@ npm notice PONG 1065ms
 
 The PONG response confirms that your credentials are valid and the registry is reachable. If the command fails, check that the .npmrc file exists in the current directory and that your token has not expired.
 
-#### Add dependencies for the project
+**4. Add dependencies and build the project**
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to minimal example project for npm

### What should this PR do?
Add back the manual instructions for configuring npmrc and include example config

### Why are we making this change?
Internal questions: https://chainguard-dev.slack.com/archives/C09MK1VTHL6/p1777386930837799

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?
Review the deploy preview