### PR TITLE
libraries/javascript/migration: fix pnpm auth for direct access and upstream-fallback

### DIFF
--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -170,7 +170,7 @@ credentials short-lived and avoids passing around static tokens.
 
 #### Local development
 
-For npm, pnpm, and Bun, run the following command to write a project-level `.npmrc` with the
+For npm and Bun, run the following command to write a project-level `.npmrc` with the
 registry URL and credentials from your current Chainguard session:
 
 ```shell
@@ -180,7 +180,10 @@ chainctl auth configure-npm
 Because [this command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) uses a session-backed bearer token, you will need to re-run it when the token expires. If the command returns an error, ensure you are
 using the [latest version of chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
-For Yarn, [configure the .npmrc manually](#manual-registry-configuration).
+For pnpm and Yarn, [configure the .npmrc manually](#manual-registry-configuration).
+`chainctl auth configure-npm` generates path-scoped credentials (`//libraries.cgr.dev/javascript/:_auth`)
+that do not cover pnpm's upstream-fallback path, causing HTTP 401 errors on packages
+Chainguard has not yet rebuilt.
 
 #### CI/CD and automated environments
 
@@ -214,7 +217,7 @@ If your platform does not support assumable identities, you can use a static pul
 chainctl auth configure-npm --pull-token
 ```
 
-This generates a project-level `.npmrc` with a pull token. It is supported for npm, pnpm, and Bun.
+This generates a project-level `.npmrc` with a pull token. It is supported for npm and Bun. For pnpm, [configure the registry manually](#manual-registry-configuration) to ensure host-level credentials are used.
 
 <a name="manual-registry-configuration"></a>
 
@@ -237,15 +240,23 @@ First create a pull token as described in the [prerequisites](#pull-token), then
 export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 
 pnpm config set registry https://libraries.cgr.dev/javascript/ --location=project
-pnpm config set //libraries.cgr.dev/javascript/:_auth "${token}" --location=project
+pnpm config set //libraries.cgr.dev/:_auth "${token}" --location=project
 ```
 
-Alternatively, use username and password directly to avoid `base64` encoding
-differences across platforms:
+The authentication entry is keyed to the whole `libraries.cgr.dev` host
+(`//libraries.cgr.dev/`) so that it also covers packages served through the
+[upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls)
+path (`/javascript-upstream/`). A credential scoped only to `/javascript/` causes
+pnpm to send no auth header for upstream-fallback packages, resulting in HTTP 401
+errors.
+
+Alternatively, use `username` and `_password` instead of `_auth`. Note that the
+`_password` value must still be base64-encoded; pnpm does not accept a raw token
+here:
 
 ```shell
-pnpm config set //libraries.cgr.dev/javascript/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
-pnpm config set //libraries.cgr.dev/javascript/:_password "${CHAINGUARD_JAVASCRIPT_TOKEN}" --location=project
+pnpm config set //libraries.cgr.dev/:username "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}" --location=project
+pnpm config set //libraries.cgr.dev/:_password "$(echo -n "${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)" --location=project
 ```
 
 **Yarn Berry (2.x+)**


### PR DESCRIPTION
Ports the pnpm credential fixes from #3445 to the migration guide, and adds a warning that `chainctl auth configure-npm` generates path-scoped credentials that break pnpm when upstream-fallback packages are involved.

- `chainctl auth configure-npm` (and `--pull-token`) now documented as npm/Bun only; pnpm users directed to the manual configuration section.
- Manual pnpm config updated to use host-level `//libraries.cgr.dev/:_auth` (and `username`/`_password`) instead of path-scoped `//libraries.cgr.dev/javascript/`, matching the fix in #3445.
- `_password` example now base64-encodes the token; pnpm rejects a raw token.
- Short explanation added of why host-level credentials are required (upstream-fallback tarballs are served from `/javascript-upstream/`, which path-scoped credentials don't cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)