### PR TITLE
chore(ci): add octo-sts trust policy for pre-commit-autoupdate

### DIFF
--- a/.github/chainguard/pre-commit-autoupdate.sts.yaml
+++ b/.github/chainguard/pre-commit-autoupdate.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/edu:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/edu/.github/workflows/pre-commit-autoupdate.yaml@refs/heads/main
+
+permissions:
+  contents: write # push the pre-commit-autoupdate branch
+  pull_requests: write # open the hook-version update PR


### PR DESCRIPTION
## Type of change

CI / tooling. Adds the octo-sts trust policy that the `pre-commit-autoupdate` workflow needs.

### What should this PR do?

Add `.github/chainguard/pre-commit-autoupdate.sts.yaml` so the `pre-commit-autoupdate` workflow (added in #3543) can federate a scoped token via octo-sts to push its branch and open the weekly hook-version update PR.

### Why are we making this change?

The autoupdate workflow requests the octo-sts identity `pre-commit-autoupdate`, which has no trust policy yet, so its first scheduled run would fail to federate a token. This provisions that identity.

### What are the acceptance criteria?

- octo-sts can issue a token for the `pre-commit-autoupdate` identity scoped to that workflow on `main`.
- The weekly autoupdate workflow can push a branch and open a PR.

### How should this PR be tested?

Modeled on the existing `.github/chainguard/*.sts.yaml` policies. The `subject` and `job_workflow_ref` scope the identity to the `pre-commit-autoupdate.yaml` workflow on `main`. Permissions are limited to `contents: write` + `pull_requests: write` (least-privilege: the bot only edits `.pre-commit-config.yaml`, so no `workflows` scope is needed). Full end-to-end validation happens on the workflow's first scheduled/dispatched run once this is on `main`.

---

**Risk**: low. A scoped trust policy for a single scheduled workflow with least-privilege permissions.

**Review focus**: confirm the identity scope (`subject` + `job_workflow_ref`) matches the autoupdate workflow, and that `contents` + `pull_requests` write are sufficient.