### PR TITLE
Add beta shortcode and standardize beta status notes

### DIFF
--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -17,7 +17,7 @@ weight: 008
 
 Policy gates enable you to filter and restrict Chainguard artifact updates. You do this by defining policies that control and restrict versions that will be pulled from Chainguard.
 
-> **Note:** Policy gates is currently in beta and available for testing. It is an opt-in feature. To enable it for your organization, contact your Chainguard customer success representative.
+{{< beta feature="Policy gates" enroll="true" >}}
 
 ## Definitions
 

--- a/content/chainguard/api/api-v2-tutorial.md
+++ b/content/chainguard/api/api-v2-tutorial.md
@@ -12,7 +12,9 @@ toc: true
 weight: 030
 ---
 
-The Chainguard API v2 is currently in a limited beta release for testing. It introduces cursor-based pagination, server-side ordering, consistent resource patterns, and structured error responses across all endpoints.
+{{< beta feature="The Chainguard API v2" >}}
+
+The v2 API introduces cursor-based pagination, server-side ordering, consistent resource patterns, and structured error responses across all endpoints.
 
 This guide walks through the v2 API using real `curl` commands.
 

--- a/content/chainguard/chainguard-images/about/catalog-starter.md
+++ b/content/chainguard/chainguard-images/about/catalog-starter.md
@@ -17,7 +17,7 @@ toc: true
 
 Chainguard Catalog Starter is a way to try production-grade Chainguard Containers for free, without committing to a full subscription. It lets you choose a set of five container images from the broader Chainguard catalog so you can validate security, performance, and operational fit in your own environment before you buy.
 
-> **Note**: As of this writing, Chainguard Catalog Starter is in beta. Some of the details included in this guide may change over time.
+{{< beta feature="Chainguard Catalog Starter" >}}
 
 ## What is Catalog Starter?
 

--- a/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md
@@ -18,6 +18,8 @@ With Chainguard's private APK repositories, you can access packages that are inc
 
 This guide provides a brief overview of Chainguard's private APK repositories and outlines different ways you can incorporate them into your organization's workflows.
 
+{{< beta feature="Private APK Repositories" access="all Chainguard Containers customers" >}}
+
 
 ## About private APK repositories
 
@@ -25,14 +27,12 @@ Chainguard's private APK repos allow customers to pull secure apk packages from 
 
 For example, say your organization has access to the [Chainguard MySQL container image](https://images.chainguard.dev/directory/image/mysql/versions). Along with `mysql`, this image comes with other apk packages, including `bash`, `openssl`, and `pwgen`. This means that you'll have access to these apk packages through your organization's private APK repository, along with any others that appear in Chainguard container images that your organization has access to.
 
-Chainguard's private APK repositories are available to all Chainguard Containers customers.
-
 
 ## Contents of private APK repositories
 
 Your private APK repository contains all packages available in the container images your organization is entitled to, plus some extra utilities, like `curl`.
 
-Chainguard offers an opt-in beta feature that extends the set of available packages in your private APK repository to include the latest versions of all 30,000 packages Chainguard maintains as part of Chainguard OS and Wolfi. If you are a catalog customer, your private APK repository will contain the full set of packages built for Chainguard OS and Wolfi. If you're a per-image customer, your private APK repository will contain most of these packages, but won't contain any "main" packages for images you aren't entitled to, preventing you from recreating our images. If you're interested in expanding the set of available packages in your private APK repository and are a current customer, reach out to your account team to be added to the Beta.
+Chainguard offers [Chainguard OS Packages](/chainguard/chainguard-os/chainguard-os-packages/), a beta feature that extends the set of available packages in your private APK repository to include the latest versions of all 30,000 packages Chainguard maintains as part of Chainguard OS and Wolfi. If you are a catalog customer, your private APK repository will contain the full set of packages built for Chainguard OS and Wolfi. If you're a per-image customer, your private APK repository will contain most of these packages, but won't contain any "main" packages for images you aren't entitled to, preventing you from recreating our images. If you're interested in expanding the set of available packages in your private APK repository and are a current customer, reach out to your account team to be added to the Beta.
 
 
 ## Your repository address
@@ -394,7 +394,7 @@ You can check this and fix it by following these steps:
 2. Create the `apk.pull` role using the steps outlined in our [Overview of Roles and Role-bindings](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) resource.
 3. Try pulling the package again.
 
-As this feature is still in its beta phase, we invite feedback. If you would like to provide feedback or need further assistance troubleshooting, please [reach out to our Customer Support team](https://www.chainguard.dev/contact?utm=docs).
+If you'd like to provide feedback or need further help troubleshooting, [reach out to our Customer Support team](https://www.chainguard.dev/contact?utm=docs).
 
 
 ## Conclusion

--- a/content/chainguard/chainguard-images/features/request-resources/index.md
+++ b/content/chainguard/chainguard-images/features/request-resources/index.md
@@ -19,7 +19,7 @@ The Chainguard Console includes the Requests section where customers can submit 
 
 This guide provides an overview of how to submit a request for a new resource to Chainguard, as well as the limitations on what resources can be built.
 
-> **Note**: As of this writing, the Requests section is in beta. Some of the details and instructions included in this guide are likely to change over time.
+{{< beta feature="The Requests section" >}}
 
 
 ## Prerequisites

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md
@@ -23,7 +23,7 @@ These notifications are different from [Chainguard Events](/chainguard/administr
 
 ## Prerequisites and limitations
 
-This feature is currently in beta.
+{{< beta feature="Chainguard Notifications" >}}
 
 Notifications are currently limited to messages related to a small set of topics like breaking changes, incidents, and product lifecycle changes like end-of-life (EOL) and new releases.
 

--- a/content/chainguard/chainguard-os/chainguard-os-packages.md
+++ b/content/chainguard/chainguard-os/chainguard-os-packages.md
@@ -9,11 +9,11 @@ draft: false
 weight: 020
 ---
 
-Chainguard OS Packages is an opt-in beta feature that expands the packages available to your [private APK repository](/chainguard/chainguard-images/features/packages/private-apk-repos/) by giving you access to the full set of 30,000 enterprise-grade, zero-CVE packages built as part of Chainguard OS and Wolfi. It also includes a small set of Chainguard base images, for example, `chainguard-base`.
+{{< beta feature="Chainguard OS Packages" enroll="true" >}}
+
+Chainguard OS Packages expands the packages available to your [private APK repository](/chainguard/chainguard-images/features/packages/private-apk-repos/) by giving you access to the full set of 30,000 enterprise-grade, zero-CVE packages built as part of Chainguard OS and Wolfi. It also includes a small set of Chainguard base images, for example, `chainguard-base`.
 
 Chainguard OS Packages is designed for larger customers who already build their own images from packages using tools like Bazel, Dockerfiles, and rules\_apko, and want to use a wider set of packages from Chainguard. Because you are creating custom builds, you are responsible for the image builds, the build tooling, validation, and compatibility. You still benefit from the fact that Chainguard builds the packages in the Chainguard Factory with complete SBOMs and our standard enterprise-grade, zero-CVE process.
-
-If you're interested and are a current customer, reach out to your account team to be added to the beta.
 
 If you need to achieve FIPS compliance, the FIPS variant of Chainguard OS Packages includes access packages with the latest versions of Chainguard’s [FIPS-validated modules](https://www.chainguard.dev/legal/fips-commitment).
 

--- a/content/chainguard/migration/the-guardener.md
+++ b/content/chainguard/migration/the-guardener.md
@@ -19,7 +19,7 @@ The Guardener migrates your Dockerfiles to use Chainguard Containers. It uses AI
 
 You interact with it through `chainctl agent dockerfile` commands. The AI runs server-side and scans your workspace to perform its analysis. Docker builds and file access remain local to your machine, and only the data necessary for analysis is processed.
 
-> **Note:** The Guardener is currently in beta. Features and behavior may change before general availability.
+{{< beta feature="The Guardener" >}}
 
 
 ## Prerequisites

--- a/layouts/shortcodes/beta.html
+++ b/layouts/shortcodes/beta.html
@@ -1,0 +1,13 @@
+{{- $feature := .Get "feature" | default "This feature" -}}
+{{- $enroll := .Get "enroll" -}}
+{{- $access := .Get "access" -}}
+{{- $feedback := .Get "feedback" -}}
+<p>
+<blockquote>
+    <p><strong>Note</strong>: {{ $feature }} is in beta.
+    {{- if eq $enroll "true" }} Contact your Chainguard account team to enable it for your organization.{{ end -}}
+    {{- with $access }} Available to {{ . }}.{{ end -}}
+    {{- if eq $feedback "true" }} Share feedback with your account team.{{ end -}}
+    </p>
+</blockquote>
+</p>


### PR DESCRIPTION
## Summary

- Add `layouts/shortcodes/beta.html` as the standard callout for beta-status features. Parameters: `feature`, `enroll`, `access`, `feedback`.
- Replace seven distinct phrasings across eight pages with the shortcode.
- For Private APK Repositories (GA but evolving), combine beta status with access scope in one sentence per legal guidance to keep the word "beta."

An audit of the `content/` directory found 21 mentions of "beta" across 9 pages using 7 different phrasings. None used a shortcode. This PR collapses that variation to one source of truth.

## Usage

```
{{< beta feature="Policy gates" enroll="true" >}}
{{< beta feature="The Guardener" >}}
{{< beta feature="Private APK Repositories" access="all Chainguard Containers customers" >}}
```

## Pages migrated

- `content/chainguard/administration/policy-gates/index.md`
- `content/chainguard/api/api-v2-tutorial.md`
- `content/chainguard/chainguard-images/about/catalog-starter.md`
- `content/chainguard/chainguard-images/features/packages/private-apk-repos/index.md`
- `content/chainguard/chainguard-images/features/request-resources/index.md`
- `content/chainguard/chainguard-images/how-to-use/use-chainguard-notifications/index.md`
- `content/chainguard/chainguard-os/chainguard-os-packages.md`
- `content/chainguard/migration/the-guardener.md`

## Items deliberately left alone

- References to beta *behavior* (rate limits, page tokens) in `api-v2-tutorial.md` — these describe operational implications, not status.
- Operational context in `the-guardener.md` ("While The Guardener is in beta…" waitlist, "joined the beta program" FAQ).
- External blog post titles in `software-security/learning-labs/ll202511.md`.

## Test plan

- [x] Hugo dev server builds cleanly
- [x] Each migrated page renders the beta callout
- [x] Visual style matches existing `note` shortcode pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)