### PR TITLE
fix(deps): bump minimatch to 3.1.5 (CVE-2026-27903)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8550,10 +8550,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17419,9 +17420,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
## Type of change

Dependency / security fix (dev tooling).

### What should this PR do?

Bump the transitive `minimatch` dependency from 3.1.2 to 3.1.5 in `package-lock.json`, resolving Dependabot alert #60 (CVE-2026-27903, high-severity ReDoS).

### Why are we making this change?

`minimatch@3.1.2` is pulled in transitively by dev/build tooling. CVE-2026-27903 is a regular-expression denial of service: `matchOne()` does unbounded recursive backtracking when a glob pattern contains multiple non-adjacent `**` segments and the input does not match, stalling the event loop for seconds. It is fixed in the 3.x line at 3.1.3. All `^3.x` dependents accept the patched version, so a lockfile update is sufficient (no `overrides` pin required). A second copy under `@babel/cli` was already on the patched 10.2.5.

### What are the acceptance criteria?

- The vulnerable `minimatch@3.1.2` no longer appears in `package-lock.json`.
- Dependabot alert #60 is resolved once merged.

### How should this PR be tested?

No published documentation content is affected; this only changes dev dependency resolution. Verified locally:

- `npm update minimatch` moved the single vulnerable node to 3.1.5; the lockfile now holds only 3.1.5 and the already-patched 10.2.5, and `npm audit` reports no minimatch advisory.

---

**Risk**: low. Dev-scope build tooling only, patch-level bump within minimatch v3, lockfile-only change.

**Review focus**: confirm the lockfile-only minimatch bump is acceptable and that no dev tooling pins minimatch below 3.1.3.