### PR TITLE
Fix MCP setup instructions for Claude Desktop

### DIFF
--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -4,20 +4,19 @@ lead: "AI-ready documentation bundle for development"
 description: "Compiled Chainguard documentation optimized for use with AI coding assistants"
 type: "article"
 date: 2025-07-29T10:00:00+00:00
-lastmod: 2026-03-30T00:00:00+00:00
+lastmod: 2026-05-20T00:00:00+00:00
 draft: false
 images: []
 weight: 50
 toc: false
 ---
 
-## AI-Ready Documentation Bundle
+## AI-ready documentation bundle
 
-This page provides compiled Chainguard documentation optimized for use with AI coding assistants like Claude, ChatGPT, GitHub Copilot, and others. Access it through our secure container image or as a standalone Python MCP server.
+This page describes a compiled bundle of Chainguard documentation that you can feed to AI coding assistants such as Claude, ChatGPT, or GitHub Copilot. Use it through the Chainguard-built container image or run the bundle as a Python MCP server.
 
-### What's Included
+### What's included
 
-A comprehensive collection of Chainguard documentation including:
 - Complete Chainguard Containers documentation
 - Security best practices and CVE management
 - Migration guides and tutorials
@@ -25,77 +24,76 @@ A comprehensive collection of Chainguard documentation including:
 - Wolfi, melange, and apko documentation
 - Compliance and supply chain security guides
 
-## Download AI Documentation Bundle
+## Download the AI documentation bundle
 
 <div style="background-color: var(--blockquote-background); border-left: 4px solid var(--link-color, #2196F3); padding: 20px; border-radius: 4px; margin: 20px 0;">
-  <h3 style="margin-top: 0; color: var(--body-color);">New: MCP Server Support</h3>
+  <h3 style="margin-top: 0; color: var(--body-color);">MCP server support</h3>
   <p style="color: var(--body-color);">Run the container as an <strong>MCP (Model Context Protocol) server</strong> for searchable, on-demand access to Chainguard documentation in AI assistants and IDEs.</p>
-  <p><a href="/mcp-server-ai-docs/" style="font-weight: bold; text-decoration: none; color: var(--link-color, #2196F3);">→ Full MCP Server Documentation</a></p>
+  <p><a href="/mcp-server-ai-docs/" style="font-weight: bold; text-decoration: none; color: var(--link-color, #2196F3);">→ Full MCP server documentation</a></p>
 </div>
 
-Choose your preferred distribution method:
+Two distribution methods are available:
 
 <div style="background-color: var(--blockquote-background); border-left: 4px solid #4CAF50; padding: 16px; border-radius: 4px; margin: 20px 0;">
-  <strong>Container Distribution Recommended</strong><br>
-  For enhanced security and verification, we recommend using the Chainguard container image. It includes built-in verification, runs as non-root, and is built on our secure <code>wolfi-base</code> image.
+  <strong>Container distribution is recommended.</strong><br>
+  The Chainguard container image includes verification scripts, runs as a non-root user, and is built on <code>wolfi-base</code>. Use it unless you have a reason to download files directly.
 </div>
 
-### Container Distribution
+### Container distribution
 
-Pull the secure, Chainguard-based container with embedded documentation:
+Pull the container, then run it to print usage, verify the bundle, or extract the documentation:
 
 ```bash
 # Pull the container image (built on Chainguard wolfi-base)
 docker pull ghcr.io/chainguard-dev/ai-docs:latest
 
-# View available commands and usage
+# Print available commands
 docker run --rm ghcr.io/chainguard-dev/ai-docs:latest
 
 # Verify documentation integrity
 docker run --rm ghcr.io/chainguard-dev/ai-docs:latest verify
 
-# Extract documentation to current directory
+# Extract documentation to the current directory
 docker run --rm -v $(pwd):/output ghcr.io/chainguard-dev/ai-docs:latest extract /output
 ```
 
-**Container Features:**
+**Container features:**
 - Built on Chainguard's minimal `wolfi-base` image
-- Runs as non-root user for enhanced security
+- Runs as a non-root user
 - Includes verification scripts and checksums
-- Cryptographically signed with Cosign
-- Automatically updated weekly
+- Signed with Cosign
+- Rebuilt weekly
 
-**Verify Container Signature:**
+**Verify the container signature:**
 ```bash
-# Verify the container image signature with Cosign
 cosign verify ghcr.io/chainguard-dev/ai-docs:latest \
   --certificate-identity-regexp ".*github.com/chainguard-dev/edu.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-### MCP Server (Model Context Protocol)
+### MCP server (Model Context Protocol)
 
-**Recommended for:** Developers, agent workflows, IDE integration
+**Recommended for:** developers, agent workflows, IDE integration.
 
-Run the container as an MCP server to provide AI assistants with searchable, on-demand access to Chainguard documentation:
+Run the same container as an MCP server so AI assistants can search the documentation on demand:
 
 ```bash
 # Run as MCP server
 docker run --rm -i ghcr.io/chainguard-dev/ai-docs:latest serve-mcp
 ```
 
-**MCP Tools Available:**
-- `search_docs` - Search across all documentation
-- `get_image_docs` - Get specific container image docs
-- `list_images` - List and filter available images with upstream mappings
-- `get_security_docs` - Get CVE and security information
-- `get_tool_docs` - Get wolfi/apko/melange/chainctl docs
-- `find_package_equivalent` - Find Wolfi packages for upstream OS packages (Debian, Fedora, Alpine)
-- `check_image_freshness` - Live registry check for image tags and availability
+**Available MCP tools:**
+- `search_docs` — search across all documentation
+- `get_image_docs` — return docs for a specific container image
+- `list_images` — list and filter available images, with optional upstream mappings
+- `get_security_docs` — return CVE and security information
+- `get_tool_docs` — return Wolfi, apko, melange, or chainctl docs
+- `find_package_equivalent` — map a Debian, Fedora, or Alpine package to its Wolfi equivalent
+- `check_image_freshness` — query the registry for current image tags
 
-**Claude Desktop Configuration:**
+**Claude Desktop configuration:**
 
-Add to your `claude_desktop_config.json`:
+Add this block to `claude_desktop_config.json`:
 
 ```json
 {
@@ -108,16 +106,11 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-**Benefits:**
-- Efficient context usage - only retrieve what you need
-- Searchable and queryable documentation
-- Perfect for automated workflows
-- Works with Claude Desktop, Cursor, and other MCP-compatible tools
-- Also available as a [standalone Python script](/mcp-server-ai-docs/#standalone-installation-without-docker) (no Docker required)
+To use the hosted server instead of running a container locally, see the [hosted server instructions](/mcp-server-ai-docs/#hosted-server-recommended) — Claude Desktop reaches it through the [`mcp-remote`](https://github.com/geelen/mcp-remote) bridge. A [standalone Python script](/mcp-server-ai-docs/#standalone-installation-without-docker) is also available for setups without Docker.
 
-[**Full MCP Server Documentation →**](/mcp-server-ai-docs/)
+[**Full MCP server documentation →**](/mcp-server-ai-docs/)
 
-### Quick Start
+### Quick start
 
 ```bash
 # Extract current documentation from the container image
@@ -126,43 +119,43 @@ docker run --rm -v $(pwd):/output ghcr.io/chainguard-dev/ai-docs:latest extract 
 # The extracted file 'chainguard-ai-docs.md' is ready to use with your AI assistant
 ```
 
-### Security Features
+### Security features
 
 <div style="border: 2px solid #4CAF50; padding: 20px; border-radius: 8px; margin: 20px 0;">
-  <h4>Available Security Features</h4>
+  <h4>Bundle security</h4>
   <ul>
     <li>Container image signed with Sigstore/Cosign</li>
-    <li>Container distribution via GitHub Container Registry</li>
-    <li>Automated updates via GitHub Actions</li>
-    <li>Security scanning with gitleaks</li>
+    <li>Distributed through GitHub Container Registry</li>
+    <li>Rebuilt weekly through GitHub Actions</li>
+    <li>Scanned with gitleaks during the build</li>
   </ul>
 </div>
 
 
-### Security Transparency
+### Security transparency
 
 <div style="background-color: var(--blockquote-background); border: 1px solid var(--sidebar-item-list-item-selected-background); padding: 16px; border-radius: 6px; margin: 20px 0;">
-  <strong>Security First:</strong> Our documentation bundles are compiled with security measures.
+  <strong>Security first.</strong> The documentation bundles are compiled under controls described on the security page.
   <a href="/ai-docs-security" style="font-weight: bold;">Learn about our security practices →</a>
 </div>
 
-View our security resources:
-- **[Security and Compilation Process](/ai-docs-security)** - Detailed security measures and verification
-- [Build Logs](https://github.com/chainguard-dev/edu/actions/workflows/compile-docs.yml) - Public compilation logs
-- [Source Code](https://github.com/chainguard-dev/edu/tree/main/scripts) - Open source compilation scripts
+Security resources:
+- **[Security and compilation process](/ai-docs-security)** — measures and verification steps
+- [Build logs](https://github.com/chainguard-dev/edu/actions/workflows/compile-docs.yml) — public compilation logs
+- [Source code](https://github.com/chainguard-dev/edu/tree/main/scripts) — open-source compilation scripts
 
-### How to Use with AI Assistants
+### How to use the bundle with AI assistants
 
-1. **Download and verify** the documentation bundle using one of the methods above
-2. **Open your AI assistant** (Claude, ChatGPT, etc.)
-3. **Upload or paste the markdown file** into your conversation
-4. **Start coding** with full Chainguard context available to your AI assistant
+1. Download and verify the documentation bundle using one of the methods above.
+2. Open your AI assistant (Claude, ChatGPT, and others).
+3. Upload or paste the markdown file into the conversation.
+4. Start coding with Chainguard context available to the assistant.
 
-### Example Prompts for Common Tasks
+### Example prompts for common tasks
 
-Once you've loaded the documentation, try these prompts with your AI assistant:
+Once the documentation is loaded, try these prompts with your AI assistant:
 
-#### Container Security and CVEs
+#### Container security and CVEs
 - "Search for Chainguard container security best practices and CVE management"
 - "How do I migrate from Docker Hub images to Chainguard images?"
 - "Show me examples of using Chainguard images in production"
@@ -170,7 +163,7 @@ Once you've loaded the documentation, try these prompts with your AI assistant:
 - "How do I scan Chainguard images for vulnerabilities?"
 - "Explain Chainguard's approach to zero CVE images"
 
-#### Development Workflows
+#### Development workflows
 - "Find information about debugging distroless containers"
 - "How do I use Chainguard images with Kubernetes?"
 - "What are the differences between Chainguard development and production images?"
@@ -178,7 +171,7 @@ Once you've loaded the documentation, try these prompts with your AI assistant:
 - "How do I add custom packages to a Chainguard image?"
 - "Create a Dockerfile using Chainguard's Python image for a Flask app"
 
-#### Specific Technologies
+#### Specific technologies
 - "Show me Chainguard's Python/Node.js/Go image documentation"
 - "Find FIPS-compliant container information"
 - "How do I use Chainguard images for AI/ML workloads?"
@@ -186,7 +179,7 @@ Once you've loaded the documentation, try these prompts with your AI assistant:
 - "How to use Chainguard's PostgreSQL image with custom extensions"
 - "Show examples of using Chainguard's NGINX image with custom configs"
 
-#### Security and Compliance
+#### Security and compliance
 - "Search for SBOM and supply chain security information"
 - "Find information about Chainguard's compliance certifications"
 - "How does Chainguard help with CVE remediation?"
@@ -194,7 +187,7 @@ Once you've loaded the documentation, try these prompts with your AI assistant:
 - "What are Chainguard's SLSA compliance levels?"
 - "How to generate and analyze SBOMs for Chainguard images"
 
-#### CI/CD Integration
+#### CI/CD integration
 - "How do I use Chainguard images in GitHub Actions?"
 - "Show me examples of using Chainguard images with GitLab CI"
 - "How to set up automated vulnerability scanning for Chainguard images"
@@ -208,27 +201,27 @@ Once you've loaded the documentation, try these prompts with your AI assistant:
 - "Common migration issues when moving from Alpine to Wolfi-based images"
 - "How to identify missing dependencies in distroless containers"
 
-#### Architecture and Best Practices
+#### Architecture and best practices
 - "Explain the architecture of Wolfi and how it differs from Alpine"
 - "What is apko and how does it relate to Chainguard images?"
 - "Best practices for minimizing image size with Chainguard"
 - "How to implement a secure software supply chain with Chainguard"
 - "Explain melange and its role in package building"
 
-### Benefits for AI-Assisted Development
+### Benefits for AI-assisted development
 
-- **Complete Context**: AI assistants have access to all Chainguard documentation at once
-- **Better Code Suggestions**: AI can reference actual Chainguard patterns and best practices
-- **Faster Development**: No need to search through multiple documentation pages
-- **Accurate Answers**: AI responses are based on official Chainguard documentation
+- **Complete context.** The assistant can see all Chainguard documentation at once.
+- **Better code suggestions.** The assistant grounds its output in actual Chainguard patterns.
+- **Faster development.** No need to search through multiple documentation pages.
+- **Accurate answers.** Responses come from official Chainguard documentation rather than the model's training data.
 
 ### Updates
 
-The bundle is regenerated periodically. Check the timestamp in the downloaded file for the compilation date.
+The bundle is rebuilt weekly. The compilation date appears at the top of the downloaded file.
 
-### Need Help?
+### Need help?
 
 If you have questions or need assistance:
 - Visit [Chainguard Support](https://support.chainguard.dev?utm=docs)
-- Join our [Community Slack](https://go.chainguard.dev/slack?utm=docs)
-- Review our [Documentation](https://edu.chainguard.dev)
+- Join our [community Slack](https://go.chainguard.dev/slack?utm=docs)
+- Browse the [documentation site](https://edu.chainguard.dev)

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -5,7 +5,7 @@ lead: "Model Context Protocol server for Chainguard documentation"
 description: "Access Chainguard documentation through MCP for AI assistants and automation"
 type: "article"
 date: 2026-01-02T21:00:00+00:00
-lastmod: 2026-04-10T00:00:00+00:00
+lastmod: 2026-05-20T00:00:00+00:00
 draft: false
 images: []
 weight: 600
@@ -15,40 +15,68 @@ aliases:
 
 ## Overview
 
-The Chainguard AI Documentation MCP (Model Context Protocol) server enables AI assistants and automation tools to interact with Chainguard's complete documentation library through a standardized protocol. This provides efficient, searchable access to container image docs, security guides, and tool references without loading entire documentation bundles into context.
+The Chainguard AI Documentation MCP server gives AI assistants and automation tools searchable access to Chainguard's container image docs, security guides, and tool references. The server returns only the sections that match each query, so clients avoid loading the full documentation bundle into context.
 
 ## What is MCP?
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that standardizes how AI applications access external data and tools. MCP servers expose structured data and capabilities that AI assistants can query and use to provide more accurate, context-aware responses.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that standardizes how AI applications access external data and tools. An MCP server exposes structured data and tools that AI clients can call to ground their responses in real information.
 
-## Why Use the MCP Server?
+## Why use the MCP server?
 
-**Efficient Context Usage**
-- Only retrieve relevant documentation sections
-- Avoid loading 2.8 MB of docs into every prompt
-- Search and filter content dynamically
+- **Lower context cost.** Clients fetch only the sections they need instead of loading 2.8 MB of documentation into every prompt.
+- **Structured queries.** Look up a specific image, search for a CVE, or find a package equivalent without writing custom scrapers.
+- **IDE integration.** Works with Claude Code, Claude Desktop, Cursor, and other MCP-compatible clients, so developers can reference Chainguard docs while they write code.
 
-**Better for Agents**
-- Programmatic access to documentation
-- Structured queries (get specific image docs, search CVEs, etc.)
-- Perfect for automated workflows and CI/CD
-
-**IDE Integration**
-- Works with Claude Desktop, Cursor, and other MCP-compatible tools
-- Access Chainguard docs while coding
-- No manual copy/paste needed
-
-## Getting Started
+## Getting started
 
 ### Prerequisites
 
-- MCP-compatible client (Claude Desktop, Cursor, Claude Code, or other MCP-compatible tools)
+- An MCP-compatible client such as Claude Code, Claude Desktop, or Cursor
 
-### Hosted Server (Recommended)
+### Hosted server (recommended)
 
-The fastest way to get started — no Docker or local setup required. Chainguard hosts a public MCP server at `mcp.edu.chainguard.dev`.
+Chainguard hosts a public MCP server at `https://mcp.edu.chainguard.dev/mcp/`. This is the fastest way to get started — no Docker or local setup required.
 
-Add this to your MCP client configuration:
+How you register the server depends on your MCP client. Clients that support HTTP transport natively can connect to the URL directly. Clients that only spawn local processes (including Claude Desktop) need a small bridge such as [`mcp-remote`](https://github.com/geelen/mcp-remote).
+
+#### Claude Code
+
+Run this command:
+
+```bash
+claude mcp add --transport http chainguard-docs https://mcp.edu.chainguard.dev/mcp/
+```
+
+The server is available immediately. Verify it with `claude mcp list`.
+
+#### Claude Desktop
+
+Claude Desktop reads MCP servers from a JSON file but does not yet support HTTP transport directly. Use `mcp-remote` to bridge to the hosted server:
+
+```json
+{
+  "mcpServers": {
+    "chainguard-docs": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.edu.chainguard.dev/mcp/"
+      ]
+    }
+  }
+}
+```
+
+The configuration file lives at:
+
+* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+`npx` downloads and runs `mcp-remote` on demand, so Node.js must be installed on the host. Restart Claude Desktop after saving the file.
+
+#### Cursor and other clients with native HTTP transport
+
+Add the server URL to your client's MCP configuration:
 
 ```json
 {
@@ -60,34 +88,17 @@ Add this to your MCP client configuration:
 }
 ```
 
-For **Claude Desktop**, the configuration file is located at:
+Consult your client's documentation for the configuration file location, then restart the client. The Chainguard documentation tools appear in the next conversation.
 
-* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+### Local Docker setup
 
-For **Claude Code**, add the server from the command line:
-
-```bash
-claude mcp add chainguard-docs --transport http https://mcp.edu.chainguard.dev/mcp/
-```
-
-After adding this configuration, restart your MCP client. The Chainguard documentation tools will be available in your conversations.
-
-### Local Docker Setup
-
-If you prefer to run the MCP server locally, you can use the container image:
+To run the MCP server locally, pull the container image:
 
 ```bash
 docker pull ghcr.io/chainguard-dev/ai-docs:latest
 ```
 
-Run in stdio mode for MCP clients that support local processes:
-
-```bash
-docker run --rm -i ghcr.io/chainguard-dev/ai-docs:latest serve-mcp
-```
-
-Claude Desktop configuration for the local Docker setup:
+The image's `serve-mcp` entrypoint speaks stdio, which works with any MCP client that launches local processes. For Claude Desktop, add this block to `claude_desktop_config.json`:
 
 ```json
 {
@@ -106,9 +117,11 @@ Claude Desktop configuration for the local Docker setup:
 }
 ```
 
-## Available Tools
+Restart the client after saving the file.
 
-The MCP server provides seven tools for querying Chainguard documentation, looking up package compatibility, and checking image availability:
+## Available tools
+
+The server exposes seven tools for querying documentation, mapping packages, and checking image availability.
 
 ### `search_docs`
 
@@ -137,11 +150,11 @@ Get documentation for a specific Chainguard container image.
 
 ### `list_images`
 
-List available Chainguard container images with optional filtering and equivalent mapping info. When the image catalog is available, results include metadata such as documentation status and alternative mappings.
+List Chainguard container images with optional filtering. When the image catalog is available, results include metadata such as documentation status and alternative mappings.
 
 **Parameters:**
 - `filter` (string, optional): Filter images by name or alternate mapping (for example, "python", "nginx", "apache")
-- `include_upstream` (Boolean, optional): Include alternate image mappings and variants in results (default: false)
+- `include_upstream` (boolean, optional): Include alternate image mappings and variants in results (default: `false`)
 
 **Example prompts:**
 - "List all Chainguard images"
@@ -171,7 +184,7 @@ Get documentation for Chainguard tools and ecosystem components.
 
 ### `find_package_equivalent`
 
-Find Chainguard OS or Wolfi package equivalents for other OS packages. This is useful when migrating Dockerfiles from Debian, Fedora, or Alpine to Chainguard images and you need to translate package names for `apk add` commands.
+Find the Wolfi package that replaces a Debian, Fedora, or Alpine package. Use this when migrating a Dockerfile to a Chainguard image and translating package names for `apk add`.
 
 **Parameters:**
 - `package` (string, required): Upstream OS package name (e.g., "build-essential", "libssl-dev", "python3-pip")
@@ -184,7 +197,7 @@ Find Chainguard OS or Wolfi package equivalents for other OS packages. This is u
 
 ### `check_image_freshness`
 
-Check a Chainguard image's availability and list its current tags via a live registry query to `cgr.dev`. Falls back to catalog data if no network access is available.
+Query `cgr.dev` for an image's availability and current tags. Falls back to catalog data if the registry is unreachable.
 
 **Parameters:**
 - `image_name` (string, required): Chainguard image name (such as "python", "node", "nginx")
@@ -194,18 +207,18 @@ Check a Chainguard image's availability and list its current tags via a live reg
 - "Show me the available tags for the nginx image"
 - "Is the golang image available on cgr.dev?"
 
-## Image Catalog
+## Image catalog
 
-The MCP server includes a pre-built image catalog that powers the `list_images`, `find_package_equivalent`, and `check_image_freshness` tools. The catalog contains:
+The `list_images`, `find_package_equivalent`, and `check_image_freshness` tools draw from a pre-built catalog that ships with the server. The catalog includes:
 
-- **All Chainguard container images** with registry references, sourced from image documentation
-- **Package mappings** across Debian, Fedora, and Alpine to Wolfi equivalents
+- Every Chainguard container image with its registry reference, sourced from the image documentation
+- Package mappings from Debian, Fedora, and Alpine to their Wolfi equivalents
 
-The catalog is regenerated automatically as part of the weekly documentation build.
+The weekly documentation build regenerates the catalog.
 
-## Example Usage
+## Example usage
 
-Once configured with Claude Desktop:
+Sample exchanges from a Claude Desktop session with the server connected:
 
 ```
 You: Search for python image security best practices
@@ -240,9 +253,9 @@ The Chainguard Python image (cgr.dev/chainguard/python) is available with these 
 latest, latest-dev, 3.13, 3.13-dev, ...
 ```
 
-## Standalone Installation (without Docker)
+## Standalone installation (without Docker)
 
-The MCP server script and its dependencies are available directly from the repository. The documentation files are distributed via the container image.
+The server script and its dependencies live in the [edu repository](https://github.com/chainguard-dev/edu). The documentation files ship inside the container image, which you can extract once and reuse.
 
 ```bash
 # Download the MCP server script and requirements
@@ -260,7 +273,7 @@ pip install -r mcp-requirements.txt
 DOCS_PATH=chainguard-ai-docs.md CATALOG_PATH=image-catalog.json python3 mcp-server.py
 ```
 
-To use this with Claude Desktop, update your configuration to point to the local script:
+To run this script under Claude Desktop, point the configuration at the local files:
 
 ```json
 {
@@ -277,73 +290,72 @@ To use this with Claude Desktop, update your configuration to point to the local
 }
 ```
 
-## Self-Hosting with HTTP Transport
+## Self-hosting with HTTP transport
 
-You can also self-host the MCP server using Streamable HTTP transport. This is useful for running your own instance behind a firewall or with custom configuration.
+Run your own HTTP instance when you need to expose the server inside a firewall or with custom configuration.
 
-### Standalone
+### From the standalone script
 
 ```bash
 python3 mcp-server.py --transport http --port 8080
 ```
 
-The server will start on `http://0.0.0.0:8080` with the MCP endpoint at `/mcp`.
+The server binds to `http://0.0.0.0:8080` with the MCP endpoint at `/mcp`.
 
-You can also configure via environment variables:
+Environment variables work too:
 
 ```bash
 MCP_TRANSPORT=http MCP_PORT=8080 python3 mcp-server.py
 ```
 
-### Docker
+### From Docker
 
 ```bash
 docker run --rm -p 8080:8080 ghcr.io/chainguard-dev/ai-docs:latest serve-mcp-http
 ```
 
-Then configure your MCP client to connect to `http://localhost:8080/mcp/`.
+Point your MCP client at `http://localhost:8080/mcp/`.
 
-### CLI Flags
+### CLI flags
 
-| Flag | Env Var | Default | Description |
+| Flag | Env var | Default | Description |
 |---|---|---|---|
 | `--transport` | `MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` or `http` |
 | `--host` | `MCP_HOST` | `0.0.0.0` | HTTP server bind address |
 | `--port` | `MCP_PORT` | `8080` | HTTP server port |
 
-## Alternative: Static Documentation
+## Alternative: static documentation
 
-If you don't need MCP server functionality, extract the documentation from the container:
+If you don't need the server at all, extract the documentation file from the container:
 
 ```bash
 docker run --rm -v $(pwd):/output \
   ghcr.io/chainguard-dev/ai-docs:latest extract /output
 ```
 
-See the [Developer Resources](/developer-resources/) page for more details on static extraction.
+See the [Developer Resources](/developer-resources/) page for more on static extraction.
 
-## Security Features
+## Security features
 
-Following Chainguard's security-first approach:
+The container image follows the standard Chainguard pattern:
 
-- **Minimal Image**: Built on `cgr.dev/chainguard/wolfi-base`
-- **Zero CVEs**: Regularly updated to maintain zero known vulnerabilities
-- **Non-root**: Runs as non-root user
-- **Signed**: Container images are signed with Cosign
-- **Transparent**: Full SBOM and provenance available
+- Built on `cgr.dev/chainguard/wolfi-base`
+- Runs as a non-root user
+- Signed with Cosign, with SBOM and provenance attached
+- Rebuilt regularly so known CVEs do not accumulate
 
 ## Troubleshooting
 
-### Server Not Appearing in Claude Desktop
+### Server does not appear in Claude Desktop
 
-1. Check that the configuration file path is correct
-2. Restart Claude Desktop after configuration changes
-3. Check Claude Desktop logs for error messages
-4. If using Docker locally, ensure Docker is running
+1. Confirm that the configuration file path is correct for your platform.
+2. Restart Claude Desktop after editing the file.
+3. Check Claude Desktop's logs for parse or connection errors.
+4. For the local Docker block, confirm Docker is running.
 
-### Connection Issues
+### Connection issues
 
-Test the hosted server:
+Test the hosted server with `curl`:
 
 ```bash
 curl -X POST https://mcp.edu.chainguard.dev/mcp/ \
@@ -352,7 +364,7 @@ curl -X POST https://mcp.edu.chainguard.dev/mcp/ \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 ```
 
-You should receive a JSON response with the server's capabilities.
+A JSON response listing the server's capabilities confirms the connection.
 
 To test a local Docker server:
 
@@ -360,11 +372,11 @@ To test a local Docker server:
 docker run --rm -i ghcr.io/chainguard-dev/ai-docs:latest serve-mcp
 ```
 
-The server should start and display startup messages.
+The container prints startup messages and then waits for stdio input.
 
-### Documentation Out of Date
+### Documentation out of date
 
-The hosted server at `mcp.edu.chainguard.dev` is updated automatically. If using Docker locally, pull the latest image:
+The hosted server updates automatically. For the local Docker setup, pull a fresh image:
 
 ```bash
 docker pull ghcr.io/chainguard-dev/ai-docs:latest
@@ -372,12 +384,12 @@ docker pull ghcr.io/chainguard-dev/ai-docs:latest
 
 ## Resources
 
-- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
-- [Chainguard MCP Blog Post](https://www.chainguard.dev/unchained/meet-chainguard-mcps-bringing-supply-chain-security-to-the-ai-era)
+- [Model Context Protocol documentation](https://modelcontextprotocol.io/)
+- [Chainguard MCP blog post](https://www.chainguard.dev/unchained/meet-chainguard-mcps-bringing-supply-chain-security-to-the-ai-era)
 - [Developer Resources](/developer-resources/)
 - [Chainguard Images Directory](https://images.chainguard.dev/)
 
-## Need Help?
+## Need help?
 
 - [Chainguard Support](https://support.chainguard.dev?utm=docs)
 - [Community Slack](https://go.chainguard.dev/slack?utm=docs)


### PR DESCRIPTION
## Summary

- Claude Desktop's config file only spawns local stdio processes, so the previous JSON snippet that registered the hosted MCP server by URL did not actually work. A solutions architect had to switch to the `npx mcp-remote` bridge to connect.
- Split the **Hosted server** section by client: **Claude Code** uses the `claude mcp add` CLI, **Claude Desktop** uses the `npx mcp-remote` bridge, and **Cursor and other clients with native HTTP transport** use the direct URL form.
- Tightened prose throughout both pages, normalized headings to sentence case (matches the site-wide majority), and standardized the build cadence to "weekly" on both pages.
- Bumped `lastmod` on both pages to 2026-05-20.

Resolves chainguard-dev/internal#5850.

## Test plan

- [x] `npm start` builds the site without errors
- [x] `/mcp-server-ai-docs/` and `/developer-resources/` return HTTP 200 from the Hugo dev server
- [x] Anchors used by cross-page links are preserved: `#hosted-server-recommended`, `#standalone-installation-without-docker`
- [x] New sub-section anchors render: `#claude-code`, `#claude-desktop`, `#cursor-and-other-clients-with-native-http-transport`
- [x] Verified `docker pull ghcr.io/chainguard-dev/ai-docs:latest` still works
- [ ] Reviewer: spot-check the Claude Desktop config block by pasting it into `claude_desktop_config.json` and confirming the server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)