### PR TITLE
Add console option to self-serve doc

### DIFF
--- a/content/chainguard/self-serve/overview.md
+++ b/content/chainguard/self-serve/overview.md
@@ -1,7 +1,7 @@
 ---
 title : "Self-serve overview"
 lead: ""
-description: "Signing yourself up for Chainguard products like the Catalog Starter plan"
+description: "Signing yourself up for the Catalog Starter plan and other Chainguard products"
 type: "article"
 date: 2026-05-12T01:00:01+00:00
 lastmod: 2026-07-01T01:00:01+00:00
@@ -44,10 +44,10 @@ To sign up, use [this console link](https://console.chainguard.dev/signup) or cl
 
 To add images in the console:
 
-1. Browse to **Settings > Plan and Subscription**, which shows your current account status and currently selected images
-1. Click **Select images**
-1. Use the checkboxes to select or deselect images
-1. Click **Review and confirm**
+1. Browse to **Settings > Plan and Subscription**, which shows your current account status and currently selected images.
+1. Click **Select images**.
+1. Use the checkboxes to select or deselect images.
+1. Click **Review and confirm**.
 
 > **Note:** Changes made to image selections can take up to a few hours to process before the images become accessible to you.
 

--- a/content/chainguard/self-serve/overview.md
+++ b/content/chainguard/self-serve/overview.md
@@ -1,10 +1,10 @@
 ---
 title : "Self-serve overview"
 lead: ""
-description: "Signing yourself up for Chainguard products"
+description: "Signing yourself up for Chainguard products like the Catalog Starter plan"
 type: "article"
 date: 2026-05-12T01:00:01+00:00
-lastmod: 2026-05-12T01:00:01+00:00
+lastmod: 2026-07-01T01:00:01+00:00
 draft: false
 weight: 010
 ---
@@ -32,7 +32,30 @@ Other limitations include:
   - BASE
 - No access to nested UIDP image repos, such as Helm charts
 
-## Sign up with `chainctl`
+## Manage Catalog Starter plans in the Chainguard Console
+
+Sign up and manage a Catalog Starter plan using the Chainguard Console. If you prefer, you can instead [use `chainctl`](#manage-catalog-starter-plans-using-chainctl).
+
+### Sign up with the Chainguard Console
+
+To sign up, use [this console link](https://console.chainguard.dev/signup) or click **Get Started** on the main login screen.
+
+### Manage image selections in the Chainguard Console
+
+To add images in the console:
+
+1. Browse to **Settings > Plan and Subscription**, which shows your current account status and currently selected images
+1. Click **Select images**
+1. Use the checkboxes to select or deselect images
+1. Click **Review and confirm**
+
+> **Note:** Changes made to image selections can take up to a few hours to process before the images become accessible to you.
+
+## Manage Catalog Starter plans using `chainctl`
+
+Sign up and manage a Catalog Starter plan using `chainctl`. If you prefer, you can instead [use the Chainguard Console](#manage-catalog-starter-plans-in-the-chainguard-console).
+
+### Sign up with `chainctl`
 
 The current method for signing up is with `chainctl`.
 
@@ -54,11 +77,11 @@ This will require selection of a valid authentication option:
 
 Use the arrow keys and click 'Enter' to select either, which will launch a browser window to the Chainguard console to complete sign-up.
 
-## Add images
+### Add images with `chainctl`
 
 You can see which images are available [using the Chainguard Directory](/chainguard/chainguard-images/how-to-use/chainguard-directory/), but remember the images available are limited to the tiers mentioned above.
 
-To add one or more images, run the following command, substituting the desired image names for the variables:
+To add one or more images with chainctl, run the following command, substituting the desired image names for the variables:
 
 ```shell
 chainctl starter add-images $IMAGE1 [$IMAGE2]
@@ -70,7 +93,7 @@ After the Chainguard system has processed your request, the image(s) will be acc
 docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest
 ```
 
-## Find status
+### Find status with `chainctl`
 
 To show the status of your catalog starter organization, including the registry path, account provisioning status, image quota usage, and per-image readiness, use:
 
@@ -78,7 +101,7 @@ To show the status of your catalog starter organization, including the registry 
 chainctl starter status
 ```
 
-## Add additional users
+## Add additional users to your Catalog Starter plan
 
 To request access for additional users for your organization, use:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
This adds parallel information about signing up for Catalog Starter and managing images using the Chainguard Console to the existing page that covers the previously `chainctl`-only method.

### What should this PR do?
Fixes https://github.com/chainguard-dev/internal/issues/5885

### What are the acceptance criteria? 
Is the writing clear? Does the [preview](https://deploy-preview-3494--ornate-narwhal-088216.netlify.app/chainguard/self-serve/overview/) render properly?

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
