### PR TITLE
update-hashes support for repo managers

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -110,15 +110,6 @@ to apply the updated hashes. The `chainctl libraries update-hashes` command will
 output a "Next steps" section that includes the tool-specific command for
 reinstalling.
 
-> **Note:** If your organization uses the [Chainguard Repository with upstream
-> npm fallback
-> enabled](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls),
-> packages that resolve through the upstream registry may still point to
-> `registry.npmjs.org` in your lockfile after running `chainctl libraries
-> update-hashes`. These packages are not automatically redirected to route
-> through Chainguard. To fully migrate these packages, update their resolved
-> URLs to use `libraries.cgr.dev/javascript-upstream/` manually.
-
 <a id="npm"></a>
 
 ## npm
@@ -236,7 +227,7 @@ npm cache verify
 ### Update lockfile hashes
 
 If you are migrating an existing project and want to preserve your current
-lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes-for-existing-projects)
+lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 to update only the integrity hashes in place instead.
 
 Now you can proceed with your development and testing. 
@@ -536,7 +527,7 @@ Use the path returned by `pnpm store path` and delete it via File Explorer or `r
 ### Update lockfile hashes
 
 If you are migrating an existing project and want to preserve your current
-lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes-for-existing-projects)
+lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 to update only the integrity hashes in place instead.
 
 Now you can proceed with your development and testing. 
@@ -703,7 +694,7 @@ checksumBehavior: reset
 ### Update lockfile hashes
 
 If you are migrating an existing project and want to preserve your current
-lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes-for-existing-projects)
+lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 to update only the integrity hashes in place instead.
 
 Now you can proceed with your development and testing. 
@@ -878,7 +869,7 @@ yarn cache clean
 ### Update lockfile hashes
 
 If you are migrating an existing project and want to preserve your current
-lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes-for-existing-projects)
+lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 to update only the integrity hashes in place instead.
 
 Now you can proceed with your development and testing. 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -69,24 +69,46 @@ recommended. See the [global
 configuration](/chainguard/libraries/javascript/global-configuration/) for setup
 guides.
 
-## Updating lockfile hashes for existing projects
+## Updating lockfile hashes
 
-> **Note**: `chainctl libraries update-hashes` does not currently support authentication through a repository manager. You will need to configure [direct access](#direct-access) credentials before running the command.
+When migrating an existing JavaScript project to Chainguard Libraries, your
+lockfile contains integrity hashes generated against packages previously downloaded from the npm registry or through your repository manager.
+Because Chainguard rebuilds packages in a secured build environment rather than
+distributing upstream artifacts directly, the resulting checksums differ even
+for identical package versions. These hashes must be updated before your package
+manager will accept packages from Chainguard.
 
-If you are migrating an existing JavaScript project to Chainguard Libraries,
-your lockfile likely contains integrity hashes generated against the npm
-registry. Because Chainguard rebuilds packages in a secured build environment rather than distributing upstream artifacts directly, the resulting checksums differ even for identical package versions; they must be updated before reinstalling.
+The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
+for all supported JavaScript lockfile formats. Rather than deleting your
+lockfile and reinstalling from scratch, you can run the command directly against
+your existing lockfile to update integrity hashes and resolved URLs to use
+Chainguard, while preserving the file's format and structure.
 
-Use the following command, in the directory containing the lockfile, to update hashes in place across all supported lockfile formats (`package-lock.json`, `yarn.lock`,
-`pnpm-lock.yaml`, `bun.lock`) without regenerating the lockfile from scratch:
+Supported formats include `package-lock.json` (npm v2/v3), `yarn.lock` (Yarn
+Classic and Berry), `pnpm-lock.yaml`, and `bun.lock`.
+
+Run the command in the directory containing the lockfile:
 
 ```bash
 chainctl libraries update-hashes
 ```
 
-After running the command, ensure your `.npmrc` is configured with Chainguard
-credentials, then reinstall to apply the updated hashes. The `chainctl libraries update-hashes` command will output
-a "Next steps" section that includes the tool-specific command for reinstalling.
+Or specify a lockfile path directly:
+
+```bash
+chainctl libraries update-hashes path/to/lockfile
+```
+
+When using a repo manager, pass the full repository URL with `--registry-url`.
+Learn about using this command with repo managers in the [Global
+configuration](/chainguard/libraries/javascript/global-configuration/) page.
+
+By default, Chainguard hashes are appended alongside existing upstream hashes
+and resolved URLs are updated to point to Chainguard. After running the command,
+ensure your `.npmrc` is configured with Chainguard credentials, then reinstall
+to apply the updated hashes. The `chainctl libraries update-hashes` command will
+output a "Next steps" section that includes the tool-specific command for
+reinstalling.
 
 > **Note:** If your organization uses the [Chainguard Repository with upstream
 > npm fallback

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -65,6 +65,23 @@ repository alongside your npm upstream, and combine them in a virtual or group
 repository with Chainguard as the first priority. The per-tool instructions on
 this page follow this pattern.
 
+### Updating lockfile hashes
+
+If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
+for all supported JavaScript lockfile formats. 
+
+When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
+
+```bash
+chainctl libraries update-hashes \
+  --registry-url https://repo.example.com:8443/repository/javascript-all/ \
+  --token "$REPO_TOKEN"
+```
+
+After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes. 
+
+Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+
 <a name="cloudsmith"></a>
 
 ## Cloudsmith

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -93,44 +93,9 @@ Configure this endpoint [globally through a repository manager](/chainguard/libr
 
 ## Updating lockfile hashes
 
-When migrating an existing JavaScript project to Chainguard Libraries, your
-lockfile contains integrity hashes generated against npm registry artifacts.
-Because Chainguard rebuilds packages in a secured build environment rather than
-distributing upstream artifacts directly, the resulting checksums differ even
-for identical package versions. These hashes must be updated before your package
-manager will accept packages from Chainguard.
+Existing JavaScript lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/). 
 
-> **Note:** `chainctl libraries update-hashes` does not currently support
-> authentication through a repository manager. You will need to
-> [configure direct access](/chainguard/libraries/javascript/build-configuration/#direct-access)
-> credentials before running the command, or update the lockfiles manually.
-
-The `chainctl libraries update-hashes` command automates lockfile hash updates
-for all supported JavaScript lockfile formats. Rather than deleting your
-lockfile and reinstalling from scratch, you can run the command directly against
-your existing lockfile to update integrity hashes and resolved URLs to use
-Chainguard, while preserving the file's format and structure.
-
-Supported formats include `package-lock.json` (npm v2/v3), `yarn.lock` (Yarn
-Classic and Berry), `pnpm-lock.yaml`, and `bun.lock`.
-
-Run the command in the directory containing the lockfile:
-
-```bash
-chainctl libraries update-hashes
-```
-
-Or specify a lockfile path directly:
-
-```bash
-chainctl libraries update-hashes path/to/lockfile
-```
-
-By default, Chainguard hashes are appended alongside existing upstream hashes
-and resolved URLs are updated to point to Chainguard. After updating the
-lockfile, ensure your `.npmrc` or equivalent is configured with Chainguard
-credentials, then reinstall to apply the changes. The `chainctl libraries update-hashes` command will output
-a "Next steps" section that includes the tool-specific command for reinstalling.
+If you install through a repository manager, see [Global configuration](/chainguard/libraries/javascript/global-configuration/#updating-lockfile-hashes/).
 
 ## Provenance and attestations
 Chainguard Libraries for JavaScript include SLSA provenance with signed attestations. 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -140,6 +140,33 @@ the Chainguard Libraries for Python directly. As an alternative that works
 across tools and is often preferred, use [.netrc for
 authentication](/chainguard/libraries/access/#netrc).
 
+### Updating lockfile hashes
+
+If you are migrating an existing Python project to Chainguard Libraries, your lockfile likely contains integrity hashes generated against packages previously downloaded from the PyPI registry or through your repository manager. Because Chainguard rebuilds packages from verified source, the checksums for those packages differ from the ones already recorded in your lockfile. These hashes must be updated before reinstalling.
+
+The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates for all supported Python lockfile formats. Rather than manually regenerating lock files with each tool, you can run the command directly against your existing lockfile to update hashes to Chainguard checksums while preserving your locked dependency versions, without re-resolving your dependency graph.
+
+Supported formats include `requirements.txt` (pip-tools `--hash` style), `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
+
+Run the command in your project directory to auto-detect the lockfile:
+
+```bash
+chainctl libraries update-hashes
+```
+
+Or specify a lockfile path directly:
+
+```bash
+chainctl libraries update-hashes path/to/requirements.txt
+```
+
+When using a repo manager, pass the full repository URL with `--registry-url`.
+Learn about using this command with repo managers in the [Global
+configuration](/chainguard/libraries/python/global-configuration/) page.
+
+By default, Chainguard hashes are appended alongside existing upstream hashes. After updating the lockfiles, to switch your environment to use Chainguard packages, configure your tool to use the Chainguard index and reinstall. The command will output
+a "Next steps" section that includes the tool-specific command for reinstalling. 
+
 <a id="pip"></a>
 
 ### pip
@@ -492,7 +519,7 @@ and environment variables as detailed in the [access
 documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
 
 > **Migrating an existing project?** If you have an existing uv lockfile with
-> upstream hashes, use [`chainctl libraries update-hashes`](/chainguard/libraries/python/overview/#updating-lockfile-hashes)
+> upstream hashes, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 > to update hashes in place rather than starting from scratch.
 
 **1. Configure credentials**
@@ -618,7 +645,7 @@ For testing purposes, you can use direct access and environment variables as det
 documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials).  
 
 > **Migrating an existing project?** If you have an existing pip lockfile with
-> upstream hashes, use [`chainctl libraries update-hashes`](/chainguard/libraries/python/overview/#updating-lockfile-hashes)
+> upstream hashes, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 > to update hashes in place rather than starting from scratch.
 
 **1. Update your configuration to point to Chainguard**

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -56,6 +56,23 @@ Before configuring your repo manager, consider how you want to handle packages t
 yet available in the Chainguard Libraries repository. If you configure a fallback to PyPI, packages sourced from that registry are not covered by Chainguard's
 malware-resistance guarantees. See the [fallback approaches](/chainguard/libraries/quickstart/#artifact-manager-recommended) described in the Chainguard Libraries quick start for guidance on choosing the right approach for your environment.
 
+### Updating lockfile hashes
+
+If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
+for all supported JavaScript lockfile formats. 
+
+When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
+
+```bash
+chainctl libraries update-hashes \
+  --registry-url https://repo.example.com:8443/repository/javascript-all/ \
+  --token "$REPO_TOKEN"
+```
+
+After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes. 
+
+Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+
 <a id="cloudsmith"></a>
 
 ## Cloudsmith

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -65,7 +65,7 @@ When you are using a repository manager, pass the full repository manager URL wi
 
 ```bash
 chainctl libraries update-hashes \
-  --registry-url https://repo.example.com:8443/repository/javascript-all/ \
+  --registry-url https://repo.example.com:8443/repository/python-all/ \
   --token "$REPO_TOKEN"
 ```
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -367,30 +367,13 @@ docker build --no-cache
 
 ### Updating lockfile hashes
 
-> Note: `chainctl libraries update-hashes` does not currently support authentication through a repository manager. You will need to [configure direct access](/chainguard/libraries/python/build-configuration/#direct-access) credentials before running the command, or [update the lockfiles manually](#update-lockfiles-manually).
+Existing Python lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/python/build-configuration/).
 
-The `chainctl libraries update-hashes` command automates lockfile hash updates for all supported Python lockfile formats. Rather than manually regenerating lock files with each tool, you can run the command directly against your existing lockfile to update hashes to Chainguard checksums while preserving your locked dependency versions, without re-resolving your dependency graph.
-
-Supported formats include `requirements.txt` (pip-tools `--hash` style), `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
-
-Run the command in your project directory to auto-detect the lockfile:
-
-```bash
-chainctl libraries update-hashes
-```
-
-Or specify a lockfile path directly:
-
-```bash
-chainctl libraries update-hashes path/to/requirements.txt
-```
-
-By default, Chainguard hashes are appended alongside existing upstream hashes. After updating the lockfiles, to switch your environment to use Chainguard packages, configure your tool to use the Chainguard index and reinstall. The `chainctl libraries update-hashes` command will output
-a "Next steps" section that includes the tool-specific command for reinstalling. 
+If you install through a repository manager, see [Global configuration](/chainguard/libraries/python/global-configuration/#updating-lockfile-hashes/).
 
 #### Update lockfiles manually
 
-If you are using a repository manager, and do not want to use direct access temporarily while updating lockfiles, you can use the following instructions to update your lockfiles: 
+Alternatively, you can use the following instructions to manually update your lockfiles: 
 
 {{< details "Manually updating lockfiles" >}}
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update existing Python and JS docs: overview, build config, global config

### What should this PR do?
- Reorganize content about the update-hashes command
- For Python, add update-hashes content to "Build config" to make it consistent with the JS docs
- Add new content explaining how to use it for repo managers 

### Why are we making this change?
We are introducing new functionality

### What are the acceptance criteria? 
The content should appear where it makes sense, and should be clear and accurate

### How should this PR be tested?
Review the deploy preview