### PR TITLE
Add pnpm trustPolicy limitation

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -335,7 +335,10 @@ other desired packages for further testing.
 JavaScript, designed as an alternative to npm and Yarn. For
 more information, see the [pnpm documentation](https://pnpm.io/motivation).
 
-> Note: The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
+Before getting started, note the following limitations:
+
+* The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
+* If you use Chainguard Libraries with pnpm `trustPolicy: no-downgrade`, pnpm may fail installation. Because Chainguard Libraries serves rebuilt packages, pnpm may treat those packages as a trust downgrade. To work around this, disable it in your pnpm configuration: `trustPolicy: off`
 
 **Declare dependencies in package.json**
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to JS build config

### What should this PR do?
Mention limitation for pnpm trustPolicy

### Why are we making this change?
To address a documented issue: https://linear.app/chainguard/issue/ECO-1748/research-pnpm-trust-support-for-chainguard-provenance

### What are the acceptance criteria? 
Content should be accurate and appear in expected location

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

