### PR TITLE
Document -full image variants and cross-link from migration docs

### DIFF
--- a/content/chainguard/chainguard-images/about/differences-development-production.md
+++ b/content/chainguard/chainguard-images/about/differences-development-production.md
@@ -1,5 +1,5 @@
 ---
-title: "Chainguard's Container Variants"
+title: "Chainguard's container variants"
 linktitle: "Container Variants"
 aliases:
 - /chainguard/chainguard-images/differences-development-production/
@@ -58,6 +58,15 @@ Slim variants start from that same security posture and then strip away even mor
 The result is a smaller, more opinionated runtime with the lowest possible footprint and attack surface, at the cost of some convenience and compatibility compared to the corresponding standard variant. In many workflows, you might build or debug using a development image, then deploy with a corresponding slim (or other standard) variant once your application artifacts are ready.
 
 Because slim variants remove general-purpose tools, they can require more deliberate configuration than other variants, particularly around entrypoints, logging, and debugging. When using a slim variant, always review the image documentation to understand its expected entrypoint, available utilities, and any behavioral differences from the corresponding standard or development image.
+
+
+## Full container variants
+
+Some Chainguard Containers also provide *full* variants, whose tags are appended with `-full`. Where standard images strip away everything but the essentials, full variants aim for parity with their upstream equivalent — typically the Debian-based image on Docker Hub. They include the packages, environment variables, and entrypoint scripts that the standard Chainguard image intentionally omits. We currently offer full variants for 10 images.
+
+Full variants exist primarily to ease migration. When you move a workload onto Chainguard Containers, your build and test pipelines may depend on components from your previous upstream image, even when the application itself doesn't need them to run. These dependencies can cause runtime crashes or pipeline failures during a switch to a more minimal image. Starting with a full variant lets you adopt Chainguard Containers without first untangling every such dependency.
+
+We recommend treating full variants as a starting point rather than a destination. Once you've migrated, review which packages your production pipeline actually requires, then move to a standard or development variant that includes only what you need. Doing so gives you the smaller attack surface and lower CVE count that make Chainguard Containers worth adopting in the first place.
 
 
 ## Special considerations

--- a/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
+++ b/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
@@ -1,5 +1,5 @@
 ---
-title: "Debugging Distroless Container Images"
+title: "Debugging distroless container images"
 linktitle: "Debugging"
 aliases:
 - /chainguard/chainguard-images/debugging-distroless-images/
@@ -22,11 +22,13 @@ Because distroless images are minimal and don't include a package manager or a s
 
 In this article, we'll discuss a few different strategies to debug distroless images.
 
-## 1. Using Development Container Image Variants
+## 1. Using development container image variants
 
 Before moving a workload to a distroless runtime image, it is important to make sure that it runs without issues in a similar but less restrictive environment, which allows for easier debugging. It is also possible to make a temporary base image change from a distroless image to a fully featured image that offers more debugging capabilities.
 
 The development variants of [Chainguard Containers](/chainguard/chainguard-images/) are designed to replicate the same packages of their distroless version, but with additional software that helps in developing, building, and debugging applications in different language ecosystems. These are sometimes referred to as `-dev` variants since they are tagged with `:latest-dev`.
+
+> **Note**: If you're debugging a workload that crashes because it expects packages from its previous upstream image, a *full* variant may help. Available for a number of our most popular Containers and tagged `-full`, these variants map their upstream equivalent. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants).
 
 For example, the following table shows a comparison between the development variants of the PHP image, and which packages are included with each variant:
 
@@ -53,12 +55,12 @@ docker run -it --entrypoint /bin/sh cgr.dev/chainguard/php:latest-dev
 
 Having a package manager and the ability to log into the image to debug any issues is very important at development time, but becomes unnecessary (and less safe) when talking about production environments. That's why we recommend using a distroless variant for production workloads.
 
-### Chainguard Containers in Production
+### Chainguard Containers in production
 Although the development image variants have similar security features as their distroless versions, such as complete SBOMs and signatures, they feature additional software that is typically not necessary in production environments. The general recommendation is to use the development variants to build the application and then copy all application artifacts into a distroless image, which will result in a final container image that has a minimal attack surface and won't allow package installations or logins.
 
 That being said, it's worth noting that the `-dev` variants of Chainguard Containers are still **more secure** than many popular container images based on fully-featured operating systems such as Debian and Ubuntu, because they carry less software, follow a more frequent patch cadence, and offer attestations for what is included.
 
-### Language Ecosystem Guides
+### Language ecosystem guides
 The following guides show how to use these development images in combination with their distroless variants in order to build a final image that is also distroless, but contains everything the application needs to run:
 
 - [Getting Started with the Python Chainguard Container](/chainguard/chainguard-images/getting-started/python/)
@@ -70,7 +72,7 @@ The following guides show how to use these development images in combination wit
 Check also the guide on [Creating Wolfi Container Images with Dockerfiles](/open-source/wolfi/wolfi-with-dockerfiles/) for guidance on how to build a custom image that can be used for development and debugging.
 
 
-## 2. Using Ephemeral Debug Containers
+## 2. Using ephemeral debug containers
 
 Another method to debug distroless images running in production is to use ephemeral debug containers, a special type of container that is temporarily attached to an existing Pod to troubleshoot and inspect running services.
 
@@ -143,7 +145,7 @@ tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN
 
 To facilitate accessing processes running in other containers without having to specify a target, you may enable [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) within your Pod setup. It's also worth noting that the filesystem may not be accessible due to default user permissions.
 
-### Troubleshooting Volume Mounts
+### Troubleshooting volume mounts
 
 Kubernetes starts the ephemeral container without mounting the same volumes in the target container. As a result, directories like `/var/log`, which are backed by a volume in the original container, will appear empty or missing in the ephemeral container.
 
@@ -250,7 +252,7 @@ In the ephemeral container shell, you should now see the expected contents withi
 
 For more strategies on how to debug production distroless containers, check the [Kubernetes documentation on debugging running Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/).
 
-## Resources to Learn More
+## Resources to learn more
 
 - [Minimal Container Images: Towards a More Secure Future ](https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future) - Chainguard Blog
 - [Why Distroless](/chainguard/chainguard-images/overview/) - Chainguard Container Documentation

--- a/content/chainguard/migration/compatibility/debian-compatibility.md
+++ b/content/chainguard/migration/compatibility/debian-compatibility.md
@@ -29,7 +29,7 @@ Generally, if a tool exists in `busybox` but does not have a `coreutils` counter
 
 You can use the `apk search` command in Wolfi, and the `apt-cache search` command in Debian to find out which package includes a tool.
 
-If your workflow depends on tools or packages from the upstream Debian image, note that Chainguard offers *full* variants (tagged `-full`) for a number of our most popular Containers. These variants map to their upstream Debian equivalent and can ease migration before you move to a more minimal image. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants).
+If your workflow depends on tools or packages from the upstream Debian image, note that Chainguard offers *full* variants (tagged `-full`) for a number of our most popular Containers.These variants map to their upstream equivalent (often the Debian image on Docker Hub) and can ease migration before you move to a more minimal image. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants).
 
 | Utility             | Wolfi busybox | Debian busybox | Wolfi coreutils | Debian coreutils |
 | ------------------- | :-----------: | :------------: | :-------------: | :--------------: |

--- a/content/chainguard/migration/compatibility/debian-compatibility.md
+++ b/content/chainguard/migration/compatibility/debian-compatibility.md
@@ -1,5 +1,5 @@
 ---
-title: "Debian Compatibility"
+title: "Debian compatibility"
 linktitle: "Debian"
 type: "article"
 aliases:
@@ -28,6 +28,8 @@ Note that `$PATH` locations like `/usr/bin` or `/sbin` are not included here. If
 Generally, if a tool exists in `busybox` but does not have a `coreutils` counterpart, there will be a specific package that includes it. For example the `zcat` utility is included in the `gzip` package in both Wolfi and Debian.
 
 You can use the `apk search` command in Wolfi, and the `apt-cache search` command in Debian to find out which package includes a tool.
+
+If your workflow depends on tools or packages from the upstream Debian image, note that Chainguard offers *full* variants (tagged `-full`) for a number of our most popular Containers. These variants map to their upstream Debian equivalent and can ease migration before you move to a more minimal image. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants).
 
 | Utility             | Wolfi busybox | Debian busybox | Wolfi coreutils | Debian coreutils |
 | ------------------- | :-----------: | :------------: | :-------------: | :--------------: |

--- a/content/chainguard/migration/migration-checklist.md
+++ b/content/chainguard/migration/migration-checklist.md
@@ -1,5 +1,5 @@
 ---
-title: "Migration Best Practices and Checklist"
+title: "Migration best practices and checklist"
 linktitle: "Migration Checklist"
 type: "article"
 description: "Recommended Practices when Migrating to Chainguard Containers"
@@ -16,7 +16,7 @@ Chainguard container images are designed to be minimal and to include special fe
 
 > **Download the [PDF version](/downloads/migrating-to-chainguard-images.pdf) of this checklist [here](/downloads/migrating-to-chainguard-images.pdf)!**
 
-## Important to Know
+## Important to know
 
  - Most Chainguard Containers don’t have a package manager or a shell by default. These are **distroless** images intended to be used as slim runtimes for production environments.
  - For every version of an image, a complimentary **standard** image is provided with a shell and the apk package manager. These are identified by the `-dev` suffix and can be customized.
@@ -24,8 +24,9 @@ Chainguard container images are designed to be minimal and to include special fe
  - Chainguard Containers typically don’t run as root, so a `USER root` statement may be required before installing software.
  - Chainguard Containers are based on **apk**. If you’re coming from Debian or Ubuntu you’ll need to replace `apt` commands with their `apk` equivalents. This also applies for other distros that are not based on **apk**.
  - Some images may behave differently than their equivalent in other distros, due to differences in entrypoint and shell availability. Always check the image documentation for usage details.
+ - For a number of our most popular Containers, a **full** variant (tagged `-full`) maps to the upstream image to ease initial migration. It's a useful starting point if your pipeline depends on packages from your previous image, though we recommend moving to a slimmer variant once you've migrated. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants).
 
-## Migration Checklist
+## Migration checklist
 - [ ] Check the image’s overview page on the [Containers Directory](https://images.chainguard.dev) for usage details and any compatibility remarks.
 - [ ] Replace your current base image with a standard `-dev` (such as `latest-dev`) variant as a starting point.
 - [ ] Add a `USER root` statement before package installations or other commands that must run as an administrative user.

--- a/content/chainguard/migration/migration-tips.md
+++ b/content/chainguard/migration/migration-tips.md
@@ -1,5 +1,5 @@
 ---
-title: "Tips for Migrating to Chainguard Containers"
+title: "Tips for migrating to Chainguard Containers"
 linktitle: "Migration Tips"
 type: "article"
 description: "This guide outlines a number of tips and strategies to keep in mind for when your organization begins migrating to Chainguard Containers."
@@ -18,7 +18,7 @@ toc: true
 The process of migrating over to Chainguard Containers isn't always straightforward. To help customers become acquainted with Chainguard Containers as they go through the migration process, we've assembled this list of tips and strategies for migrating over their applications.
 
 
-## Use Development Variants When You Need a Shell
+## Use development variants when you need a shell
 
 Chainguard provides development (or `-dev`) variants of its containers which include a shell and package manager to allow users to more easily debug and modify the image.
 
@@ -52,7 +52,7 @@ Although the `-dev` variants have similar security features as their distroless 
 
 That being said, it's worth noting that `-dev` variants of Chainguard Containers are completely fine to run in production environments. After all, the `-dev` variants are still **more secure** than many popular container images based on fully-featured operating systems such as Debian and Ubuntu since they carry less software, follow a more frequent patch cadence, and offer attestations for what they include.
 
-## Install a Different Shell
+## Install a different shell
 
 The `-dev` variants and `chainguard-base` image use the [ash](https://en.wikipedia.org/wiki/Almquist_shell) shell from BusyBox by default. This is nice from a minimalism perspective, but it's not so great if you need to port a bash and Debian centric entrypoint script to Chainguard Containers.
 
@@ -156,7 +156,7 @@ ae154854dc6d:/# apk add cmd:ldd
 OK: 27 MiB in 22 packages
 ```
 
-## Watch Out for Entrypoint Differences
+## Watch out for entrypoint differences
 
 In some cases, the entrypoint of Chainguard Containers can have a different behavior from their equivalent images based on other distros. This happens because many popular container images use an entrypoint script that allows running commands on the image through a shell. Since our images typically don't have a shell by default, this can lead to unexpected behavior.
 
@@ -201,7 +201,7 @@ docker run -it cgr.dev/chainguard/python:latest-dev echo "in a shell"
 
 Other images, such as our [WordPress container images](https://images.chainguard.dev/directory/image/wordpress/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrations-overview), will have a different entrypoint behavior in their `-dev` variant to allow for customization and to facilitate migration from other base images. It's important to always read the image's documentation to understand how the entrypoint works, and if there are any major differences from other images you may be used to work with.
 
-## Containers Don't Run As root By Default
+## Containers don't run as root by default
 
 Although there are exceptions, Chainguard Containers typically don’t run as the root user. The reason for this is that distroless containers should have no privileged capabilities, and containers that run as a non-root user and use a minimal seccomp profile are ideal from a security perspective.
 
@@ -228,13 +228,15 @@ docker run -it --user root --entrypoint bin/bash chainguard/python:latest-dev
 Here, the `--user` option tells Docker to assume the root user role.
 
 
-## Packages Not Found
+## Packages not found
 
 Container images are usually meant to support every possible use case. Because of this, they often contain packages that aren't always necessary, which increases the container image's attack surface and makes it more likely to contain CVEs.
 
 Chainguard Containers are built with minimalism in mind, and thus contain the bare minimum packages needed for an image to function. However, this also means that Chainguard Containers may not contain the packages that you'd expect to find in third-party alternatives.
 
 If a Chainguard Container is missing certain packages that are required for your application, we recommend using a base image and installing the required dependencies on top of it, preferably in a multi-stage Docker build. Our guides on [How to Use Chainguard Containers](/chainguard/chainguard-images/how-to-use-chainguard-images/#extending-chainguard-base-images) and [Getting Started with Distroless](/chainguard/migration/migrations-overview/) include guidance on how you can extend Chainguard base images.
+
+For a number of our most popular Containers, Chainguard offers a *full* variant (tagged `-full`) that maps to the upstream image, including the packages you'd expect from the third-party alternative. If a full variant is available for an image you're migrating, it can serve as a low-friction starting point while you determine which packages your workload actually needs. See [Full container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants) for details.
 
 Alternatively, you can take advantage of Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) and [Private APK Repositories](/chainguard/chainguard-images/features/private-apk-repos/) features to extend your container images. Custom Assembly allows users to create customers container images with extra packages added. This reduces their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs.
 
@@ -243,6 +245,6 @@ Private APK Repositories, meanwhile, allow customers to pull secure apk packages
 In some cases you may have Docker builds that copy in binaries to run agents or similar tooling. You may find these binaries don’t work as expected as they are designed to run on a different Linux distribution. Be aware that Chainguard Containers may not have the dependencies required by third-party binaries, or they may be stored at a different path.
 
 
-## Learn More
+## Learn more
 
 For more resources on migrating to Chainguard Containers, please refer to our [Containers Migration documentation](/chainguard/migration/). In particular, our [Migration Overview](/chainguard/migration/migrations-overview/) may be of interest. Chainguard Academy also hosts a number of [Compatibility Resources](/chainguard/migration/compatibility/) and [Migration Guides](/chainguard/migration/migration-guides/) for specific platforms and tools.

--- a/content/chainguard/migration/migrations-overview.md
+++ b/content/chainguard/migration/migrations-overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview of Migrating to Chainguard Containers"
+title: "Overview of migrating to Chainguard Containers"
 linktitle: "Migration Overview"
 aliases:
 - /chainguard/migration-guides/migration-overview/
@@ -32,7 +32,7 @@ The main features of Chainguard Containers include:
 
 Because of their minimalist design, Chainguard Containers sometimes require users to adjust their image workflows. This document is intended to serve as a migration guide for customers transitioning their organizations to use Chainguard Containers. It includes general tips and strategies for migrating to Chainguard Containers as well as a curated set of migration-related resources.
 
-## Migration Key Points
+## Migration key points
 
 * Most Chainguard Containers have no shell or package manager by default. This is great for security, but sometimes you need these things, especially in builder images. For those cases we have development container images (also known as `-dev` images, as in `cgr.dev/chainguard/python:latest-dev`) which do include a shell and package manager.
 * The development variants and `wolfi-base` / `chainguard-base` use BusyBox by default, so any `groupadd` or `useradd` commands will need to be ported to `addgroup` and `adduser`.
@@ -43,7 +43,7 @@ Because of their minimalist design, Chainguard Containers sometimes require user
 
 Perhaps the best place for most users to get started with migrating to Chainguard Containers is by following our guide on [How to Port a Sample Application to Chainguard Containers](/chainguard/migration/porting-apps-to-chainguard/). This guide involves updating a sample application made up of three services to use Chainguard Containers. Although the application involved is fairly simple, the concepts outlined in the guide can also be useful for migrating more complex applications.
 
-### Development Containers
+### Development containers
 
 As mentioned previously, Chainguard's standard container images typically do not include a shell or package manager. This helps to minimize the size of containers and also reduces their potential attack surface, but many users find that they need images that include a shell or package manager to support their specific use case. For this reason, Chainguard offers development containers (also known as `-dev` variants, since their image tags are appended with `-dev`). These variants come with more tooling than our standard container images, including a shell and package manager. 
 
@@ -51,14 +51,20 @@ Although development variants are still more secure than most popular container 
 
 Refer to our guide on [Chainguard's Container variants](/chainguard/chainguard-images/about/differences-development-production/) for more information on development containers.
 
-## Before Migrating
+### Full variants
+
+For a number of our most popular Containers, Chainguard also offers *full* variants, whose tags are appended with `-full`. Unlike standard or development variants, full variants are designed to map to their upstream equivalent — typically the Debian-based image on Docker Hub — including the packages, environment variables, and entrypoint scripts that our minimal images omit. They exist primarily to ease migration: if your build or test pipelines depend on components from your previous image, starting with a full variant lets you adopt Chainguard Containers without untangling those dependencies first. Once you've migrated, we recommend moving to a slimmer variant that includes only what your workload needs.
+
+Refer to our guide on [Chainguard's Container variants](/chainguard/chainguard-images/about/differences-development-production/#full-container-variants) for more information on full variants.
+
+## Before migrating
 
 Before you begin actively migrating to Chainguard Containers, review the images that your organization has access to and determine which teams and applications will be using each image. Notify the teams involved in the migration process so they can begin preparing. For teams that are new to Chainguard Containers, we recommend taking the online self-paced course, [Linky’s Guide to Chainguard Containers](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images).
 
 Next, determine which users and/or systems are going to need access to your Chainguard registry in order to begin preparing access. Most customers will need to copy images from their Chainguard registry into their organization's registry. An easy way to do this is by configuring the organization's registry as a pull-through mirror of the Chainguard registry. We have a guide on [how to configure Artifactory](/chainguard/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/) for this use case.
 
 
-## Recommended Rollout Approach
+## Recommended rollout approach
 
 When the goal is to migrate multiple deployments to Chainguard Containers, a major consideration is the strategy in which these container images are rolled out and deployed throughout your environment. The recommended rollout strategy for most customers is as follows:
 
@@ -91,17 +97,17 @@ A common requirement for many customers is to add a company specific certificate
 
 The process of adding or updating certificates, configuring APK repositories, and implementing other organization-specific customizations into an image is commonly known as creating a “Golden Image”. This approach enables these standard modifications to be applied once and then distributed across all teams, thereby reducing the risk of errors and minimizing friction during the migration process.
 
-### Image Type Considerations
+### Image type considerations
 
 Many Chainguard customers use both application and base container images, but it often takes more time to migrate your applications to a base image in comparison to an application image due to the complexity of coordinating multiple teams, testing, and release schedules. We recommend starting with and migrating to application images first while your teams get trained and onboarded with base images.
 
-####  Application Images
+#### Application images
 
 When migrating to a [Chainguard Application Container](/chainguard/chainguard-images/about/images-categories/#application-containers) you should first check the image’s overview page on the [Containers  Directory](https://images.chainguard.dev) for usage details and any compatibility notes. There may be user, permissions, or volume path differences with the Chainguard Image that you should be aware of. 
 
 It is a best practice to use the same version of the Chainguard Application Image as what is currently running in your environment, if that version is available from Chainguard. Post-migration you should thoroughly test and monitor your application.
 
-#### Base Images
+#### Base images
 
 When migrating to a [Chainguard Base Container](/chainguard/chainguard-images/about/images-categories/#base-containers) you should first check the images’s overview page on the [Containers Directory](https://images.chainguard.dev) for usage details and any compatibility remarks. You should understand the libraries, runtime requirements, and operating system dependencies of the applications you plan to have running on the base image. 
 
@@ -119,7 +125,7 @@ Custom Assembly allows users to create customers container images with extra pac
 Private APK Repositories, meanwhile, allow customers to pull secure apk packages from Chainguard. The list of packages available in an organization’s private repository is based on the apk repositories that the organization already has access to. For example, say your organization has access to the [Chainguard MySQL container image](https://images.chainguard.dev/directory/image/mysql/versions). Along with `mysql`, this image comes with other apk packages, including `bash`, `openssl`, and `pwgen`. This means that you'll have access to these apk packages through your organization's private APK repository, along with any others that appear in Chainguard container images that your organization has access to. 
 
 
-## Tips for Migrating to Chainguard Containers
+## Tips for migrating to Chainguard Containers
 Although not fully comprehensive, it can be helpful to keep the following list of tips and strategies in mind when migrating to Chainguard Containers.
 
 * Use development variants when you need a shell
@@ -159,7 +165,7 @@ We also have a video on [Debugging Distroless Containers with Docker Debug](/cha
 Lastly, you might also find help in the [Chainguard Containers FAQs](/chainguard/chainguard-images/faq/).
 
 
-## Migration Resources
+## Migration resources
 
 Chainguard Academy hosts a number of resources that can be useful when migrating to Chainguard Containers.
 
@@ -175,7 +181,7 @@ In addition to these, Chainguard Academy includes several types of resources tha
 * **Chainguard Courses** — Chainguard Courses exist to reduce onboarding friction through product-centered education.
 
 
-### Language- or Platform-specific resources
+### Language- or platform-specific resources
 
 We currently offer both Migration and Getting Started Guides for these Containers:
 
@@ -186,7 +192,7 @@ We currently offer both Migration and Getting Started Guides for these Container
 | PHP	| [✅ (link)](/chainguard/migration/migrating-php/)	| [✅ (link)](/chainguard/chainguard-images/getting-started/php/) |
 
 
-### Migration Guides
+### Migration guides
 
 * [Node](/chainguard/migration/migrating-node/)
 * [PHP](/chainguard/migration/migrating-php/)
@@ -199,7 +205,7 @@ In addition, we have a few migration guides in the form of videos:
 * [Node (video)](/chainguard/chainguard-images/videos/node-images/)
 
 
-### Compatibility Guides
+### Compatibility guides
 
 * [Alpine](/chainguard/migration/alpine-compatibility/)
 * [Debian](/chainguard/migration/debian-compatibility/)
@@ -207,7 +213,7 @@ In addition, we have a few migration guides in the form of videos:
 * [Ubuntu](/chainguard/migration/ubuntu-compatibility/)
 
 
-### Getting Started Guides
+### Getting started guides
 
 * [Cilium](/chainguard/chainguard-images/getting-started/cilium/)
 * [Go](/chainguard/chainguard-images/getting-started/go/)
@@ -233,24 +239,24 @@ In addition to the Academy resources listed above, Chainguard offers a number of
 
 * [Chainguard Containers Crash Course](https://courses.chainguard.dev/linkys-crash-course-on-chainguard-images): A quick overview of everything you need to know to get started ASAP.
 
-#### Getting Started (Developer-focused)
+#### Getting started (developer-focused)
 * [Getting Started With Chainguard Containers](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/getting-started-with-chainguard-images): Intro to everything you need to know - from basic setup to security scanning.
 * [Foundations of Supply Chain Security](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/foundations-of-software-supply-chain-security): The what, why, and how of keeping your software supply chain secure.
 * [Migration Guidance](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/migration-guidance): Your friendly guide to moving to Chainguard Containers without the headaches.
 
-#### Level Up (Next Level Courses)
+#### Level up (next level courses)
 
 * [Foundations of Supply Chain Security](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/foundations-of-software-supply-chain-security): The what, why, and how of keeping your software supply chain secure.
 * [Images! Images! Images!](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/images-images-images): Become an image expert - from FIPS to SBOMs and everything in between.
 * [Crush Your CVEs](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/crush-your-cves): Master vulnerability management and keep your systems secure.
 
-#### Running the Show (Admin Courses)
+#### Running the show (admin courses)
 
 * [Registry Rockstar](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/registry-rockstar): Everything you need to know about managing access, identity, and registry setup.
 * [Chainguard's Superstar Support](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images/chainguards-superstar-support): Get the most out of Chainguard's support resources and tools.
 
 
-## Further Reading
+## Further reading
 
 * [Overview of Chainguard Containers](/chainguard/chainguard-images/overview/)
 * [How to Use Chainguard Containers](/chainguard/chainguard-images/how-to-use-chainguard-images/)


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Add a "Full container variants" section to the container variants doc explaining what `-full` tags are and when to use them
- Cross-link the new section from the migration overview, migration tips, migration checklist, Debian compatibility, and debugging guides
- Convert affected titles and headings to sentence case

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/5870

Document the new `-full` image variants and point readers to that explanation from the relevant migration and troubleshooting docs.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Customers migrating to Chainguard Containers sometimes hit runtime crashes or pipeline failures when an image omits packages their workflow expects. The new `-full` variants map their upstream equivalent to ease that migration, but our docs didn't yet explain what they are, that they're available for a limited set of images, or that they're meant as a migration starting point rather than a long-term destination.

### What are the acceptance criteria?
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The container variants doc has a "Full container variants" section describing `-full` tags, their purpose, and the recommendation to move to a slimmer variant after migrating
- The migration overview, migration tips, migration checklist, Debian compatibility, and debugging guides each link to the new section
- The specific image count appears only in the canonical variants doc; cross-references use generic phrasing
- Titles and headings in the changed files follow sentence case, with `linktitle` left in Title Case

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Open the container variants page and confirm the "Full container variants" section reads correctly
3. From the migration overview, tips, checklist, Debian compatibility, and debugging pages, click each "Full container variants" link and confirm it resolves to the new section anchor
