### PR TITLE
Raise nginx header buffers to 32k to fix 400s from large cookies

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,12 @@ http {
     default_type  application/octet-stream;
     sendfile        on;
     keepalive_timeout  65;
+
+    # Allow request headers up to 32k (matches the Cloud Run/GFE ceiling).
+    # Marketing trackers set large cookies on .chainguard.dev that are sent to
+    # every subdomain; nginx's default 8k buffer rejects those requests with
+    # "400 Request Header Or Cookie Too Large".
+    large_client_header_buffers 4 32k;
     gzip  on;
     gzip_disable "msie6"; # Disable comnpression on really old Internet Explorer
 


### PR DESCRIPTION
## Problem

Users are intermittently getting **400 Bad Request** on edu.chainguard.dev, "fixed" only by clearing cookies (reported by Leo Borda in [#engineering](https://chainguard-dev.slack.com/archives/C032M6DDY03/p1781038740653739)).

Root cause: marketing trackers (HubSpot, ZoomInfo, 6sense, Clearbit, …) set cookies on the parent `.chainguard.dev` domain, which browsers send to every subdomain including `edu.`. Once a user's accumulated cookies push the `Cookie` header past nginx's default `large_client_header_buffers` of **8k**, nginx rejects every request with `400 Request Header Or Cookie Too Large` until the user clears cookies — which only helps until the trackers repopulate.

## Evidence

- Reproduced externally: requests to `https://edu.chainguard.dev/` succeed with ≤8175 bytes of cookies and return nginx's `400 Request Header Or Cookie Too Large` page starting exactly at the 8192-byte buffer boundary.
- Cloud Run request logs (`chainguard-academy`) show **20–450 real-browser 400s per day**, every day, going back at least to the start of log retention (May 10) — ~1,000 in the last 5 days from 19 distinct IPs, excluding scanner noise.
- Not related to the recent image digest bump; the 400s long predate it.

## Fix

Set `large_client_header_buffers 4 32k;` — 32k matches the Cloud Run / Google Frontend request-header ceiling, so nginx is no longer the weakest link.

## Testing

Built the image locally and verified with `curl`: requests carrying 8k–31k of cookies now return 200 instead of 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)