### PR TITLE
Add Chainguard Agent Skills documentation

### DIFF
--- a/content/chainguard/agent-skills/_index.md
+++ b/content/chainguard/agent-skills/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Agent Skills"
+linkTitle: "Agent Skills"
+description: "Hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail."
+type: "article"
+date: 2026-06-05T08:48:45+00:00
+lastmod: 2026-06-05T08:48:45+00:00
+draft: false
+images: []
+weight: 025
+---
+
+Chainguard Agent Skills is a catalog of hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail. It lets teams extend their AI agents without extending their attack surface.
+
+- **[Overview](/chainguard/agent-skills/overview/)** — what agent skills are, the supply chain risk they introduce, and how Chainguard hardens them.
+- **[Private registry](/chainguard/agent-skills/private-catalog/)** — publish, install, and run a skill scoped to your organization with `chainctl`.
+- **[Public catalog](/chainguard/agent-skills/public-catalog/)** — browse, inspect, install, and run hardened skills from Chainguard's public catalog.

--- a/content/chainguard/agent-skills/_index.md
+++ b/content/chainguard/agent-skills/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Agent Skills"
-linkTitle: "Agent Skills"
+title: "Chainguard Agent Skills"
+linkTitle: "Chainguard Agent Skills"
 description: "Hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail."
 type: "article"
 date: 2026-06-05T08:48:45+00:00
@@ -13,5 +13,5 @@ weight: 025
 Chainguard Agent Skills is a catalog of hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail. It lets teams extend their AI agents without extending their attack surface.
 
 - **[Overview](/chainguard/agent-skills/overview/)** — what agent skills are, the supply chain risk they introduce, and how Chainguard hardens them.
-- **[Private registry](/chainguard/agent-skills/private-catalog/)** — publish, install, and run a skill scoped to your organization with `chainctl`.
+- **[Skills Registry](/chainguard/agent-skills/skills-registry/)** — publish, install, and run a skill scoped to your organization with `chainctl`.
 - **[Public catalog](/chainguard/agent-skills/public-catalog/)** — browse, inspect, install, and run hardened skills from Chainguard's public catalog.

--- a/content/chainguard/agent-skills/overview.md
+++ b/content/chainguard/agent-skills/overview.md
@@ -53,4 +53,4 @@ To interact with either of these registries, use the [`chainctl skills` commands
 
 ## Next steps
 
-To install and run a skill hardened by Chainguard, check out our guide on [Getting started with the Chainguard Agent Skills public catalog](/chainguard/agent-skills/public-catalog/). Alternatively, to publish, push, and run skills in your organization's private registry, refer to our guide on [Getting started with the Chainguard Agent Skills private registry](/chainguard/agent-skills/private-catalog/).
+To install and run a skill hardened by Chainguard, check out our guide on [Getting started with the Chainguard Agent Skills public catalog](/chainguard/agent-skills/public-catalog/). Alternatively, to publish, push, and run skills in your organization's private registry, refer to our guide on [Getting started with the Chainguard Skills Registry](/chainguard/agent-skills/skills-registry/).

--- a/content/chainguard/agent-skills/overview.md
+++ b/content/chainguard/agent-skills/overview.md
@@ -1,0 +1,56 @@
+---
+title: "Chainguard Agent Skills overview"
+linktitle: "Overview"
+description: "Learn what Chainguard Agent Skills are, the supply chain risk they address, and how Chainguard hardens skills before you install them."
+type: "article"
+date: 2026-06-05T08:48:45+00:00
+lastmod: 2026-06-05T08:48:45+00:00
+draft: false
+tags: ["Agent Skills", "Overview"]
+images: []
+menu:
+  docs:
+    parent: "agent-skills"
+toc: true
+weight: 001
+---
+
+Chainguard Agent Skills is a catalog of hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail. It lets teams extend their AI agents without extending their attack surface.
+
+> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+
+## What is an agent skill?
+
+An agent skill is a small, modular instruction set — typically a single `SKILL.md` file — that extends what an AI agent can do. Agents such as Claude Code use skills to perform tasks like browser automation, database management, and code generation.
+
+Skills are the newest class of third-party software dependency, much like npm packages or container images. Like any dependency, a skill you install runs in your environment with whatever permissions and shell access its author gave it.
+
+## The problem with skill registries
+
+Community skill registries are growing quickly, but most have no review process, no permission scoping, no integrity verification, and no audit trail. A skill can ship with broad tool permissions, unrestricted shell access, or a vague description that causes an agent to invoke it in the wrong context. Recent supply chain attacks have used malicious skills to direct agents into installing credential-stealing malware.
+
+Every skill installed without review is an unaudited dependency with arbitrary permissions running where your agent runs.
+
+## How Chainguard hardens skills
+
+Chainguard applies the same model it brings to container images and language libraries — hardened defaults, continuous updates, and verifiable provenance — to agent skills:
+
+- **Ingest and review.** Chainguard pulls popular skills from community registries and reviews each one against a security and quality ruleset.
+- **Target real attack vectors.** The ruleset addresses how attackers exploit the agent-skill trust relationship, including unrestricted shell access, overly broad tool permissions, and vague descriptions that enable mis-invocation.
+- **Harden with an audit trail.** An automated agentic pipeline applies fixes one at a time, committing each change individually. Every published skill links to a pull request with a full diff showing what changed and why.
+- **Reconcile continuously.** Rather than scanning once, the catalog runs a persistent loop that compares each skill against the current rules. When an upstream source changes or a new rule is added, affected skills are re-evaluated and re-hardened, so the catalog doesn't go stale.
+
+The security work happens upstream, before you or your agent ever touches the skill. To install a hardened skill, you just need to add its `SKILL.md` to your agent; there's no new toolchain or configuration required.
+
+## Public catalog and private registries
+
+Chainguard Agent Skills involves two registries, both served from `skills.cgr.dev`:
+
+- **The public catalog**, maintained by Chainguard at `skills.cgr.dev/chainguard/<skill>`. This is the hardened catalog described above. Anyone can pull from it, and the skills in it are reviewed and re-hardened on an ongoing basis.
+- **Your organization's private registry**, available to customers with access, at `skills.cgr.dev/<your-org>/<skill>`. You can use it to publish, manage, and distribute your own skills scoped to your organization, and you control who can push and install them.
+
+To interact with either of these registries, use the [`chainctl skills` commands](/chainguard/chainctl/chainctl-docs/chainctl_skills/).
+
+## Next steps
+
+To install and run a skill hardened by Chainguard, check out our guide on [Getting started with the Chainguard Agent Skills public catalog](/chainguard/agent-skills/public-catalog/). Alternatively, to publish, push, and run skills in your organization's private registry, refer to our guide on [Getting started with the Chainguard Agent Skills private registry](/chainguard/agent-skills/private-catalog/).

--- a/content/chainguard/agent-skills/overview.md
+++ b/content/chainguard/agent-skills/overview.md
@@ -17,7 +17,7 @@ weight: 001
 
 Chainguard Agent Skills is a catalog of hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail. It lets teams extend their AI agents without extending their attack surface.
 
-> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+{{< beta feature="Chainguard Agent Skills" access="Chainguard Containers customers who sign up for the beta program. You can sign up by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**" >}}
 
 ## What is an agent skill?
 

--- a/content/chainguard/agent-skills/private-catalog.md
+++ b/content/chainguard/agent-skills/private-catalog.md
@@ -1,0 +1,194 @@
+---
+title: "Getting started with the Chainguard Agent Skills private registry"
+linktitle: "Private Registry"
+description: "Enable Chainguard Agent Skills, then push, install, and run an agent skill scoped to your organization."
+type: "article"
+date: 2026-06-05T08:48:45+00:00
+lastmod: 2026-06-05T08:48:45+00:00
+draft: false
+tags: ["Agent Skills", "Overview"]
+images: []
+menu:
+  docs:
+    parent: "agent-skills"
+toc: true
+weight: 002
+---
+
+Chainguard Agent Skills lets you publish, manage, and distribute skills scoped to your organization. Skills are stored as OCI artifacts at `skills.cgr.dev/<your-org>/<skill-name>:<tag>` and managed with `chainctl`.
+
+This guide walks through the full workflow, including how to enable the registry for your org, then push, install, and run a skill.
+
+> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+
+## Prerequisites
+
+To follow this guide, you need:
+
+* `chainctl` **v0.2.275** or later, installed and authenticated. See [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
+* An active Chainguard organization.
+* Owner access on the organization.
+
+The examples use an `$ORG` environment variable to refer to your organization. Set it to the name of your organization before you begin:
+
+```shell
+export ORG=<your-organization>
+```
+
+## Enabling the skills entitlement
+
+Before your org can push or install skills, create a skills entitlement:
+
+```shell
+chainctl skills entitlements create --parent $ORG
+```
+
+```output
+Created skills entitlement for org example.dev (717b474ac6972745c5706a898aa6e67ffba97dad)
+```
+
+Next, accept the Skills Registry terms of service for your org:
+
+```shell
+chainctl skills accept-terms --group $ORG
+```
+
+This opens an interactive prompt:
+
+```output
+   Chainguard Legal Agreements
+   To continue, please review and accept the following:
+   ▶ [] I agree to the Skills Registry Terms of Service
+         https://www.chainguard.dev/legal/agent-skills-disclosure
+
+   ↑/↓ navigate  •  space toggle  •  enter confirm  •  q cancel
+```
+
+Press <kbd>SPACE</kbd> to accept the terms of service and <kbd>ENTER</kbd> to confirm.
+
+
+## Creating an example skill
+
+A skill is a directory containing a `SKILL.md` file. The `SKILL.md` frontmatter declares the skill's `name` and a `description` that tells an agent when to use it. The rest of the file contains the instructions the agent follows.
+
+The next section has a few examples that refer to a skill named `hello-world`. You can create a sample `hello-world` skill with the following command:
+
+```shell
+mkdir hello-world
+cat > hello-world/SKILL.md << 'EOF'
+---
+name: hello-world
+description: A simple hello world skill. Use this to verify your skills registry setup is working end to end.
+---
+
+When this skill is invoked, greet the user with:
+
+"Hello from Chainguard Agent Skills! Your skill installed and loaded successfully."
+
+If the user provides their name, greet them by name instead:
+
+"Hello, <name>! Welcome to Chainguard Agent Skills."
+EOF
+```
+
+Your directory now looks like this:
+
+```
+hello-world/
+└── SKILL.md
+```
+
+The directory name (`hello-world/`) must match the `name` field in the frontmatter (`name: hello-world`). If they don't match, the skill will fail to push.
+
+## Manage skills with `chainctl`
+
+This section outlines some of the `chainctl` commands you can use to manage skills in your organization's private Skills Registry. The following commands use the `hello-world` skill as an example, but you can use any other skills you've created in its place.
+
+Check out the [`chainctl skills` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_skills/) for more information.
+
+### Push the skill to your organization's registry
+
+From the parent directory of `hello-world/`, push the skill to your org's registry and tag it:
+
+```shell
+chainctl skills push hello-world --group $ORG --tag v1.0.0
+```
+```output
+            REFERENCE             |        DIGEST
+----------------------------------|------------------------
+ skills.cgr.dev/example.dev/hello-world:v1.0.0 | sha256:3196...
+```
+
+### List your skills
+
+Confirm the skill was published with the `list` subcommand:
+
+```shell
+chainctl skills list --group $ORG
+```
+```output
+    NAME      | LATEST TAG | UPDATED
+--------------|------------|----------
+ hello-world  | v1.0.0     | just now
+```
+
+To view a skill's reference, digest, tags, and metadata, use the `describe` subcommand:
+
+```shell
+chainctl skills describe skills.cgr.dev/$ORG/hello-world:v1.0.0
+```
+```output
+    FIELD    |                                              VALUE                                               
+-------------|--------------------------------------------------------------------------------------------------
+ Name        | hello-world                                                                                      
+ Description | A simple hello world skill. Use this to verify your skills registry setup is working end to end. 
+ Tag         | v1.0.0                                                                                           
+ Digest      | sha256:393c0a2556c626010dfacaa402508122cbb4218be786882b7c74d9d61b38d19e                          
+ Size        | 709 B                                                                                            
+ Published   | just now  
+```
+
+
+### Install the skill
+
+Download and install the skill to make it available to agents on your machine:
+
+```shell
+chainctl skills install skills.cgr.dev/$ORG/hello-world:v1.0.0
+```
+
+This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
+
+```output
+Installing hello-world
+    AGENT    |          LOCATION          |                    MODE                    
+-------------|----------------------------|--------------------------------------------
+ Claude Code | .claude/skills/hello-world | symlink → ../../.agents/skills/hello-world 
+```
+
+### Run the skill from an agent
+
+Load `hello-world` into Claude or any MCP-compatible agent. In Claude Code, invoke it with:
+
+```Agent
+/hello-world
+```
+
+The agent responds:
+
+```output
+Hello from Chainguard Agent Skills! Your skill installed and loaded successfully.
+```
+
+This confirms the skill was published, installed, and loaded correctly end to end.
+
+## Command reference
+
+| Action | Command |
+| ----- | ----- |
+| Enable the entitlement | `chainctl skills entitlements create --parent $ORG` |
+| Accept the registry terms | `chainctl skills accept-terms --group $ORG` |
+| Push a skill | `chainctl skills push <name> --group $ORG --tag <version>` |
+| List skills | `chainctl skills list --group $ORG` |
+| Describe a skill | `chainctl skills describe skills.cgr.dev/$ORG/<name>:<version>` |
+| Install a skill | `chainctl skills install skills.cgr.dev/$ORG/<name>:<version>` |

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -17,87 +17,158 @@ weight: 003
 
 Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/chainguard`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The Chainguard Agent Skills public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
 
-This guide walks through the full workflow: listing the available skills, inspecting one, installing it, and running it with an agent.
+This guide walks through the full workflow: listing the available skills, inspecting one, pulling it to audit how Chainguard hardened it, installing it, and running it with an agent.
 
 {{< beta feature="Chainguard Agent Skills" access="Chainguard Containers customers who sign up for the beta program. You can sign up by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**" >}}
 
 ## Prerequisites
 
-To follow this guide, you need `chainctl` **v0.2.275** or later, installed. Refer to our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
+To follow this guide, you need `chainctl` **v0.2.282** or later, installed. Refer to our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
 
-Unlike a [private Chainguard Skills Registry](/chainguard/agent-skills/skills-registry/), the public catalog requires no entitlement, terms acceptance, or organization membership.
+Unlike a [private Chainguard Skills Registry](/chainguard/agent-skills/skills-registry/), the public catalog requires no entitlement, terms acceptance, or organization membership. You do need a Chainguard account to list and pull skills, but you don't need to be a customer.
 
 ## List available skills
 
-You can browse the skills published in the public Chainguard catalog with the `list` subcommand:
+Sign in, then browse the skills published in the public Chainguard catalog with the `list` subcommand. The `--recursive` flag lists skills across every owner in the catalog:
 
 ```shell
-chainctl skills list --group chainguard
+chainctl auth login
+chainctl skills list --group chainguard --recursive
 ```
 ```output
-    NAME      | LATEST TAG | UPDATED
---------------|------------|----------
- hello-world  | v1.0.0     | 2 days ago
+              NAME              | LATEST TAG |   UPDATED
+--------------------------------|------------|--------------
+ agentspace-so/agentspace       | latest     | 21 hours ago
+ antfu/antfu                    | latest     | 21 hours ago
+ antfu/nuxt                     | latest     | 21 hours ago
+ antfu/vitest                   | latest     | 21 hours ago
+ antfu/vue                      | latest     | 21 hours ago
+ anthropics/doc-coauthoring     | latest     | 21 hours ago
+ anthropics/frontend-design     | latest     | 21 hours ago
+ apollographql/apollo-client    | latest     | 21 hours ago
+ 
+ . . .
+```
+
+To list the skills from a single upstream owner, name it in the `--group` value:
+
+```shell
+chainctl skills list --group chainguard/anthropics
+```
+```output
+ TYPE  |      NAME       | LATEST TAG | UPDATED
+-------|-----------------|------------|------------
+ skill | doc-coauthoring | latest     | 1 hour ago
+ skill | frontend-design | latest     | 1 hour ago
 ```
 
 ## Inspect a skill
 
-To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand:
+To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand. The output records the upstream source and the exact commit Chainguard hardened from:
 
 ```shell
-chainctl skills describe skills.cgr.dev/chainguard/hello-world:v1.0.0
+chainctl skills describe skills.cgr.dev/chainguard/github/add-educational-comments:latest
 ```
 ```output
-    FIELD    |                                              VALUE                                               
--------------|--------------------------------------------------------------------------------------------------
- Name        | hello-world                                                                                      
- Description | A simple hello world skill. Use this to verify your skills registry setup is working end to end. 
- Tag         | v1.0.0                                                                                           
- Digest      | sha256:393c0a2556c626010dfacaa402508122cbb4218be786882b7c74d9d61b38d19e                          
- Size        | 709 B                                                                                            
- Published   | 2 days ago  
+      FIELD      |                                                    VALUE                                                     
+-----------------|--------------------------------------------------------------------------------------------------------------
+ Display Name    | add-educational-comments
+ Reference       | chainguard/github/add-educational-comments
+ Install Name    | chainguard-github-add-educational-comments
+ OCI URL         | skills.cgr.dev/chainguard/github/add-educational-comments:latest
+ Description     | Add educational comments to the file specified, or prompt asking for file to comment if one is not provided.
+ License         | MIT
+ Upstream        | github.com/github/awesome-copilot/skills/add-educational-comments
+ Upstream Commit | cf4347e88c2e40a9aabe5801748ec6bf924c09be
+ License Source  | LICENSE
+ Tag             | cf4347e88c2e40a9aabe5801748ec6bf924c09be
+ Digest          | sha256:59b781f87f82aba08ccf622b60a31ee5b8fbb27fa447ed5910850d4320505735
+ Size            | 1.1 KB
+ Published       | 1 day ago   
 ```
+
+## Pull a skill to inspect it
+
+Where `install` drops a skill straight into your agent's skills directory, `pull` writes the skill's files to a directory you choose so you can inspect them first:
+
+```shell
+chainctl skills pull skills.cgr.dev/chainguard/github/add-educational-comments:latest ./add-educational-comments
+```
+```output
+Skill written to: /home/linky/add-educational-comments
+```
+
+Every hardened skill ships with a `HARDENING.md` that records the upstream source, the exact commit Chainguard hardened from, and every change the hardening engine made:
+
+```shell
+cat add-educational-comments/HARDENING.md
+```
+```output
+# Hardening Report: github.com/github/awesome-copilot/skills/add-educational-comments
+
+| Field | Value |
+|---|---|
+| Upstream SHA | `cf4347e88c2e40a9aabe5801748ec6bf924c09be` |
+| Hardened at | 2026-06-09T23:14:22Z |
+| Files processed | 2 |
+| .md files (clean after harden) | 1 |
+| .md files (attempts exhausted) | 0 |
+| Non-.md files (copied verbatim) | 1 |
+
+## Markdown files
+
+### `SKILL.md`
+
+- Status: **clean**
+- Attempts used: 2
+- Findings + fixes applied:
+
+  | Attempt | Rule | Severity | Finding |
+  |---|---|---|---|
+  | 1 | `minimal-permissions` | high | The skill's purpose is to statically analyze and add comments to code files. It does not require the ability to execute the code to fulfill its objectives. The prompt's rules about not 'breaking execution' are constraints on the output, not a requirement to test the code by running it in a live environment. |
+
+## Verbatim files
+
+- `LICENSE`
+```
+
+Here, the engine flagged `minimal-permissions`: the skill only needs to read and comment on files, so the hardened version drops the implied permission to execute them.
 
 ## Install a skill
 
 Download and install the skill to make it available to agents on your machine with the `install` subcommand:
 
 ```shell
-chainctl skills install skills.cgr.dev/chainguard/hello-world:v1.0.0
+chainctl skills install skills.cgr.dev/chainguard/github/add-educational-comments:latest
 ```
 
 This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
 
 ```output
-Installing hello-world
-    AGENT    |          LOCATION          |                    MODE                    
--------------|----------------------------|--------------------------------------------
- Claude Code | .claude/skills/hello-world | symlink → ../../.agents/skills/hello-world 
+Installing github/add-educational-comments
+    AGENT    |                         LOCATION                          |                                   MODE                                    
+-------------|-----------------------------------------------------------|---------------------------------------------------------------------------
+ Claude Code | .claude/skills/chainguard-github-add-educational-comments | symlink → ../../.agents/skills/chainguard-github-add-educational-comments 
 ```
 
 ## Run the skill from an agent
 
-Load `hello-world` into Claude Code or any MCP-compatible agent. In Claude Code, invoke it by name:
+Load the skill into Claude Code or any MCP-compatible agent. In Claude Code, invoke it by name:
 
 ```Agent
-/hello-world
+/add-educational-comments
 ```
 
-The agent responds:
-
-```output
-Hello from Chainguard Agent Skills! Your skill installed and loaded successfully.
-```
-
-This confirms the skill installed and loaded correctly end to end.
+The agent loads the skill and runs it, confirming it installed and loaded correctly end to end.
 
 ## Command reference
 
 | Action | Command |
 | ----- | ----- |
-| List skills | `chainctl skills list --group chainguard` |
-| Describe a skill | `chainctl skills describe skills.cgr.dev/chainguard/<name>:<tag>` |
-| Install a skill | `chainctl skills install skills.cgr.dev/chainguard/<name>:<tag>` |
+| List skills | `chainctl skills list --group chainguard --recursive` |
+| Describe a skill | `chainctl skills describe skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
+| Pull a skill | `chainctl skills pull skills.cgr.dev/chainguard/<owner>/<name>:<tag> <dir>` |
+| Install a skill | `chainctl skills install skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
 
 ## Next steps
 

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -1,0 +1,104 @@
+---
+title: "Getting started with the Chainguard Agent Skills public catalog"
+linktitle: "Public Catalog"
+description: "Browse, inspect, install, and run hardened agent skills from Chainguard's public catalog with chainctl."
+type: "article"
+date: 2026-06-08T08:48:45+00:00
+lastmod: 2026-06-08T08:48:45+00:00
+draft: false
+tags: ["Agent Skills", "Overview"]
+images: []
+menu:
+  docs:
+    parent: "agent-skills"
+toc: true
+weight: 003
+---
+
+Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/chainguard`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
+
+This guide walks through the full workflow: listing the available skills, inspecting one, installing it, and running it with an agent.
+
+> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+
+## Prerequisites
+
+To follow this guide, you need `chainctl` **v0.2.275** or later, installed. Refer to our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
+
+Unlike your organization's [private registry](/chainguard/agent-skills/private-catalog/), the public catalog requires no entitlement, terms acceptance, or organization membership.
+
+## List available skills
+
+You can browse the skills published in the public Chainguard catalog with the `list` subcommand:
+
+```shell
+chainctl skills list --group chainguard
+```
+```output
+    NAME      | LATEST TAG | UPDATED
+--------------|------------|----------
+ hello-world  | v1.0.0     | 2 days ago
+```
+
+## Inspect a skill
+
+To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand:
+
+```shell
+chainctl skills describe skills.cgr.dev/chainguard/hello-world:v1.0.0
+```
+```output
+    FIELD    |                                              VALUE                                               
+-------------|--------------------------------------------------------------------------------------------------
+ Name        | hello-world                                                                                      
+ Description | A simple hello world skill. Use this to verify your skills registry setup is working end to end. 
+ Tag         | v1.0.0                                                                                           
+ Digest      | sha256:393c0a2556c626010dfacaa402508122cbb4218be786882b7c74d9d61b38d19e                          
+ Size        | 709 B                                                                                            
+ Published   | 2 days ago  
+```
+
+## Install a skill
+
+Download and install the skill to make it available to agents on your machine with the `install` subcommand:
+
+```shell
+chainctl skills install skills.cgr.dev/chainguard/hello-world:v1.0.0
+```
+
+This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
+
+```output
+Installing hello-world
+    AGENT    |          LOCATION          |                    MODE                    
+-------------|----------------------------|--------------------------------------------
+ Claude Code | .claude/skills/hello-world | symlink → ../../.agents/skills/hello-world 
+```
+
+## Run the skill from an agent
+
+Load `hello-world` into Claude Code or any MCP-compatible agent. In Claude Code, invoke it by name:
+
+```Agent
+/hello-world
+```
+
+The agent responds:
+
+```output
+Hello from Chainguard Agent Skills! Your skill installed and loaded successfully.
+```
+
+This confirms the skill installed and loaded correctly end to end.
+
+## Command reference
+
+| Action | Command |
+| ----- | ----- |
+| List skills | `chainctl skills list --group chainguard` |
+| Describe a skill | `chainctl skills describe skills.cgr.dev/chainguard/<name>:<tag>` |
+| Install a skill | `chainctl skills install skills.cgr.dev/chainguard/<name>:<tag>` |
+
+## Next steps
+
+To publish, install, and run skills scoped to your own organization, see [Getting started with the Chainguard Agent Skills private registry](/chainguard/agent-skills/private-catalog/).

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -19,7 +19,7 @@ Chainguard publishes a curated set of hardened agent skills in a public catalog 
 
 This guide walks through the full workflow: listing the available skills, inspecting one, installing it, and running it with an agent.
 
-> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+{{< beta feature="Chainguard Agent Skills" access="Chainguard Containers customers who sign up for the beta program. You can sign up by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**" >}}
 
 ## Prerequisites
 

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -15,7 +15,7 @@ toc: true
 weight: 003
 ---
 
-Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/chainguard`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
+Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/chainguard`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The Chainguard Agent Skills public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
 
 This guide walks through the full workflow: listing the available skills, inspecting one, installing it, and running it with an agent.
 
@@ -25,7 +25,7 @@ This guide walks through the full workflow: listing the available skills, inspec
 
 To follow this guide, you need `chainctl` **v0.2.275** or later, installed. Refer to our guide on [How to Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
 
-Unlike your organization's [private registry](/chainguard/agent-skills/private-catalog/), the public catalog requires no entitlement, terms acceptance, or organization membership.
+Unlike a [private Chainguard Skills Registry](/chainguard/agent-skills/skills-registry/), the public catalog requires no entitlement, terms acceptance, or organization membership.
 
 ## List available skills
 
@@ -101,4 +101,4 @@ This confirms the skill installed and loaded correctly end to end.
 
 ## Next steps
 
-To publish, install, and run skills scoped to your own organization, see [Getting started with the Chainguard Agent Skills private registry](/chainguard/agent-skills/private-catalog/).
+To publish, install, and run skills scoped to your own organization, see [Getting started with the Chainguard Skills Registry](/chainguard/agent-skills/skills-registry/).

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -1,7 +1,7 @@
 ---
-title: "Getting started with the Chainguard Agent Skills private registry"
-linktitle: "Private Registry"
-description: "Enable Chainguard Agent Skills, then push, install, and run an agent skill scoped to your organization."
+title: "Getting started with the Chainguard Skills Registry"
+linktitle: "Skills Registry"
+description: "Enable the Chainguard Skills Registry, then push, install, and run an agent skill scoped to your organization."
 type: "article"
 date: 2026-06-05T08:48:45+00:00
 lastmod: 2026-06-05T08:48:45+00:00
@@ -15,11 +15,11 @@ toc: true
 weight: 002
 ---
 
-Chainguard Agent Skills lets you publish, manage, and distribute skills scoped to your organization. Skills are stored as OCI artifacts at `skills.cgr.dev/<your-org>/<skill-name>:<tag>` and managed with `chainctl`.
+The Chainguard Skills Registry lets you publish, manage, and distribute skills scoped to your organization. Skills are stored as OCI artifacts at `skills.cgr.dev/<your-org>/<skill-name>:<tag>` and managed with `chainctl`.
 
 This guide walks through the full workflow, including how to enable the registry for your org, then push, install, and run a skill.
 
-> **Note**: As of this writing, Chainguard Agent Skills are in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+> **Note**: As of this writing, the Chainguard Skills Registry is in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ To follow this guide, you need:
 * An active Chainguard organization.
 * Owner access on the organization.
 
-The examples use an `$ORG` environment variable to refer to your organization. Set it to the name of your organization before you begin:
+The examples in this guide use an `$ORG` environment variable to refer to your organization. Set it to the name of your organization before you begin:
 
 ```shell
 export ORG=<your-organization>
@@ -42,7 +42,6 @@ Before your org can push or install skills, create a skills entitlement:
 ```shell
 chainctl skills entitlements create --parent $ORG
 ```
-
 ```output
 Created skills entitlement for org example.dev (717b474ac6972745c5706a898aa6e67ffba97dad)
 ```
@@ -91,7 +90,7 @@ If the user provides their name, greet them by name instead:
 EOF
 ```
 
-Your directory now looks like this:
+After running this command, your directory will have the following structure:
 
 ```
 hello-world/
@@ -104,7 +103,7 @@ The directory name (`hello-world/`) must match the `name` field in the frontmatt
 
 This section outlines some of the `chainctl` commands you can use to manage skills in your organization's private Skills Registry. The following commands use the `hello-world` skill as an example, but you can use any other skills you've created in its place.
 
-Check out the [`chainctl skills` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_skills/) for more information.
+Refer to the [`chainctl skills` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_skills/) for more information.
 
 ### Push the skill to your organization's registry
 
@@ -168,7 +167,7 @@ Installing hello-world
 
 ### Run the skill from an agent
 
-Load `hello-world` into Claude or any MCP-compatible agent. In Claude Code, invoke it with:
+Load `hello-world` into Claude Code or any MCP-compatible agent. In Claude Code, invoke it with:
 
 ```Agent
 /hello-world

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -19,7 +19,7 @@ The Chainguard Skills Registry lets you publish, manage, and distribute skills s
 
 This guide walks through the full workflow, including how to enable the registry for your org, then push, install, and run a skill.
 
-> **Note**: As of this writing, the Chainguard Skills Registry is in beta. You can sign up for the beta program by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**.
+{{< beta feature="Chainguard Skills Registry" >}}
 
 ## Prerequisites
 

--- a/layouts/shortcodes/beta.html
+++ b/layouts/shortcodes/beta.html
@@ -6,7 +6,7 @@
 <blockquote>
     <p><strong>Note</strong>: {{ $feature }} is in beta.
     {{- if eq $enroll "true" }} Contact your Chainguard account team to enable it for your organization.{{ end -}}
-    {{- with $access }} Available to {{ . }}.{{ end -}}
+    {{- with $access }} Available to {{ . | markdownify }}.{{ end -}}
     {{- if eq $feedback "true" }} Share feedback with your account team.{{ end -}}
     </p>
 </blockquote>


### PR DESCRIPTION
## Type of change
**New Content**
- Adds a new `content/chainguard/agent-skills/` docs section: an overview, plus getting-started guides for the public catalog and the private registry.

## What should this PR do?

resolves https://github.com/chainguard-dev/internal/issues/5864

## Why are we making this change?

Chainguard Agent Skills (currently in beta) had no end-user documentation. This adds a section explaining what hardened agent skills are and the supply-chain risk they address, with step-by-step guides for installing from the public catalog and for publishing to an organization's private registry with `chainctl`.

## What are the acceptance criteria?

- The Agent Skills section renders with four pages: Overview, Public Catalog, and Private Registry (plus the section index).
- All internal cross-links resolve (overview → public-catalog/ and private-catalog/; the two guides link to each other).
- `chainctl` command examples and example output are accurate and correctly formatted.

## How should this PR be tested?

1. Check the [preview link](https://deploy-preview-3395--ornate-narwhal-088216.netlify.app/chainguard/agent-skills/overview/) and ensure the changes look right.
2. Navigate to the Agent Skills section and verify the Overview, Public Catalog, and Private Registry pages render and that every internal link resolves (no 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
