### PR TITLE
chore: scope CODEOWNERS to edu content/tooling and devrel learning labs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,19 +1,16 @@
 # Default owners for everything not matched below.
 # Also acts as the fallback owner for infra/config/tooling folders
 # (scripts/, terraform/, iac/, .github/, root config) that have no
-# dedicated current-team owner.
+# dedicated team owner.
 *   @chainguard-dev/education-team-write @chainguard-dev/devrel-team-write
 
-# Education owns the product and platform documentation content.
-/content/chainguard/           @chainguard-dev/education-team-write
-/content/platform/             @chainguard-dev/education-team-write
-/content/get-started/          @chainguard-dev/education-team-write
-/content/compliance/           @chainguard-dev/education-team-write
-/content/software-security/    @chainguard-dev/education-team-write
-/content/open-source/          @chainguard-dev/education-team-write
+# Education (edu) team owns all documentation content and site tooling.
+/content/                      @chainguard-dev/education-team-write
+/tools/                        @chainguard-dev/education-team-write
+/static/                       @chainguard-dev/education-team-write
+/layouts/                      @chainguard-dev/education-team-write
+/assets/                       @chainguard-dev/education-team-write
 
-# DevRel owns site tooling, templates, and front-end assets.
-/tools/                        @chainguard-dev/devrel-team-write
-/static/                       @chainguard-dev/devrel-team-write
-/layouts/                      @chainguard-dev/devrel-team-write
-/assets/                       @chainguard-dev/devrel-team-write
+# DevRel owns learning labs only.
+# Placed last so last-match-wins overrides the /content/ rule above.
+/content/software-security/learning-labs/   @chainguard-dev/devrel-team-write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,19 @@
+# Default owners for everything not matched below.
+# Also acts as the fallback owner for infra/config/tooling folders
+# (scripts/, terraform/, iac/, .github/, root config) that have no
+# dedicated current-team owner.
 *   @chainguard-dev/education-team-write @chainguard-dev/devrel-team-write
+
+# Education owns the product and platform documentation content.
+/content/chainguard/           @chainguard-dev/education-team-write
+/content/platform/             @chainguard-dev/education-team-write
+/content/get-started/          @chainguard-dev/education-team-write
+/content/compliance/           @chainguard-dev/education-team-write
+/content/software-security/    @chainguard-dev/education-team-write
+/content/open-source/          @chainguard-dev/education-team-write
+
+# DevRel owns site tooling, templates, and front-end assets.
+/tools/                        @chainguard-dev/devrel-team-write
+/static/                       @chainguard-dev/devrel-team-write
+/layouts/                      @chainguard-dev/devrel-team-write
+/assets/                       @chainguard-dev/devrel-team-write


### PR DESCRIPTION
## Type of change

### What should this PR do?
Scope `CODEOWNERS` so the education (edu) team owns all documentation content and site tooling, and DevRel owns only `content/software-security/learning-labs/`. Everything else falls through to the two-team default.

### Why are we making this change?
Per team-lead feedback, DevRel no longer owns the tooling and the edu team owns essentially all content. The only area DevRel still owns is the learning labs. This routes review requests to the team that actually maintains each area.

### What are the acceptance criteria?
- Education owns `/content/` plus site tooling (`/tools/`, `/static/`, `/layouts/`, `/assets/`).
- DevRel owns only `/content/software-security/learning-labs/`.
- Unowned infra/config/tooling (e.g. `scripts/`, `terraform/`, `iac/`, `.github/`, root config) falls through to the two-team `*` default.
- CODEOWNERS parses cleanly and every referenced team has write access (DevRel write access tracked in chainguard-dev/infra#3058).

### How should this PR be tested?
Confirm the last-match-wins ordering resolves as intended: the `*` default first, `/content/` and tooling to education, and the `learning-labs` rule last so DevRel wins for that path only.
