### PR TITLE
Note pnpm v11 support in JS migration guide

### DIFF
--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -236,6 +236,8 @@ First create a pull token as described in the [prerequisites](#pull-token), then
 
 **pnpm**
 
+> Note: The Chainguard Repository [upstream fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) has been tested with pnpm v11. We recommend using pnpm v11 or newer.
+
 ```shell
 export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 


### PR DESCRIPTION
Mirrors the notes added to `overview.md` and `build-configuration.md` in #3410 — upstream fallback has been tested against pnpm v11, so we recommend v11 or newer.

Adds the note in the pnpm section of the manual registry configuration block, which is where the pnpm-specific upstream fallback auth instructions live.