### PR TITLE
fix(ai-docs): generate container-specific checksums.txt so verify/extract work

### DIFF
--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -216,8 +216,15 @@ jobs:
 
         # Copy necessary files for container build (rename to match Dockerfile expectations)
         cp "$TEMP_BUILD_DIR/chainguard-complete-docs.md" scripts/chainguard-ai-docs.md
-        cp "$TEMP_BUILD_DIR/checksums.txt" scripts/checksums.txt
         # verification.sh is already in scripts/ directory
+
+        # Generate a container-specific checksums.txt whose entries match the
+        # filenames actually shipped inside the image under /docs. The release
+        # checksums.txt in $TEMP_BUILD_DIR references chainguard-complete-docs.*
+        # (the release artifact names) and is signed as such, so it cannot be
+        # reused here -- doing so makes the in-image `verify` and `extract`
+        # commands fail because those filenames do not exist in /docs.
+        ( cd scripts && sha256sum chainguard-ai-docs.md image-catalog.json verification.sh > checksums.txt )
 
         # Build container with GitHub Container Registry
         docker build -f scripts/Dockerfile.ai-docs -t "ghcr.io/$REPO_OWNER/ai-docs:latest" scripts/


### PR DESCRIPTION
## Problem

Running the documented extract command against the published image fails:

```bash
$ docker run --rm -v \"\$(pwd):/output\" ghcr.io/chainguard-dev/ai-docs:latest extract /output
=== Container Documentation Verification ===

[INFO] Checking file integrity...
[FAIL] File integrity check failed
```

No files are extracted. \`docker run ... verify\` fails the same way.

## Root cause

The image ships four files in \`/docs\`:

- \`chainguard-ai-docs.md\`
- \`image-catalog.json\`
- \`checksums.txt\`
- \`verification.sh\`

But \`checksums.txt\` inside the image references the **release artifact** filenames, not what's actually shipped:

\`\`\`
bccc08f7…  chainguard-complete-docs.md
ecad1165…  chainguard-complete-docs.md.gz
14706ac0…  chainguard-complete-docs.tar.gz
8b7a0a28…  chainguard-complete-docs.zip
\`\`\`

None of those files exist in \`/docs\`, so \`sha256sum -c checksums.txt\` in \`scripts/verify.sh\` fails on missing files. Since \`scripts/extract.sh\` runs \`verify\` before copying, \`extract\` aborts too.

This happens because \`.github/workflows/compile-docs.yml\` generates \`checksums.txt\` from the release artifacts (\`chainguard-complete-docs.*\`) and then copies that same file unchanged into the container build context, while the markdown file gets renamed to \`chainguard-ai-docs.md\` on the way in.

The release \`checksums.txt\` is signed with cosign against the release filenames, so it can't simply be renamed — the two use cases need two files.

## Fix

Generate a container-specific \`checksums.txt\` in \`scripts/\` at image-build time that lists the files actually shipped in \`/docs\`. The release \`checksums.txt\` and its cosign bundle are unchanged.

## Verification

Reproduced against the current \`ghcr.io/chainguard-dev/ai-docs:latest\`:

\`\`\`
[FAIL] File integrity check failed
\`\`\`

After the fix, \`sha256sum -c checksums.txt\` inside \`/docs\` will succeed, unblocking \`verify\` and \`extract\`.