### PR TITLE
Fix duplicate Hugo menu identifiers and normalize FAQ linktitles

### DIFF
--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -1,6 +1,6 @@
 ---
 title: "Chainguard Containers FAQs"
-linktitle: "FAQs"
+linktitle: "FAQ"
 type: "article"
 description: "Chainguard container FAQs: why they have zero CVEs, how they compare to DockerHub, what makes them more secure, pricing, and enterprise deployment best practices"
 date: 2022-09-01T08:49:31+00:00
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
+    identifier: "Chainguard Images FAQ"
 weight: 060
 toc: true
 ---

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-images"
+    identifier: "Chainguard Images Overview"
 weight: 005
 toc: true
 ---

--- a/content/chainguard/chainguard-os/faq.md
+++ b/content/chainguard/chainguard-os/faq.md
@@ -1,6 +1,6 @@
 ---
 title: "Chainguard OS FAQs"
-linktitle: "FAQs"
+linktitle: "FAQ"
 type: "article"
 description: "Frequently asked questions about Chainguard OS, the secure operating system powering production Chainguard containers with enterprise features and continuous updates"
 lead: "Chainguard OS powers production container images with enhanced security, continuous updates, and enterprise-grade features - find answers to common questions about this purpose-built container operating system."
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-os"
+    identifier: "Chainguard OS FAQ"
 weight: 030
 toc: true
 ---

--- a/content/chainguard/chainguard-os/overview.md
+++ b/content/chainguard/chainguard-os/overview.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-os"
+    identifier: "Chainguard OS Overview"
 weight: 010
 toc: true
 ---

--- a/content/chainguard/factory/faq.md
+++ b/content/chainguard/factory/faq.md
@@ -1,6 +1,6 @@
 ---
 title: "Chainguard Factory FAQs"
-linktitle: "FAQs"
+linktitle: "FAQ"
 type: "article"
 description: "Frequently asked questions about Chainguard Factory, the automated build system that monitors and updates thousands of open source projects for enhanced security"
 lead: "Chainguard Factory is the automated infrastructure that continuously transforms thousands of open source projects into containers, libraries, and VMs with enhanced security posture and the latest patches."
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-factory"
+    identifier: "Chainguard Factory FAQ"
 weight: 010
 toc: true
 ---

--- a/content/chainguard/factory/overview/index.md
+++ b/content/chainguard/factory/overview/index.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "chainguard-factory"
+    identifier: "Chainguard Factory Overview"
 weight: 005
 toc: true
 ---

--- a/content/chainguard/fips/faqs/index.md
+++ b/content/chainguard/fips/faqs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Chainguard FIPS Container FAQs"
-linktitle: "FAQs"
+linktitle: "FAQ"
 aliases: 
 - /chainguard/chainguard-images/features/fips/faqs/
 type: "article"
@@ -13,6 +13,7 @@ images: []
 menu:
   docs:
     parent: "features"
+    identifier: "FIPS FAQ"
 weight: 060
 toc: true
 ---

--- a/content/chainguard/libraries/faq.md
+++ b/content/chainguard/libraries/faq.md
@@ -10,6 +10,7 @@ tags: ["Chainguard Libraries", "Overview"]
 menu:
   docs:
     parent: "libraries"
+    identifier: "Libraries FAQ"
 weight: 010
 toc: true
 ---

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -10,6 +10,7 @@ tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
     parent: "java"
+    identifier: "Java Build Configuration"
 weight: 053
 toc: true
 ---

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "java"
+    identifier: "Java Global Configuration"
 weight: 052
 toc: true
 ---

--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "java"
+    identifier: "Java Management"
 weight: 053
 toc: true
 ---

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -10,6 +10,7 @@ tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
     parent: "javascript"
+    identifier: "JavaScript Build Configuration"
 weight: 053
 toc: true
 ---

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "javascript"
+    identifier: "JavaScript Global Configuration"
 weight: 052
 toc: true
 ---

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -10,6 +10,7 @@ tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
     parent: "python"
+    identifier: "Python Build Configuration"
 weight: 053
 toc: true
 ---

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "python"
+    identifier: "Python Global Configuration"
 weight: 052
 toc: true
 ---

--- a/content/chainguard/libraries/python/management.md
+++ b/content/chainguard/libraries/python/management.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "python"
+    identifier: "Python Management"
 weight: 053
 toc: true
 ---

--- a/content/chainguard/migration/dockerfile-conversion.md
+++ b/content/chainguard/migration/dockerfile-conversion.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "migration"
+    identifier: "Migration Dockerfile Converter"
 weight: 035
 toc: true
 ---

--- a/content/chainguard/vms/faq.md
+++ b/content/chainguard/vms/faq.md
@@ -10,6 +10,7 @@ tags: ["Chainguard VMs", "FAQ"]
 menu:
   docs:
     parent: "vms"
+    identifier: "VMs FAQ"
 weight: 010
 toc: true
 ---

--- a/content/open-source/octo-sts/faq.md
+++ b/content/open-source/octo-sts/faq.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "octo-sts"
+    identifier: "Octo STS FAQ"
 weight: 60
 toc: true
 ---

--- a/content/open-source/octo-sts/overview/index.md
+++ b/content/open-source/octo-sts/overview/index.md
@@ -12,6 +12,7 @@ images: []
 menu:
   docs:
     parent: "open-source"
+    identifier: "Octo STS Overview"
 weight: 001
 toc: true
 ---

--- a/content/software-security/learning-labs/ll202508.md
+++ b/content/software-security/learning-labs/ll202508.md
@@ -10,6 +10,7 @@ tags: ["Learning Labs", "Chainguard Containers", "dfc"]
 menu:
   docs:
     parent: "learning-labs"
+    identifier: "Learning Labs Dockerfile Converter"
 weight: 93
 toc: true
 ---


### PR DESCRIPTION
## Summary

- Fixes Hugo build warnings because two pages should never have the exact same meny entry.
- Adds explicit `identifier` fields to 21 pages whose shared `linktitle` values (`FAQ`, `Overview`, `Build configuration`, `Global configuration`, `Management`, `Dockerfile Converter`) caused Hugo to emit duplicate menu entry warnings at build time.
- Normalizes four `linktitle: "FAQs"` entries to `linktitle: "FAQ"` for consistency across the site.
- No page URLs are affected — `linktitle` and `identifier` are menu display/deduplication fields only; no aliases are needed.

## Test plan

- [ ] Verify Hugo build produces no duplicate menu entry warnings
- [ ] Spot-check that affected pages still appear correctly in the site navigation

---
Created in collaboration with Claude Code running claude-sonnet-4-6 on 2026-06-01.