### PR TITLE
Fix cosign command

### DIFF
--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -139,12 +139,14 @@ curl -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.de
 ```
 cosign verify-blob-attestation \
   --bundle PACKAGE-provenance.sigstore.json \
-  --new-bundle-format \
+  --type slsaprovenance1 \
   --certificate-oidc-issuer=https://issuer.enforce.dev \
   --certificate-identity-regexp="^https://issuer.enforce.dev/" \
   --check-claims=false \
   PACKAGE-VERSION.tgz
 ```
+
+If this command returns an error, ensure you are using the latest version of `cosign`.
 
 A successful verification returns:
 ```


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to JavaScript overview

### What should this PR do?
Fix the cosign command - it changed with a more recent version

### Why are we making this change?
Ensure accurate docs

### What are the acceptance criteria? 
Content should appear in the accurate location on the JS overview page

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

While on cosign v3.0.6+, run the commands to manually verify an attestation. I tested on axios-1.7.9: 
1. `curl -L -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.dev)" "https://libraries.cgr.dev/javascript/mock-adapter/-/mock-adapter-1.17.0.tgz" -o mock-adapter-1.17.0.tgz`
2. `curl -s -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.dev)" "https://libraries.cgr.dev/javascript/-/npm/v1/attestations/axios@1.7.9" | jq -c '.attestations[] | select(.predicateType | contains("slsa")) | .bundle' > axios-provenance.sigstore.json`
3. `cosign verify-blob-attestation --bundle axios-provenance.sigstore.json --type slsaprovenance1 --certificate-oidc-issuer=https://issuer.enforce.dev --certificate-identity-regexp="^https://issuer.enforce.dev/" --check-claims=false axios-1.7.9.tgz`
