### PR TITLE
Fix broken JFrog Artifactory documentation links

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -253,7 +253,7 @@ retrieved from Chainguard.
 [JFrog Artifactory](https://jfrog.com/artifactory/) supports Maven repositories
 for proxying and hosting, and virtual repositories to combine them. Refer to the
 [Maven Repository documentation for
-Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/maven-repository)
+Artifactory](https://docs.jfrog.com/artifactory/docs/maven-repositories)
 for more information.
 
 ### Initial configuration

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -175,8 +175,8 @@ token for the registry access:
 
 [JFrog Artifactory](https://jfrog.com/artifactory/) supports npm repositories
 for proxying and hosting, and virtual repositories to combine them. Refer to the
-[npm registry documentation for
-Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/npm-registry)
+[npm Repository documentation for
+Artifactory](https://docs.jfrog.com/artifactory/docs/npm-repositories)
 for more information.
 
 ### Initial configuration

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -224,7 +224,7 @@ Combine the two repositories in a new virtual repository:
 for proxying and virtual repositories to combine multiple sources into a single
 repository. The following instructions are based on the [PyPI Repository
 documentation for
-Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/set-up-pypi-repositories-on-artifactory).
+Artifactory](https://docs.jfrog.com/artifactory/docs/pypi-repositories).
 
 ### Initial configuration
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Replace three broken JFrog Artifactory documentation links across the Java, JavaScript, and Python library global configuration guides

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/edu/issues/3442

Points the Maven, npm, and PyPI Artifactory documentation links at their working `docs.jfrog.com` pages.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The existing `jfrog.com/help/r/jfrog-artifactory-documentation/...` URLs redirect to pages that return a 404. The replacement `docs.jfrog.com/artifactory/docs/...` URLs resolve correctly and point to the equivalent content.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- All three JFrog links return a 200 and load the correct repository documentation
- Link text matches the destination page titles (Maven Repositories, npm Repositories, PyPI Repositories)

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [\`edu\` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. In each of the Java, JavaScript, and Python global configuration guides, navigate to the **JFrog Artifactory** section and confirm the documentation link opens the correct JFrog page

🤖 Generated with [Claude Code](https://claude.com/claude-code)