### PR TITLE
Chainguard Repo for Python

### DIFF
--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -23,7 +23,17 @@ The configuration for the use of Chainguard Libraries depends on how you've set 
 - Remove local caches on workstations and CI/CD pipelines. This step ensures that dependencies are preferentially sourced from Chainguard Libraries.
 - Finally, confirm that your development tools and CI/CD workflows are correctly ingesting dependencies from Chainguard Libraries.
 
-These changes must be performed on all workstations of individual developers and other engineers running relevant application builds. They must also be performed on any build tool such as Jenkins, TeamCity, GitHub Actions, or other infrastructure that draws in dependencies.
+These changes must be performed on all workstations of individual developers and
+other engineers running relevant application builds. They must also be performed
+on any build tool such as Jenkins, TeamCity, GitHub Actions, or other
+infrastructure that draws in dependencies.
+
+The `https://libraries.cgr.dev/python/` endpoint is also the [Chainguard
+Repository](/chainguard/chainguard-repository/overview/) endpoint for Python. By
+default, it serves only Chainguard-built artifacts. When [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
+enabled for your organization, the same endpoint can also serve requested
+versions from PyPI under Chainguard security controls. 
 
 See the [minimal example projects](#minimal-example-projects) on this page for demonstrations using `uv` and `pip`.
 
@@ -132,6 +142,8 @@ See examples using `uv` and `pip` under [Minimal example projects](#minimal-exam
 Once you have credentials and the index URL from your organization's repository
 manager, you're ready to set up specific build tools for local development or
 CI/CD.
+
+The recommended configuration is to use the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint rather than manually configuring fallback to upstream PyPI. 
 
 ### Authentication
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -60,11 +60,11 @@ approach. Refer to the [direct access documentation for build
 tools](/chainguard/libraries/python/build-configuration/#direct-access) for more
 information.
 
-### Considerations for fallback approach
+### Manually managing fallback 
 
-Before configuring your repo manager, consider how you want to handle packages that aren't
-yet available in the Chainguard Libraries repository. If you configure a fallback to PyPI, packages sourced from that registry are not covered by Chainguard's
-malware-resistance guarantees. See the [fallback approaches](/chainguard/libraries/quickstart/#artifact-manager-recommended) described in the Chainguard Libraries quick start for guidance on choosing the right approach for your environment.
+Chainguard recommends using the [Chainguard Repository built-in upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) rather than configuring a public PyPI fallback in your repository manager. Configuring your own fallback bypasses the protection and policy behavior provided by Chainguard Repository.
+
+However, if you intentionally want to manage fallback ordering yourself, you can continue using the repository manager patterns described on this page to combine Chainguard and PyPI sources.
 
 ### Updating lockfile hashes
 
@@ -104,14 +104,14 @@ First, create a repository:
 
 1. Log in to your Cloudsmith instance as user with administrator privileges.
 1. Select the **Repositories** tab near the top of the screen.
-1. Navigate to the **Repositories Overview**, then select **+ New repository**.
+1. Navigate to the **Repositories Overview**, then select **+New repository**.
 1. At the new repository form, enter the name *python-all* for your new
    repository. The name should include *python* to identify the repository
    format. This convention helps avoid confusion, since repositories in
    Cloudsmith are multi-format. 
 1. Select a storage region that is appropriate for your organization and
    infrastructure.
-1. Select **+ Create Repository**. 
+1. Select **+Create Repository**. 
 
 Next, configure the upstream proxies:
 
@@ -132,7 +132,7 @@ Next, configure the upstream proxies:
    repeat the preceding two steps with the name `python-chainguard-remediated`,
    the priority `2`, the same authentication details, and the URL
    `https://libraries.cgr.dev/python-remediated/`.
-1. Configure another upstream proxy with the following details
+1. If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure another upstream proxy with the following details:
     * **Name**: `python-public`
     * **Priority**: `3`
     * **Upstream URL**: `https://pypi.org/`
@@ -180,24 +180,14 @@ value as retrieved with chainctl](/chainguard/libraries/access/):
 
 Navigate to Artifact Registry and select **Repositories** in the left hand
 navigation under the **Artifact Registry** label to configure a remote
-repository for the Pypi Package Index:
+repository for Chainguard Libraries for Python repository:
 
-1. Click **Create a Repository** or the **+** button.
-1. Set the **Name** to *python-public*.
-1. Set the **Format** to *Python*.
-1. Select *Remote* for the **Mode**.
-1. Select *PyPi* for the **Remote repository source**.
-1. Choose a suitable **Region** for your development in **Location type**.
-1. Click **Create**.
-
-Configure a remote repository for the Chainguard Libraries for Python repository:
-
-1. Click **+** to add another repository.
+1. Click **+Create a Repository**.
 1. Set the **Name** to *python-chainguard*.
 1. Set the **Format** to *Python*.
 1. Select *Remote* for the **Mode**.
 1. Select *Custom* for the **Remote repository source**.
-1. Set the URL for the Custom repository to *https://libraries.cgr.dev/python/*.
+1. Set the URL for the Custom repository to `https://libraries.cgr.dev/python/`.
 1. Select *Authenticated* in **Remote repository authentication mode**.
 1. Set **Username for the upstream repository** to the [value as retrieved
    with chainctl](/chainguard/libraries/access/).
@@ -206,7 +196,15 @@ Configure a remote repository for the Chainguard Libraries for Python repository
    as configured for the *python-public* repository.
 1. Click **Create**.
 
-Combine the two repositories in a new virtual repository:
+If you want to use the separate repository with [remediated Python
+libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
+preceding steps with the name `python-chainguard-remediated`, the same
+authentication details, and the URL
+`https://libraries.cgr.dev/python-remediated/`.
+
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
+
+Combine the repositories in a new virtual repository:
 
 1. Click **+** to add another repository.
 1. Set the **Name** to `python-all`.
@@ -266,31 +264,19 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-Configure a remote repository for the PyPI public index:
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI index. 
 
-1. Select **Create a Repository** and choose the **Remote** option.
-1. Select `PyPI` as the Package type.
-1. Set the **Repository Key** to `python-public`.
-1. Set the **URL** to `https://files.pythonhosted.org`.
-1. Set the **PyPI Settings - Registry URL** to `https://pypi.org/`.
-1. Select **Create Remote Repository**.
-
-Combine the two repositories in a new virtual repository:
+Combine the repositories in a new virtual repository:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
 1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-all`.
-1. In the **Repositories** section, find the `python-chainguard` and
-   `python-public` repositories. Ensure the `python-chainguard` repository is
-   the first in the displayed list. Use the icon on the right of the repository
-   name to drag and drop repositories into the desired position.
+1. In the **Repositories** section, find `python-chainguard`, `python-chainguard-remediated`, and if manually managing fallback, the `python-public` repository. Ensure the `python-chainguard-remediated` repository is the first in the displayed list. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
 
 At this point, you have a virtual repository set up in Artifactory that allows
 you or others in your organization to access Chainguard Libraries for Python,
-optionally including remediated versions, with your chosen tools. This setup
-falls back to the public PyPI index in cases where a package is not available in
-Chainguard's index.
+optionally including remediated versions, with your chosen tools. 
 
 ### Validate the remote repository
 
@@ -362,17 +348,7 @@ First, log in to Sonatype Nexus as a user with administrator privileges and
 access the **Server administration** and configuration section within the gear
 icon in the top navigation bar.
 
-Next, configure a remote repository for the public PyPI index:
-
-1. Select **Repository - Repositories** in the left hand navigation.
-1. Select **Create repository**.
-1. Select the **PyPI (proxy)** recipe.
-1. Provide a new name, such as `python-public`.
-1. In the **Proxy - Remote storage** field, add the following URL:
-   `https://pypi.org/`.
-1. Select **Create repository**.
-
-Configure a remote repository for the Chainguard Libraries for Python repository:
+Next, configure a remote repository for Chainguard Libraries for Python repository:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Select **Create repository**.
@@ -391,17 +367,16 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-Finally, create a new repository group and add the two repositories:
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
+
+Finally, create a new repository group and add the repositories:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Select **Create repository**.
 1. Select the **PyPI (group)** recipe.
 1. Provide a new name, such as `python-all`.
 1. In the section **Group - Member repositories**, move the new repositories
-   `python-public` and `python-chainguard` to the right and move the
-   `python-chainguard` repository to the top of the list with the arrow control.
-   If you configured the  `python-chainguard-remediated` repository, also move
-   it to the right and the top of the list.
+   `python-chainguard-remediated` and `python-chainguard` to the right. Move the  `python-chainguard-remediated` repository to the top of the list.
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -24,10 +24,19 @@ Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
 repository manager acts as a single point of access for developers and
 development tools to retrieve the required libraries.
 
-At a high level, adopting the use of Chainguard Libraries consists of the
-following steps:
+The recommended approach is to use the [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls)
+feature of Chainguard Repository, which allows you to configure your repository
+manager with a single upstream pointed at `https://libraries.cgr.dev/python/`. The
+Chainguard Repository handles fallback and policy enforcement; your repository
+manager handles local caching and access control. Chainguard also retrieves
+packages from the public PyPI repository on your behalf when upstream
+fallback is enabled. This includes protections such as malware detection and a
+cooldown period for newly published packages.
 
-* Add Chainguard Libraries as a remote repository for library retrieval.
+At a high level, adopting the use of Chainguard Libraries consists of the following steps:
+
+* Configure your environment to use `https://libraries.cgr.dev/python/` as the single upstream source for Python package retrieval. 
 * Add the public [PyPI](https://pypi.org/) repository as a remote repository.
 * Create a group, virtual, or polyglot repository combining these repository
   sources with any desired internal repositories. Configure the Chainguard

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -24,19 +24,10 @@ Repository](https://www.sonatype.com/products/sonatype-nexus-repository). The
 repository manager acts as a single point of access for developers and
 development tools to retrieve the required libraries.
 
-The recommended approach is to use the [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls)
-feature of Chainguard Repository, which allows you to configure your repository
-manager with a single upstream pointed at `https://libraries.cgr.dev/python/`. The
-Chainguard Repository handles fallback and policy enforcement; your repository
-manager handles local caching and access control. Chainguard also retrieves
-packages from the public PyPI repository on your behalf when upstream
-fallback is enabled. This includes protections such as malware detection and a
-cooldown period for newly published packages.
+At a high level, adopting the use of Chainguard Libraries consists of the
+following steps:
 
-At a high level, adopting the use of Chainguard Libraries consists of the following steps:
-
-* Configure your environment to use `https://libraries.cgr.dev/python/` as the single upstream source for Python package retrieval. 
+* Add Chainguard Libraries as a remote repository for library retrieval.
 * Add the public [PyPI](https://pypi.org/) repository as a remote repository.
 * Create a group, virtual, or polyglot repository combining these repository
   sources with any desired internal repositories. Configure the Chainguard
@@ -60,11 +51,11 @@ approach. Refer to the [direct access documentation for build
 tools](/chainguard/libraries/python/build-configuration/#direct-access) for more
 information.
 
-### Manually managing fallback 
+### Considerations for fallback approach
 
-Chainguard recommends using the [Chainguard Repository built-in upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) rather than configuring a public PyPI fallback in your repository manager. Configuring your own fallback bypasses the protection and policy behavior provided by Chainguard Repository.
-
-However, if you intentionally want to manage fallback ordering yourself, you can continue using the repository manager patterns described on this page to combine Chainguard and PyPI sources.
+Before configuring your repo manager, consider how you want to handle packages that aren't
+yet available in the Chainguard Libraries repository. If you configure a fallback to PyPI, packages sourced from that registry are not covered by Chainguard's
+malware-resistance guarantees. See the [fallback approaches](/chainguard/libraries/quickstart/#artifact-manager-recommended) described in the Chainguard Libraries quick start for guidance on choosing the right approach for your environment.
 
 ### Updating lockfile hashes
 
@@ -104,14 +95,14 @@ First, create a repository:
 
 1. Log in to your Cloudsmith instance as user with administrator privileges.
 1. Select the **Repositories** tab near the top of the screen.
-1. Navigate to the **Repositories Overview**, then select **+New repository**.
+1. Navigate to the **Repositories Overview**, then select **+ New repository**.
 1. At the new repository form, enter the name *python-all* for your new
    repository. The name should include *python* to identify the repository
    format. This convention helps avoid confusion, since repositories in
    Cloudsmith are multi-format. 
 1. Select a storage region that is appropriate for your organization and
    infrastructure.
-1. Select **+Create Repository**. 
+1. Select **+ Create Repository**. 
 
 Next, configure the upstream proxies:
 
@@ -132,7 +123,7 @@ Next, configure the upstream proxies:
    repeat the preceding two steps with the name `python-chainguard-remediated`,
    the priority `2`, the same authentication details, and the URL
    `https://libraries.cgr.dev/python-remediated/`.
-1. If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure another upstream proxy with the following details:
+1. Configure another upstream proxy with the following details
     * **Name**: `python-public`
     * **Priority**: `3`
     * **Upstream URL**: `https://pypi.org/`
@@ -180,14 +171,24 @@ value as retrieved with chainctl](/chainguard/libraries/access/):
 
 Navigate to Artifact Registry and select **Repositories** in the left hand
 navigation under the **Artifact Registry** label to configure a remote
-repository for Chainguard Libraries for Python repository:
+repository for the Pypi Package Index:
 
-1. Click **+Create a Repository**.
+1. Click **Create a Repository** or the **+** button.
+1. Set the **Name** to *python-public*.
+1. Set the **Format** to *Python*.
+1. Select *Remote* for the **Mode**.
+1. Select *PyPi* for the **Remote repository source**.
+1. Choose a suitable **Region** for your development in **Location type**.
+1. Click **Create**.
+
+Configure a remote repository for the Chainguard Libraries for Python repository:
+
+1. Click **+** to add another repository.
 1. Set the **Name** to *python-chainguard*.
 1. Set the **Format** to *Python*.
 1. Select *Remote* for the **Mode**.
 1. Select *Custom* for the **Remote repository source**.
-1. Set the URL for the Custom repository to `https://libraries.cgr.dev/python/`.
+1. Set the URL for the Custom repository to *https://libraries.cgr.dev/python/*.
 1. Select *Authenticated* in **Remote repository authentication mode**.
 1. Set **Username for the upstream repository** to the [value as retrieved
    with chainctl](/chainguard/libraries/access/).
@@ -196,15 +197,7 @@ repository for Chainguard Libraries for Python repository:
    as configured for the *python-public* repository.
 1. Click **Create**.
 
-If you want to use the separate repository with [remediated Python
-libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
-preceding steps with the name `python-chainguard-remediated`, the same
-authentication details, and the URL
-`https://libraries.cgr.dev/python-remediated/`.
-
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
-
-Combine the repositories in a new virtual repository:
+Combine the two repositories in a new virtual repository:
 
 1. Click **+** to add another repository.
 1. Set the **Name** to `python-all`.
@@ -254,7 +247,7 @@ Configure a remote repository for the Chainguard Libraries for Python index:
 1. Set the **PyPI Settings - Registry URL** to
    `https://libraries.cgr.dev/python/`.
 1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. Disable **URL Normalization** and disable **Block
+1. Click the **Advanced** configuration tab. Ensure **Disable URL Normalization** is checked, and disable **Block
    Mismatching Mime Types** in the **Others** section.
 1. Click **Create Remote Repository**.
 
@@ -264,19 +257,31 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI index. 
+Configure a remote repository for the PyPI public index:
 
-Combine the repositories in a new virtual repository:
+1. Select **Create a Repository** and choose the **Remote** option.
+1. Select `PyPI` as the Package type.
+1. Set the **Repository Key** to `python-public`.
+1. Set the **URL** to `https://files.pythonhosted.org`.
+1. Set the **PyPI Settings - Registry URL** to `https://pypi.org/`.
+1. Select **Create Remote Repository**.
+
+Combine the two repositories in a new virtual repository:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
 1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-all`.
-1. In the **Repositories** section, find `python-chainguard`, `python-chainguard-remediated`, and if manually managing fallback, the `python-public` repository. Ensure the `python-chainguard-remediated` repository is the first in the displayed list. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
+1. In the **Repositories** section, find the `python-chainguard` and
+   `python-public` repositories. Ensure the `python-chainguard` repository is
+   the first in the displayed list. Use the icon on the right of the repository
+   name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
 
 At this point, you have a virtual repository set up in Artifactory that allows
 you or others in your organization to access Chainguard Libraries for Python,
-optionally including remediated versions, with your chosen tools. 
+optionally including remediated versions, with your chosen tools. This setup
+falls back to the public PyPI index in cases where a package is not available in
+Chainguard's index.
 
 ### Validate the remote repository
 
@@ -348,7 +353,17 @@ First, log in to Sonatype Nexus as a user with administrator privileges and
 access the **Server administration** and configuration section within the gear
 icon in the top navigation bar.
 
-Next, configure a remote repository for Chainguard Libraries for Python repository:
+Next, configure a remote repository for the public PyPI index:
+
+1. Select **Repository - Repositories** in the left hand navigation.
+1. Select **Create repository**.
+1. Select the **PyPI (proxy)** recipe.
+1. Provide a new name, such as `python-public`.
+1. In the **Proxy - Remote storage** field, add the following URL:
+   `https://pypi.org/`.
+1. Select **Create repository**.
+
+Configure a remote repository for the Chainguard Libraries for Python repository:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Select **Create repository**.
@@ -367,16 +382,17 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
-
-Finally, create a new repository group and add the repositories:
+Finally, create a new repository group and add the two repositories:
 
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Select **Create repository**.
 1. Select the **PyPI (group)** recipe.
 1. Provide a new name, such as `python-all`.
 1. In the section **Group - Member repositories**, move the new repositories
-   `python-chainguard-remediated` and `python-chainguard` to the right. Move the  `python-chainguard-remediated` repository to the top of the list.
+   `python-public` and `python-chainguard` to the right and move the
+   `python-chainguard` repository to the top of the list with the arrow control.
+   If you configured the  `python-chainguard-remediated` repository, also move
+   it to the right and the top of the list.
 
 ### Build tool access
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -530,10 +530,4 @@ Repository](/chainguard/chainguard-repository/overview/). By default, the endpoi
 only Chainguard-built packages. When the upstream fallback is enabled, upstream packages are
 subject to additional security controls before being served.
 
-When using upstream fallback, the visibility of Chainguard-built versus upstream-fallback artifacts depends on the package manager in use:
-
-- **uv**: When `uv lock` resolves dependencies through Chainguard Repository, the resulting `uv.lock` can include per-artifact URLs that point to both `.../python/simple/` and `.../python-upstream/simple/`. This provides visibility of upstream fallback usage directly in the lockfile.
-- **pip**: To inspect whether a dependency was built by Chainguard or served from the upstream fallback, use `pip install --report` and review the per-artifact URLs that point to either `.../python/simple` or `.../python-upstream/simple/`. 
-- **Poetry**: Inspect the lockfile for the package source URLs.
-
 Learn about managing fallback and cooldown controls in the [Chainguard Libraries Overview](/chainguard/libraries/overview/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -530,4 +530,10 @@ Repository](/chainguard/chainguard-repository/overview/). By default, the endpoi
 only Chainguard-built packages. When the upstream fallback is enabled, upstream packages are
 subject to additional security controls before being served.
 
+When using upstream fallback, the visibility of Chainguard-built versus upstream-fallback artifacts depends on the package manager in use:
+
+- **uv**: When `uv lock` resolves dependencies through Chainguard Repository, the resulting `uv.lock` can include per-artifact URLs that point to both `.../python/simple/` and `.../python-upstream/simple/`. This makes upstream fallback visible directly in the lockfile.
+- **pip**: To inspect whether a dependency came from the Chainguard-built path, use `pip install --report` and review the reported download URLs.
+- **Poetry**: Inspect the lockfile for the package source URLs.
+
 Learn about managing fallback and cooldown controls in the [Chainguard Libraries Overview](/chainguard/libraries/overview/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -533,7 +533,7 @@ subject to additional security controls before being served.
 When using upstream fallback, the visibility of Chainguard-built versus upstream-fallback artifacts depends on the package manager in use:
 
 - **uv**: When `uv lock` resolves dependencies through Chainguard Repository, the resulting `uv.lock` can include per-artifact URLs that point to both `.../python/simple/` and `.../python-upstream/simple/`. This provides visibility of upstream fallback usage directly in the lockfile.
-- **pip**: To inspect whether a dependency came from the Chainguard-built path, use `pip install --report` and review the reported download URLs.
+- **pip**: To inspect whether a dependency was built by Chainguard or served from the upstream fallback, use `pip install --report` and review the per-artifact URLs that point to either `.../python/simple` or `.../python-upstream/simple/`. 
 - **Poetry**: Inspect the lockfile for the package source URLs.
 
 Learn about managing fallback and cooldown controls in the [Chainguard Libraries Overview](/chainguard/libraries/overview/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -14,8 +14,6 @@ weight: 010
 toc: true
 ---
 
-## Introduction
-
 Chainguard Libraries for Python provides enhanced security for the vast Python
 ecosystem by rebuilding PyPI packages with comprehensive supply chain protection
 and automated patching. With over 600,000 packages on the [Python Package Index
@@ -70,16 +68,13 @@ from PyPI. Chainguard Libraries for Python are rebuilt from source and require
 that source be available. Therefore, packages that do not provide a valid source
 URL cannot be rebuilt within the Chainguard Factory.
 
-Since the Chainguard Libraries for Python index is not complete, you should
-strongly consider setting the PyPI public package index as a fallback within
-your repository manager. In this case, failed requests are logged by Chainguard
-and, where possible, the package is prioritized for a new build from source.
-Typically, access is [configured globally on a repository manager for your
-organization](/chainguard/libraries/python/global-configuration/).
-
-Alternatively, you can use the token for direct access to the Chainguard
-Libraries for Python index as discussed in [Build
-configuration](/chainguard/libraries/python/build-configuration/).
+Chainguard Libraries for Python can be consumed through [Chainguard
+Repository](/chainguard/libraries/chainguard-repository/), which provides a single endpoint for Python package retrieval and
+supports protected upstream fallback when configured for your organization. This
+allows builds to prefer Chainguard-built packages first while still covering
+packages or wheel files that Chainguard does not currently serve directly. Configure this endpoint [globally through a repository manager](/chainguard/libraries/python/global-configuration/) for centralized
+access control across your organization, or use it [directly from individual
+build tools](/chainguard/libraries/python/build-configuration/) if that matches your environment.
 
 Follow the steps detailed in [Manual Access](#manual) to browse the Python index
 and find available packages, package versions, source distribution (sdist), and
@@ -527,4 +522,12 @@ as `bundle.json` from the integrity context at
 `https://libraries.cgr.dev/python/integrity/PACKAGE/VERSION/FILE/bundle.json`
 specifically for each package, version, and file. 
 
+## Upstream fallback policy and controls
 
+Chainguard Libraries for Python supports an optional built-in fallback to
+the upstream PyPI index, managed through the [Chainguard
+Repository](/chainguard/chainguard-repository/overview/). By default, the endpoint serves
+only Chainguard-built packages. When the upstream fallback is enabled, upstream packages are
+subject to additional security controls before being served.
+
+Learn about managing fallback and cooldown controls in the [Chainguard Libraries Overview](/chainguard/libraries/overview/).

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -74,7 +74,7 @@ supports protected upstream fallback when configured for your organization. This
 allows builds to prefer Chainguard-built packages first while still covering
 packages or wheel files that Chainguard does not currently serve directly. Configure this endpoint [globally through a repository manager](/chainguard/libraries/python/global-configuration/) for centralized
 access control across your organization, or use it [directly from individual
-build tools](/chainguard/libraries/python/build-configuration/) if that matches your environment.
+build tools](/chainguard/libraries/python/build-configuration/).
 
 Follow the steps detailed in [Manual Access](#manual) to browse the Python index
 and find available packages, package versions, source distribution (sdist), and

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -532,7 +532,7 @@ subject to additional security controls before being served.
 
 When using upstream fallback, the visibility of Chainguard-built versus upstream-fallback artifacts depends on the package manager in use:
 
-- **uv**: When `uv lock` resolves dependencies through Chainguard Repository, the resulting `uv.lock` can include per-artifact URLs that point to both `.../python/simple/` and `.../python-upstream/simple/`. This makes upstream fallback visible directly in the lockfile.
+- **uv**: When `uv lock` resolves dependencies through Chainguard Repository, the resulting `uv.lock` can include per-artifact URLs that point to both `.../python/simple/` and `.../python-upstream/simple/`. This provides visibility of upstream fallback usage directly in the lockfile.
 - **pip**: To inspect whether a dependency came from the Chainguard-built path, use `pip install --report` and review the reported download URLs.
 - **Poetry**: Inspect the lockfile for the package source URLs.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to existing Python library docs

### What should this PR do?
- Explain Chainguard Repository upstream fallback support
- Reframe repo manager setups to consider Chainguard Repository the default setup
- Update info on Build config, Global Config, and Python overview
- This does not include updates to the /chainguard-repository/overview.md page; I will make those updates in a separate PR to avoid a merge conflict with the Java updates

### Why are we making this change?
Product updates

### What are the acceptance criteria? 
Information should be complete and accurate. We should make sure that upstream fallback support is mentioned wherever relevant.

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

Review the deploy preview to ensure content appears correctly.
