### PR TITLE
Fix broken links

### DIFF
--- a/content/chainguard/chainguard-images/staying-secure/enforcement/kyverno/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/enforcement/kyverno/index.md
@@ -23,7 +23,7 @@ To follow the examples in this guide, you will need the following:
 
 ## Ensure Images are Pulled from Allowed Repositories
 
-You can use the [`ClusterPolicy` policy type](https://kyverno.io/docs/policy-types/cluster-policy/) to ensure that images are only pulled from a list of allowed repositories.
+You can use the [`ClusterPolicy` policy type](https://kyverno.io/docs/policy-types/cluster-policy/overview/) to ensure that images are only pulled from a list of allowed repositories.
 
 Create file named `restrict-image-registries.yaml` with the following content:
 


### PR DESCRIPTION
[ X ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Fix two broken links to Kyverno docs

### Why are we making this change?
Fixes the 404s identified in https://github.com/chainguard-dev/edu/issues/3342
