### PR TITLE
Add new policy gates documentation page

### DIFF
--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -1,0 +1,68 @@
+---
+title: "Policy Gates"
+linktitle: "Policy Gates"
+type: "article"
+description: "Control your image updates"
+date: 2026-05-21T08:48:45+00:00
+lastmod: 2026-05-21T08:48:45+00:00
+draft: false
+tags: ["Overview"]
+images: []
+menu:
+  docs:
+    parent: "administration"
+toc: true
+weight: 008
+---
+
+Policy gates enable you to filter and restrict Chainguard artifact updates. You do this by defining policies that control and restrict versions that will be pulled from Chainguard.
+
+> **Note:** Policy gates is currently in beta and available for testing. It is an opt-in feature. To enable it for your organization, contact your Chainguard customer success representative.
+
+## Definitions
+
+This is how policy gates uses the following terms.
+
+- **Policy** — A reusable rule that determines whether an image is allowed. Each policy has a name, a description, and the resource types it applies to. Policies apply to registry repositories.
+- **Binding** — A link between a policy and an organization. While a binding exists, the policy is active for image pulls under that organization. Without a binding, the policy has no effect.
+- **Mode** — A binding's mode controls what happens when the policy denies an image:
+  •  `ENFORCE` — Block the pull.
+  •  `LOG` — Allow the pull but record the violation.
+
+The default mode for new bindings is `LOG`.
+
+## Usage
+
+Policy gates are managed using `chainctl`. System policies are shipped with the platform.
+
+See which policies are available to your organization.
+
+```shell
+chainctl policy-gate list
+```
+
+See which policies are currently active.
+
+```shell
+chainctl policy-gate binding list
+```
+
+Activate a policy in `LOG` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `LOG` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
+
+```shell
+chainctl policy-gate enable --policy=no-eol --mode=LOG
+```
+
+Promote a policy to `ENFORCE`.
+
+```shell
+chainctl policy-gate enable --policy=no-eol --mode=ENFORCE
+```
+
+Disable a policy.
+
+```shell
+chainctl policy-gate disable --policy=no-eol
+```
+
+See `chainctl policy-gate --help` or the [chainctl reference pages](/chainguard/chainctl) for more information.

--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -27,9 +27,9 @@ This is how policy gates uses the following terms.
 - **Binding** — A link between a policy and an organization. While a binding exists, the policy is active for image pulls under that organization. Without a binding, the policy has no effect.
 - **Mode** — A binding's mode controls what happens when the policy denies an image:
   •  `ENFORCE` — Block the pull.
-  •  `LOG` — Allow the pull but record the violation.
+  •  `DRY_RUN` — Allow the pull but record the violation.
 
-The default mode for new bindings is `LOG`.
+The default mode for new bindings is `DRY_RUN`.
 
 ## Usage
 
@@ -38,25 +38,36 @@ Policy gates are managed using `chainctl`. System policies are shipped with the 
 See which policies are available to your organization.
 
 ```shell
-chainctl policy-gate list
+chainctl policy-gates list
 ```
 
 See which policies are currently active.
 
 ```shell
-chainctl policy-gate binding list
+chainctl policy-gates binding list
 ```
 
-Activate a policy in `LOG` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `LOG` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
+Activate a policy in `DRY_RUN` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `DRY_RUN` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
 
 ```shell
-chainctl policy-gate enable --policy=no-eol --mode=LOG
+chainctl policy-gates enable --policy=no-eol --mode=DRY_RUN
 ```
 
 Promote a policy to `ENFORCE`.
 
 ```shell
-chainctl policy-gate enable --policy=no-eol --mode=ENFORCE
+chainctl policy-gates enable --policy=no-eol --mode=ENFORCE
+```
+
+Check the results of specific policies on an image, including `DRY_RUN` policies which wouldn't cause the registry to block a pull.
+
+```shell
+chainctl policy-gates check cgr.dev/$ORGANIZATION/bash:latest
+
+  POLICY  |  MODE   | RESULT
+----------|---------|---------
+ cooldown | DRY_RUN | DENIED
+ no-eol   | DRY_RUN | ALLOWED
 ```
 
 Disable a policy.

--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -26,8 +26,8 @@ This is how policy gates uses the following terms.
 - **Policy** — A reusable rule that determines whether an image is allowed. Each policy has a name, a description, and the resource types it applies to. Policies apply to registry repositories.
 - **Binding** — A link between a policy and an organization. While a binding exists, the policy is active for image pulls under that organization. Without a binding, the policy has no effect.
 - **Mode** — A binding's mode controls what happens when the policy denies an image:
-  •  `ENFORCE` — Block the pull.
-  •  `DRY_RUN` — Allow the pull but record the violation.
+  - `ENFORCE` — Block the pull.
+  - `DRY_RUN` — Allow the pull but record the violation.
 
 The default mode for new bindings is `DRY_RUN`.
 
@@ -35,13 +35,13 @@ The default mode for new bindings is `DRY_RUN`.
 
 Policy gates are managed using `chainctl`. System policies are shipped with the platform.
 
-See which policies are available to your organization.
+See which policies are available to your organization:
 
 ```shell
 chainctl policy-gates list
 ```
 
-See which policies are currently active.
+See which policies are currently active:
 
 ```shell
 chainctl policy-gates binding list
@@ -53,13 +53,13 @@ Activate a policy in `DRY_RUN` mode. This example activates the "no end-of-life"
 chainctl policy-gates enable --policy=no-eol --mode=DRY_RUN
 ```
 
-Promote a policy to `ENFORCE`.
+Promote a policy to `ENFORCE`:
 
 ```shell
 chainctl policy-gates enable --policy=no-eol --mode=ENFORCE
 ```
 
-Check the results of specific policies on an image, including `DRY_RUN` policies which wouldn't cause the registry to block a pull.
+Check the results of specific policies on an image, including `DRY_RUN` policies which wouldn't cause the registry to block a pull:
 
 ```shell
 chainctl policy-gates check cgr.dev/$ORGANIZATION/bash:latest
@@ -70,7 +70,7 @@ chainctl policy-gates check cgr.dev/$ORGANIZATION/bash:latest
  no-eol   | DRY_RUN | ALLOWED
 ```
 
-Disable a policy.
+Disable a policy:
 
 ```shell
 chainctl policy-gate disable --policy=no-eol


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/internal/issues/5835

This adds a new page about a new feature called Policy Gates. The page is short as this is an early beta release (on Friday 5/22). The page will expand as the feature evolves.

To review: does the new page render cleanly in the preview? Any typos or unclear or info? Reviewers cannot currently test the code unless you have an organization that has been enabled.

EDIT: [Preview link](https://deploy-preview-3348--ornate-narwhal-088216.netlify.app/chainguard/administration/policy-gates/)