### PR TITLE
Add self-serve to docs

### DIFF
--- a/content/chainguard/self-serve/_index.md
+++ b/content/chainguard/self-serve/_index.md
@@ -1,0 +1,10 @@
+---
+title : "Self-serve"
+lead: ""
+description: "Signing yourself up for Chainguard products"
+type: "article"
+date: 2026-05-12T01:00:01+00:00
+lastmod: 2026-05-12T01:00:01+00:00
+draft: false
+weight: 005
+---

--- a/content/chainguard/self-serve/_index.md
+++ b/content/chainguard/self-serve/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "Self-serve"
 lead: ""
-description: "Signing yourself up for Chainguard products"
+description: "How to sign yourself up for Chainguard products"
 type: "article"
 date: 2026-05-12T01:00:01+00:00
 lastmod: 2026-05-12T01:00:01+00:00

--- a/content/chainguard/self-serve/overview.md
+++ b/content/chainguard/self-serve/overview.md
@@ -14,14 +14,15 @@ being able to Chainguard products (images etc.) on their own
 without any direct help or involvement of Chainguard employees.
 
 This applies to both paying customers/prospects, as well
-as *free-tier* users who have not formally engaged with us (yet).
+as *Free-tier* users who have not formally engaged with us (yet).
 
 **Catalog Starter** refers to a specific plan that enables users
 to self-serve up to 5 images for free.
 
 The Catalog Starter plan has the following restrictions:
 
-- You must be authenticated with a business email address using one of the following:
+You must be authenticated with a business email address using one of the following:
+
 - Email and password
 - Google (only if your business uses a Google Workspace account)
 
@@ -66,7 +67,7 @@ To add one or more images, run the following command, substituting the desired i
 chainctl image entitlements add-images $IMAGE1 $IMAGE2
 ```
 
-After the Chainguard system has processed your request, the image(s) will be accessible. This will take anywhere from a few minutes (best case) to a few hours. When available, you will be able to pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name.
+After the Chainguard system has processed your request, the image(s) will be accessible. This can take up to a few hours. When available, you will be able to pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name.
 
 ```shell
 docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest

--- a/content/chainguard/self-serve/overview.md
+++ b/content/chainguard/self-serve/overview.md
@@ -1,0 +1,81 @@
+---
+title : "Self-serve overview"
+lead: ""
+description: "Signing yourself up for Chainguard products"
+type: "article"
+date: 2026-05-12T01:00:01+00:00
+lastmod: 2026-05-12T01:00:01+00:00
+draft: false
+weight: 010
+---
+
+**Self-Serve** is a general term to capture all forms of users
+being able to Chainguard products (images etc.) on their own
+without any direct help or involvement of Chainguard employees.
+
+This applies to both paying customers/prospects, as well
+as *free-tier* users who have not formally engaged with us (yet).
+
+**Catalog Starter** refers to a specific plan that enables users
+to self-serve up to 5 images for free.
+
+The Catalog Starter plan has the following restrictions:
+
+- You must be authenticated with a business email address using one of the following:
+- Email and password
+- Google (only if your business uses a Google Workspace account)
+
+Other limitations include:
+
+- Only a maximum of 5 Chainguard Images can be used
+- Only images from the following tiers are available:
+  - AI
+  - APPLICATION
+  - BASE
+- No access to nested UIDP image repos, such as Helm charts
+
+## Sign up with `chainctl`
+
+The current method for signing up is with `chainctl`.
+
+To begin, sign up with a brand new account (identity)
+using the following interactive command:
+
+```shell
+chainctl catalog-starter create
+```
+
+This will require selection of a valid authentication option:
+
+```shell
+    Choose an identity provider to login to Chainguard
+
+  > Google
+    Email and password
+```
+
+Click 'Enter' for either, which will launch a browser window to the Chainguard console to complete sign-up.
+
+## Add images
+
+You can see which images are available [using the Chainguard Directory](chainguard/chainguard-images/how-to-use/chainguard-directory/), but remember the images available are limited to the tiers mentioned above.
+
+To add one or more images, run the following command, substituting the desired image names for the variables:
+
+```shell
+chainctl image entitlements add-images $IMAGE1 $IMAGE2
+```
+
+After the Chainguard system has processed your request, the image(s) will be accessible. This will take anywhere from a few minutes (best case) to a few hours. When available, you will be able to pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name.
+
+```shell
+docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest
+```
+
+## Add additional users
+
+To request access for additional users for your organization, use:
+
+```shell
+chainctl catalog-starter request-access
+```

--- a/content/chainguard/self-serve/overview.md
+++ b/content/chainguard/self-serve/overview.md
@@ -13,9 +13,6 @@ weight: 010
 being able to Chainguard products (images etc.) on their own
 without any direct help or involvement of Chainguard employees.
 
-This applies to both paying customers/prospects, as well
-as *Free-tier* users who have not formally engaged with us (yet).
-
 **Catalog Starter** refers to a specific plan that enables users
 to self-serve up to 5 images for free.
 
@@ -43,7 +40,7 @@ To begin, sign up with a brand new account (identity)
 using the following interactive command:
 
 ```shell
-chainctl catalog-starter create
+chainctl starter init
 ```
 
 This will require selection of a valid authentication option:
@@ -51,11 +48,11 @@ This will require selection of a valid authentication option:
 ```shell
     Choose an identity provider to login to Chainguard
 
-  > Google
-    Email and password
+  > Email and password
+    Google
 ```
 
-Click 'Enter' for either, which will launch a browser window to the Chainguard console to complete sign-up.
+Use the arrow keys and click 'Enter' to select either, which will launch a browser window to the Chainguard console to complete sign-up.
 
 ## Add images
 
@@ -64,7 +61,7 @@ You can see which images are available [using the Chainguard Directory](chaingua
 To add one or more images, run the following command, substituting the desired image names for the variables:
 
 ```shell
-chainctl image entitlements add-images $IMAGE1 $IMAGE2
+chainctl starter add-images $IMAGE1 [$IMAGE2]
 ```
 
 After the Chainguard system has processed your request, the image(s) will be accessible. This can take up to a few hours. When available, you will be able to pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name.
@@ -73,10 +70,18 @@ After the Chainguard system has processed your request, the image(s) will be acc
 docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest
 ```
 
+## Find status
+
+To show the status of your catalog starter organization, including the registry path, account provisioning status, image quota usage, and per-image readiness, use:
+
+```shell
+chainctl starter status
+```
+
 ## Add additional users
 
 To request access for additional users for your organization, use:
 
 ```shell
-chainctl catalog-starter request-access
+chainctl starter request-access
 ```


### PR DESCRIPTION
We are enabling users to sign up for Chainguard as customers themselves and are calling it "self-serve".

Because it will eventually cover many (all?) of our products, I have put the new page at the top of the product section of the documentation.

There will eventually be a need for images in the page, which requires that the page be in a directory, so that's how that happened.

This is rudimentary at the moment as the only way this can be done is via some new `chainctl` commands. This is also a pretty urgent request, so it isn't yet refined. This is truly the traditional open source MVP that will evolve and improve over time.

Fixes https://github.com/chainguard-dev/internal/issues/5842 but there will certainly be a newer issue created next week once Matthew meets with people working on the project and we move forward. This is baby step number one.