### PR TITLE
add images section parallel to libraries section for policies in repo

### DIFF
--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -46,15 +46,33 @@ For language dependencies, policies apply to both Chainguard-built packages and 
 
 All upstream packages are checked against public malware identifier feeds, and any package with a known malware idenitifier is blocked before being served.
 
+See [Libraries Overview](/chainguard/libraries/overview/#upstream-fallback-and-controls) for more information.
 
-## **Management**
+
+## Policies for Images
+
+As with Libraries, you can also set policies for Chainguard Images to define rules governing which images can be consumed and under what conditions. Policies can be configured in the Chainguard Console or with `chainctl`, and are enforced automatically across your environment.
+
+Available policies include:
+
+* **no-eol**: Prevent end-of-life images from being used.  
+* **Cooldown**: Block newly published image versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
+
+> **Note**: Chainguard recommends a 7-day cooldown when enabling upstream fallback, to block a large share of malicious packages identified shortly after publication. Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them.
+
+The packages that make up Chainguard Images are checked against public malware identifier feeds, and any package with a known malware idenitifier is remediated before being used in any image.
+
+See [Policies](/chainguard/administration/policies/) for more information.
+
+
+## Management
 
 The Chainguard Console and `chainctl` can be used for configuring and managing policies across your organization. Learn more in [Using the Chainguard Console](/chainguard/chainguard-images/how-to-use/images-directory/) and [Get Started with chainctl](/chainguard/chainctl-usage/getting-started-with-chainctl/).
 
 Access the Console at [console.chainguard.dev](https://console.chainguard.dev).
 
 
-## **Learn more**
+## Learn more
 
 * [Chainguard Repository for JavaScript Libraries](/chainguard/libraries/chainguard-repository/)  
 

--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -56,7 +56,7 @@ As with Libraries, you can also set policies for Chainguard Images to define rul
 Available policies include:
 
 * **no-eol**: Prevent end-of-life images from being used.  
-* **Cooldown**: Block newly published image versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
+* **cooldown**: Block newly published image versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
 
 > **Note**: Chainguard recommends a 7-day cooldown when enabling upstream fallback, to block a large share of malicious packages identified shortly after publication. Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Content addition

### What should this PR do?
Adds information about policies for images parallel to existing information about policies for libraries into the documentation page for Chainguard Repositories.

### Why are we making this change?
Requested for Innovation Week and because development is maturing to the point where this is needed.

### What are the acceptance criteria? 
Is the new info clear? Does it express parity across the libraries and images implementations of the feature?

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
