### PR TITLE
Add Java verification approach for Maven

### DIFF
--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -197,7 +197,7 @@ chainctl libraries verify -o json --detailed target/chainguard-verify/*.jar \
 
 > Note: If you belong to multiple Chainguard organizations, include the `--parent=<org>` flag in the command.
 
-This returns output similar to the following:
+It can take up to 5 minutes for this command to return results. It returns output similar to the following:
 
 ```bash
 {

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -182,6 +182,46 @@ Analyze a file and create JSON output:
 chainctl libraries verify -o json commons-lang3-3.17.0.jar
 ```
 
+#### Recommended build-time workflow for Maven
+
+For Maven-based applications, a recommended workflow is to copy only runtime dependencies into a dedicated directory then verify those files, allowing you to avoid noise from unrelated artifacts in `~/.m2/repository`. For example:
+
+```bash
+mvn -U -q -s settings.xml dependency:copy-dependencies \
+  -DincludeScope=runtime \
+  -DoutputDirectory=target/chainguard-verify
+
+chainctl libraries verify -o json --detailed target/chainguard-verify/*.jar \
+  > provenance-report.json
+```
+
+> Note: If you belong to multiple Chainguard organizations, include the `--parent=<org>` flag in the command.
+
+This returns output similar to the following:
+
+```bash
+{
+  "artifactVerificationCoverage": 74.19354838709677,
+  "verifiedItems": 23,
+  "totalItems": 31,
+  "artifactsSummary": {
+    "totalArtifacts": 31,
+    "fullyVerified": 23,
+    "partiallyVerified": 0,
+    "notVerified": 8,
+    "verifiedPercent": 74.19354838709677
+  },
+  "results": [
+    {
+      "artifact": "target/chainguard-verify/jakarta.validation-api-3.0.2.jar",
+      "artifactVerificationCoverage": 100,
+      "details": "Fully verified by Chainguard (signature verified)\nMaven artifact: jakarta.validation:jakarta.validation-api:3.0.2"
+    },
+...
+```
+
+In this example, out of 31 `totalItems`, 23 were verified. The `arfifactVerificationCoverage` percent is 74.
+
 #### Java fat JAR limitations
 
 The fat JAR packaging approach merges the class files from all dependency
@@ -369,6 +409,12 @@ Use the `help` command for more command options and details for the `verify` com
 ```sh
 chainctl help libraries verify
 ```
+
+## Troubleshooting
+
+#### Why might I see 0% coverage when verifying Java artifacts?
+
+A 0% coverage result is expected when verifying a fat JAR, uber JAR, or shaded JAR. Those packaging formats merge dependency contents into a single archive, so `chainctl libraries verify` cannot trace merged classes back to the original JARs.
 
 ## Resources
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to Verification docs

### What should this PR do?
- Explain a recommended workflow for verifying Java runtime dependencies, not including everything locally cached
- This update does not include similar workflows for Gradle/Bazel - I will investigate those separately. 

### Why are we making this change?
Requested: https://linear.app/chainguard/issue/FEA-516/feature-request-submission

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

In a test Java project with dependencies:
1. Confirmed settings.xml resolves against the Chainguard Libraries repo before testing the real workflow (mvn -s settings.xml help:effective-settings in a test dir — surfaced a missing-file error until pointed at a project with a working settings.xml, which caught a config issue early rather than during the actual dependency copy).
2. Run: `mvn -U -q -s settings.xml dependency:copy-dependencies \
     -DincludeScope=runtime \
     -DoutputDirectory=target/chainguard-verify`
3. Run `ls target/chainguard-verify` to see if only runtime-scoped jars are present
4. Run `chainctl libraries verify -o json --parent=chainguard.edu --detailed target/chainguard-verify/*.jar > provenance-report.json` (replace with whatever org you want to use)
    - I first ran `chainctl libraries verify -o json --detailed target/chainguard-verify/*.jar > provenance-report.json` and it failed with `not running in an interactive terminal`. It needed the org specified.

It should return output summarizing the total artifacts and how many were verified.  
