### PR TITLE
Add info about transitive dependencies to CVE Remediation

### DIFF
--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -66,7 +66,12 @@ Remediation propagates across the dependency tree through the index, not through
 
 **Java**
 
-Java remediation behavior differs from Python. Because Maven POMs typically pin dependencies to exact versions rather than using version ranges, Chainguard may update a package's POM dependency tree directly to reference remediated versions of its dependencies. This means transitive dependencies can receive CVE remediations without requiring changes to your own dependency declarations.
+Java remediation behavior differs from Python. For Java packages that publish a BOM, Chainguard may update the BOM to roll forward dependencies to remediated versions. This means transitive dependencies can receive CVE remediations without requiring changes to your own dependency declarations.
+
+Note that BOM-based remediation is best-effort and does not cover all packages or
+dependency trees. To ensure full control over dependency versions in your
+project, use `dependencyManagement` or equivalent tooling to explicitly manage
+and override dependency versions.
 
 ### CVE remediation for vendored dependencies
 

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -54,6 +54,14 @@ For Python, remediated packages use a `+cgr.N` local version suffix. For example
 
 For Java, remediated artifacts use a `-0.cgr.N` suffix appended to the base version. For example, if `org.apache.commons:commons-lang3:3.18.0` has a remediated build, that build is published as org.apache.`commons:commons-lang3:3.18.0-0.cgr.1`. If Chainguard publishes another remediated iteration for the same base version, the trailing number increases, such as `-0.cgr.2` or `-0.cgr.3`.
 
+### Remediation and transitive dependencies
+
+Installing a `+cgr.N` package doesn't automatically remediate its entire dependency tree. Chainguard publishes a `+cgr.N` version only for a package that has a remediation to deliver, and it leaves that package's own dependency declarations unchanged.
+
+This is intentional. Most packages don't pin their dependencies tightly enough to require a rewrite, so the package metadata stays identical to upstream.
+
+Remediation propagates across the dependency tree through the index, not through dependency declarations. When you configure the Chainguard index, your package manager resolves every dependency, both direct and transitive, through Chainguard Libraries rather than the upstream index. As described in [Remediated version naming](#remediated-version-naming), a `+cgr.N` build is a higher-precedence local version, so the resolver selects it automatically wherever Chainguard has published one. Dependencies without a remediation resolve to the standard upstream version served through the same index.
+
 ### CVE remediation for vendored dependencies
 
 Some Python packages bundle compiled code written in other languages (such as Go, Rust, or C/C++) directly into their wheel. When a CVE exists in a dependency of that

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -56,11 +56,17 @@ For Java, remediated artifacts use a `-0.cgr.N` suffix appended to the base vers
 
 ### Remediation and transitive dependencies
 
-Installing a `+cgr.N` package doesn't automatically remediate its entire dependency tree. Chainguard publishes a `+cgr.N` version only for a package that has a remediation to deliver, and it leaves that package's own dependency declarations unchanged.
+**Python** 
+
+For Python, installing a `+cgr.N` package doesn't automatically remediate its entire dependency tree. Chainguard publishes a `+cgr.N` version only for a package that has a remediation to deliver, and it leaves that package's own dependency declarations unchanged.
 
 This is intentional. Most packages don't pin their dependencies tightly enough to require a rewrite, so the package metadata stays identical to upstream.
 
 Remediation propagates across the dependency tree through the index, not through dependency declarations. When you configure the Chainguard index, your package manager resolves every dependency, both direct and transitive, through Chainguard Libraries rather than the upstream index. As described in [Remediated version naming](#remediated-version-naming), a `+cgr.N` build is a higher-precedence local version, so the resolver selects it automatically wherever Chainguard has published one. Dependencies without a remediation resolve to the standard upstream version served through the same index.
+
+**Java**
+
+Java remediation behavior differs from Python. Because Maven POMs typically pin dependencies to exact versions rather than using version ranges, Chainguard may update a package's POM dependency tree directly to reference remediated versions of its dependencies. This means transitive dependencies can receive CVE remediations without requiring changes to your own dependency declarations.
 
 ### CVE remediation for vendored dependencies
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to CVE Remediation page

### What should this PR do?
- Clarify that installing a +cgr.N package doesn't automatically remediate its entire dependency tree.
- Adds a "Remediation and transitive dependencies" subsection to the CVE remediation page explaining that Chainguard publishes +cgr.N versions only where there's a remediation to deliver
- Adds note about how this differs for Java

### Why are we making this change?
Feedback from Slack: https://chainguard-dev.slack.com/archives/C07FTFZNP51/p1780493504623989

### What are the acceptance criteria? 
- Content should be clear and accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

Review the deploy preview to ensure content appears as expected.

 ---Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-06-09.