### PR TITLE
Adding April learning labs page

### DIFF
--- a/content/software-security/learning-labs/_index.md
+++ b/content/software-security/learning-labs/_index.md
@@ -3,7 +3,7 @@ title: "Learning Labs"
 description: "Education and training videos on demand"
 type: "article"
 date: 2025-06-18T21:00:00+00:00
-lastmod: 2025-12-17T21:00:00+00:00
+lastmod: 2026-05-13T21:00:00+00:00
 draft: false
 images: []
 tags: ["Learning Labs", "Overview"]
@@ -22,6 +22,7 @@ The lab notes often include demo projects, a slide presentation, sample
 commands, links to specific sections in the video, and pointers to more
 resources:
 
+- [{{<icon "play-circle-fill">}} Securing CI/CD with Chainguard - April 2026](/software-security/learning-labs/ll202604/)
 - [{{<icon "play-circle-fill">}} Software supply chain attacks and Chainguard Libraries - March 2026](/software-security/learning-labs/ll202603/)
 - [{{<icon "play-circle-fill">}} AI-assisted migration to Chainguard Containers - February 2026](https://www.youtube.com/watch?v=JUPBtq3DyUw&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)
 - [{{<icon "play-circle-fill">}} AI with hardened containers and libraries - January 2026](https://www.youtube.com/watch?v=hkoj-dm-5z8&list=PLLjvkjPNmuZmvi2ZDXicVAWAC_mg2Jpgn)

--- a/content/software-security/learning-labs/ll202604.md
+++ b/content/software-security/learning-labs/ll202604.md
@@ -1,0 +1,47 @@
+---
+title: "Securing CI/CD with Chainguard"
+linktitle: "Strategies to Mitigate Risks in your CI/CD Pipelines"
+description: "Learning lab for April 2026 on recent software supply chain incidents in GitHub Actions and how to leverage Chainguard products and tools to mitigate risks"
+type: "article"
+date: 2026-04-30T12:00:00+00:00
+lastmod: 2026-04-30T12:00:00+00:00
+draft: false
+tags: ["Learning Labs", "Chainguard Actions"]
+menu:
+  docs:
+    parent: "learning-labs"
+weight: 90
+toc: true
+---
+
+The April 2026 Learning Lab with Erika Heidi goes through how attackers exploit vulnerable GitHub Actions workflows, and how Chainguard can protect your CI/CD pipelines from these threats. 
+{{< youtube D9tORVR4H9g }}
+
+## Sections
+
+- [0:00](https://www.youtube.com/watch?v=D9tORVR4H9g) Introduction and agenda
+- [5:31](https://www.youtube.com/watch?v=D9tORVR4H9g&t=331s) Timeline of CI/CD software supply chain incidents
+- [11:25](https://www.youtube.com/watch?v=D9tORVR4H9g&t=685s) Open Source and CI/CD as the new target
+- [12:47](https://www.youtube.com/watch?v=D9tORVR4H9g&t=767s) 2026: the year of AI-assisted attacks
+- [15:16](https://www.youtube.com/watch?v=D9tORVR4H9g&t=916s) Unpacking the Trivy Compromise
+- [19:57](https://www.youtube.com/watch?v=D9tORVR4H9g&t=1197s) Secret exfiltration live demo
+- [36:17](https://www.youtube.com/watch?v=D9tORVR4H9g&t=2177s) What could unfold from here
+- [39:04](https://www.youtube.com/watch?v=D9tORVR4H9g&t=2344s) Strategies to mitigate risks
+- [39:24](https://www.youtube.com/watch?v=D9tORVR4H9g&t=2364s) Repository inspection for insecure defaults
+- [44:03](https://www.youtube.com/watch?v=D9tORVR4H9g&t=2643s) Minimize attack surface
+- [48:48](https://www.youtube.com/watch?v=D9tORVR4H9g&t=2928s) Pull from trusted sources
+- [52:21](https://www.youtube.com/watch?v=D9tORVR4H9g&t=3141s) Pin by digest
+- [54:28](https://www.youtube.com/watch?v=D9tORVR4H9g&t=3268s) Use short lived tokens (ban PATs)
+- [55:32](https://www.youtube.com/watch?v=D9tORVR4H9g&t=3332s) Use Chainguard Actions
+- [58:55](https://www.youtube.com/watch?v=D9tORVR4H9g&t=3535s) Closing notes
+
+
+
+## Resources
+
+- [Slide deck](/downloads/learning-lab-securing-cicd-202604.pdf)
+- [Chainguard Containers](/chainguard/chainguard-images/overview/)
+- [Chainguard Libraries](/chainguard/libraries/overview/)
+- [Chainguard Actions](https://www.chainguard.dev/actions)
+- [Digestabot](https://github.com/marketplace/actions/update-the-image-digest)
+- [Octo-STS](https://github.com/apps/octo-sts)


### PR DESCRIPTION
This PR adds a page for Learning Labs April 2026 and updates the listing page to include the new one. It also adds the slides in the download folder.