### PR TITLE
Fix npm WARN EBADENGINE warnings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/autodocs-platform.yaml
+++ b/.github/workflows/autodocs-platform.yaml
@@ -46,7 +46,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 16
+        node-version: 22
 
     - name: Update themes
       run: git submodule update --init --recursive

--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -32,7 +32,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Update themes
       run: git submodule update --init --recursive

--- a/.github/workflows/validate-nginx-config.yaml
+++ b/.github/workflows/validate-nginx-config.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Build project
         run: |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Chainguard Academy",
   "version": "0.4.3",
   "engines": {
-    "node": ">=16.15.0"
+    "node": ">=22"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
## Summary

- Upgrade `node-version` from 16 → 22 in `autodocs-platform.yaml` and `validate-nginx-config.yaml`
- Upgrade `node-version` from 20 → 22 in `cloud-run.yaml`
- Update `package.json` `engines.node` from `>=16.15.0` to `>=22` to match actual dependency requirements

## Why

Several transitive dependencies require Node 22 (notably `@scalar/api-reference`, `@scalar/api-client`, and `unplugin`). The workflows were pinned to Node 16 and 20, causing `npm WARN EBADENGINE` warnings on every `npm install` run. Node 22 is the current LTS and satisfies all constraints in the dependency tree.

## Test plan

- [ ] Confirm `npm WARN EBADENGINE` warnings are absent in the next CI run for each affected workflow
- [ ] Verify `npm run build` succeeds in all three workflows

---
Created in collaboration with Claude Code running claude-sonnet-4-6[1m] on 2026-06-01.