### PR TITLE
Clarify Disable URL Normalization step in libraries guides

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -287,7 +287,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * Deactivate **Maven Settings - Handle Snapshots**.
 1. Optionally click **Test** to verify connection and authentication.
 1. Click the **Advanced** configuration tab. Under the **Others** section, deactivate the **Block
-   Mismatching Mime Types** setting. Disable **URL Normalization**
+   Mismatching Mime Types** setting. Ensure **Disable URL Normalization** is checked.
 1. Click **Create Remote Repository**.
 1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -197,7 +197,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-1. Click the **Advanced** configuration tab. Disable **URL Normalization**
+1. Click the **Advanced** configuration tab. Ensure **Disable URL Normalization** is checked.
 1. Click **Create Remote Repository**.
 
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -247,7 +247,7 @@ Configure a remote repository for the Chainguard Libraries for Python index:
 1. Set the **PyPI Settings - Registry URL** to
    `https://libraries.cgr.dev/python/`.
 1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. Disable **URL Normalization** and disable **Block
+1. Click the **Advanced** configuration tab. Ensure **Disable URL Normalization** is checked, and disable **Block
    Mismatching Mime Types** in the **Others** section.
 1. Click **Create Remote Repository**.
 


### PR DESCRIPTION
The setting is called **Disable URL Normalization** in Artifactory. This understandably confused a customer, who thought they had to disable that setting, given the bold emphasis and the wording. Hopefully this change makes it clearer?

Personally I think this is on Artifactory for their horrible naming.