### PR TITLE
docs(libraries): clarify Artifactory URL normalization and mime type settings

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -286,8 +286,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * **User Name** and **Password / Access Token**: Set to the [values as retrieved with chainctl](/chainguard/libraries/access/).
     * Deactivate **Maven Settings - Handle Snapshots**.
 1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. Under the **Others** section, deactivate the **Block
-   Mismatching Mime Types** setting. Ensure **Disable URL Normalization** is checked.
+1. Click the **Advanced** configuration tab. In the **Others** section, check the box next to **Disable URL Normalization** and uncheck the box next to **Block Mismatching Mime Types**.
 1. Click **Create Remote Repository**.
 1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -197,7 +197,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-1. Click the **Advanced** configuration tab. Ensure **Disable URL Normalization** is checked.
+1. Click the **Advanced** configuration tab, then check the box next to **Disable URL Normalization**.
 1. Click **Create Remote Repository**.
 
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -252,8 +252,7 @@ Configure a remote repository for the Chainguard Libraries for Python index:
    `https://libraries.cgr.dev/`.
 1. Set the **PyPI Settings - Registry Index Location URL Suffix** to `python/simple`.
 1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. Disable **URL Normalization** and disable **Block
-   Mismatching Mime Types** in the **Others** section.
+1. Click the **Advanced** configuration tab. In the **Others** section, check the box next to **Disable URL Normalization** and uncheck the box next to **Block Mismatching Mime Types**.
 1. Click **Create Remote Repository**.
 
 If you want to use the separate repository with [remediated Python


### PR DESCRIPTION
## What this changes

Clarifies the JFrog Artifactory **Advanced** tab instructions on the Chainguard Libraries global configuration pages. The prior Python wording ("Disable **URL Normalization** and disable **Block Mismatching Mime Types**") was ambiguous, because "Disable URL Normalization" is itself the checkbox label — so the instruction read as if you should turn it *off*, the opposite of what's intended.

The pages now use explicit check/uncheck phrasing, applied consistently:

| Page | Change |
|---|---|
| Python `global-configuration.md` | Check the box next to **Disable URL Normalization**; uncheck the box next to **Block Mismatching Mime Types** |
| Java `global-configuration.md` | Aligned to the same check/uncheck phrasing (previously "deactivate"/"is checked") |
| JavaScript `global-configuration.md` | Clarified the **Disable URL Normalization** instruction only |

## Related-page check

Ran the related-pages check across `content/`. Beyond the three edited pages:

- **`artifactory-images-pull-through`** instructs users to *check* Block Mismatching Mime Types — the opposite of the libraries guidance. Left unchanged, as it covers a different product (images, not packages). Flagging the divergence for awareness.
- **`artifactory-packages-pull-through`** (APK) already gives consistent Disable URL Normalization guidance. No change.

## Open questions for reviewers

- **JavaScript + Block Mismatching Mime Types:** the JS page does not mention this setting. If npm proxying through Artifactory requires it unchecked like Python and Java do, that's a gap to confirm with engineering.
- Confirm the images pull-through divergence (check vs. uncheck) is intentional.

## Test plan

1. In JFrog Artifactory, create a PyPI remote repository following the Python global configuration page.
2. On the **Advanced** configuration tab, confirm the **Others** section contains checkboxes labeled exactly **Disable URL Normalization** and **Block Mismatching Mime Types**.
3. Set them as documented: check **Disable URL Normalization**, uncheck **Block Mismatching Mime Types**.
4. Click **Create Remote Repository**.
5. Run the checksum validation from the "Validate the remote repository" section: fetch a wheel directly from `libraries.cgr.dev` and the same wheel through the Artifactory remote repository, then confirm the two `sha256sum` values match.
6. Repeat steps 1–5 against the Java page (Maven remote) to confirm the same checkbox labels and behavior.
7. On the JavaScript page, confirm the **Disable URL Normalization** checkbox is present on the npm remote repository's Advanced tab and that the reworded instruction matches the UI.

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-07-01.