### PR TITLE
Revert instructions for configure-npm with pnpm

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -521,16 +521,28 @@ pnpm init
 For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#env). 
 
-Once
-the environment variables are set, the following steps configure registry
+Once the environment variables are set, the following steps configure registry
 access and authentication in the `.npmrc` file in the current project
 directory:
 
-```shell
-chainctl auth configure-npm --pull-token
+```bash
+export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
+
+pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
+pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+Note that the `-w 0` option for `base64` is required and supported by the GNU
+coreutils versions included in most operating systems. To avoid the use of
+`base64`, which can behave differently across operating systems, you can
+alternatively set `username` and `_password` instead of `auth` with a token.
+
+```shell
+pnpm config set //libraries.cgr.dev/javascript/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
+pnpm config set //libraries.cgr.dev/javascript/:_password "${CHAINGUARD_JAVASCRIPT_TOKEN}" --location=project
+```
+
+Also note that the trailing slash in the registry URL is required.
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to pnpm minimal example in Build configuration docs

### What should this PR do?
Revert the instructions for updating your npmrc file

### Why are we making this change?
Issue reported here: https://chainguard-dev.slack.com/archives/C09MK1VTHL6/p1778080178619079

### What are the acceptance criteria? 
Content should appear in the expected location

### How should this PR be tested?
Review the deploy preview