### PR TITLE
ci(pre-commit): add zizmor + actionlint hooks and resolve cache-poisoning finding (#74)

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -33,6 +33,7 @@ jobs:
         persist-credentials: false
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # zizmor: ignore[cache-poisoning] - no cache input is set, so setup-node creates no cache to poison
       with:
         node-version: 22
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,19 @@ repos:
       - id: gitleaks
         args: ['--config', '.github/gitleaks.toml']
 
+  # GitHub Actions linting. These also run as standalone CI workflows
+  # (zizmor.yaml uploads SARIF to code scanning, actionlint.yaml adds shellcheck
+  # + annotations); the hooks give the same checks locally on changed files.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor # auto-loads .github/zizmor.yml
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:


### PR DESCRIPTION
## Type of change

CI / tooling. Adds GitHub Actions linting to pre-commit and resolves code-scanning alert #74.

### What should this PR do?

1. Add `zizmor` and `actionlint` as pre-commit hooks so workflow changes get security/lint feedback locally and on changed files via the pre-commit CI ratchet.
2. Add an inline `zizmor: ignore[cache-poisoning]` to the `setup-node` step in `cloud-run.yaml`, resolving code-scanning alert #74.

### Why are we making this change?

These checks run today only as standalone CI workflows; adding them to pre-commit gives fast local feedback before pushing. While wiring zizmor in, it flagged the existing #74 cache-poisoning finding on `cloud-run.yaml` — that `setup-node` step sets no `cache:` input, so it creates no cache to poison. The finding is low confidence and does not apply, so it is suppressed inline with a justification.

### What are the acceptance criteria?

- `zizmor` and `actionlint` run on changed workflow files via pre-commit.
- The zizmor hook honors the existing `.github/zizmor.yml` suppressions.
- Code-scanning alert #74 is resolved (cleared on the next `zizmor.yaml` SARIF run after merge).
- The standalone `zizmor.yaml` / `actionlint.yaml` workflows remain (they provide SARIF/code-scanning upload and shellcheck the hooks do not).

### How should this PR be tested?

- Both hooks install and run: `zizmor` (v1.26.1, matching CI) and `actionlint` (v1.7.12) pass on the changed files.
- After the inline ignore, `zizmor .github/workflows/cloud-run.yaml` reports "No findings (1 ignored, 14 suppressed)"; the zizmor and actionlint pre-commit hooks pass on `cloud-run.yaml`.

### Notes

The standalone workflows are intentionally kept: `zizmor.yaml` uploads SARIF to code scanning (the Security-tab alerts) and `actionlint.yaml` adds shellcheck + annotations, neither of which the pre-commit hooks provide. The overlap is deliberate — hooks for speed/local feedback, workflows for reporting.

---

**Risk**: low. Additive hooks scoped to workflow files, plus a single justified inline suppression; no existing workflow removed and no runtime behavior changed.

**Review focus**:
1. Confirm the `cache-poisoning` suppression is warranted (the `setup-node` step has no `cache:` input).
2. Confirm the intentional overlap of keeping both the standalone workflows and the new hooks.