### PR TITLE
fix(deps): bump lodash to 4.18.1 (CVE-2026-4800)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7354,10 +7354,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16657,9 +16658,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash.debounce": {


### PR DESCRIPTION
## Type of change

Dependency / security fix (dev tooling).

### What should this PR do?

Bump the transitive `lodash` dependency from 4.17.21 to 4.18.1 in `package-lock.json`, resolving Dependabot alert #82 (CVE-2026-4800, high-severity code injection via `_.template`).

### Why are we making this change?

`lodash` is pulled in transitively by SCSS/stylelint dev tooling (`scss-parser` via `purgecss-whitelister`, and `stylelint-scss`). CVE-2026-4800 allows arbitrary code execution at template compilation time when untrusted input reaches `_.template` `options.imports` key names, and is fixed in lodash 4.18.0. Both consumers use caret ranges that already accept the patched minor, so a lockfile update is sufficient (no `overrides` pin required).

### What are the acceptance criteria?

- The vulnerable `lodash@4.17.x` no longer appears in `package-lock.json`.
- Dependabot alert #82 is resolved once merged.

### How should this PR be tested?

No published documentation content is affected; this only changes dev dependency resolution. Verified locally:

- `npm update lodash` moved the single lodash node to 4.18.1; the vulnerable 4.17.x is gone from the lockfile and `npm audit` reports no lodash advisory.
- `npm ls lodash` shows a single deduped `lodash@4.18.1` across both consumers.

---

**Risk**: low. Dev-scope tooling only, minor version bump within lodash v4, lockfile-only change.

**Review focus**: confirm the lockfile-only lodash bump is acceptable and that no dev tooling pins lodash below 4.18.0.