### PR TITLE
docs: add Custom Assembly custom runtime repositories documentation

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -202,7 +202,7 @@ Be aware that Custom Assembly blocks any environment variable that begins with `
 
 ## Custom runtime repositories
 
-Custom Assembly allows you to replace the default APK repository URLs written to `/etc/apk/repositories` in your assembled images. This is useful if your organization mirrors Chainguard's APK feed to an internal registry and requires containers to resolve packages from internal infrastructure at runtime.
+Custom Assembly lets you replace the default APK repository URLs written to `/etc/apk/repositories` in your assembled images. This is useful if your organization mirrors Chainguard's APK feed to an internal registry and requires containers to resolve packages from internal infrastructure at runtime.
 
 > **Note**: This feature only affects which repository URLs are written into the image for runtime use. Build-time package resolution always uses Chainguard's `apk.cgr.dev` repositories. For more details on limitations and compatibility, refer to the [Custom runtime repositories overview](/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-runtime-repositories).
 
@@ -231,7 +231,7 @@ https://apk-mirror.example.com/chainguard
 https://apk-mirror.example.com/extras
 ```
 
-The default `virtualapk.cgr.dev` entries will not be present in the image.
+The default `virtualapk.cgr.dev` entries aren't present in the image.
 
 You can also apply custom runtime repositories declaratively using the `apply` subcommand:
 
@@ -257,15 +257,15 @@ To remove custom runtime repositories and revert to the default `virtualapk.cgr.
 
 Custom runtime repository URLs are validated when the configuration is applied. URLs that do not pass validation will be rejected. The following rules apply:
 
-* Each URL must use HTTPS (`https://`). HTTP, `file://`, and other schemes are rejected.
+* Each URL must use HTTPS (`https://`). HTTP, `file://`, and other schemes aren't allowed.
 * At least one URL must be provided if the `runtime_repositories` field is set.
-* Duplicate URLs are not allowed.
-* Loopback addresses (`127.0.0.0/8`, `::1`) are not allowed.
-* Private network addresses (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) are not allowed.
-* Link-local addresses (`169.254.0.0/16`, `fe80::/10`) are not allowed.
-* Hostnames ending in `.internal`, `.local`, or `.svc.cluster.local` are not allowed.
-* `localhost` is not allowed.
-* Hostnames that resolve to any of the blocked IP ranges listed above are also rejected.
+* Duplicate URLs aren't allowed.
+* Loopback addresses (`127.0.0.0/8`, `::1`) aren't allowed.
+* Private network addresses (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) aren't allowed.
+* Link-local addresses (`169.254.0.0/16`, `fe80::/10`) aren't allowed.
+* Hostnames ending in `.internal`, `.local`, or `.svc.cluster.local` aren't allowed.
+* `localhost` isn't allowed.
+* Hostnames that resolve to any of the blocked IP ranges listed earlier aren't allowed either.
 
 
 ## Retrieving Information about Custom Assembly Containers

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -200,6 +200,74 @@ After saving and confirming these changes, Custom Assembly will add these five c
 Be aware that Custom Assembly blocks any environment variable that begins with `CHAINGUARD_` from being added or changed. This is to prevent conflicts with configuration details managed by Chainguard.
 
 
+## Custom runtime repositories
+
+Custom Assembly allows you to replace the default APK repository URLs written to `/etc/apk/repositories` in your assembled images. This is useful if your organization mirrors Chainguard's APK feed to an internal registry and requires containers to resolve packages from internal infrastructure at runtime.
+
+> **Note**: This feature only affects which repository URLs are written into the image for runtime use. Build-time package resolution always uses Chainguard's `apk.cgr.dev` repositories. For more details on limitations and compatibility, refer to the [Custom runtime repositories overview](/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-runtime-repositories).
+
+To add custom runtime repositories, use `chainctl image repo build edit` as with other customizations:
+
+```shell
+chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+```
+
+In the text editor, add a `runtime_repositories` field under `contents`:
+
+```yaml
+contents:
+  packages:
+    - curl
+    - jq
+  runtime_repositories:
+    - https://apk-mirror.example.com/chainguard
+    - https://apk-mirror.example.com/extras
+```
+
+After saving and confirming the changes, the resulting image's `/etc/apk/repositories` will contain only your custom URLs:
+
+```
+https://apk-mirror.example.com/chainguard
+https://apk-mirror.example.com/extras
+```
+
+The default `virtualapk.cgr.dev` entries will not be present in the image.
+
+You can also apply custom runtime repositories declaratively using the `apply` subcommand:
+
+```shell
+cat > build.yaml <<EOF
+contents:
+  packages:
+    - curl
+    - jq
+  runtime_repositories:
+    - https://apk-mirror.example.com/chainguard
+    - https://apk-mirror.example.com/extras
+EOF
+```
+
+```shell
+chainctl image repo build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+```
+
+To remove custom runtime repositories and revert to the default `virtualapk.cgr.dev` URLs, edit the configuration and remove the `runtime_repositories` field entirely.
+
+### Validation rules
+
+Custom runtime repository URLs are validated when the configuration is applied. URLs that do not pass validation will be rejected. The following rules apply:
+
+* Each URL must use HTTPS (`https://`). HTTP, `file://`, and other schemes are rejected.
+* At least one URL must be provided if the `runtime_repositories` field is set.
+* Duplicate URLs are not allowed.
+* Loopback addresses (`127.0.0.0/8`, `::1`) are not allowed.
+* Private network addresses (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) are not allowed.
+* Link-local addresses (`169.254.0.0/16`, `fe80::/10`) are not allowed.
+* Hostnames ending in `.internal`, `.local`, or `.svc.cluster.local` are not allowed.
+* `localhost` is not allowed.
+* Hostnames that resolve to any of the blocked IP ranges listed above are also rejected.
+
+
 ## Retrieving Information about Custom Assembly Containers
 
 You can also use the `list` subcommand to retrieve every one of a customized image's builds from the past 24 hours:

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -182,23 +182,23 @@ To learn more, refer to our [Private APK Repositories documentation](/chainguard
 
 By default, Custom Assembly images have `/etc/apk/repositories` pointing to Chainguard's `virtualapk.cgr.dev` tracking proxy. Some organizations mirror Chainguard's APK feed to internal registries — for example, to satisfy internal security policies that require all package sources to resolve to internal infrastructure.
 
-Custom Assembly allows you to specify custom APK repository URLs that replace the default `virtualapk.cgr.dev` entries in `/etc/apk/repositories`. This means runtime `apk add` commands inside the container will resolve packages from your internal mirror instead of Chainguard's endpoints, without requiring Dockerfile modifications.
+Custom Assembly lets you specify custom APK repository URLs that replace the default `virtualapk.cgr.dev` entries in `/etc/apk/repositories`. This means runtime `apk add` commands inside the container resolve packages from your internal mirror instead of Chainguard's endpoints, without requiring Dockerfile modifications.
 
-Build-time package resolution is unaffected by this setting. Packages are always fetched from `apk.cgr.dev` during the Custom Assembly build, preserving Chainguard's supply-chain integrity guarantees. The custom repository URLs are only written to the image's `/etc/apk/repositories` file for use at runtime.
+This setting doesn't affect build-time package resolution. Packages are always fetched from `apk.cgr.dev` during the Custom Assembly build, preserving Chainguard's supply-chain guarantees. The custom repository URLs are only written to the image's `/etc/apk/repositories` file for use at runtime.
 
 To learn how to configure custom runtime repositories using `chainctl`, refer to the [Custom runtime repositories section](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#custom-runtime-repositories) of the `chainctl` Custom Assembly guide.
 
 ### Limitations and compatibility
 
-Custom runtime repositories work with APK mirrors that serve packages with the original Chainguard signatures. The Chainguard signing key is baked into the image at build time, so `apk` will verify packages from your mirror using this existing key.
+Custom runtime repositories work with APK mirrors that serve packages with the original Chainguard signatures. The Chainguard signing key is embedded in the image at build time, so `apk` verifies packages from your mirror using this existing key.
 
 This means custom runtime repositories are compatible with:
 
-* **Artifactory remote repositories** — Remote repositories in [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/) act as pull-through caches and serve packages with their original signatures intact. These work with custom runtime repositories without any additional configuration.
+* **Artifactory remote repositories** — Remote repositories in [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/) act as pull-through caches and serve packages with their original signatures intact. These work with custom runtime repositories without additional configuration.
 
 Custom runtime repositories are **not compatible** with repositories that use their own signing key, including:
 
-* **Artifactory virtual repositories** — Virtual repositories in Artifactory add an additional signing key to packages. Because the Custom Assembly image only contains the Chainguard signing key, `apk` will not trust packages signed with a different key. Users who need to use virtual repositories can work around this by using the `--allow-untrusted` flag with `apk`, or by injecting the additional signing key into the image via a Dockerfile.
+* **Artifactory virtual repositories** — Virtual repositories in Artifactory add an additional signing key to packages. Because the Custom Assembly image contains only the Chainguard signing key, `apk` won't trust packages signed with a different key. Users who need virtual repositories can work around this by using the `--allow-untrusted` flag with `apk`, or by injecting the additional signing key into the image via a Dockerfile.
 * **Sonatype Nexus Alpine repositories** — Nexus requires its own signing key for Alpine repositories. As with Artifactory virtual repositories, this is incompatible with the Chainguard signing key embedded in Custom Assembly images.
 
 Support for custom keyrings may be added in a future release, which would allow repositories with their own signing keys to be used with Custom Assembly. Contact your account team if this is a requirement for your organization.

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -39,6 +39,7 @@ With Custom Assembly, you can add the following to your container images:
 * [Chainguard-managed certificate bundles](/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs/#chainguard-managed-certificate-bundles) — Pre-packaged certificate bundles for regulated environments, such as commercial AWS or AWS GovCloud.
 * [Environment variables and annotations](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#adding-custom-annotations-and-environment-variables) — Set custom runtime environment variables and custom metadata annotations.
 * [Custom user accounts and groups](/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/) — Use `chainctl images repos build apply` or `chainctl images repos build edit` to define custom users with specific UIDs/GIDs, home directories, group memberships, and specify which user the image runs as. 
+* [Custom runtime repositories](#custom-runtime-repositories) — Replace the default APK repository URLs in the assembled image with your own internal mirror URLs, so that runtime `apk add` commands resolve against your infrastructure instead of Chainguard's default endpoints.
 
 Note: You cannot remove base packages that come with the source image — you can only add to them.
 
@@ -176,6 +177,33 @@ OK: 719 MiB in 78 packages
 
 To learn more, refer to our [Private APK Repositories documentation](/chainguard/chainguard-images/features/private-apk-repos/).
 
+
+## Custom runtime repositories
+
+By default, Custom Assembly images have `/etc/apk/repositories` pointing to Chainguard's `virtualapk.cgr.dev` tracking proxy. Some organizations mirror Chainguard's APK feed to internal registries — for example, to satisfy internal security policies that require all package sources to resolve to internal infrastructure.
+
+Custom Assembly allows you to specify custom APK repository URLs that replace the default `virtualapk.cgr.dev` entries in `/etc/apk/repositories`. This means runtime `apk add` commands inside the container will resolve packages from your internal mirror instead of Chainguard's endpoints, without requiring Dockerfile modifications.
+
+Build-time package resolution is unaffected by this setting. Packages are always fetched from `apk.cgr.dev` during the Custom Assembly build, preserving Chainguard's supply-chain integrity guarantees. The custom repository URLs are only written to the image's `/etc/apk/repositories` file for use at runtime.
+
+To learn how to configure custom runtime repositories using `chainctl`, refer to the [Custom runtime repositories section](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#custom-runtime-repositories) of the `chainctl` Custom Assembly guide.
+
+### Limitations and compatibility
+
+Custom runtime repositories work with APK mirrors that serve packages with the original Chainguard signatures. The Chainguard signing key is baked into the image at build time, so `apk` will verify packages from your mirror using this existing key.
+
+This means custom runtime repositories are compatible with:
+
+* **Artifactory remote repositories** — Remote repositories in [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/) act as pull-through caches and serve packages with their original signatures intact. These work with custom runtime repositories without any additional configuration.
+
+Custom runtime repositories are **not compatible** with repositories that use their own signing key, including:
+
+* **Artifactory virtual repositories** — Virtual repositories in Artifactory add an additional signing key to packages. Because the Custom Assembly image only contains the Chainguard signing key, `apk` will not trust packages signed with a different key. Users who need to use virtual repositories can work around this by using the `--allow-untrusted` flag with `apk`, or by injecting the additional signing key into the image via a Dockerfile.
+* **Sonatype Nexus Alpine repositories** — Nexus requires its own signing key for Alpine repositories. As with Artifactory virtual repositories, this is incompatible with the Chainguard signing key embedded in Custom Assembly images.
+
+Support for custom keyrings may be added in a future release, which would allow repositories with their own signing keys to be used with Custom Assembly. Contact your account team if this is a requirement for your organization.
+
+> **Note**: Custom runtime repository URLs must use HTTPS. Chainguard does not validate the reachability of custom repository URLs at configuration time. A misconfigured URL will not cause build failures, but will cause runtime `apk add` failures inside the container.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Documents the new custom runtime repositories feature for Custom Assembly, which allows customers to replace default `virtualapk.cgr.dev` entries in `/etc/apk/repositories` with their own internal mirror URLs
- Adds overview section in `custom-assembly.md` covering the feature, compatibility limitations (Artifactory remote repos work; virtual repos and Nexus do not due to signing keys), and a note about future keyring support
- Adds `chainctl` usage section in `custom-assembly-chainctl.md` with YAML config examples, declarative `build apply` workflow, and the full set of URL validation rules (HTTPS-only, no private/loopback/link-local IPs, no internal hostnames)

## References

- Linear: [CON-1759](https://linear.app/chainguard/issue/CON-1759/document-custom-apk-repositories-on-educhainguarddev)
- Project: [Custom Assembly - Custom APK Repositories](https://linear.app/chainguard/project/custom-assembly-custom-apk-repositories-456a3a1e770c/overview)
- Design doc: https://docs.google.com/document/d/1esti3mf8PHl-GWlGK69K0QheJhZNQUdUl3KEm7mw_H8
- Platform PRs: chainguard-dev/mono#41940, chainguard-dev/mono#42101

## Test plan

- [ ] Verify Hugo renders both pages without errors
- [ ] Review YAML examples match the actual `chainctl` behavior
- [ ] Confirm validation rules match the implementation in mono PRs
- [ ] Check all internal links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)