### PR TITLE
Add pnpm11 limitation for lockfile re-verification

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -335,17 +335,14 @@ other desired packages for further testing.
 JavaScript, designed as an alternative to npm and Yarn. For
 more information, see the [pnpm documentation](https://pnpm.io/motivation).
 
+**Limitations**
+
 Before getting started, note the following limitations:
 
-* The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
-    * pnpm v11 re-verifies lockfile entries during install, including when you run `pnpm install --frozen-lockfile`. With Chainguard Repository for JavaScript, this can cause `ERR_PNPM_TARBALL_URL_MISMATCH` or `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` errors even when the lockfile is up to date. If this issue occurs, configure pnpm to trust the existing lockfile in the `pnpm-workspace.yaml`:
-    <br>
-    ```yaml
-    trustLockfile: true
-    ```
-    <br>
-    * Setting `lockfileIncludeTarballUrl: true` in the `pnpm-workspace.yaml` ensures pnpm continues to fetch the upstream tarball URL recorded in the lockfile. Without this setting, you can encounter integrity errors when Chainguard builds a package version that had previously been mirrored from upstream. This helps avoid integrity errors until the lockfile is updated.
-* If you use Chainguard Libraries with pnpm `trustPolicy: no-downgrade`, pnpm may fail installation. Because Chainguard Libraries serves rebuilt packages, pnpm may treat those packages as a trust downgrade. To work around this, disable it in your pnpm configuration: `trustPolicy: off`
+- The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
+- pnpm v11 re-verifies lockfile entries during install, including when you run `pnpm install --frozen-lockfile`. With Chainguard Repository for JavaScript, this can cause errors even when the lockfile is up to date. If this issue occurs, set `trustLockfile: true` in the `pnpm-workspace.yaml` to configure pnpm to trust the existing lockfile.
+- Setting `lockfileIncludeTarballUrl: true` in the `pnpm-workspace.yaml` ensures pnpm continues to fetch the upstream tarball URL recorded in the lockfile. Without this setting, you can encounter integrity errors when Chainguard builds a package version that had previously been mirrored from upstream. This helps avoid integrity errors until the lockfile is updated.
+- If you use Chainguard Libraries with pnpm `trustPolicy: no-downgrade`, pnpm may fail installation. Because Chainguard Libraries serves rebuilt packages, pnpm may treat those packages as a trust downgrade. To work around this, disable it in your pnpm configuration: `trustPolicy: off`
 
 **Declare dependencies in package.json**
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -338,15 +338,13 @@ more information, see the [pnpm documentation](https://pnpm.io/motivation).
 Before getting started, note the following limitations:
 
 * The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
-    * pnpm v11 re-verifies lockfile entries during install, including when you run `pnpm install --frozen-lockfile`. With Chainguard Repository for JavaScript, this can cause `ERR_PNPM_TARBALL_URL_MISMATCH` or `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` errors even when the lockfile is up to date. If this issue occurs, temporarily configure pnpm to trust the existing lockfile in the `pnpm-workspace.yaml`:
+    * pnpm v11 re-verifies lockfile entries during install, including when you run `pnpm install --frozen-lockfile`. With Chainguard Repository for JavaScript, this can cause `ERR_PNPM_TARBALL_URL_MISMATCH` or `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` errors even when the lockfile is up to date. If this issue occurs, configure pnpm to trust the existing lockfile in the `pnpm-workspace.yaml`:
     <br>
     ```yaml
-    trustPolicy: off
     trustLockfile: true
-    lockfileIncludeTarballUrl: true
     ```
-    Note that this reduces pnpm 11 supply-chain enforcement; setting this configuration reduces friction in the process but increases lockfile-poisoning risk.  
     <br>
+    * Setting `lockfileIncludeTarballUrl: true` in the `pnpm-workspace.yaml` ensures pnpm continues to fetch the upstream tarball URL recorded in the lockfile. Without this setting, you can encounter integrity errors when Chainguard builds a package version that had previously been mirrored from upstream. This helps avoid integrity errors until the lockfile is updated.
 * If you use Chainguard Libraries with pnpm `trustPolicy: no-downgrade`, pnpm may fail installation. Because Chainguard Libraries serves rebuilt packages, pnpm may treat those packages as a trust downgrade. To work around this, disable it in your pnpm configuration: `trustPolicy: off`
 
 **Declare dependencies in package.json**

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -338,6 +338,15 @@ more information, see the [pnpm documentation](https://pnpm.io/motivation).
 Before getting started, note the following limitations:
 
 * The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
+    * pnpm v11 re-verifies lockfile entries during install, including when you run `pnpm install --frozen-lockfile`. With Chainguard Repository for JavaScript, this can cause `ERR_PNPM_TARBALL_URL_MISMATCH` or `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` errors even when the lockfile is up to date. If this issue occurs, temporarily configure pnpm to trust the existing lockfile in the `pnpm-workspace.yaml`:
+    <br>
+    ```yaml
+    trustPolicy: off
+    trustLockfile: true
+    lockfileIncludeTarballUrl: true
+    ```
+    Note that this reduces pnpm 11 supply-chain enforcement; setting this configuration reduces friction in the process but increases lockfile-poisoning risk.  
+    <br>
 * If you use Chainguard Libraries with pnpm `trustPolicy: no-downgrade`, pnpm may fail installation. Because Chainguard Libraries serves rebuilt packages, pnpm may treat those packages as a trust downgrade. To work around this, disable it in your pnpm configuration: `trustPolicy: off`
 
 **Declare dependencies in package.json**


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to JS build config

### What should this PR do?
Explain the workaround for a pnpm v11 issue affecting lockfile verification when using Chainguard Repository

### Why are we making this change?
Internal request: https://chainguard-dev.slack.com/archives/C09MK1VTHL6/p1781695510603849
Linear: https://linear.app/chainguard/issue/ECO-2150/pnpm-11-lockfile-reverification-conflicts-with-chainguard-repository

### What are the acceptance criteria? 
Content should be clear and accurate and note the tradeoff of compatibility/risk

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

