### PR TITLE
Document chainctl skills validate, uninstall, and delete commands

### DIFF
--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -161,6 +161,25 @@ Load the skill into Claude Code or any MCP-compatible agent. In Claude Code, inv
 
 The agent loads the skill and runs it, confirming it installed and loaded correctly end to end.
 
+## Uninstall the skill
+
+To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `chainguard-github-add-educational-comments`:
+
+```shell
+chainctl skills uninstall chainguard-github-add-educational-comments
+```
+
+The command prompts for confirmation before removing any files:
+
+```output
+This will remove skill "chainguard-github-add-educational-comments" from local agent directories.
+Proceed?
+Do you want to continue? [y,N]: 
+Uninstalled skill "chainguard-github-add-educational-comments".
+```
+
+By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.
+
 ## Command reference
 
 | Action | Command |
@@ -169,6 +188,7 @@ The agent loads the skill and runs it, confirming it installed and loaded correc
 | Describe a skill | `chainctl skills describe skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
 | Pull a skill | `chainctl skills pull skills.cgr.dev/chainguard/<owner>/<name>:<tag> <dir>` |
 | Install a skill | `chainctl skills install skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
+| Uninstall a skill | `chainctl skills uninstall <install-name>` |
 
 ## Next steps
 

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -105,6 +105,47 @@ This section outlines some of the `chainctl` commands you can use to manage skil
 
 Refer to the [`chainctl skills` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_skills/) for more information.
 
+### Validate the skill
+
+Before you publish, check that the skill directory meets the spec with the `validate` subcommand. It runs locally and makes no network calls:
+
+```shell
+chainctl skills validate hello-world
+```
+```output
+✓  SKILL.md found
+✓  Frontmatter valid
+✓  name: "hello-world" (matches directory basename)
+✓  description: 96 chars
+✓  Total size: 387 B / 10 MB
+✓  1 file(s) will be published:
+     SKILL.md
+
+Validation passed.
+```
+
+`validate` confirms that the directory contains a `SKILL.md`, that its frontmatter is valid, that the `name` field matches the directory name, and that the skill is within the size limit. It also lists the files that `push` will publish.
+
+To also flag optional fields that Chainguard recommends, add the `--strict` flag:
+
+```shell
+chainctl skills validate hello-world --strict
+```
+```output
+✓  SKILL.md found
+✓  Frontmatter valid
+✓  name: "hello-world" (matches directory basename)
+✓  description: 96 chars
+✓  Total size: 387 B / 10 MB
+✓  1 file(s) will be published:
+     SKILL.md
+⚠  license field is recommended
+
+Validation passed.
+```
+
+Here, `--strict` warns that the skill omits the recommended `license` field. Warnings don't cause validation to fail, but addressing them produces a more complete skill.
+
 ### Push the skill to your organization's registry
 
 From the parent directory of `hello-world/`, push the skill to your org's registry and tag it:
@@ -181,13 +222,58 @@ Hello from Chainguard Agent Skills! Your skill installed and loaded successfully
 
 This confirms the skill was published, installed, and loaded correctly end to end.
 
+### Uninstall the skill
+
+To remove a skill from your machine, pass its name to the `uninstall` subcommand. You only need the name, not the full registry reference:
+
+```shell
+chainctl skills uninstall hello-world
+```
+
+The command prompts for confirmation before removing any files:
+
+```output
+This will remove skill "hello-world" from local agent directories.
+Proceed?
+Do you want to continue? [y,N]: 
+Uninstalled skill "hello-world".
+```
+
+By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.
+
+`uninstall` operates only on the local files on your machine. It doesn't modify your organization's registry. To remove a published skill from the registry, use [`chainctl skills delete`](/chainguard/chainctl/chainctl-docs/chainctl_skills_delete/) instead.
+
+### Delete a skill from the registry
+
+To remove a published version of a skill from your organization's registry, pass its full reference to the `delete` subcommand. The reference must include an explicit tag:
+
+```shell
+chainctl skills delete skills.cgr.dev/$ORG/hello-world:v1.0.0
+```
+
+The command prompts for confirmation before removing the version:
+
+```output
+Delete skills.cgr.dev/example.dev/hello-world:v1.0.0?
+Do you want to continue? [y,N]: 
+```
+
+Press <kbd>y</kbd> and <kbd>ENTER</kbd> to confirm. Add the `-y` flag to skip the prompt and delete the version non-interactively.
+
+The command requires a tag so you don't delete the `latest` tag by accident. Deleting `latest` is still possible, but it prompts for an additional confirmation.
+
+Unlike `uninstall`, `delete` removes the skill from the registry for your whole organization. It doesn't remove copies already installed on anyone's machine.
+
 ## Command reference
 
 | Action | Command |
 | ----- | ----- |
 | Enable the entitlement | `chainctl skills entitlements create --parent $ORG` |
 | Accept the registry terms | `chainctl skills accept-terms --group $ORG` |
+| Validate a skill | `chainctl skills validate <name>` |
 | Push a skill | `chainctl skills push <name> --group $ORG --tag <version>` |
 | List skills | `chainctl skills list --group $ORG` |
 | Describe a skill | `chainctl skills describe skills.cgr.dev/$ORG/<name>:<version>` |
 | Install a skill | `chainctl skills install skills.cgr.dev/$ORG/<name>:<version>` |
+| Uninstall a skill | `chainctl skills uninstall <name>` |
+| Delete a published skill | `chainctl skills delete skills.cgr.dev/$ORG/<name>:<version>` |


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Document the `chainctl skills uninstall` command in both the public catalog and skills registry guides
- Add `chainctl skills validate` (including `--strict`) coverage to the skills registry guide
- Add `chainctl skills delete` coverage for removing published skills from the registry
- Add the new commands to each page's command reference table

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/internal/issues/5881

Documents the `validate`, `uninstall`, and `delete` subcommands across the Agent Skills public catalog and skills registry pages.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The Agent Skills docs covered pushing, installing, and running skills but omitted how to validate a skill before publishing, uninstall a skill locally, or delete a published version from the registry. These gaps left users without guidance for the full skill lifecycle.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The public catalog page documents `uninstall`, including its flags and confirmation prompt
- The skills registry page documents `validate` (with `--strict`), `uninstall`, and `delete`, and clearly distinguishes local uninstall from registry deletion
- Both command reference tables list the new commands
- Code snippets and example output match actual `chainctl skills` behavior

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the [preview link](https://deploy-preview-3459--ornate-narwhal-088216.netlify.app/chainguard/agent-skills/) and ensure the changes look right
2. Navigate to the Agent Skills public catalog page and verify the "Uninstall the skill" section and command reference table
3. Navigate to the skills registry page and verify the "Validate the skill", "Uninstall the skill", and "Delete a skill from the registry" sections and command reference table
