### PR TITLE
libraries/javascript: fix pnpm auth for upstream-fallback packages

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -390,13 +390,31 @@ URL to point to Chainguard and set auth credentials. The following command write
 export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 
 pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
-pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
-pnpm config set //libraries.cgr.dev/javascript-upstream/:_auth "${token}" --location=project
+pnpm config set //libraries.cgr.dev/:_auth "${token}" --location=project
 ```
 
 To set the registry at the user level instead of project-level, omit the `--location=project` flag.
 
 The configuration should look like the following:
+
+```properties
+registry=https://libraries.cgr.dev/javascript/
+//libraries.cgr.dev/:_auth=<base64-encoded-token>
+```
+
+The registry URL always points to the `/javascript/` repository; you do not point
+it at `/javascript-upstream/`. The authentication entry, however, is keyed to the
+whole `libraries.cgr.dev` host (`//libraries.cgr.dev/`) rather than to the
+`/javascript/` path alone. This matters because packages that Chainguard has not
+yet rebuilt are served through the [upstream
+fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls)
+at `https://libraries.cgr.dev/javascript-upstream/`, and pnpm authenticates against
+whatever tarball URL the registry returns for each package. A credential keyed to
+the host covers both the `/javascript/` and `/javascript-upstream/` paths.
+
+If you prefer to scope credentials per path, you must configure **both** paths.
+Otherwise, installs that resolve upstream-fallback packages fail with an HTTP 401
+error:
 
 ```properties
 registry=https://libraries.cgr.dev/javascript/
@@ -528,15 +546,23 @@ directory:
 export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 
 pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
-pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
-pnpm config set //libraries.cgr.dev/javascript-upstream/:_auth "${token}" --location=project
+pnpm config set //libraries.cgr.dev/:_auth "${token}" --location=project
 ```
 
-The trailing slash in the registry URL is required. Note that the `-w 0` option for `base64` is required and supported by the GNU coreutils versions included in most operating systems. To avoid the use of `base64`, which can behave differently across operating systems, you can alternatively set `username` and `_password` instead of `auth` with a token:
+The trailing slash in the registry URL is required. The authentication entry is
+keyed to the whole `libraries.cgr.dev` host (`//libraries.cgr.dev/`) so that it
+also covers packages served through the [upstream
+fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls)
+path. Note that the `-w 0` option for `base64` is required and supported by the GNU
+coreutils versions included in most operating systems.
+
+Alternatively, you can set `username` and `_password` instead of `_auth`. Note
+that the `_password` value must still be base64-encoded; pnpm does not accept a
+raw token here:
 
 ```bash
-pnpm config set //libraries.cgr.dev/javascript/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
-pnpm config set //libraries.cgr.dev/javascript/:_password "${CHAINGUARD_JAVASCRIPT_TOKEN}" --location=project
+pnpm config set //libraries.cgr.dev/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
+pnpm config set //libraries.cgr.dev/:_password "$(echo -n "${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)" --location=project
 ```
 
 Add dependencies for your project into the `package.json` file to test retrieval


### PR DESCRIPTION
## What

Scopes a small fix to the **pnpm** section of the JavaScript build-configuration docs so direct-access auth works for packages served through the upstream fallback.

- Configure pnpm direct-access credentials keyed to the whole `libraries.cgr.dev` host (`//libraries.cgr.dev/:_auth`) instead of scoping them to the `/javascript/` path.
- Fix the `username`/`_password` example: pnpm requires the `_password` value to be **base64-encoded** and rejects a raw token. The previous example used the raw token and fails.

## Why

pnpm authenticates against whatever tarball URL the registry returns for each package. Packages Chainguard has not yet rebuilt are served from `https://libraries.cgr.dev/javascript-upstream/`. With credentials scoped only to `//libraries.cgr.dev/javascript/`, pnpm sends **no auth header** for the `/javascript-upstream/` path, so any install that resolves an upstream-fallback package (e.g. `react`) fails with `ERR_PNPM_FETCH_401`.

A credential keyed to the host covers both `/javascript/` and `/javascript-upstream/`. The explicit two-path form is kept in the docs as an alternative.

## Testing

Verified against **pnpm 11.8.0** with a fresh project/lockfile against `libraries.cgr.dev/javascript`:

- Host-keyed `//libraries.cgr.dev/:_auth` → `react` (upstream-fallback) resolves and downloads. ✅
- Path-scoped `//libraries.cgr.dev/javascript/:_auth` only → `ERR_PNPM_FETCH_401` on `…/javascript-upstream/react/…tgz` ("No authorization header was set"). ❌
- `username`/`_password` with a raw token fails; base64-encoded `_password` succeeds.

The **npm** section is intentionally left unchanged: npm authenticates upstream-fallback tarball fetches even with path-scoped `/javascript/` credentials, so it is already correct.

## Scope

pnpm section only (2 hunks). No changes to npm, Yarn, Bun, or repository-manager sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)