### PR TITLE
Update Policy Gates docs page

### DIFF
--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -38,37 +38,37 @@ Policy gates are managed using `chainctl`. System policies are shipped with the 
 See which policies are available to your organization:
 
 ```shell
-chainctl policy-gate list
+chainctl policy-gate list --parent=$ORGANIZATION
 ```
 
 Inspect a policy to see its full definition and configurable parameters before enabling it:
 
 ```shell
-chainctl policy-gate describe --policy=$POLICY
+chainctl policy-gate describe --policy=$POLICY --parent=$ORGANIZATION
 ```
 
 See which policies are currently active:
 
 ```shell
-chainctl policy-gate binding list
+chainctl policy-gate binding list --parent=$ORGANIZATION
 ```
 
 Activate a policy in `DRY_RUN` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `DRY_RUN` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
 
 ```shell
-chainctl policy-gate enable --policy=no-eol --mode=DRY_RUN
+chainctl policy-gate enable --policy=no-eol --mode=DRY_RUN --parent=$ORGANIZATION
 ```
 
 Some policies accept parameters. Use `--param=KEY=VALUE` to supply them:
 
 ```shell
-chainctl policy-gate enable --policy=cooldown --mode=DRY_RUN --param=days=7
+chainctl policy-gate enable --policy=cooldown --mode=DRY_RUN --param=days=7 --parent=$ORGANIZATION
 ```
 
 Promote a policy to `ENFORCE`:
 
 ```shell
-chainctl policy-gate enable --policy=no-eol --mode=ENFORCE
+chainctl policy-gate enable --policy=no-eol --mode=ENFORCE --parent=$ORGANIZATION
 ```
 
 Check the results of specific policies on an image, including `DRY_RUN` policies which wouldn't cause the registry to block a pull:
@@ -87,7 +87,7 @@ chainctl policy-gate check cgr.dev/$ORGANIZATION/bash:latest
 Disable a policy:
 
 ```shell
-chainctl policy-gate disable --policy=no-eol
+chainctl policy-gate disable --policy=no-eol --parent=$ORGANIZATION
 ```
 
 See `chainctl policy-gate --help` or the [chainctl reference pages](/chainguard/chainctl) for more information.

--- a/content/chainguard/administration/policy-gates/index.md
+++ b/content/chainguard/administration/policy-gates/index.md
@@ -38,32 +38,46 @@ Policy gates are managed using `chainctl`. System policies are shipped with the 
 See which policies are available to your organization:
 
 ```shell
-chainctl policy-gates list
+chainctl policy-gate list
+```
+
+Inspect a policy to see its full definition and configurable parameters before enabling it:
+
+```shell
+chainctl policy-gate describe --policy=$POLICY
 ```
 
 See which policies are currently active:
 
 ```shell
-chainctl policy-gates binding list
+chainctl policy-gate binding list
 ```
 
 Activate a policy in `DRY_RUN` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `DRY_RUN` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
 
 ```shell
-chainctl policy-gates enable --policy=no-eol --mode=DRY_RUN
+chainctl policy-gate enable --policy=no-eol --mode=DRY_RUN
+```
+
+Some policies accept parameters. Use `--param=KEY=VALUE` to supply them:
+
+```shell
+chainctl policy-gate enable --policy=cooldown --mode=DRY_RUN --param=days=7
 ```
 
 Promote a policy to `ENFORCE`:
 
 ```shell
-chainctl policy-gates enable --policy=no-eol --mode=ENFORCE
+chainctl policy-gate enable --policy=no-eol --mode=ENFORCE
 ```
 
 Check the results of specific policies on an image, including `DRY_RUN` policies which wouldn't cause the registry to block a pull:
 
 ```shell
-chainctl policy-gates check cgr.dev/$ORGANIZATION/bash:latest
+chainctl policy-gate check cgr.dev/$ORGANIZATION/bash:latest
+```
 
+```output
   POLICY  |  MODE   | RESULT
 ----------|---------|---------
  cooldown | DRY_RUN | DENIED


### PR DESCRIPTION
This changes the sample code to match the reference code in `--help` and in the [chainctl Reference](https://edu.chainguard.dev/chainguard/chainctl/chainctl-docs/chainctl_policy-gate/) pages. Instead of `policy-gates` (which is a valid alias) the page now uses `policy-gate` in the commands.

It adds information about the `--policy=` switch that was recently added.

It adds `chainctl policy-gate describe`.

It adds ` --parent=$ORGANIZATION` to match reference pages.

It separates the command from the output into two code boxes when output is included.