### PR TITLE
Remove EOL version section from Libraries Overview

### DIFF
--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -124,15 +124,6 @@ Our current minimum supported toolchains are:
 
 We will attempt to rebuild any libraries that meet the [licensing and source availability criteria](#licensing-and-source-availability) using the supported toolchains.
 
-### EOL version support
-
-When a library version reaches end of life (EOL) upstream, Chainguard Libraries continues to build packages and provide security fixes for that version for six months beyond the upstream EOL date.
-
-After that six-month window closes, Chainguard Libraries will:
-- No longer build new packages that require the EOL version
-- No longer provide security fixes for packages built against the EOL version
-- Continue to serve previously built packages
-
 ## Upstream fallback and controls
 
 Chainguard Libraries support an optional protected upstream fallback, managed through the [Chainguard


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update Libraries overview

### What should this PR do?
Remove the "EOL version support" section

### Why are we making this change?
[Internal request](https://chainguard-dev.slack.com/archives/C085187D8RE/p1783363428014079)

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
