### PR TITLE
Update JS build config pnpm instructions

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -405,10 +405,19 @@ values in the `integrity` field and other information for each module.
 **Direct access: Point registry to Chainguard**
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to Chainguard in your user `.npmrc` file: 
+URL to point to Chainguard and set auth credentials. The following command writes to the project-level configuration:
 
 ```bash
-pnpm config set registry https://libraries.cgr.dev/javascript/
+pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
+```
+
+To set the registry at the user level instead of project-level, omit the `--location=project` flag.
+
+The configuration should look like the following:
+
+```properties
+registry=https://libraries.cgr.dev/javascript/
+//libraries.cgr.dev/javascript/:_auth=<base64-encoded-token>
 ```
 
 ### Using a repository manager 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -405,12 +405,14 @@ values in the `integrity` field and other information for each module.
 **Direct access: Point registry to Chainguard**
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to Chainguard and set auth credentials. You can set auth and configure the registry by using the `chainctl auth configure-npm --pull-token`, as demonstrated in the [minimal example project](#minimal-example-project-1) on this page.
-
-Alternatively, you can manually set the registry and auth credentials. The following command writes to the project-level configuration:
+URL to point to Chainguard and set auth credentials. The following command writes to the project-level configuration:
 
 ```bash
+export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
+
 pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
+pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
+pnpm config set //libraries.cgr.dev/javascript-upstream/:_auth "${token}" --location=project
 ```
 
 To set the registry at the user level instead of project-level, omit the `--location=project` flag.
@@ -420,6 +422,7 @@ The configuration should look like the following:
 ```properties
 registry=https://libraries.cgr.dev/javascript/
 //libraries.cgr.dev/javascript/:_auth=<base64-encoded-token>
+//libraries.cgr.dev/javascript-upstream/:_auth=<base64-encoded-token>
 ```
 
 ### Using a repository manager 
@@ -532,16 +535,31 @@ pnpm init
 For testing purposes, you can use direct access and environment variables as
 detailed in the [access documentation](/chainguard/libraries/access/#env). 
 
+To create pull token credentials and set them as environment variables, run:
+
+```bash
+eval $(chainctl auth pull-token --output env --repository=javascript)
+```
+
 Once
 the environment variables are set, the following steps configure registry
 access and authentication in the `.npmrc` file in the current project
 directory:
 
-```shell
-chainctl auth configure-npm --pull-token
+```bash
+export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
+
+pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
+pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
+pnpm config set //libraries.cgr.dev/javascript-upstream/:_auth "${token}" --location=project
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) creates a pull token (valid for 30 days by default) scoped to your organization and writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+The trailing slash in the registry URL is required. Note that the `-w 0` option for `base64` is required and supported by the GNU coreutils versions included in most operating systems. To avoid the use of `base64`, which can behave differently across operating systems, you can alternatively set `username` and `_password` instead of `auth` with a token:
+
+```bash
+pnpm config set //libraries.cgr.dev/javascript/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
+pnpm config set //libraries.cgr.dev/javascript/:_password "${CHAINGUARD_JAVASCRIPT_TOKEN}" --location=project
+```
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -405,7 +405,9 @@ values in the `integrity` field and other information for each module.
 **Direct access: Point registry to Chainguard**
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to Chainguard and set auth credentials. The following command writes to the project-level configuration:
+URL to point to Chainguard and set auth credentials. You can set auth and configure the registry by using the `chainctl auth configure-npm --pull-token`, as demonstrated in the [minimal example project](#minimal-example-project-1) on this page.
+
+Alternatively, you can manually set the registry and auth credentials. The following command writes to the project-level configuration:
 
 ```bash
 pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -132,20 +132,6 @@ lockfile, ensure your `.npmrc` or equivalent is configured with Chainguard
 credentials, then reinstall to apply the changes. The `chainctl libraries update-hashes` command will output
 a "Next steps" section that includes the tool-specific command for reinstalling.
 
-> **Note:** Packages that resolve through the Chainguard Repository's upstream
-> npm fallback may still point to `registry.npmjs.org` in your lockfile after
-> running the command. See [Upstream packages](#upstream-packages) for
-> details.
-
-#### Upstream packages
-
-If your organization uses the Chainguard Repository with upstream npm fallback
-enabled, packages that resolve through the upstream registry may still point to
-`registry.npmjs.org` in your lockfile after running `chainctl libraries
-update-hashes`. These packages are not automatically redirected to route through
-Chainguard. Once Chainguard has rebuilt the package from source, a subsequent
-run of `update-hashes` will update it automatically.
-
 ## Provenance and attestations
 Chainguard Libraries for JavaScript include SLSA provenance with signed attestations. 
 These attestations cryptographically link each package to the Chainguard 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to build config and JS overview

### What should this PR do?
- Correct the npm instructions - they mentioned the npmrc but didn't have the correct command to set the npmrc. It now specifies using the `--location=project `flag to set a project-level configuration, and mentions including auth
- Removed content from the JS overview because it is no longer relevant. The `update-hashes` command functionality has been updated so we don't need to mention the upstream package issue.

### Why are we making this change?
The pnpm docs didn't work as written

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?
Review the deploy preview