### PR TITLE
chore: update CODEOWNERS and allow GitHub verified signatures in source policy

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -10,3 +10,6 @@ spec:
     - key:
         # Allow commits signed by GitHub.
         kms: https://github.com/web-flow.gpg
+  # Allow Github verified ssh, gpg, and smime signatures
+  github:
+    verified: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @chainguard-dev/deved-team
+*   @chainguard-dev/education-team-write @chainguard-dev/devrel-team-write


### PR DESCRIPTION
## Type of change

### What should this PR do?
- Replace the retiring `@chainguard-dev/deved-team` in `CODEOWNERS` with `@chainguard-dev/education-team-write` and `@chainguard-dev/devrel-team-write`.
- Add a `github.verified: true` block to `.chainguard/source.yaml` so GitHub verified ssh, gpg, and smime signatures are accepted.

### Why are we making this change?
The deved team is being deleted, so ownership needs to move to the two teams that will carry it forward. The source policy update aligns signature verification with the `chainguard-dev/mono` source policy.

### What are the acceptance criteria?
- `CODEOWNERS` no longer references `@chainguard-dev/deved-team`.
- Both replacement teams have write access and are valid owners (confirmed with owners).
- `.chainguard/source.yaml` accepts GitHub verified signatures at the `spec` level.

### How should this PR be tested?
Confirm the two replacement team slugs are correct and resolve to teams with write access to the repository, and that the `github.verified` block sits at `spec` level (sibling of `authorities`). No content or code changes.
