### PR TITLE
Revise the .NET migration guide

### DIFF
--- a/content/chainguard/migration/migration-guides/migrating-dotnet.md
+++ b/content/chainguard/migration/migration-guides/migrating-dotnet.md
@@ -4,7 +4,7 @@ linktitle: ".NET"
 type: "article"
 description: "Learn how to migrate .NET applications from images provided by Microsoft to Chainguard's security-hardened .NET container images."
 date: 2025-11-05T00:00:00+00:00
-lastmod: 2025-11-05T00:00:00+00:00
+lastmod: 2026-06-22T00:00:00+00:00
 draft: false
 tags: ["Chainguard Containers", "Migration"]
 images: []
@@ -14,12 +14,12 @@ toc: true
 
 Chainguard's [.NET container images](https://images.chainguard.dev/directory/image/dotnet-sdk/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-dotnet) provide a security-hardened foundation for building and running applications with significantly fewer vulnerabilities than .NET images provided by Microsoft. Chainguard's .NET container images maintain full .NET compatibility while dramatically reducing the attack surface.
 
-This guide demonstrates migrating a .NET application from Microsoft's official images to Chainguard's .NET container images by comparing two nearly identical versions of an application side-by-side. This guide also highlights concrete examples of the security improvements resulting from migrating to Chainguard Containers.
+This guide demonstrates migrating a .NET application from Microsoft's official images to Chainguard's .NET container images by building one application with two different Dockerfiles and comparing the results side by side. This guide also highlights concrete examples of the security improvements resulting from migrating to Chainguard Containers.
 
 
 ## Prerequisites
 
-This tutorial uses the publicly available .NET container images from Chainguard's [Free tier](/chainguard/chainguard-images/about/images-categories/#starter-containers) of images. You don't need special access or permissions to use these images. 
+This tutorial uses the publicly available .NET container images from Chainguard's [Free tier](/chainguard/chainguard-images/about/images-categories/#free-containers) of images. You don't need special access or permissions to use these images.
 
 To follow along, you must have Docker installed on your local machine. If you don't have Docker installed, you can download and install it from the [official Docker website](https://docs.docker.com/get-docker/). Optionally, you can install [Grype](https://github.com/anchore/grype) to scan container images for vulnerabilities and compare the security posture of different base images.
 
@@ -32,7 +32,7 @@ This step involves downloading the demo application code to your local machine. 
 cd /tmp/
 ```
 
-Most systems will automatically delete the `/tmp/` directory's contents the next time it shuts down or reboots.
+Most systems automatically delete the `/tmp/` directory's contents the next time they shut down or reboot.
 
 The code that comprises this demo application is hosted in a [public GitHub repository managed by Chainguard](https://github.com/chainguard-dev/edu-images-demos). Pull down the example application files from GitHub with the following command:
 
@@ -40,7 +40,7 @@ The code that comprises this demo application is hosted in a [public GitHub repo
 git clone --sparse https://github.com/chainguard-dev/edu-images-demos.git
 ```
 
-Because this guide's demo application code is stored in a repository with other examples, we don't need to pull down every file from this repository. For this reason, this command includes the `--sparse` option. This initializes a [sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) file, causing the working directory to contain only the files in the root of the repository until the sparse-checkout configuration is modified.
+Because this guide's demo application code is stored in a repository with other examples, we don't need to pull down every file from this repository. For this reason, this command includes the `--sparse` option. This initializes a [sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) file, causing the working directory to contain only the files in the root of the repository until you modify the sparse-checkout configuration.
 
 Navigate into this new directory:
 
@@ -62,14 +62,17 @@ Navigate into the `dotnet` directory:
 cd dotnet/
 ```
 
-Here you'll find two subdirectories:
-- `not-linky/`: Contains an application that uses Microsoft's official .NET images
-- `linky/`: Contains a nearly identical application, but with a Dockerfile that uses Chainguard Containers
+This directory holds a single .NET application along with two Dockerfiles that build it:
+
+- `notlinky.Dockerfile`: Builds the application on Microsoft's official .NET images
+- `linky.Dockerfile`: Builds the same application on Chainguard Containers
+
+Both Dockerfiles compile the same `Program.cs` and `dotnetapp.csproj`, so the only difference between the two images comes from the base images each Dockerfile uses.
 
 
 ## Understanding the Demo Application
 
-The demo application in both directories is a .NET console program that displays runtime and system information, including:
+The demo application is a .NET console program that displays runtime and system information, including:
 
 - Operating system architecture and description
 - .NET framework version
@@ -77,7 +80,7 @@ The demo application in both directories is a .NET console program that displays
 - Hardware information (processor count and memory)
 - Container cgroup memory limits and usage
 
-The only significant difference between the two is that the application in the `not-linky` directory prints an ASCII art banner reading `dotnet`, while the `linky` directory's application prints ASCII art of Linky, Chainguard's octopus mascot. Otherwise, both directories' `Program.cs` and `dotnetapp.csproj` files are identical.
+When it runs, the application prints an ASCII art banner reading `dotnet` followed by these runtime details. It also writes the same output to a file named `output.txt` in its working directory, so the runtime image must allow the application's user to write to that directory. This detail matters when you build with Chainguard Containers, as explained later in this guide.
 
 This sample application is based on Microsoft's [dotnet-runtimeinfo sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/) and demonstrates a typical .NET console application that could be containerized for various use cases.
 
@@ -86,63 +89,55 @@ In the following sections, we'll build and compare both versions of the applicat
 
 ## Building with Microsoft's .NET Images
 
-Let's start by building and running the application using the .NET container images provided by Microsoft to establish a baseline for comparison.
+Start by building and running the application with the .NET container images provided by Microsoft to establish a baseline for comparison.
 
-Navigate to the `not-linky` directory:
-
-```sh
-cd not-linky
-```
-
-You can inspect the Dockerfile to see how it's structured:
+Inspect `notlinky.Dockerfile` to see how it's structured:
 
 ```sh
-cat Dockerfile
+cat notlinky.Dockerfile
 ```
-```Output
-# Learn about building .NET container images:
-# https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
-ARG IMAGE_REGISTRY="mcr.microsoft.com"
-FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet/sdk:9.0 AS build
-ARG TARGETARCH
+```output
+FROM mcr.microsoft.com/dotnet/sdk AS build
+
 WORKDIR /source
 
-# Copy project file and restore as distinct layers
-COPY --link *.csproj .
-RUN dotnet restore -a $TARGETARCH
+COPY dotnetapp.csproj .
+RUN dotnet restore
 
-# Copy source code and publish app
-COPY --link . .
-RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+COPY . .
+RUN dotnet publish --no-restore -o /app
 
-# Runtime stage
-FROM ${IMAGE_REGISTRY}/dotnet/runtime:9.0
+FROM mcr.microsoft.com/dotnet/runtime
+
+COPY --from=build --chown=app:app /app /app
+
 WORKDIR /app
-COPY --link --from=build /app .
-USER $APP_UID
+
+USER app
+
 ENTRYPOINT ["./dotnetapp"]
 ```
 
 This Dockerfile uses a multi-stage build pattern:
 
-1. **Build stage**: Uses `mcr.microsoft.com/dotnet/sdk:9.0` to compile the application
-2. **Runtime stage**: Uses `mcr.microsoft.com/dotnet/runtime:9.0` for the final image
-3. **User configuration**: Explicitly switches to a non-root user with `USER $APP_UID`
+1. **Build stage**: Uses `mcr.microsoft.com/dotnet/sdk` to restore dependencies and publish the application
+2. **Runtime stage**: Uses `mcr.microsoft.com/dotnet/runtime` for the final image
+3. **User configuration**: Copies the published files with `--chown=app:app` and then switches to the non-root `app` user with `USER app`
 
-Build the container image:
-
-```sh
-docker build -t dotnet-notlinky .
-```
-
-This `docker build` command builds a container image named `dotnet-notlinky`.
-
-Run the application:
+Build the container image using this Dockerfile:
 
 ```sh
-docker run --rm dotnet-notlinky
+docker build -t dotnet-example:notlinky -f notlinky.Dockerfile .
 ```
-```Output
+
+Using `notlinky.Dockerfile`, this `docker build` command builds an image tagged `dotnet-example:notlinky`.
+
+Use this image to run the application:
+
+```sh
+docker run --rm dotnet-example:notlinky
+```
+```output
          42                                                    
          42              ,d                             ,d     
          42              42                             42     
@@ -153,14 +148,14 @@ a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42
  `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428  
 
 OSArchitecture: X64
-OSDescription: Debian GNU/Linux 12 (bookworm)
-FrameworkDescription: .NET 9.0.10
+OSDescription: Ubuntu 24.04.4 LTS
+FrameworkDescription: .NET 10.0.9
 
 UserName: app
-HostName : 33b915776b75
+HostName : ca426367d7a5
 
 ProcessorCount: 16
-TotalAvailableMemoryBytes: 16472768512 (15.34 GiB)
+TotalAvailableMemoryBytes: 16472748032 (15.34 GiB)
 ```
 
 Running the container returns system information, including a stylized ASCII art banner followed by runtime details.
@@ -168,193 +163,151 @@ Running the container returns system information, including a stylized ASCII art
 
 ## Building with Chainguard's .NET Container Images
 
-Now let's build the application with Chainguard's .NET container images. Navigate to the `linky` directory:
+Next, build the application with Chainguard's .NET container images. Inspect `linky.Dockerfile` to understand the differences:
 
 ```sh
-cd ../linky
+cat linky.Dockerfile
 ```
+```output
+FROM cgr.dev/chainguard/dotnet-sdk AS build
 
-The main difference between the two application directories is their respective Dockerfiles. Inspect the `linky` directory's Dockerfile to understand the differences:
-
-```sh
-cat Dockerfile
-```
-```Output
-# Learn about building .NET container images:
-# https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
-ARG IMAGE_REGISTRY="cgr.dev/chainguard"
-FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet-sdk:latest-dev AS build
-ARG TARGETARCH
 WORKDIR /source
 
-# Copy project file and restore as distinct layers
-COPY --link *.csproj .
-# switch to root user in order to do restore
-USER 0
-RUN dotnet restore -a $TARGETARCH
+COPY dotnetapp.csproj .
+USER root
+RUN dotnet restore
 
-# Copy source code and publish app
-COPY --link . .
-RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+COPY . .
+RUN dotnet publish --no-restore -o /app
 
-# Runtime stage
-FROM ${IMAGE_REGISTRY}/aspnet-runtime:latest
+FROM cgr.dev/chainguard/dotnet-runtime
+
+COPY --from=build --chown=65532:65532 /app /app
+
 WORKDIR /app
-COPY --link --from=build /app .
+
 ENTRYPOINT ["./dotnetapp"]
 ```
 
-Like the Dockerfile in the `not-linky` directory, this Dockerfile uses a multi-stage build. However, there are a few key differences between the two Dockerfiles. To find these differences, run the following `diff` command:
+Like `notlinky.Dockerfile`, this Dockerfile uses a multi-stage build. To find the differences between the two, run the following `diff` command:
 
-```shell
-git diff --no-index -U10000 ../not-linky/Dockerfile Dockerfile
+```sh
+git diff --no-index -U1000 notlinky.Dockerfile linky.Dockerfile
 ```
 ```diff
-diff --git a/../not-linky/Dockerfile b/Dockerfile
-index ce4d06d..cdd6a64 100644
---- a/../not-linky/Dockerfile
-+++ b/Dockerfile
-@@ -1,21 +1,22 @@
- # Learn about building .NET container images:
- # https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
--ARG IMAGE_REGISTRY="mcr.microsoft.com"
--FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet/sdk:9.0 AS build
-+ARG IMAGE_REGISTRY="cgr.dev/chainguard"
-+FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet-sdk:latest-dev AS build
- ARG TARGETARCH
+diff --git a/notlinky.Dockerfile b/linky.Dockerfile
+index 3b7a6e2..8cd6f2e 100644
+--- a/notlinky.Dockerfile
++++ b/linky.Dockerfile
+@@ -1,19 +1,18 @@
+-FROM mcr.microsoft.com/dotnet/sdk AS build
++FROM cgr.dev/chainguard/dotnet-sdk AS build
+ 
  WORKDIR /source
  
- # Copy project file and restore as distinct layers
- COPY --link *.csproj .
-+# switch to root user in order to do restore
-+USER 0
- RUN dotnet restore -a $TARGETARCH
+ COPY dotnetapp.csproj .
++USER root
+ RUN dotnet restore
  
- # Copy source code and publish app
- COPY --link . .
- RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+ COPY . .
+ RUN dotnet publish --no-restore -o /app
  
- # Runtime stage
--FROM ${IMAGE_REGISTRY}/dotnet/runtime:9.0
-+FROM ${IMAGE_REGISTRY}/aspnet-runtime:latest
+-FROM mcr.microsoft.com/dotnet/runtime
++FROM cgr.dev/chainguard/dotnet-runtime
+ 
+-COPY --from=build --chown=app:app /app /app
++COPY --from=build --chown=65532:65532 /app /app
+ 
  WORKDIR /app
- COPY --link --from=build /app .
--USER $APP_UID
+ 
+-USER app
+-
  ENTRYPOINT ["./dotnetapp"]
 ```
 
 This `diff` output highlights the following differences:
 
-1. **Build stage**: The `linky` directory's Dockerfile uses `cgr.dev/chainguard/dotnet-sdk:latest-dev` with the `-dev` variant for build tools instead of `mcr.microsoft.com/dotnet/sdk:9.0`
-2. **User switching**: This Dockerfile switches to `USER 0` (root) during the restore phase, as this is required for package operations in Chainguard's security model
-3. **Runtime stage**: The `linky` Dockerfile uses `cgr.dev/chainguard/aspnet-runtime:latest` which runs as non-root by default, meaning it doesn't require explicit `USER` directives
+1. **Registry and images**: The Chainguard Dockerfile uses `cgr.dev/chainguard/dotnet-sdk` and `cgr.dev/chainguard/dotnet-runtime` instead of the `mcr.microsoft.com` equivalents.
+2. **User switching during restore**: The Chainguard Dockerfile switches to `USER root` before `dotnet restore`. Chainguard's .NET images run as a non-root user by default, and restoring packages requires root.
+3. **File ownership**: Both Dockerfiles use `--chown` so the runtime user owns the copied files and can write the application's `output.txt`. The Microsoft image names its user `app`, while Chainguard's default non-root user is UID `65532`. The default username varies across Chainguard's container images (for example, `nonroot` or `app`), so referencing the UID is less ambiguous.
+4. **No explicit runtime user**: The Microsoft Dockerfile ends with `USER app` to drop root privileges. The Chainguard runtime already runs as non-root, so the Chainguard Dockerfile omits this line.
 
 Build a container image with this Dockerfile:
 
 ```sh
-docker build -t dotnet-linky .
+docker build -t dotnet-example:linky -f linky.Dockerfile .
 ```
 
-Here, the `docker build` command names the image `dotnet-linky`.
+Here, the `docker build` command tags the image `dotnet-example:linky`.
 
 Run the application:
 
 ```sh
-docker run --rm dotnet-linky
+docker run --rm dotnet-example:linky
 ```
-```Output
-******************************************************************************++++++++++++++++++++++
-*************************************************************************+++++++++++++++++++++++++++
-*************************************************************************+++++++++++++++++++++++++++
-************************************************++++******************++++++++++++++++++++++++++++++
-******************************************+-:..........:-+**********++++++++++++++++++++++++++++++++
-***************************************+:.....:-=++=-:.....:=****+++++++++++++++++++++++++++++++++++
-*************************************-....=**************=....-+*+++++++++++++++++++++++++++++++++++
-***********************************=...:***+.....:*********+:...=+++++++++++++++++++++++++++++++++++
-**********************************:..:****-......-************:..:++++++++++++++++++++++++++++++++++
-********************************+...=**-:*+....-***************=...=++++++++++++++++++++++++++++++++
-*******************************+...+*=...+**********************+...=+++++++++++++++++++++++++++++++
-******************************+...***+:-*************************+...=++++++++++++++++++++++++++++++
-*****************************+...*********************************+...++++++++++++++++++++++++++++++
-*****************************:..+**********************************=..:+++++++++++++++++++++++++++++
-****************************=..-***********************************+:..=++++++++++++++++++++++++++++
-***************************+...**********-....:+**********-....:+**++...++++++++++++++++++++++++++++
-***************************=..:********=..=+*+..:*******+..=+++:.:+++:..=+++++++++++++++++++++++++++
-***************************=..-********..****:...+*****+..+**+-...=++-..=+++++++++++++++++++++++++++
-***************************=..-********..+*****:.+*****+..+**+*+:.=++-..-+++++++++++++++++++++++++++
-***************************=..:********=..-++=..-*******+..-===..-+++:..=+++++++++++++++++++++++++++
-***************************+...+*********=:..:-+*********+=:..:-+++++...++++++++++++++++++++++++++++
-****************************+...*************************+++++++++++...=++++++++++++++++++++++++++++
-************************+=-:....:**********************++++++++++++:....:-=+++++++++++++++++++++++++
-*******************+=:.......:-+********************+++++++++++++++++-:.... ..:-=+++++++++++++++++++
-****************+:.....:=+************************++++++++++++++++++++++++=-:.....:=++++++++++++++++
-***************-...=****************************++++++++++++++++++++++++++++++++-...-+++++++++++++++
-**************+..:*****************************+++++++++++++++++++++++++++++++++++...+++++++++++++++
-***************-..:**************************+++++++++++++++++++++++++++++++++++=:..:+++++++++++++++
-****************-.. ....::::-*************++++++++++++++=++++++++++++++::::........-++++++++++++++++
-******************+=:......=**************=-++++++++++++-=++++++++++++++-......:-+++++++++++++++++++
-***********************=..-*************+-.-++++++++++++:.-++++++++++++++-..-+++++++++++++++++++++++
-******************+++++=..-***********+=....++++++++++++....-++++++++++++:..=+++++++++++++++++++++++
-*****************+++++*+:...-++**++=-.......-++++++++++-.......:=+++++=-...:++++++++++++++++++++++++
-***************++*++++++++:...........:=++:..-++++++++-..:++=:...........:=+++++++++++++++++++++++++
-*************++++++++++++++++======++++++++:...=++++=...:+++++++===--==+++++++++++++++++++++++++++++
-**********++*+++++++++++++++++++++++++++++++=..........=++++++++++++++++++++++++++++++++++++++++++++
-**********+++++++++++++++++++++++++++++++++++++-::::=+++++++++++++++++++++++++++++++++++++++++++++++
-********++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-*****+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+```output
+         42                                                    
+         42              ,d                             ,d     
+         42              42                             42     
+ ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM  
+a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42     
+8b       42 8b       d8  42    42       42 8PP!!!!!!!   42     
+"8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,    
+ `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428  
 
 OSArchitecture: X64
 OSDescription: Wolfi
-FrameworkDescription: .NET 9.0.10
+FrameworkDescription: .NET 10.0.9
 
 UserName: nonroot
-HostName : 1914681fe4cb
+HostName : 7e5255990efe
 
 ProcessorCount: 16
-TotalAvailableMemoryBytes: 16472768512 (15.34 GiB)
+TotalAvailableMemoryBytes: 16472748032 (15.34 GiB)
 ```
 
-This output is similar to what was returned by running the `dotnet-notlinky` image, albeit with different ASCII art. Otherwise, the two applications function identically.
+This output is nearly identical to what the `dotnet-example:notlinky` image returned. The differences reflect the underlying base image: the operating system is `Wolfi` rather than Ubuntu, and the application runs as `nonroot` rather than `app`. Otherwise, the two applications function identically.
 
 
 ## Comparing the Results
 
-If you have Grype installed, you can scan both the container images you've built for vulnerabilities. Start by scanning the `dotnet-notlinky` image:
+If you have Grype installed, you can scan both of the container images you've built for vulnerabilities. Start by scanning the `dotnet-example:notlinky` image:
 
 ```sh
-grype dotnet-notlinky
+grype dotnet-example:notlinky
 ```
 ```output
 . . .
 
-[0014]  INFO found 72 vulnerability matches across 262 packages
+[0014]  INFO found 19 vulnerability matches across 270 packages
 [0014] DEBUG   ├── fixed: 0
 [0014] DEBUG   ├── ignored: 0 (due to user-provided rule)
 [0014] DEBUG   ├── dropped: 0 (due to hard-coded correction)
-[0014] DEBUG   └── matched: 72
+[0014] DEBUG   └── matched: 19
 [0014] DEBUG       ├── unknown severity: 0
-[0014] DEBUG       ├── negligible: 48
-[0014] DEBUG       ├── low: 6
-[0014] DEBUG       ├── medium: 12
-[0014] DEBUG       ├── high: 5
-[0014] DEBUG       └── critical: 1
-NAME                INSTALLED               FIXED-IN     TYPE  VULNERABILITY     SEVERITY   
-apt                 2.6.1                                deb   CVE-2011-3374     Negligible  
-bsdutils            1:2.38.1-5+deb12u3                   deb   CVE-2022-0563     Negligible  
+[0014] DEBUG       ├── negligible: 0
+[0014] DEBUG       ├── low: 12
+[0014] DEBUG       ├── medium: 7
+[0014] DEBUG       ├── high: 0
+[0014] DEBUG       └── critical: 0
+NAME                INSTALLED                FIXED-IN  TYPE  VULNERABILITY   SEVERITY   
+coreutils           9.4-3ubuntu6.2                     deb   CVE-2025-5278   Low        
+dpkg                1.22.6ubuntu6.6                    deb   CVE-2026-2219   Medium     
+gpgv                2.4.4-2ubuntu17.4                  deb   CVE-2025-68972  Medium     
 . . .
 ```
 
-This portion of the `grype` output shows that the `dotnet-notlinky` container image has 72 vulnerabilities, including five high-severity vulnerabilities and one critical vulnerability.
+This portion of the `grype` output shows that the `dotnet-example:notlinky` container image has 19 vulnerabilities, including 12 low-severity and 7 medium-severity vulnerabilities.
 
 Next, scan the Chainguard-based image:
 
 ```sh
-grype dotnet-linky
+grype dotnet-example:linky
 ```
 ```output
 . . .
 
-[0002]  INFO found 0 vulnerability matches across 333 packages
+[0002]  INFO found 0 vulnerability matches across 195 packages
 [0002] DEBUG   ├── fixed: 0
 [0002] DEBUG   ├── ignored: 0 (due to user-provided rule)
 [0002] DEBUG   ├── dropped: 0 (due to hard-coded correction)
@@ -368,19 +321,20 @@ grype dotnet-linky
 No vulnerabilities found
 ```
 
-As this output shows, `grype` didn't find any vulnerabilities in the `dotnet-linky` image.
+As this output shows, `grype` didn't find any vulnerabilities in the `dotnet-example:linky` image.
 
 You can compare the sizes of the two container images with `docker`:
 
 ```sh
-docker image list | grep dotnet-
+docker images dotnet-example
 ```
 ```output
-dotnet-linky                                       latest       046ae0be8f9b   5 minutes ago   171MB
-dotnet-notlinky                                    latest       ab2b43e44aca   7 minutes ago   199MB
+REPOSITORY       TAG        IMAGE ID       CREATED         SIZE
+dotnet-example   linky      defe30f42942   5 minutes ago   151MB
+dotnet-example   notlinky   70e03529cea6   7 minutes ago   210MB
 ```
 
-This output shows that the `dotnet-linky` container image is significantly smaller than the `dotnet-notlinky` image.
+This output shows that the `dotnet-example:linky` container image is significantly smaller than the `dotnet-example:notlinky` image.
 
 > **Note**: The command outputs shown in these examples were validated at the time of this writing. Over time, the number of vulnerabilities in either image is likely to change, though you can always expect the Chainguard-based image to contain fewer vulnerabilities.
 
@@ -391,22 +345,27 @@ When migrating a .NET application to use Chainguard Containers, keep the followi
 
 - **Registry change**: Update image references from `mcr.microsoft.com` to `cgr.dev/chainguard` (or to your organization's private repository within the Chainguard registry, as in `cgr.dev/example.com`)
 - **Multi-stage builds**: Both approaches use [multi-stage builds](/chainguard/chainguard-images/about/getting-started-distroless/#multi-stage-builds) to separate build-time and runtime dependencies
-- **Development variants**: Use [development variants](/chainguard/chainguard-images/about/differences-development-production/) of Chainguard Containers for build stages that need package management tools
-- **`restore` operations**: Chainguard's security model requires explicit root user switching for `dotnet restore` or `apk` operations:
+- **`restore` operations**: Chainguard's security model requires switching to root for `dotnet restore` or `apk` operations:
 
 ```dockerfile
-USER 0
-RUN dotnet restore -a $TARGETARCH
+USER root
+RUN dotnet restore
 ```
 
-The runtime stage automatically runs as non-root, so you don't need to add `USER` directives.
+- **File ownership**: Chainguard runtime images run as a non-root user by default. If your application writes to its working directory, copy the published files with `--chown` so the runtime user owns them. Referencing the default non-root UID, `65532`, avoids ambiguity, since the username varies across Chainguard Containers:
 
-When migrating your .NET applications to Chainguard Containers, remember to use the `dotnet-sdk:latest-dev` container image for the build stage, and to choose the appropriate runtime based on the type of application:
+```dockerfile
+COPY --from=build --chown=65532:65532 /app /app
+```
 
-- `cgr.dev/chainguard/aspnet-runtime:latest` for ASP.NET applications (these are oftentimes web applications)
-- `cgr.dev/chainguard/dotnet-runtime:latest` for .NET Core applications (these are oftentimes console applications)
+Because the Chainguard runtime image already runs as non-root, you don't need to add a `USER` directive to drop privileges in the runtime stage.
 
-Though not recommended, the `aspnet-runtime` image can be used to run .NET Core applications, since it contains the `dotnet-#-runtime` package.
+Choose the runtime image based on the type of application:
+
+- `cgr.dev/chainguard/dotnet-runtime:latest` for .NET Core applications (these are often console applications, like the one in this guide)
+- `cgr.dev/chainguard/aspnet-runtime:latest` for ASP.NET applications (these are typically web applications)
+
+If a build stage needs a shell or package manager, use a [development variant](/chainguard/chainguard-images/about/differences-development-production/) of the relevant Chainguard container image.
 
 
 ## Learn More
@@ -414,13 +373,13 @@ Though not recommended, the `aspnet-runtime` image can be used to run .NET Core 
 Migrating .NET applications from Microsoft's official images to Chainguard's container images provides significant security benefits with minimal code changes. The multi-stage build pattern remains the same, with the primary differences being:
 
 1. Updated image registry and tags
-2. Explicit user switching during package operations in build stages
-3. Automatic non-root execution in runtime stages
+2. Switching to root during package operations in the build stage
+3. Automatic non-root execution in the runtime stage
 
 These small changes result in containerized applications with few-to-zero vulnerabilities and smaller image sizes.
 
 For detailed information about Chainguard's .NET container images and additional configuration options, refer to the following resources:
 
-- The [.NET SDK](https://images.chainguard.dev/directory/image/dotnet-sdk/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-dotnet) and [ASP.NET Runtime](https://images.chainguard.dev/directory/image/aspnet-runtime/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-dotnet) documentation pages contain full details on Chainguard's .NET images, including usage documentation, provenance and security advisories.
+- The [.NET SDK](https://images.chainguard.dev/directory/image/dotnet-sdk/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-dotnet) and [.NET Runtime](https://images.chainguard.dev/directory/image/dotnet-runtime/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-dotnet) documentation pages contain full details on Chainguard's .NET images, including usage documentation, provenance, and security advisories.
 - Our [General Migration Guidance](/chainguard/migration/migrating-to-chainguard-images/) is helpful for understanding migration best practices.
-- Chainguard's [Dockerfile Converter (dfc)](/chainguard/migration/dockerfile-conversion/) is a helpful tool for porting existing Dockerfiles to use Chainguard Containers.
+- [The Guardener](/chainguard/migration/the-guardener/) is an AI-powered agent that iteratively converts, builds, and validates your Dockerfiles for use with Chainguard Containers.


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Reframe the .NET migration guide around one application built with two Dockerfiles, compared side by side
- Clarify the Chainguard-specific Dockerfile changes (root for `restore`, `--chown` to UID `65532`, no runtime `USER` directive)
- Refresh command outputs (vulnerability scans, image sizes) and bump `lastmod`

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/5863

Revises the .NET migration guide so readers build a single application with both a Microsoft-based and a Chainguard-based Dockerfile, then compare the resulting images.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The previous version described "two nearly identical versions of an application," which obscured that the only real difference is the base images. Building one application two ways makes the migration steps and their security benefits concrete and easier to follow.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The guide accurately describes building the demo app with `notlinky.Dockerfile` (Microsoft) and `linky.Dockerfile` (Chainguard)
- The `diff` and explanation of Dockerfile differences (root during `restore`, `--chown=65532:65532`, omitted runtime `USER`) match the example files
- Command outputs (Grype scans, `docker images` sizes) render correctly
- Migration considerations and best practices remain accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the [preview link](https://deploy-preview-3458--ornate-narwhal-088216.netlify.app/chainguard/migration/migration-guides/migrating-dotnet/) and ensure the changes look right
2. Navigate to the .NET migration guide and confirm the side-by-side build flow, the Dockerfile `diff`, and the comparison outputs read correctly
