### PR TITLE
fix(deps): bump picomatch to 2.3.2 (CVE-2026-33672)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9079,10 +9079,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -17779,9 +17780,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pify": {


### PR DESCRIPTION
## Type of change

Dependency / security fix (dev tooling).

### What should this PR do?

Bump the transitive `picomatch` dependency from 2.3.1 to 2.3.2 in `package-lock.json`, resolving Dependabot alert #70 (CVE-2026-33672, medium-severity method injection in POSIX bracket expressions).

### Why are we making this change?

`picomatch@2.3.1` is pulled in transitively by dev/build tooling. CVE-2026-33672 lets specially crafted POSIX bracket expressions (e.g. `[[:constructor:]]`) reference inherited `Object.prototype` methods, which get injected into the generated regex and cause incorrect glob matching (integrity impact, no RCE). It is fixed in the 2.x line at 2.3.2. All `^2.x` dependents accept the patched version, so a lockfile update is sufficient (no `overrides` pin required).

### What are the acceptance criteria?

- The vulnerable `picomatch@2.3.1` no longer appears in `package-lock.json`.
- Dependabot alert #70 is resolved once merged.

### How should this PR be tested?

No published documentation content is affected; this only changes dev dependency resolution. Verified locally:

- `npm update picomatch` moved the single vulnerable node to 2.3.2; the lockfile no longer contains 2.3.1 and `npm audit` reports no picomatch advisory.

---

**Risk**: low. Dev-scope build tooling only, patch-level bump within picomatch v2, lockfile-only change.

**Review focus**: confirm the lockfile-only picomatch bump is acceptable and that no dev tooling pins picomatch below 2.3.2.