### PR TITLE
Add URL normalization detail to Java and JS Artifactory config

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -287,7 +287,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * Deactivate **Maven Settings - Handle Snapshots**.
 1. Optionally click **Test** to verify connection and authentication.
 1. Click the **Advanced** configuration tab. Under the **Others** section, deactivate the **Block
-   Mismatching Mime Types** setting.
+   Mismatching Mime Types** setting. Disable **URL Normalization**
 1. Click **Create Remote Repository**.
 1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -197,6 +197,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
+1. Click the **Advanced** configuration tab. Disable **URL Normalization**
 1. Click **Create Remote Repository**.
 
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -260,7 +260,7 @@ authentication details, and the URL
 Configure a remote repository for the PyPI public index:
 
 1. Select **Create a Repository** and choose the **Remote** option.
-1. Select *PyPI* as the Package type.
+1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-public`.
 1. Set the **URL** to `https://files.pythonhosted.org`.
 1. Set the **PyPI Settings - Registry URL** to `https://pypi.org/`.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -269,7 +269,7 @@ Configure a remote repository for the PyPI public index:
 Combine the two repositories in a new virtual repository:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
-1. Select *PyPI* as the Package type.
+1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-all`.
 1. In the **Repositories** section, find the `python-chainguard` and
    `python-public` repositories. Ensure the `python-chainguard` repository is


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update global config pages for consistency 

### What should this PR do?
Add instruction to disable URL Normalization in Artifactory for JS and Java (it was already added to Python in a separate PR)

### Why are we making this change?
Prevent issues that occur after the R2 migration

### What are the acceptance criteria? 
Content should be accurate and appear in the expected location

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
