### PR TITLE
Add info about preview mode for library policies

### DIFF
--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -46,9 +46,9 @@ For language dependencies, policies apply to both Chainguard-built packages and 
 * **Upstream fallback**: Control whether packages not yet built by Chainguard can be sourced from the upstream public registry.  
 * **Cooldown**: When upstream fallback is enabled, block newly published package versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
 
-> **Note**: Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them, but they can also add operational complexity and introduce breakage. Choose a cooldown policy based on your own risk tolerance and priorities.
-
 All upstream packages are checked against public malware identifier feeds, and any package with a known malware idenitifier is blocked before being served.
+
+> **Note**: With fallback enabled, Chainguard's malware and greyware scanning covers upstream packages, which addresses the primary risk a cooldown period is meant to mitigate. A cooldown period can still add a small buffer against issues the broader community surfaces after publication and is applied globally across your organization, but it also adds operational complexity and can introduce breakage. Choose a cooldown policy based on your own risk tolerance and priorities.
 
 See [Libraries Overview](/chainguard/libraries/overview/#upstream-fallback-and-controls) for more information.
 

--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -46,7 +46,7 @@ For language dependencies, policies apply to both Chainguard-built packages and 
 * **Upstream fallback**: Control whether packages not yet built by Chainguard can be sourced from the upstream public registry.  
 * **Cooldown**: When upstream fallback is enabled, block newly published package versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
 
-> **Note**: Chainguard recommends a 7-day cooldown when enabling upstream fallback, to block a large share of malicious packages identified shortly after publication. Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them.
+> **Note**: Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them, but they can also add operational complexity and introduce breakage. Choose a cooldown policy based on your own risk tolerance and how your build handles transitive dependency changes.
 
 All upstream packages are checked against public malware identifier feeds, and any package with a known malware idenitifier is blocked before being served.
 

--- a/content/chainguard/chainguard-repository/overview.md
+++ b/content/chainguard/chainguard-repository/overview.md
@@ -46,7 +46,7 @@ For language dependencies, policies apply to both Chainguard-built packages and 
 * **Upstream fallback**: Control whether packages not yet built by Chainguard can be sourced from the upstream public registry.  
 * **Cooldown**: When upstream fallback is enabled, block newly published package versions for a defined period before they can be pulled, giving the security community time to detect threats. The cooldown is configurable (0 to 3650 days) with a default of 7 days. It is applied globally across all packages to prevent dependency resolution errors.
 
-> **Note**: Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them, but they can also add operational complexity and introduce breakage. Choose a cooldown policy based on your own risk tolerance and how your build handles transitive dependency changes.
+> **Note**: Shorter cooldown periods increase the risk of pulling malicious or compromised upstream packages before the broader ecosystem can detect and report them, but they can also add operational complexity and introduce breakage. Choose a cooldown policy based on your own risk tolerance and priorities.
 
 All upstream packages are checked against public malware identifier feeds, and any package with a known malware idenitifier is blocked before being served.
 

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -496,14 +496,20 @@ You can create, disable, and list library policies using [`chainctl libraries po
 
 ### Create and enable a cooldown policy
 
-When upstream fallback is enabled, users with the Owner role can create and enable a cooldown policy with `chainctl`. In the following example, a 10-day cooldown policy is created, then it is enforced on the JavaScript ecosystem:
+When upstream fallback is enabled, users with the Owner role can create and enable a cooldown policy with `chainctl`. The cooldown period provides an additional layer of defense on top of malware and greyware scanning, giving the broader security community time to surface threats that may not be immediately detectable. 
+
+In the following example, a 10-day cooldown policy is created, then it is enforced on the JavaScript ecosystem:
 
 ```bash
 chainctl libraries policy create --name=js-cooldown --cooldown-days=10
 chainctl libraries policy enable --policy=js-cooldown --ecosystem=JAVASCRIPT --mode=ENFORCE
 ```
 
-The default cooldown period is 7 days. The cooldown period provides an additional layer of defense on top of malware and greyware scanning, giving the broader security community time to surface threats that may not be immediately detectable. 
+The default cooldown period is 7 days. 
+
+#### Preview a cooldown policy
+
+To understand the impact before enforcing a policy, use `--mode=PREVIEW`. In preview mode, installs continue to succeed, but Chainguard records what _would have been blocked_ if the policy were enforced.
 
 ### Disable cooldown
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to library access docs, Chainguard Repository overview

### What should this PR do?
- Explain preview mode for policies
- Remove recommendation of 7 day cooldown. Instead, it now says to choose a policy based on your risk tolerance

### Why are we making this change?
[Internal questions](https://chainguard-dev.slack.com/archives/C0A1AANTEF7/p1783047634205209?thread_ts=1781808655.103509&cid=C0A1AANTEF7)

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

