### PR TITLE
Fix robots.txt override by doks theme to restore AI crawler allowances

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -145,7 +145,7 @@ notAlternative = true
   [[module.mounts]]
     source = "node_modules/@hyas/doks/layouts"
     target = "layouts"
-    excludeFiles = ["index.html", "index.redirects", "_default/_markup/render-heading.html", "_default/_markup/render-image.html", "_default/baseof.html", "_default/list.html", "404.html", "partials/footer/footer.html", "partials/footer/script-footer.html", "partials/head/script-header.html", "partials/head/seo.html", "partials/header/header.html", "partials/sidebar/auto-collapsible-menu.html", "partials/sidebar/docs-toc.html", "partials/sidebar/nav-bottom.html", "shortcodes/alert.html"]
+    excludeFiles = ["index.html", "index.redirects", "_default/_markup/render-heading.html", "_default/_markup/render-image.html", "_default/baseof.html", "_default/list.html", "404.html", "partials/footer/footer.html", "partials/footer/script-footer.html", "partials/head/script-header.html", "partials/head/seo.html", "partials/header/header.html", "partials/sidebar/auto-collapsible-menu.html", "partials/sidebar/docs-toc.html", "partials/sidebar/nav-bottom.html", "shortcodes/alert.html", "robots.txt"]
   [[module.mounts]]
     source = "node_modules/@hyas/doks/static"
     target = "static"


### PR DESCRIPTION
## Summary

- The `@hyas/doks` theme owns `layouts/robots.txt` and was silently overriding the project's version due to Hugo module mount ordering — `robots.txt` was never added to the `excludeFiles` list.
- The live site was serving the doks minimal template (`User-agent: * / Allow: /`) instead of the project's detailed version, which has explicit per-agent allowances for `Claude-Web`, `anthropic-ai`, `GPTBot`, and other AI crawlers.
- This change adds `robots.txt` to the `excludeFiles` list so the project's template wins, matching the behavior documented in the comment on that line ("the theme version silently wins").

Fixes [internal#5862](https://github.com/chainguard-dev/internal/issues/5862).

## Test plan

- [ ] Confirm `https://edu.chainguard.dev/robots.txt` shows the full per-agent entries after deploy (currently shows only the doks minimal version)
- [ ] Confirm `User-agent: Claude-Web`, `User-agent: anthropic-ai`, and other AI crawler entries appear in the live output

---
Created in collaboration with Claude Code running claude-sonnet-4-6[1m] on 2026-06-10.