### PR TITLE
chore: add digestabot Workflow

### DIFF
--- a/.github/chainguard/digestabot.sts.yaml
+++ b/.github/chainguard/digestabot.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/edu:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: chainguard-dev/edu/.github/workflows/digestabot.yaml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Image digest update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+permissions: {}
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+    if: github.repository == 'chainguard-dev/edu'
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            api.github.com:443
+            cgr.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            octo-sts.dev:443
+            rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: chainguard-dev/actions/setup-gitsign@3b7bbeebc3a5d2bc37aa008350202651c32a26e1 # main
+
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: digestabot
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        # zizmor: ignore[artipacked] - credentials needed for digestabot to push and create PRs
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - uses: chainguard-dev/digestabot@33d0b78e580aa0c83fe188eb3dfad6611b662479 # v1.3.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          include-files: ".github/workflows/*.yaml,Dockerfile*"


### PR DESCRIPTION
## Type of change

New GitHub Actions Workflow/ancillary `octo-sts` trust policy

### What should this PR do?

Adds a new Workflow to automatically handle image digest updates across Workflows and the `Dockerfile` in the repository's root

### Why are we making this change?

Dependabot doesn't handle pinned digests in Dockerfiles

### What are the acceptance criteria? 

- the Workflow runs after merging to `main`
- image digests are updated correctly

### How should this PR be tested?

- run the Workflow via the `workflow_dispatch` trigger after merge

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
