### PR TITLE
Add Python 3.9 EOL info to libraries docs

### DIFF
--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -99,6 +99,15 @@ Chainguard Libraries is available for the following library ecosystems:
 * Python and the larger ecosystem with
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/)
 
+## Library version support
+
+When a library version reaches end of life (EOL) upstream, Chainguard Libraries continues to build packages and provide security fixes for that version for six months beyond the upstream EOL date.
+
+After that six-month window closes, Chainguard Libraries will:
+- No longer build new packages that require the EOL version
+- No longer provide security fixes for packages built against the EOL version
+- Continue to serve previously built packages, but these will not receive updates
+
 ## Other resources
 
 * [Chainguard Libraries product page](https://www.chainguard.dev/libraries)

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -106,7 +106,7 @@ When a library version reaches end of life (EOL) upstream, Chainguard Libraries 
 After that six-month window closes, Chainguard Libraries will:
 - No longer build new packages that require the EOL version
 - No longer provide security fixes for packages built against the EOL version
-- Continue to serve previously built packages, but these will not receive updates
+- Continue to serve previously built packages
 
 ## Other resources
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -149,19 +149,11 @@ where NVIDIA publishes them directly.
 
 ## Python version support
 
-When a Python version reaches [end of life (EOL) upstream](https://devguide.python.org/versions/), Chainguard Libraries continues to build packages and provide security fixes for that version for six months beyond the upstream EOL date.
-
-After that six-month window closes, Chainguard Libraries will:
-- No longer build new packages that require the EOL Python version
-- No longer provide security fixes for packages built against the EOL Python version
-- Continue to serve previously built packages, but these will not receive updates
-
-### Python 3.9 EOL
-
 Python 3.9 reached upstream EOL on October 31, 2025. Chainguard Libraries' extended support window for Python 3.9 ends on May 15, 2026. After this date, no new Python 3.9 packages will be built, and existing Python 3.9 packages will no longer receive security updates.
 
 To continue receiving up-to-date, secure packages from Chainguard Libraries, we strongly recommend migrating to a supported Python version. Currently supported versions are Python 3.10 and later.
 
+Learn about Chainguard's library version support in the [Libraries overview](/chainguard/libraries/overview/#library-version-support).
 
 ## Runtime and build requirements
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -147,6 +147,22 @@ must configure your package manager to pull NVIDIA components from an
 upstream source such as NVIDIA's index at https://pypi.nvidia.com, or from PyPI 
 where NVIDIA publishes them directly.
 
+## Python version support
+
+When a Python version reaches [end of life (EOL) upstream](https://devguide.python.org/versions/), Chainguard Libraries continues to build packages and provide security fixes for that version for six months beyond the upstream EOL date.
+
+After that six-month window closes, Chainguard Libraries will:
+- No longer build new packages that require the EOL Python version
+- No longer provide security fixes for packages built against the EOL Python version
+- Continue to serve previously built packages, but these will not receive updates
+
+### Python 3.9 EOL
+
+Python 3.9 reached upstream EOL on October 31, 2025. Chainguard Libraries' extended support window for Python 3.9 ends on May 15, 2026. After this date, no new Python 3.9 packages will be built, and existing Python 3.9 packages will no longer receive security updates.
+
+To continue receiving up-to-date, secure packages from Chainguard Libraries, we strongly recommend migrating to a supported Python version. Currently supported versions are Python 3.10 and later.
+
+
 ## Runtime and build requirements
 
 The runtime requirements for Python artifacts available from Chainguard


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to Python overview page

### What should this PR do?
Explain the general EOL policy and the specific dates for Python 3.9 EOL

### Why are we making this change?
Awareness for 3.9 support ending soon

### What are the acceptance criteria? 
Content should be clear and accurate and appear in the expected location

### How should this PR be tested?
Review the deploy preview