### PR TITLE
Fix: allow release-assets.githubusercontent.com in AI docs workflow

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -45,6 +45,7 @@ jobs:
           iamcredentials.googleapis.com:443
           oauth2.googleapis.com:443
           objects.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           pypi.org:443
           raw.githubusercontent.com:443
           rekor.sigstore.dev:443


### PR DESCRIPTION
GitHub now redirects release asset downloads to release-assets.githubusercontent.com, which was blocked by harden-runner's egress policy, causing cosign install to fail with curl exit code 6 (could not resolve host).

This fixes that issue.