### PR TITLE
chore: consolidate content tag/spell checks into pre-commit framework

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,427 +1,97 @@
 #!/usr/bin/env python3
-"""
-Pre-commit hook to validate tags and check spelling in Hugo content files.
-Ensures tags conform to approved taxonomy and guidelines, and checks for spelling errors.
+"""Git pre-commit hook: stamp date/lastmod on Hugo content files.
+
+This is kept as a native git hook (enabled via ./setup-hooks.sh) rather than a
+pre-commit-framework hook because it stamps the current time and re-stages the
+file into the same commit -- pre-commit does not auto-restage, and a "now"
+timestamp can never pass a CI idempotency check.
+
+Tag validation and spell checking now live in the pre-commit framework
+(.pre-commit-config.yaml -> scripts/hooks/content_checks.py).
 """
 
 import re
-import sys
 import subprocess
-import json
-from pathlib import Path
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
-# Approved tags from TAG_GUIDELINES.md
-APPROVED_TAGS = {
-    # Product Tags
-    "Chainguard Containers", "Chainguard Libraries", "chainctl", "Enforce", "Chainguard OS",
-    
-    # Action-Oriented Tags
-    "Migration", "Integration", "Configuration", "Monitoring", "Debugging", 
-    "Performance", "Automation", "Troubleshooting",
-    
-    # Problem-Solving Tags
-    "FAQ", "Recommended Practices",
-    
-    # Content Type Tags
-    "Overview", "Procedural", "Conceptual", "Reference", "Video", 
-    "Learning Labs", "Workshop",
-    
-    # Lifecycle Tags
-    "Installation", "Upgrade", "Deprecation", "Getting Started",
-    
-    # Platform/Tool Tags
-    "AWS", "GCP", "Azure", "Multi-Cloud", "JFrog Artifactory", "Sonatype Nexus Repository", "Cloudsmith", "GitHub", 
-    "GitLab", "Jenkins", "Harbor", "Docker Hub", "Terraform", "Kubernetes", "OIDC",
-    
-    # Topic Tags
-    "Security", "SBOM", "CVE", "VEX", "Compliance", "Standards", "SLSA", "OCI", "AI",
-    
-    # Language/Framework Tags
-    "Python", "Java", "Go", "Node.js", "JavaScript", "Ruby", "PHP", "Rust", ".NET",
-    
-    # Tool-Specific Tags
-    "apko", "melange", "Wolfi", "Cosign", "Rekor", "Fulcio",
-    
-    # Compliance Standards
-    "CMMC 2.0", "PCI DSS 4.0",
-    
-    # Other existing tags
-    "Product", "chainctl"
-}
 
-def get_changed_files():
-    """Get list of changed markdown files."""
-    result = subprocess.run(['git', 'diff', '--name-only'], 
-                          capture_output=True, text=True)
-    files = result.stdout.strip().split('\n')
-    return [f for f in files if f.endswith('.md') and f.startswith('content/')]
+def _staged(diff_filter):
+    result = subprocess.run(
+        ['git', 'diff', '--cached', '--name-only', f'--diff-filter={diff_filter}'],
+        capture_output=True, text=True,
+    )
+    return [f for f in result.stdout.strip().split('\n') if f]
 
-def extract_tags(filepath):
-    """Extract tags from a markdown file's frontmatter."""
-    try:
-        with open(filepath, 'r', encoding='utf-8') as f:
-            content = f.read()
-        
-        # Look for tags in frontmatter
-        match = re.search(r'^tags:\s*\[(.*?)\]', content, re.MULTILINE)
-        if not match:
-            return []
-        
-        # Parse tags
-        tags_str = match.group(1)
-        tags = re.findall(r'"([^"]+)"', tags_str)
-        return tags
-    except Exception as e:
-        print(f"Error reading {filepath}: {e}")
-        return []
 
-def validate_tags(filepath, tags):
-    """Validate tags against approved list and guidelines."""
-    warnings = []
-    errors = []
-    
-    # Check tag count
-    if len(tags) > 5:
-        warnings.append(f"  ⚠️  Too many tags ({len(tags)}). Maximum recommended: 5")
-    
-    # Check each tag
-    for tag in tags:
-        if tag not in APPROVED_TAGS:
-            warnings.append(f"  ⚠️  Tag not in approved list: '{tag}'")
-        
-        # Check case formatting for non-acronyms
-        if tag not in ["CVE", "SBOM", "FAQ", "OCI", "SLSA", "VEX", "AI", "OIDC", 
-                       "AWS", "GCP", "CMMC 2.0", "PCI DSS 4.0", ".NET"]:
-            if tag.isupper():
-                errors.append(f"  ❌  Tag should use Title Case: '{tag}'")
-    
-    return warnings, errors
+def _is_content_md(path):
+    return path.startswith('content/') and path.endswith('.md') and Path(path).exists()
 
-def check_spelling(filepath):
-    """Check spelling in a markdown file using aspell."""
-    # Check if aspell is installed
-    try:
-        subprocess.run(['which', 'aspell'], check=True, capture_output=True)
-    except subprocess.CalledProcessError:
-        return {}, ["aspell not installed. Install with: brew install aspell (macOS), apt install aspell (Ubuntu/Debian), yum install aspell (RHEL/CentOS), or apk add aspell (Alpine)"]
-    
-    # Read file and track line numbers
-    try:
-        with open(filepath, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
-        
-        # Find frontmatter end
-        frontmatter_end = 0
-        if lines and lines[0].strip() == '---':
-            for i, line in enumerate(lines[1:], 1):
-                if line.strip() == '---':
-                    frontmatter_end = i + 1
-                    break
-        
-        # Process content line by line
-        spelling_errors = {}
-        in_code_block = False
-        
-        for line_num, line in enumerate(lines, 1):
-            # Skip frontmatter
-            if line_num <= frontmatter_end:
-                continue
-            
-            # Track code blocks
-            if line.strip().startswith('```'):
-                in_code_block = not in_code_block
-                continue
-            
-            # Skip lines inside code blocks
-            if in_code_block:
-                continue
-            
-            # Skip Hugo shortcodes
-            if re.match(r'\s*\{\{[</%].*?[>/%]\}\}\s*$', line):
-                continue
-            
-            # Remove Hugo shortcodes from the line
-            cleaned_line = re.sub(r'\{\{[</%].*?[>/%]\}\}', '', line)
-            
-            # Remove inline code
-            cleaned_line = re.sub(r'`[^`]+`', '', cleaned_line)
-            
-            # Remove URLs
-            cleaned_line = re.sub(r'https?://[^\s\)]+', '', cleaned_line)
-            
-            # Check spelling for this line
-            if cleaned_line.strip():
-                temp_file = f"/tmp/spell_check_line_{line_num}.txt"
-                with open(temp_file, 'w', encoding='utf-8') as f:
-                    f.write(cleaned_line)
-                
-                # Run aspell
-                personal_dict = Path(__file__).parent.parent / '.aspell.en.pws'
-                cmd = ['aspell', 'list', '--mode=markdown', '--lang=en_US']
-                
-                if personal_dict.exists():
-                    cmd.extend(['--personal', str(personal_dict)])
-                else:
-                    cmd.extend(['--personal=/dev/null'])
-                
-                cmd.append('--repl=/dev/null')
-                
-                result = subprocess.run(cmd, stdin=open(temp_file), 
-                                      capture_output=True, text=True)
-                
-                # Parse misspelled words
-                misspelled = result.stdout.strip().split('\n')
-                misspelled = [w for w in misspelled if w and len(w) > 2]
-                
-                # Clean up temp file
-                Path(temp_file).unlink(missing_ok=True)
-                # Filter technical terms and add to errors dict
-                tech_terms = {
-                    'chainguard', 'chainctl', 'kubernetes', 'docker', 'terraform',
-                    'yaml', 'json', 'api', 'cli', 'sdk', 'oauth', 'oidc', 'jwt',
-                    'sbom', 'cve', 'vex', 'slsa', 'oci', 'cosign', 'rekor', 'fulcio',
-                    'apko', 'melange', 'wolfi', 'distroless', 'cgr', 'dev',
-                    'dockerfile', 'github', 'gitlab', 'jenkins', 'artifactory',
-                    'npm', 'pip', 'maven', 'gradle', 'cargo', 'rustup',
-                    'aws', 'gcp', 'azure', 'eks', 'gke', 'aks',
-                    'https', 'http', 'url', 'uri', 'uuid', 'sha', 'md',
-                    'config', 'repo', 'env', 'vars', 'auth', 'creds',
-                    'namespace', 'pod', 'configmap', 'deployment', 'ingress',
-                    'frontend', 'backend', 'middleware', 'webhook', 'async',
-                    'boolean', 'string', 'int', 'float', 'struct', 'enum',
-                    'stdin', 'stdout', 'stderr', 'regex', 'grep', 'sed',
-                    'ci', 'cd', 'devops', 'gitops', 'mlops', 'devsecops',
-                    'lts', 'eol', 'semver', 'changelog', 'readme',
-                    'grype', 'apks', 'glibc', 'musl', 'unpatched', 'sla', 'slas',
-                    'chainguard\'s', 'bazel', 'apk', 'nano', 'lastmod', 'netrc',
-                    'iam'
-                }
-                
-                # Filter and track errors with line numbers
-                for word in misspelled:
-                    if word.lower() not in tech_terms and not word.isupper():
-                        # Check if it's a camelCase or PascalCase word
-                        if not re.match(r'^[a-z]+[A-Z]', word) and not re.match(r'^[A-Z][a-z]+[A-Z]', word):
-                            if word not in spelling_errors:
-                                spelling_errors[word] = []
-                            spelling_errors[word].append(line_num)
-        
-        return spelling_errors, []
-        
-    except Exception as e:
-        return {}, [f"Error checking spelling: {str(e)}"]
 
 def update_dates():
-    """Update date fields in changed markdown files (date for new files, lastmod for modified)"""
-    # Get new files
-    result_new = subprocess.run(
-        ['git', 'diff', '--cached', '--name-only', '--diff-filter=A'], 
-        capture_output=True, text=True
-    )
-    new_files = result_new.stdout.strip().split('\n') if result_new.stdout.strip() else []
-    
-    # Get modified files
-    result_mod = subprocess.run(
-        ['git', 'diff', '--cached', '--name-only', '--diff-filter=M'], 
-        capture_output=True, text=True
-    )
-    modified_files = result_mod.stdout.strip().split('\n') if result_mod.stdout.strip() else []
-    
-    updated_files = []
-    added_dates = []
-    
-    # Current timestamp
-    current_time = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S+00:00')
-    
-    # Process new files - add date and lastmod
-    for file in new_files:
-        if file.startswith('content/') and file.endswith('.md') and Path(file).exists():
-            try:
-                with open(file, 'r', encoding='utf-8') as f:
-                    content = f.read()
-                
-                # Check if file has frontmatter
-                if not content.startswith('---'):
-                    continue
-                
-                # Find end of frontmatter
-                frontmatter_end = content.find('\n---\n', 4)
-                if frontmatter_end == -1:
-                    continue
-                
-                frontmatter = content[:frontmatter_end + 5]
-                body = content[frontmatter_end + 5:]
-                
-                # Check if date field already exists
-                if not re.search(r'^date:', frontmatter, re.MULTILINE):
-                    # Add date after title or at the end of frontmatter
-                    if re.search(r'^title:', frontmatter, re.MULTILINE):
-                        new_frontmatter = re.sub(
-                            r'^(title:\s*.*)$', 
-                            f'\\1\ndate: {current_time}\nlastmod: {current_time}', 
-                            frontmatter, 
-                            flags=re.MULTILINE
-                        )
-                    else:
-                        # Add before the closing ---
-                        new_frontmatter = frontmatter[:-4] + f'date: {current_time}\nlastmod: {current_time}\n---\n'
-                    
-                    # Write updated content
-                    with open(file, 'w', encoding='utf-8') as f:
-                        f.write(new_frontmatter + body)
-                    
-                    added_dates.append(file)
-                    
-                    # Re-stage the file
-                    subprocess.run(['git', 'add', file])
-                
-            except Exception as e:
-                print(f"  ⚠️  Could not add date to {file}: {str(e)}")
-    
-    # Process modified files - update lastmod
-    for file in modified_files:
-        if file.startswith('content/') and file.endswith('.md') and Path(file).exists():
-            try:
-                with open(file, 'r', encoding='utf-8') as f:
-                    content = f.read()
-                
-                # Check if file has frontmatter
-                if not content.startswith('---'):
-                    continue
-                
-                # Find end of frontmatter
-                frontmatter_end = content.find('\n---\n', 4)
-                if frontmatter_end == -1:
-                    continue
-                
-                frontmatter = content[:frontmatter_end + 5]
-                body = content[frontmatter_end + 5:]
-                
-                # Replace existing lastmod or add if missing
-                if re.search(r'^lastmod:', frontmatter, re.MULTILINE):
-                    new_frontmatter = re.sub(
-                        r'^lastmod:\s*.*$', 
-                        f'lastmod: {current_time}', 
-                        frontmatter, 
-                        flags=re.MULTILINE
-                    )
-                else:
-                    # Add lastmod after date field
-                    new_frontmatter = re.sub(
-                        r'^(date:\s*.*)$', 
-                        f'\\1\nlastmod: {current_time}', 
-                        frontmatter, 
-                        flags=re.MULTILINE
-                    )
-                
-                # Write updated content
-                with open(file, 'w', encoding='utf-8') as f:
-                    f.write(new_frontmatter + body)
-                
-                updated_files.append(file)
-                
-                # Re-stage the file
-                subprocess.run(['git', 'add', file])
-                
-            except Exception as e:
-                print(f"  ⚠️  Could not update lastmod for {file}: {str(e)}")
-    
-    return updated_files, added_dates
+    """Add date/lastmod to new content files and refresh lastmod on modified ones."""
+    now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S+00:00')
+    added, updated = [], []
+
+    for file in _staged('A'):
+        if not _is_content_md(file):
+            continue
+        content = Path(file).read_text(encoding='utf-8')
+        if not content.startswith('---'):
+            continue
+        end = content.find('\n---\n', 4)
+        if end == -1:
+            continue
+        frontmatter, body = content[:end + 5], content[end + 5:]
+        if re.search(r'^date:', frontmatter, re.MULTILINE):
+            continue
+        if re.search(r'^title:', frontmatter, re.MULTILINE):
+            frontmatter = re.sub(
+                r'^(title:\s*.*)$', f'\\1\ndate: {now}\nlastmod: {now}',
+                frontmatter, flags=re.MULTILINE,
+            )
+        else:
+            frontmatter = frontmatter[:-4] + f'date: {now}\nlastmod: {now}\n---\n'
+        Path(file).write_text(frontmatter + body, encoding='utf-8')
+        subprocess.run(['git', 'add', file])
+        added.append(file)
+
+    for file in _staged('M'):
+        if not _is_content_md(file):
+            continue
+        content = Path(file).read_text(encoding='utf-8')
+        if not content.startswith('---'):
+            continue
+        end = content.find('\n---\n', 4)
+        if end == -1:
+            continue
+        frontmatter, body = content[:end + 5], content[end + 5:]
+        if re.search(r'^lastmod:', frontmatter, re.MULTILINE):
+            frontmatter = re.sub(r'^lastmod:\s*.*$', f'lastmod: {now}',
+                                 frontmatter, flags=re.MULTILINE)
+        else:
+            frontmatter = re.sub(r'^(date:\s*.*)$', f'\\1\nlastmod: {now}',
+                                 frontmatter, flags=re.MULTILINE)
+        Path(file).write_text(frontmatter + body, encoding='utf-8')
+        subprocess.run(['git', 'add', file])
+        updated.append(file)
+
+    return added, updated
+
 
 def main():
-    """Main validation function."""
-    changed_files = get_changed_files()
-    if not changed_files or changed_files == ['']:
-        return 0
-    
-    total_warnings = []
-    total_errors = []
-    spelling_errors_by_file = {}
-    
-    print("\n🔍 Running pre-commit checks...")
-    
-    # Update dates for new and modified files
-    updated_files, added_dates = update_dates()
-    if added_dates:
-        print(f"\n📅 Added date fields to {len(added_dates)} new file(s)")
-        for file in added_dates:
-            print(f"   - {file}")
-    if updated_files:
-        print(f"\n📅 Updated lastmod dates for {len(updated_files)} file(s)")
-        for file in updated_files:
-            print(f"   - {file}")
-    
-    for filepath in changed_files:
-        if not Path(filepath).exists():
-            continue
-        
-        file_warnings = []
-        file_errors = []
-        
-        # Check tags
-        tags = extract_tags(filepath)
-        if tags:
-            warnings, errors = validate_tags(filepath, tags)
-            file_warnings.extend(warnings)
-            file_errors.extend(errors)
-        
-        # Check spelling
-        spelling_errors, spell_check_errors = check_spelling(filepath)
-        if spelling_errors:
-            spelling_errors_by_file[filepath] = spelling_errors
-        if spell_check_errors:
-            file_errors.extend(spell_check_errors)
-        
-        # Display results for this file
-        if file_warnings or file_errors or spelling_errors:
-            print(f"\n📄 {filepath}")
-            
-            if tags:
-                print(f"   Tags: {', '.join(tags)}")
-            
-            for warning in file_warnings:
-                print(warning)
-                total_warnings.append(warning)
-            
-            for error in file_errors:
-                print(error)
-                total_errors.append(error)
-            
-            if spelling_errors:
-                print(f"  📝 Spelling errors found:")
-                for word, line_nums in list(spelling_errors.items())[:10]:
-                    lines_str = ', '.join(map(str, line_nums[:5]))
-                    if len(line_nums) > 5:
-                        lines_str += f", ... ({len(line_nums) - 5} more)"
-                    print(f"     - '{word}' on line(s): {lines_str}")
-                if len(spelling_errors) > 10:
-                    print(f"     ... and {len(spelling_errors) - 10} more words with errors")
-    
-    # Summary
-    if total_warnings or total_errors or spelling_errors_by_file:
-        print("\n" + "="*60)
-        print("Pre-commit Check Summary:")
-        print(f"  Tag Warnings: {len(total_warnings)}")
-        print(f"  Tag Errors: {len(total_errors)}")
-        print(f"  Files with spelling issues: {len(spelling_errors_by_file)}")
-        
-        if total_warnings:
-            print("\n💡 Consider reviewing TAG_GUIDELINES.md for approved tags")
-        
-        if spelling_errors_by_file:
-            print("\n📝 Spelling issues found. Consider:")
-            print("   - Fixing typos")
-            print("   - Adding technical terms to your personal dictionary")
-            print("   - Using 'git commit --no-verify' to skip this check")
-        
-        if total_errors:
-            print("\n❌ Commit blocked due to tag errors. Please fix and try again.")
-            return 1
-    else:
-        print("\n✅ All checks passed!")
-    
+    added, updated = update_dates()
+    if added:
+        print(f"📅 Added date/lastmod to {len(added)} new file(s):")
+        for f in added:
+            print(f"   - {f}")
+    if updated:
+        print(f"📅 Updated lastmod on {len(updated)} file(s):")
+        for f in updated:
+            print(f"   - {f}")
     return 0
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     sys.exit(main())

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -69,7 +69,11 @@ jobs:
       # lint errors, so gating the whole tree would make every PR responsible
       # for cleaning up files it never touched. --from-ref/--to-ref scopes the
       # run to files changed between the PR base and head (ratchet model).
+      # SKIP=content-spellcheck: the aspell prose check is advisory and local-only
+      # (aspell is not installed here, and spelling should not gate merges).
       - name: Run pre-commit
+        env:
+          SKIP: content-spellcheck
         run: |
           pip install pre-commit
           pre-commit run --show-diff-on-failure --color=always \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,11 @@ repos:
     rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08  # frozen: 1.9.4
     hooks:
       - id: bandit
-        args: ['-r', 'scripts/', '-ll']
-        files: \.py$
+        # Scan the changed Python files (ratchet model), reporting medium+
+        # severity. Previously used -r scripts/, which rescanned the whole tree
+        # and could not mix with the filenames pre-commit appends.
+        args: ['-ll']
+        files: ^scripts/.*\.py$
 
   - repo: https://github.com/psf/black
     rev: 87928e6d6761a4a6d22250e1fee5601b3998086e  # frozen: 26.5.1
@@ -70,6 +73,22 @@ repos:
         entry: bash -c 'find static/downloads -name "*.md" -size +50M -exec echo "File {} exceeds 50MB limit" \; -exec false \;'
         language: system
         pass_filenames: false
+
+      # Content tag validation against the approved taxonomy (TAG_GUIDELINES.md).
+      # Blocking; runs locally and in CI.
+      - id: content-tags
+        name: Validate content tags
+        entry: python3 scripts/hooks/content_checks.py --mode tags
+        language: system
+        files: ^content/.*\.md$
+
+      # Prose spell check (aspell). Advisory only, and local-only: the CI job
+      # sets SKIP=content-spellcheck, and aspell may be absent there anyway.
+      - id: content-spellcheck
+        name: Spell-check content prose
+        entry: python3 scripts/hooks/content_checks.py --mode spell
+        language: system
+        files: ^content/.*\.md$
 
   # Lint the theme's own JavaScript (assets/js, config). Uses ESLint 9 flat
   # config (eslint.config.js). @eslint/js and globals are required by that

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Any documentation published to Chainguard Academy is reviewed carefully for accu
 We also test drafts by previewing rendered content before it's published. Draft content passes through several checks between your editor and the live site:
 
 - **Local preview** — Run `npm install` once, then `npm run start` to serve the site at `http://localhost:1313` with live reload. Use this to confirm pages render correctly, formatting holds up, and internal links resolve. When a doc includes commands or examples, run them to confirm they still work.
-- **Pre-commit hooks** — When you commit, automated hooks manage dates, validate tags, and spell-check your prose. See [Pre-commit Hooks](#pre-commit-hooks) below for setup.
+- **Pre-commit checks** — A required `pre-commit` check validates tags, lints, and scans changed files; a git hook stamps content dates; spell-check runs locally. See [Pre-commit](#pre-commit) below for setup.
 - **Deploy previews** — Every pull request builds a Netlify deploy preview with a staging URL. Reviewers open this link to see your changes rendered as they'll appear in production.
 
 When you open a pull request, describe how you tested the change so reviewers know what to verify. Recent PRs often list the steps taken, such as previewing pages in the Hugo dev server, confirming links resolve, and running any commands the doc relies on.
@@ -118,20 +118,35 @@ You can review our current list of [Tags](https://edu.chainguard.dev/tags).
 
 ## Quick Reference for Contributors
 
-### Pre-commit Hooks
+### Pre-commit
 
-This repository uses automated pre-commit hooks to maintain content quality:
+This repository uses the [pre-commit](https://pre-commit.com/) framework to check
+changes before they merge. The `pre-commit` check is **required** on pull requests,
+and it runs only on the files a PR changes (a pre-existing backlog is not gated).
+It checks:
 
-- **Automatic date management** - Adds `date` field to new files and updates `lastmod` when you edit
-- **Tag validation** - Ensures tags match our approved taxonomy
-- **Spell checking** - Catches typos before they're committed (ignores code blocks and technical terms)
+- Secret scanning, private keys, large files, and file hygiene (whitespace, EOF, line endings)
+- GitHub Actions security (`zizmor`) and linting (`actionlint`)
+- JavaScript (`eslint`), Markdown (`markdownlint`), and Python (`bandit`, `black`)
+- **Content tag validation** against the approved taxonomy (blocking)
+- **Spell checking** of prose with aspell — advisory and local-only (skipped in CI)
 
 **Setup (one-time):**
 ```sh
-# Install spell checker
-brew install aspell
+# Install pre-commit
+brew install pre-commit        # or: pipx install pre-commit
 
-# Enable hooks
+# Enable it in your clone
+pre-commit install
+
+# Optional: enable local prose spell checking
+brew install aspell
+```
+
+Separately, a native git hook stamps `date`/`lastmod` on content files (it
+re-stages into the same commit, so it stays a git hook rather than a pre-commit
+hook). Enable it once with:
+```sh
 ./setup-hooks.sh
 ```
 
@@ -139,4 +154,3 @@ brew install aspell
 - 📖 [Complete Pre-commit Hook Guide for Contributors](docs/pre-commit-hook-guide.md) - Detailed guide with examples
 - 📋 [Tag Guidelines](TAG_GUIDELINES.md) - Complete approved tag taxonomy
 - 📝 [Custom Dictionary](.aspell.en.pws) - Technical terms for spell checker
-

--- a/docs/pre-commit-hook-guide.md
+++ b/docs/pre-commit-hook-guide.md
@@ -1,69 +1,86 @@
 # Pre-commit Hook Guide for Contributors
 
-This guide explains how to use the pre-commit hook that automatically checks your content before committing changes to the repository.
+This guide explains the automated checks that run on your content before it merges.
 
-## What is a Pre-commit Hook?
+## Two systems
 
-A pre-commit hook is an automated script that runs every time you try to commit changes. It helps maintain consistency and quality by catching common issues before they enter the codebase.
+Content quality is enforced by two complementary systems:
 
-## What Does Our Hook Check?
+1. **The [pre-commit](https://pre-commit.com/) framework** (`.pre-commit-config.yaml`)
+   runs on `git commit` and as a **required** CI check on pull requests. It handles
+   tag validation and spell checking (plus repo-wide security/lint hooks). In CI it
+   runs only on the files a PR changes.
+2. **A native git hook** (`.githooks/pre-commit`, enabled via `./setup-hooks.sh`)
+   stamps content dates. It stays a git hook because it re-stages the stamped file
+   into your commit, which the pre-commit framework does not do.
 
-### 1. Automatic Date Management
+## What gets checked
+
+### 1. Automatic Date Management (git hook)
+
 - **New files**: Automatically adds `date` and `lastmod` fields with the current timestamp
 - **Modified files**: Automatically updates the `lastmod` field to reflect when changes were made
 - **Format**: Uses ISO 8601 format with UTC timezone (e.g., `2025-01-16T10:30:45+00:00`)
 - **No manual work needed**: You no longer need to add or update these fields yourself!
 
-### 2. Tag Validation
+### 2. Tag Validation (pre-commit framework, blocking)
+
 - Ensures all tags match our approved taxonomy
 - Checks that you haven't exceeded 5 tags per article
 - Verifies proper capitalization (Title Case vs. acronyms)
 
-### 3. Spelling
-- Catches typos and misspellings
-- Ignores code blocks (between ```)
-- Ignores Hugo shortcodes (e.g., `{{< youtube >}}`)
-- Ignores inline code (between `)
-- Ignores URLs
-- Uses a custom dictionary for technical terms
+### 3. Spelling (pre-commit framework, advisory + local-only)
 
-## Setting Up the Hook
+- Catches typos and misspellings; reports but never blocks a commit
+- Runs locally only — the CI check skips it (`SKIP=content-spellcheck`)
+- Ignores code blocks (between ```), Hugo shortcodes (e.g. `{{< youtube >}}`), inline code (between `), and URLs
+- Uses a custom dictionary for technical terms (`.aspell.en.pws`)
 
-### One-time Setup
+## Setting up
 
-1. **Install aspell** (for spell checking):
+### One-time setup
+
+1. **Install and enable pre-commit** (tags, spell check, security/lint):
+
    ```bash
-   # macOS
-   brew install aspell
-   
-   # Ubuntu/Debian
-   sudo apt install aspell
-   
-   # RHEL/CentOS/Fedora
-   sudo yum install aspell
-   # or
-   sudo dnf install aspell
-   
-   # Alpine Linux
-   apk add aspell
-   
-   # Arch Linux
-   sudo pacman -S aspell
+   brew install pre-commit        # or: pipx install pre-commit
+   pre-commit install
    ```
 
-2. **Enable the git hooks**:
+2. **Enable the date-stamping git hook**:
+
    ```bash
    ./setup-hooks.sh
    ```
 
-That's it! The hook will now run automatically when you commit.
+3. **(Optional) Install aspell** so the local spell check runs:
+
+   ```bash
+   # macOS
+   brew install aspell
+
+   # Ubuntu/Debian
+   sudo apt install aspell
+
+   # RHEL/CentOS/Fedora
+   sudo dnf install aspell
+
+   # Alpine Linux
+   apk add aspell
+
+   # Arch Linux
+   sudo pacman -S aspell
+   ```
+
+That's it! Both run automatically when you commit.
 
 ## Understanding the Output
 
 When you run `git commit`, you'll see output like this:
 
 ### ✅ Success Case
-```
+
+```text
 🔍 Running pre-commit checks...
 
 📅 Updated lastmod dates for 1 file(s)
@@ -73,7 +90,8 @@ When you run `git commit`, you'll see output like this:
 ```
 
 ### ⚠️ With Warnings
-```
+
+```text
 🔍 Running pre-commit checks...
 
 📅 Added date fields to 1 new file(s)
@@ -101,7 +119,8 @@ Pre-commit Check Summary:
 ```
 
 ### ❌ With Errors (Blocks Commit)
-```
+
+```text
 🔍 Running pre-commit checks...
 
 📄 content/chainguard/tutorial.md
@@ -125,6 +144,7 @@ Pre-commit Check Summary:
 When creating a new article, you no longer need to add date fields manually. Just focus on your content:
 
 **What you write:**
+
 ```yaml
 ---
 title: "Getting Started with Chainguard Images"
@@ -134,6 +154,7 @@ tags: ["Chainguard Containers", "Getting Started", "Overview"]
 ```
 
 **What gets committed (automatically):**
+
 ```yaml
 ---
 title: "Getting Started with Chainguard Images"
@@ -149,6 +170,7 @@ tags: ["Chainguard Containers", "Getting Started", "Overview"]
 When you modify an article, the `lastmod` field is automatically updated:
 
 **Before your edit:**
+
 ```yaml
 ---
 title: "Security Best Practices"
@@ -158,6 +180,7 @@ lastmod: 2024-12-15T14:30:00+00:00
 ```
 
 **After commit (automatic update):**
+
 ```yaml
 ---
 title: "Security Best Practices"
@@ -188,11 +211,13 @@ The spell checker might flag technical terms as errors. You have three options:
 
 2. **Add technical terms to the dictionary**:
    If you're using a legitimate technical term that's flagged:
+
    ```bash
    echo "MyTechnicalTerm" >> .aspell.en.pws
    ```
 
 3. **Skip the check** (use sparingly):
+
    ```bash
    git commit --no-verify -m "Your commit message"
    ```
@@ -202,11 +227,13 @@ The spell checker might flag technical terms as errors. You have three options:
 ### Most Common Tags
 
 **Product Tags:**
+
 - `Chainguard Containers`
 - `Chainguard Libraries`
 - `chainctl`
 
 **Content Types:**
+
 - `Overview` - High-level introductions
 - `Procedural` - Step-by-step guides
 - `Conceptual` - Theory/background
@@ -214,6 +241,7 @@ The spell checker might flag technical terms as errors. You have three options:
 - `FAQ` - Common questions
 
 **Action Tags:**
+
 - `Getting Started`
 - `Migration`
 - `Configuration`
@@ -221,6 +249,7 @@ The spell checker might flag technical terms as errors. You have three options:
 - `Integration`
 
 **Platform Tags:**
+
 - `AWS`, `GCP`, `Azure`
 - `Kubernetes`
 - `Docker Hub`
@@ -233,6 +262,7 @@ For the complete list, see [TAG_GUIDELINES.md](../TAG_GUIDELINES.md).
 ### "aspell not installed" Error
 
 Install aspell using your system's package manager:
+
 ```bash
 # macOS
 brew install aspell
@@ -253,12 +283,14 @@ sudo pacman -S aspell
 ### Hook Not Running
 
 Make sure hooks are enabled:
+
 ```bash
 git config core.hooksPath
 # Should output: .githooks
 ```
 
 If not, run:
+
 ```bash
 ./setup-hooks.sh
 ```
@@ -266,6 +298,7 @@ If not, run:
 ### Need to Temporarily Disable
 
 For urgent commits where you need to bypass the check:
+
 ```bash
 git commit --no-verify -m "Emergency fix"
 ```

--- a/scripts/hooks/content_checks.py
+++ b/scripts/hooks/content_checks.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Content checks for Hugo markdown, run as pre-commit hooks.
+
+Two modes, selected with --mode:
+
+  tags   Validate frontmatter tags against the approved taxonomy. Blocks the
+         commit on errors (e.g. an all-caps tag that is not a known acronym).
+         Runs locally and in CI.
+
+  spell  Spell-check prose with aspell, skipping code blocks, shortcodes and
+         URLs. Advisory only: it reports misspellings but never fails. Runs
+         locally; the CI job skips it via SKIP=content-spellcheck.
+
+Filenames are provided by pre-commit; only content/*.md paths are considered.
+Date/lastmod stamping is intentionally NOT here -- that stays in the
+.githooks/pre-commit git hook so it can auto-restage into the same commit.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Approved tags from TAG_GUIDELINES.md
+APPROVED_TAGS = {
+    # Product Tags
+    "Chainguard Containers",
+    "Chainguard Libraries",
+    "chainctl",
+    "Enforce",
+    "Chainguard OS",
+    # Action-Oriented Tags
+    "Migration",
+    "Integration",
+    "Configuration",
+    "Monitoring",
+    "Debugging",
+    "Performance",
+    "Automation",
+    "Troubleshooting",
+    # Problem-Solving Tags
+    "FAQ",
+    "Recommended Practices",
+    # Content Type Tags
+    "Overview",
+    "Procedural",
+    "Conceptual",
+    "Reference",
+    "Video",
+    "Learning Labs",
+    "Workshop",
+    # Lifecycle Tags
+    "Installation",
+    "Upgrade",
+    "Deprecation",
+    "Getting Started",
+    # Platform/Tool Tags
+    "AWS",
+    "GCP",
+    "Azure",
+    "Multi-Cloud",
+    "JFrog Artifactory",
+    "Sonatype Nexus Repository",
+    "Cloudsmith",
+    "GitHub",
+    "GitLab",
+    "Jenkins",
+    "Harbor",
+    "Docker Hub",
+    "Terraform",
+    "Kubernetes",
+    "OIDC",
+    # Topic Tags
+    "Security",
+    "SBOM",
+    "CVE",
+    "VEX",
+    "Compliance",
+    "Standards",
+    "SLSA",
+    "OCI",
+    "AI",
+    # Language/Framework Tags
+    "Python",
+    "Java",
+    "Go",
+    "Node.js",
+    "JavaScript",
+    "Ruby",
+    "PHP",
+    "Rust",
+    ".NET",
+    # Tool-Specific Tags
+    "apko",
+    "melange",
+    "Wolfi",
+    "Cosign",
+    "Rekor",
+    "Fulcio",
+    # Compliance Standards
+    "CMMC 2.0",
+    "PCI DSS 4.0",
+    # Other existing tags
+    "Product",
+}
+
+# Tags allowed to be all-caps (acronyms / product names).
+ACRONYM_TAGS = {
+    "CVE",
+    "SBOM",
+    "FAQ",
+    "OCI",
+    "SLSA",
+    "VEX",
+    "AI",
+    "OIDC",
+    "AWS",
+    "GCP",
+    "CMMC 2.0",
+    "PCI DSS 4.0",
+    ".NET",
+}
+
+TECH_TERMS = {
+    "chainguard",
+    "chainctl",
+    "kubernetes",
+    "docker",
+    "terraform",
+    "yaml",
+    "json",
+    "api",
+    "cli",
+    "sdk",
+    "oauth",
+    "oidc",
+    "jwt",
+    "sbom",
+    "cve",
+    "vex",
+    "slsa",
+    "oci",
+    "cosign",
+    "rekor",
+    "fulcio",
+    "apko",
+    "melange",
+    "wolfi",
+    "distroless",
+    "cgr",
+    "dev",
+    "dockerfile",
+    "github",
+    "gitlab",
+    "jenkins",
+    "artifactory",
+    "npm",
+    "pip",
+    "maven",
+    "gradle",
+    "cargo",
+    "rustup",
+    "aws",
+    "gcp",
+    "azure",
+    "eks",
+    "gke",
+    "aks",
+    "https",
+    "http",
+    "url",
+    "uri",
+    "uuid",
+    "sha",
+    "md",
+    "config",
+    "repo",
+    "env",
+    "vars",
+    "auth",
+    "creds",
+    "namespace",
+    "pod",
+    "configmap",
+    "deployment",
+    "ingress",
+    "frontend",
+    "backend",
+    "middleware",
+    "webhook",
+    "async",
+    "boolean",
+    "string",
+    "int",
+    "float",
+    "struct",
+    "enum",
+    "stdin",
+    "stdout",
+    "stderr",
+    "regex",
+    "grep",
+    "sed",
+    "ci",
+    "cd",
+    "devops",
+    "gitops",
+    "mlops",
+    "devsecops",
+    "lts",
+    "eol",
+    "semver",
+    "changelog",
+    "readme",
+    "grype",
+    "apks",
+    "glibc",
+    "musl",
+    "unpatched",
+    "sla",
+    "slas",
+    "chainguard's",
+    "bazel",
+    "apk",
+    "nano",
+    "lastmod",
+    "netrc",
+    "iam",
+}
+
+
+def content_markdown(paths):
+    """Filter args down to existing content/*.md files."""
+    return [
+        p
+        for p in paths
+        if p.endswith(".md") and p.startswith("content/") and Path(p).exists()
+    ]
+
+
+def extract_tags(filepath):
+    try:
+        content = Path(filepath).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading {filepath}: {exc}")
+        return []
+    match = re.search(r"^tags:\s*\[(.*?)\]", content, re.MULTILINE)
+    if not match:
+        return []
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def validate_tags(paths):
+    """Return exit code: 1 if any blocking tag errors found, else 0."""
+    had_error = False
+    for filepath in content_markdown(paths):
+        tags = extract_tags(filepath)
+        if not tags:
+            continue
+        warnings, errors = [], []
+        if len(tags) > 5:
+            warnings.append(
+                f"  ⚠️  Too many tags ({len(tags)}). Maximum recommended: 5"
+            )
+        for tag in tags:
+            if tag not in APPROVED_TAGS and tag not in ACRONYM_TAGS:
+                warnings.append(f"  ⚠️  Tag not in approved list: '{tag}'")
+            if tag not in ACRONYM_TAGS and tag.isupper():
+                errors.append(f"  ❌  Tag should use Title Case: '{tag}'")
+        if warnings or errors:
+            print(f"\n📄 {filepath}")
+            print(f"   Tags: {', '.join(tags)}")
+            for line in warnings + errors:
+                print(line)
+        if errors:
+            had_error = True
+    if had_error:
+        print("\n❌ Commit blocked due to tag errors. See TAG_GUIDELINES.md.")
+        return 1
+    return 0
+
+
+def check_spelling(paths):
+    """Advisory spell check. Always returns 0 (never blocks)."""
+    if subprocess.run(["which", "aspell"], capture_output=True).returncode != 0:
+        print(
+            "ℹ️  aspell not installed; skipping spell check "
+            "(brew install aspell / apt install aspell)."
+        )
+        return 0
+
+    personal_dict = Path(__file__).resolve().parent.parent.parent / ".aspell.en.pws"
+    for filepath in content_markdown(paths):
+        lines = Path(filepath).read_text(encoding="utf-8").splitlines()
+        frontmatter_end = 0
+        if lines and lines[0].strip() == "---":
+            for i, line in enumerate(lines[1:], 1):
+                if line.strip() == "---":
+                    frontmatter_end = i + 1
+                    break
+
+        misspelled_by_word = {}
+        in_code_block = False
+        for line_num, line in enumerate(lines, 1):
+            if line_num <= frontmatter_end:
+                continue
+            if line.strip().startswith("```"):
+                in_code_block = not in_code_block
+                continue
+            if in_code_block:
+                continue
+            cleaned = re.sub(r"\{\{[</%].*?[>/%]\}\}", "", line)
+            cleaned = re.sub(r"`[^`]+`", "", cleaned)
+            cleaned = re.sub(r"https?://[^\s\)]+", "", cleaned)
+            if not cleaned.strip():
+                continue
+            cmd = ["aspell", "list", "--mode=markdown", "--lang=en_US"]
+            cmd.extend(
+                ["--personal", str(personal_dict)]
+                if personal_dict.exists()
+                else ["--personal=/dev/null"]
+            )
+            result = subprocess.run(cmd, input=cleaned, capture_output=True, text=True)
+            for word in result.stdout.split():
+                if len(word) <= 2 or word.lower() in TECH_TERMS or word.isupper():
+                    continue
+                if re.match(r"^[a-z]+[A-Z]", word) or re.match(
+                    r"^[A-Z][a-z]+[A-Z]", word
+                ):
+                    continue
+                misspelled_by_word.setdefault(word, []).append(line_num)
+
+        if misspelled_by_word:
+            print(f"\n📝 Possible spelling issues in {filepath}:")
+            for word, line_nums in list(misspelled_by_word.items())[:10]:
+                shown = ", ".join(map(str, line_nums[:5]))
+                if len(line_nums) > 5:
+                    shown += f", ... (+{len(line_nums) - 5})"
+                print(f"     - '{word}' on line(s): {shown}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", required=True, choices=["tags", "spell"])
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+
+    paths = content_markdown(args.files)
+    if not paths:
+        return 0
+    return validate_tags(paths) if args.mode == "tags" else check_spelling(paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,33 +1,26 @@
 #!/bin/bash
-# Setup script to enable custom git hooks
+# Enable the native git hook that stamps date/lastmod on content files.
+#
+# Tag validation and spell checking now run via the pre-commit framework
+# (see .pre-commit-config.yaml and the README "Pre-commit" section), not here.
 
 echo "Setting up git hooks..."
-
-# Check if aspell is installed
-if ! command -v aspell &> /dev/null; then
-    echo "⚠️  Warning: aspell is not installed. Spell checking will be skipped."
-    echo "   To enable spell checking, install aspell:"
-    echo "     macOS:           brew install aspell"
-    echo "     Ubuntu/Debian:   sudo apt install aspell"
-    echo "     RHEL/CentOS:     sudo yum install aspell"
-    echo "     Alpine:          apk add aspell"
-    echo "     Arch:            sudo pacman -S aspell"
-    echo ""
-fi
 
 # Configure git to use the .githooks directory
 git config core.hooksPath .githooks
 
 echo "✅ Git hooks enabled!"
 echo ""
-echo "The pre-commit hook will now:"
-echo "  • Validate tags against approved list"
-echo "  • Check for spelling errors (if aspell is installed)"
+echo "The pre-commit git hook will now:"
+echo "  • Add date/lastmod to new content files and refresh lastmod on edits"
 echo ""
-echo "To disable hooks temporarily, use:"
+echo "Tag validation and spell checking are handled by the pre-commit framework."
+echo "Install it and enable its hooks with:"
+echo "  brew install pre-commit   # or: pipx install pre-commit"
+echo "  pre-commit install"
+echo ""
+echo "To disable git hooks temporarily, use:"
 echo "  git commit --no-verify"
 echo ""
-echo "To disable hooks permanently, use:"
+echo "To disable git hooks permanently, use:"
 echo "  git config --unset core.hooksPath"
-echo ""
-echo "Custom dictionary for technical terms: .aspell.en.pws"


### PR DESCRIPTION
## Type of change

Tooling / docs. Consolidates content-quality checks under one system.

### What should this PR do?

Move tag validation and spell checking out of the bespoke `.githooks/pre-commit` script into the pre-commit framework, so a single system covers them alongside the existing security/lint hooks. Update the README and contributor guide to document the setup.

### Why are we making this change?

The repo had two overlapping hook systems: a custom git hook (`setup-hooks.sh` -> `.githooks/`) doing dates/tags/spelling, and the pre-commit framework doing security + eslint/markdownlint/zizmor/actionlint. The README only documented the former, while the latter is now a required CI check. Consolidating removes the confusion and gives one place for content checks.

### What are the acceptance criteria?

- Tag validation and spell checking run via pre-commit.
- Date/lastmod stamping still works (kept as the git hook).
- README and guide document the single setup accurately.

### How should this PR be tested?

- `content-tags` (blocking) flags an all-caps non-acronym tag; `content-spellcheck` is advisory (never fails) and is skipped in CI via `SKIP=content-spellcheck`.
- The slimmed `.githooks/pre-commit` still stamps `date`/`lastmod` on new and modified content files.
- All pre-commit hooks pass on the changed files.

### Notes

- **Date stamping stays a git hook** on purpose: it re-stages the stamped file into the same commit (pre-commit does not auto-restage), and a `lastmod: <now>` value can never pass a CI idempotency check. `setup-hooks.sh` still enables it.
- **bandit hook fix**: it was erroring under the newer pinned version because `-r scripts/` was mixed with the filenames pre-commit appends. Changed to lint changed Python files (ratchet model, medium+ severity), consistent with the other hooks. Pre-existing medium findings in other scripts are only scanned when those files are touched.
- The contributor guide's console-output examples are illustrative/simplified; happy to refine them further if desired.

---

**Risk**: medium. Touches the required pre-commit gate and hook wiring; mitigated by keeping tag validation blocking, spell-check advisory/local-only, and date stamping behavior unchanged.

**Review focus**:
1. `content_checks.py` tag rules match the previous `.githooks` behavior (blocks all-caps non-acronym tags).
2. The bandit change from whole-tree scan to per-changed-file scanning is acceptable.