### PR TITLE
docs(libraries): document update-hashes authentication flow

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -93,7 +93,7 @@ which requires authentication. Choose whichever fits your environment:
   `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
   automatically. (`chainctl auth configure-npm` also sets up this
   libraries-scoped session as part of configuring npm.)
-- **CI or non-interactive.**
+- **CI or non-interactive**:
   - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
     token must be scoped to the libraries registry; mint one with
     `chainctl auth token --audience=libraries.cgr.dev`.

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -78,6 +78,38 @@ manager will accept packages from Chainguard.
 
 Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile) and in the [`chainctl libraries update-hashes` command docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
+<a id="update-hashes-auth"></a>
+
+### Authentication
+
+`update-hashes` fetches checksums from Chainguard Libraries (`libraries.cgr.dev`),
+which requires authentication. Choose whichever fits your environment:
+
+- **Logged in locally.** Run the command while authenticated; if you have no
+  other credential it prompts for an organization and authenticates with a
+  [pull token](/chainguard/libraries/access/#pull-token). Pass
+  `--parent <organization>` to skip the prompt. To avoid the prompt entirely,
+  scope your login to the libraries registry once with
+  `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
+  automatically. (`chainctl auth configure-npm` also sets up this
+  libraries-scoped session as part of configuring npm.)
+- **CI or non-interactive.**
+  - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
+    token must be scoped to the libraries registry; mint one with
+    `chainctl auth token --audience=libraries.cgr.dev`.
+  - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
+    secret), pass it as basic auth: `--username <identity> --password <secret>`,
+    or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
+- **From `~/.netrc`.** Credentials for the registry host are read from `~/.netrc`
+  (or `$NETRC`); see [.netrc for authentication](/chainguard/libraries/access/#netrc).
+  Pass `--ignore-netrc` to skip an unrelated entry.
+
+When you target a repository manager with `--registry-url` (for example
+Artifactory or JFrog), authenticate with **that** registry's credentials —
+`--username`/`--password`, the `CHAINCTL_REGISTRY_USERNAME` /
+`CHAINCTL_REGISTRY_PASSWORD` environment variables, or a matching `~/.netrc`
+entry. Chainguard-scoped tokens are never sent to third-party hosts.
+
 
 <a id="npm"></a>
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -100,7 +100,7 @@ which requires authentication. Choose whichever fits your environment:
   - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
     secret), pass it as basic auth: `--username <identity> --password <secret>`,
     or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
-- **From `~/.netrc`.** Credentials for the registry host are read from `~/.netrc`
+- **From `~/.netrc`**: Credentials for the registry host are read from `~/.netrc`
   (or `$NETRC`); see [.netrc for authentication](/chainguard/libraries/access/#netrc).
   Pass `--ignore-netrc` to skip an unrelated entry.
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -85,7 +85,7 @@ Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/
 `update-hashes` fetches checksums from Chainguard Libraries (`libraries.cgr.dev`),
 which requires authentication. Choose whichever fits your environment:
 
-- **Logged in locally.** Run the command while authenticated; if you have no
+- **Logged in locally**: Run the command while authenticated; if you have no
   other credential it prompts for an organization and authenticates with a
   [pull token](/chainguard/libraries/access/#pull-token). Pass
   `--parent <organization>` to skip the prompt. To avoid the prompt entirely,

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -179,7 +179,7 @@ which requires authentication. Choose whichever fits your environment:
   scope your login to the libraries registry once with
   `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
   automatically.
-- **CI or non-interactive.**
+- **CI or non-interactive**:
   - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
     token must be scoped to the libraries registry; mint one with
     `chainctl auth token --audience=libraries.cgr.dev`.

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -165,6 +165,37 @@ When using a repo manager, pass the full repository URL with `--registry-url`.
 Learn about using this command with repo managers in the [Global
 configuration](/chainguard/libraries/python/global-configuration/) page.
 
+<a id="update-hashes-auth"></a>
+
+#### Authentication
+
+`update-hashes` fetches checksums from Chainguard Libraries (`libraries.cgr.dev`),
+which requires authentication. Choose whichever fits your environment:
+
+- **Logged in locally.** Run the command while authenticated; if you have no
+  other credential it prompts for an organization and authenticates with a
+  [pull token](/chainguard/libraries/access/#pull-token). Pass
+  `--parent <organization>` to skip the prompt. To avoid the prompt entirely,
+  scope your login to the libraries registry once with
+  `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
+  automatically.
+- **CI or non-interactive.**
+  - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
+    token must be scoped to the libraries registry; mint one with
+    `chainctl auth token --audience=libraries.cgr.dev`.
+  - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
+    secret), pass it as basic auth: `--username <identity> --password <secret>`,
+    or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
+- **From `~/.netrc`.** Credentials for the registry host are read from `~/.netrc`
+  (or `$NETRC`); see [.netrc for authentication](/chainguard/libraries/access/#netrc).
+  Pass `--ignore-netrc` to skip an unrelated entry.
+
+When you target a repository manager with `--registry-url` (for example
+Artifactory or JFrog), authenticate with **that** registry's credentials —
+`--username`/`--password`, the `CHAINCTL_REGISTRY_USERNAME` /
+`CHAINCTL_REGISTRY_PASSWORD` environment variables, or a matching `~/.netrc`
+entry. Chainguard-scoped tokens are never sent to third-party hosts.
+
 By default, Chainguard hashes are appended alongside existing upstream hashes. After updating the lockfiles, to switch your environment to use Chainguard packages, configure your tool to use the Chainguard index and reinstall. The command will output
 a "Next steps" section that includes the tool-specific command for reinstalling. 
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -172,7 +172,7 @@ configuration](/chainguard/libraries/python/global-configuration/) page.
 `update-hashes` fetches checksums from Chainguard Libraries (`libraries.cgr.dev`),
 which requires authentication. Choose whichever fits your environment:
 
-- **Logged in locally.** Run the command while authenticated; if you have no
+- **Logged in locally**: Run the command while authenticated; if you have no
   other credential it prompts for an organization and authenticates with a
   [pull token](/chainguard/libraries/access/#pull-token). Pass
   `--parent <organization>` to skip the prompt. To avoid the prompt entirely,

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -186,7 +186,7 @@ which requires authentication. Choose whichever fits your environment:
   - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
     secret), pass it as basic auth: `--username <identity> --password <secret>`,
     or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
-- **From `~/.netrc`.** Credentials for the registry host are read from `~/.netrc`
+- **From `~/.netrc`**: Credentials for the registry host are read from `~/.netrc`
   (or `$NETRC`); see [.netrc for authentication](/chainguard/libraries/access/#netrc).
   Pass `--ignore-netrc` to skip an unrelated entry.
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -210,7 +210,11 @@ and
 > **Migrating an existing Python or JavaScript project?** If you have an
 > existing lockfile with upstream hashes, use `chainctl libraries update-hashes`
 > to update checksums to Chainguard's automatically, without regenerating your
-> lockfile from scratch.
+> lockfile from scratch. The command authenticates to Chainguard Libraries; see
+> the authentication options in the
+> [Python](/chainguard/libraries/python/build-configuration/#update-hashes-auth) and
+> [JavaScript](/chainguard/libraries/javascript/build-configuration/#update-hashes-auth)
+> build configuration guides.
 
 ## Step 4: Verify your libraries
 


### PR DESCRIPTION

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Documentation update.

### What should this PR do?

Add an Authentication subsection to the JavaScript and Python build configuration guides covering how `chainctl libraries update-hashes` authenticates to Chainguard Libraries: logged-in session (and `chainctl auth login --audience=libraries.cgr.dev` / `configure-npm` for no prompt), `--parent` / pull-token, `--token` / `CHAINCTL_AUTH_TOKEN` for CI, `~/.netrc` (and `--ignore-netrc`), and credentials for `--registry-url` repository managers. Point the quickstart migration note at these sections via stable anchors.

Missing docs were reported at https://linear.app/chainguard/issue/ECO-2157/prospect-cyberhaven-chainctl-libraries-update-hashes-hides-bad-netrc 

### Why are we making this change?

Current documentation lacks information about chainctl authentication to libraries registry.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

Testing should include confirmation that listed arguments are included in the help for the latest version of chainctl. Also, while running update-hashes with example project:

- package.json:

```json
{
  "name": "doc-test",
  "version": "1.0.0",
  "private": true,
  "packageManager": "yarn@4.17.0",
  "devDependencies": {
    "typescript": "5.3.3"
  }
}
```

and yarn.lock:

```
# This file is generated by running "yarn install" inside your project.
# Manual changes might be lost - proceed with caution!

__metadata:
  version: 10
  cacheKey: 10c0

"cgr-yarn-typescript-patch-repro@workspace:.":
  version: 0.0.0-use.local
  resolution: "cgr-yarn-typescript-patch-repro@workspace:."
  dependencies:
    typescript: "npm:5.3.3"
  languageName: unknown
  linkType: soft

"typescript@npm:5.3.3":
  version: 5.3.3
  resolution: "typescript@npm:5.3.3::__archiveUrl=https%3A%2F%2Flibraries.cgr.dev%2Fjavascript%2Ftypescript%2F-%2Ftypescript-5.3.3.tgz"
  bin:
    tsc: bin/tsc
    tsserver: bin/tsserver
  languageName: node
  linkType: hard

"typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>":
  version: 5.3.3
  resolution: "typescript@patch:typescript@npm%3A5.3.3%3A%3A__archiveUrl=https%253A%252F%252Flibraries.cgr.dev%252Fjavascript%252Ftypescript%252F-%252Ftypescript-5.3.3.tgz#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
  bin:
    tsc: bin/tsc
    tsserver: bin/tsserver
  checksum: 10c0/de158df8d56c668e721b6a0317af3e12338d42bb0277b741c30b57296569b2a54f5b6b5a2cd4f9a41c6e4997701f4f3ef5d31f9cfe8170a19d21b7d384595939
  languageName: node
  linkType: hard
```

we should get:
- interactive flow if no credentials exist
- passing run if .netrc contains proper authentication
- failing run if .netrc contains outdated/incorrect authentication (just edit the token in .netrc to break it)
- interactive flow if .netrc is broken but `--ignore-netrc` is provided
- passing run if `--parent` is provided
- passing run after running `chainctl auth configure-npm`
- passing run after running `chainctl auth login --audience=libraries.cgr.dev`
- passing run after setting CHAINCTL_AUTH_TOKEN to pull token
- failing run after setting CHAINCTL_AUTH_TOKEN to incorrect token