### PR TITLE
docs(debugging): add securityContext and /proc/1/root tips for ephemeral containers

### DIFF
--- a/content/chainguard/chainctl-usage/how-to-install-chainctl.md
+++ b/content/chainguard/chainctl-usage/how-to-install-chainctl.md
@@ -90,6 +90,32 @@ Following that you can use `chainctl`. Be aware that Windows PowerShell does not
 
 Also, please note that while [`chainctl` commands](/chainguard/chainctl/) will generally work, some are not as thoroughly tested on Windows and may not behave as expected.
 
+#### Docker credential helper on Windows
+On Windows, `chainctl auth configure-docker` updates your Docker config, but Docker also expects a `docker-credential-cgr.exe` helper to be available on your `PATH`. To make Docker pulls work:
+
+1. Add `chainctl.exe` to the `PATH` (replace `C:\Tools` with the actual directory you used):
+
+```PowerShell
+$env:Path += ";C:\Tools"
+```
+
+For a persistent setup, add that directory to your user or system `PATH` via the Windows Environment Variables settings.
+
+2. Authenticate and configure Docker credentials:
+```PowerShell
+chainctl auth login
+chainctl auth configure-docker
+```
+
+3. Create the Docker credential helper symlink in the same directory as `chainctl.exe`:
+```PowerShell
+New-Item -ItemType SymbolicLink -Path "docker-credential-cgr.exe" -Target "chainctl.exe"
+```
+If this command fails with a permissions error, try running PowerShell as Administrator or ensure that Windows Developer Mode is enabled so you can create symbolic links.
+
+Then you can verify Docker pulls from Chainguard by pulling a private image.
+
+Also, please note that while [`chainctl` commands](/chainguard/chainctl/) will generally work, some are not as thoroughly tested on Windows and may not behave as expected.
 
 ## Verifying the `chainctl` binary with Cosign
 

--- a/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
+++ b/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
@@ -187,6 +187,60 @@ curl http://localhost:8001/api/v1/namespaces/default/pods/<pod-name>/ephemeralco
 - Replace `<pod-name>` and `<container-name>` with your actual values.
 - Be sure to match the `volumeMounts` spec to those in your target container.
 
+#### Pods enforcing runAsNonRoot
+
+If the pod enforces `runAsNonRoot: true`, the ephemeral container will fail to start with a `CreateContainerConfigError` because `wolfi-base` runs as root by default. In this case, add a `securityContext` to the patch that matches the target container’s policy:
+
+```
+curl http://localhost:8001/api/v1/namespaces/default/pods/<pod-name>/ephemeralcontainers \
+-X PATCH \
+-H ‘Content-Type: application/strategic-merge-patch+json’ \
+-d ‘
+{
+  "spec": {
+    "ephemeralContainers": [
+      {
+        "name": "debugger",
+        "command": ["sh"],
+        "image": "cgr.dev/chainguard/wolfi-base",
+        "targetContainerName": "<container-name>",
+        "stdin": true,
+        "tty": true,
+        "securityContext": {
+          "runAsUser": 1001,
+          "runAsNonRoot": true,
+          "allowPrivilegeEscalation": false,
+          "capabilities": {
+            "drop": ["ALL"]
+          }
+        },
+        "volumeMounts": [
+          {
+            "mountPath": "/var/log",
+            "name": "varlog",
+            "readOnly": true
+          }
+        ]
+      }
+    ]
+  }
+}’
+```
+
+Set `runAsUser` to match the UID of the target container’s process. You can find this in the Pod spec’s `securityContext.runAsUser`, or by running `ps aux` in the ephemeral container before the `securityContext` constraint takes effect.
+
+#### Accessing the target container’s filesystem without volumeMounts
+
+As an alternative to replicating `volumeMounts`, you can access the target container’s filesystem directly via `/proc/1/root/<path>` in the ephemeral container. Because `targetContainerName` puts the ephemeral container in the same PID namespace as the target, PID 1 is the target container’s main process, and `/proc/1/root/` traverses its full mount namespace — including Kubernetes-backed volumes such as `emptyDir`, `configMap`, `secret`, and persistent volume claims.
+
+For example, to read a log file from the target container:
+
+```shell
+cat /proc/1/root/var/log/app/app.log
+```
+
+This requires the ephemeral container to run as the same UID as the target process, which is why the `securityContext` fix above is a prerequisite. If security policies in your environment block `/proc/<pid>/root` access (for example, strict seccomp or AppArmor profiles), use the explicit `volumeMounts` approach instead.
+
 Attach to the debug container:
 ```
 kubectl attach <pod-name> -c debugger -ti


### PR DESCRIPTION
## Summary

- **securityContext required for runAsNonRoot pods**: `wolfi-base` runs as root by default. If a pod enforces `runAsNonRoot: true` (without an explicit `runAsUser`), adding an ephemeral debug container without a matching `securityContext` will fail with `CreateContainerConfigError: container has runAsNonRoot and image will run as root`. Added a `#### Pods enforcing runAsNonRoot` subsection with an updated patch example.

- **/proc/1/root/ as an alternative to volumeMounts**: When `targetContainerName` is set, the ephemeral container shares the PID namespace and can access the target container's full mount namespace via `/proc/1/root/<path>` — including both overlay filesystem paths and Kubernetes-backed volumes (emptyDir, configMap, PVCs). This requires matching UIDs. Added a `#### Accessing the target container's filesystem without volumeMounts` subsection explaining when to use this vs. explicit volumeMounts.

Both additions sourced from customer feedback (ticket #8947) and verified against a live k3d cluster.

## Test plan

- [x] Deployed pod with `runAsNonRoot: true` (no `runAsUser`) and confirmed ephemeral `wolfi-base` container fails with `CreateContainerConfigError`
- [x] Added `securityContext: {runAsUser: 65532, runAsNonRoot: true}` to the patch and confirmed container starts
- [x] Deployed pod with emptyDir volume at `/var/log` and file at `/tmp` (overlay); confirmed both accessible via `/proc/1/root/` from ephemeral container without volumeMounts
- [x] Confirmed `/var/log` in ephemeral container is empty without explicit volumeMounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)