### PR TITLE
Fix internal links broken by IA reorg

### DIFF
--- a/content/chainguard/chainguard-images/about/images-categories.md
+++ b/content/chainguard/chainguard-images/about/images-categories.md
@@ -27,7 +27,6 @@ Within the [Chainguard Containers Directory](https://images.chainguard.dev/), Ch
 
 This conceptual article will outline each of these categories in turn, including their uses as well as examples of images from each category. It will also highlight important considerations one should make when using images from these categories.
 
-
 ## Free Containers
 
 Chainguard offers a set of container images that are publicly available and don’t require authentication for download and use; they are free to use for everyone. We refer to these as our *Free Containers*, and they cover several use cases for different language ecosystems. Free Containers are limited to the latest build of a given image, and are always tagged as `latest` and `latest-dev`.
@@ -46,14 +45,13 @@ docker pull cgr.dev/chainguard.edu/chainguard-base
 
 Note that you won't have access to the organization's repository used in this example, but if your organization has access to the `chainguard-base` image you will be able to pull this image using your organization's repository name in place of `chainguard.edu`. Chainguard's registry provides public access to all Free images, and provides customer access for Production images after logging in and authenticating.
 
-For a complete list of Free images that are currently available, check out the [**Free** category on Chainguard Containers Directory](https://images.chainguard.dev/?category=free). Registered users can also access all Free and available Production images in the [Chainguard Console](https://console.chainguard.dev/overview). After logging in you will be able to find all the currently available Free Containers in the **Public images** tab. 
+For a complete list of Free images that are currently available, check out the [**Free** category on Chainguard Containers Directory](https://images.chainguard.dev/?category=free). Registered users can also access all Free and available Production images in the [Chainguard Console](https://console.chainguard.dev/overview). After logging in you will be able to find all the currently available Free Containers in the **Public images** tab.
 
 ### Production Containers
 
 The rest of Chainguard Containers, those that **are not** Free images and not included in the free tier of images, are referred to as *Production Containers*. Production images are enterprise-ready images that come with patch SLAs and features such as Federal Information Processing Standard (FIPS) readiness and unique time-stamped tags. Unlike Free images, which are typically paired with only the latest version of an upstream package, Production images offer specific major and minor versions of open source software.
 
 As with the Free Container category, any container image considered a Production image will also fall into at least one of the other categories listed in this guide. To view the Production container images that your organization has access to, select the appropriate organization in the drop-down menu above the left-hand navigation and then click the **Organization images** tab.
-
 
 ## Base Containers
 
@@ -67,17 +65,15 @@ It is a best practice to use the same versions of any languages or applications 
 
 If you need a package to use with your Chainguard Base Container, Wolfi packages are available using `apk`. Ensure you only use Wolfi packages, as Alpine APK’s are not compatible with Wolfi. Additionally, it is important to note that vendor-provided packages need to be glibc-based and their functionality should be fully tested along with the application. For additional tips, please refer to our guide on [Troubleshooting apko Builds](/open-source/build-tools/apko/troubleshooting/).
 
-> **Note**: Base Containers often require more customization by the user. Be aware that Chainguard offers a customization platform called [Custom Assembly](/chainguard/chainguard-images/features/custom-assembly/) to streamline this requirement without customers having to stand up their own custom pipelines.
-
+> **Note**: Base Containers often require more customization by the user. Be aware that Chainguard offers a customization platform called [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) to streamline this requirement without customers having to stand up their own custom pipelines.
 
 ## Application Containers
 
-In contrast with Base container images, which are intended to be built upon, Application Containers are designed to be used directly, often by plugging into systems like Helm. Some examples of Chainguard's Application images include [nginx](https://images.chainguard.dev/directory/image/nginx/overview), [Fulcio](https://images.chainguard.dev/directory/image/fulcio/overview), and [apko](https://images.chainguard.dev/directory/image/apko/overview). 
+In contrast with Base container images, which are intended to be built upon, Application Containers are designed to be used directly, often by plugging into systems like Helm. Some examples of Chainguard's Application images include [nginx](https://images.chainguard.dev/directory/image/nginx/overview), [Fulcio](https://images.chainguard.dev/directory/image/fulcio/overview), and [apko](https://images.chainguard.dev/directory/image/apko/overview).
 
 When it comes to maintaining Application container images, Chainguard is responsible for rebuilding the upstream project with the latest toolchain and patching static and dynamic dependencies where such a change is non-breaking. Customers are responsible for tracking a supported version of the Chainguard Container.
 
 When migrating to a Chainguard Application container image you should first check the image’s overview page on the Containers Directory for usage details and any compatibility notes. There may be user ID, permissions, or volume path differences with the Chainguard image that you should be aware of. It is a best practice to use the same version of the Chainguard Application container image as what is currently running in your environment.
-
 
 ## AI Container
 
@@ -85,7 +81,7 @@ Artificial intelligence and machine learning (AI/ML) systems are used in a wide 
 
 Due to their unique features and uses, these systems often pose a greater risk than traditional software systems. Chainguard offers a suite of CPU- and GPU-enabled AI Containers which can help to mitigate these risks. Some of these AI container images include [NeMo](https://images.chainguard.dev/directory/image/nemo/overview), [PyTorch](https://images.chainguard.dev/directory/image/pytorch/overview), and [TensorFlow](https://images.chainguard.dev/directory/image/tensorflow/overview).
 
-These images are hardened, minimal, and optimized for efficient AI development and deployment. By leveraging Chainguard AI Containers, organizations can confidently secure their AI infrastructure, streamline vulnerability management, and maintain high performance with low-to-zero vulnerabilities. Rather than starting with tens, dozens, or hundreds of CVEs in your application or pipeline, you start with a clean slate. 
+These images are hardened, minimal, and optimized for efficient AI development and deployment. By leveraging Chainguard AI Containers, organizations can confidently secure their AI infrastructure, streamline vulnerability management, and maintain high performance with low-to-zero vulnerabilities. Rather than starting with tens, dozens, or hundreds of CVEs in your application or pipeline, you start with a clean slate.
 
 To learn more about Chainguard's AI Containers and their uses, we encourage you to check out our course on [Securing the AI/ML Supply Chain](https://courses.chainguard.dev/securing-ai).
 
@@ -93,14 +89,13 @@ To learn more about Chainguard's AI Containers and their uses, we encourage you 
 
 FIPS — or, Federal Information Processing Standards — are publicly announced standards developed by the National Institute of Standards and Technology (NIST). Chainguard offers images that use FIPS-validated cryptographic software modules to help users ensure that their applications meet FIPS standards.
 
-Chainguard offers FIPS versions of many of its container images, so FIPS Containers will fall into more than one category. Some Chainguard container images with FIPS variants are [nginx](https://images.chainguard.dev/directory/image/tensorflow/overview), [PHP](https://images.chainguard.dev/directory/image/php-fips/overview), and [PyTorch](https://images.chainguard.dev/directory/image/pytorch-fips/overview). 
+Chainguard offers FIPS versions of many of its container images, so FIPS Containers will fall into more than one category. Some Chainguard container images with FIPS variants are [nginx](https://images.chainguard.dev/directory/image/tensorflow/overview), [PHP](https://images.chainguard.dev/directory/image/php-fips/overview), and [PyTorch](https://images.chainguard.dev/directory/image/pytorch-fips/overview).
 
-For more information, please refer to our conceptual article on [FIPS Chainguard Containers](/chainguard/chainguard-images/features/fips/fips-images/).
-
+For more information, please refer to our conceptual article on [FIPS Chainguard Containers](/platform/fips/fips-images/).
 
 ## Container Image Type Considerations
 
-There is some overlap between the different container image categories outlined in this guide. For example, the [PyTorch](https://images.chainguard.dev/directory/image/pytorch/overview) image is an AI image, but it is also part of our free tier, meaning it's also a Free image. 
+There is some overlap between the different container image categories outlined in this guide. For example, the [PyTorch](https://images.chainguard.dev/directory/image/pytorch/overview) image is an AI image, but it is also part of our free tier, meaning it's also a Free image.
 
 Many customers use both Application and Base Containers. Note that it often takes more time to migrate your applications to a Base container image in comparison to an Application image due to the complexity of coordinating multiple teams, testing, and release schedules. We recommend starting with and migrating to Application container images first while your teams get trained and onboarded with Base container images.
 
@@ -111,7 +106,6 @@ A common requirement for many customers is to add a company-specific certificate
 3. Using the Java `keytool` utility within a Dockerfile
 
 The process of adding or updating certificates, configuring APK repositories, and implementing other organization-specific customizations into an image is commonly known as creating a "Golden Image". This approach enables these standard modifications to be applied once and then distributed across all teams, thereby reducing the risk of errors and minimizing friction during the migration process.
-
 
 ## Learn More
 

--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -23,15 +23,15 @@ Chainguard offers a collection of images that are publicly available, don't requ
 
 ## Signing Up
 
-You can register a Chainguard account through our [sign up form](https://console.chainguard.dev/auth/login?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement). This will create your account and a [Chainguard IAM organization](/chainguard/administration/iam-organizations/overview-of-chainguard-iam-model/). If you already have an account, you can log in through the [login page](https://console.chainguard.dev/auth/login?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).
+You can register a Chainguard account through our [sign up form](https://console.chainguard.dev/auth/login?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement). This will create your account and a [Chainguard IAM organization](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/). If you already have an account, you can log in through the [login page](https://console.chainguard.dev/auth/login?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).
 
-For more details on signing in, you can review our [sign in guidance](/chainguard/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/#logging-in). If your organization is interested in (or already using) custom identity providers like Okta, you can read [how to authenticate to Chainguard with custom identity providers](/chainguard/administration/custom-idps/custom-idps/).
+For more details on signing in, you can review our [sign in guidance](/platform/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/#logging-in). If your organization is interested in (or already using) custom identity providers like Okta, you can read [how to authenticate to Chainguard with custom identity providers](/platform/administration/custom-idps/custom-idps/).
 
 ## Authenticating with the `chainctl` Credential Helper
 
 You can configure authentication by using the credential helper included with `chainctl`. This is the workflow recommended by Chainguard.
 
-First [install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) and configure the credential helper:
+First [install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/) and configure the credential helper:
 
 ```sh
 chainctl auth configure-docker
@@ -45,7 +45,7 @@ Pulls authenticated in this way are associated with your user.
 
 You can also create a "pull token" using `chainctl`. This generates a longer-lived token that can be used to pull images from other environments that don't support OIDC, such as some CI environments, Kubernetes clusters, or with registry mirroring tools like Artifactory.
 
-First [install `chainctl`](/chainguard/administration/how-to-install-chainctl/), then log in and configure a pull token:
+First [install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/), then log in and configure a pull token:
 
 ```sh
 chainctl auth configure-docker --pull-token
@@ -65,7 +65,7 @@ Pulls authenticated in this way are associated with a Chainguard identity, which
 
 You can also export the pull token details into environment variables for
 [authentication in automated
-systems](/chainguard/chainguard-images/features/private-apk-repos/#pull-token-automation).
+systems](/chainguard/chainguard-images/features/packages/private-apk-repos/#pull-token-automation).
 
 ### Note on Multiple Pull Tokens
 
@@ -93,7 +93,6 @@ You can also create and view pull tokens in the [Chainguard Console](https://con
 
 After navigating to the Console, click on **Settings** in the left-hand navigation menu. From the **Settings** pane, click on **Pull tokens**. There, you'll be presented with a table listing of all the active pull tokens for your selected organization.
 
-
 ![Screenshot showing the Pull tokens page within the Settings pane. This example shows four pull tokens in the table.](pull-tokens-console-1.png)
 
 This table shows the name of each pull token, their descriptions, the date they were created, and the number of days until they expire.
@@ -103,7 +102,6 @@ You can create a new pull token by clicking the **Create pull token** button at 
 ![Screenshot showing the Create pull token pane. This example shows all the fields filled in: the Name is "new-pull-token", the Description reads "This is a description for the new pull token.", with a custom expiration date and the selection calendar showing March 2025.](pull-tokens-console-2.png)
 
 After entering these details, click the **Create token** button and your new pull token will appear in the list with the rest of your organization's tokens.
-
 
 ## Authenticating with GitHub Actions
 
@@ -129,7 +127,7 @@ name: Registry Example
 
 on:
   push:
-	branches: ['main']
+ branches: ['main']
 
 permissions:
   contents: read
@@ -137,24 +135,23 @@ permissions:
 
 jobs:
   example:
-	runs-on: ubuntu-latest
-	steps:
-  	- uses: chainguard-dev/setup-chainctl@main
-    	with:
-      	identity: [[ The Chainguard Identity ID you created above ]]
-  	- run: docker pull cgr.dev/chainguard/node
+ runs-on: ubuntu-latest
+ steps:
+   - uses: chainguard-dev/setup-chainctl@main
+     with:
+       identity: [[ The Chainguard Identity ID you created above ]]
+   - run: docker pull cgr.dev/chainguard/node
 ```
 
 Pulls authenticated in this way are associated with the Chainguard identity you created, which is associated with the organization selected when the identity was created.
 
 If the identity is configured to only work with GitHub Actions workflow runs from a given repo and branch, that identity will not be able to pull from other repos or branches, including pull requests targeting the specified branch.
 
-
 ## Authenticating with CircleCI OIDC Token
 
 You can configure authentication with OIDC-aware CircleCI platform.
 
-First, use `chainctl` to create an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Replace `1234` with your identity issuer org. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
+First, use `chainctl` to create an [assumed identity](/platform/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). This example uses a CircleCI ID of `1234` and will work for all projects in that organization. Replace `1234` with your identity issuer org. Modify the subject pattern regex to reduce the scope to specific repos in the organization.
 
 ```sh
 chainctl iam identities create circleci-identity
@@ -202,11 +199,10 @@ workflows:
   version: 2
   chainctl-workflow:
     jobs:
-      - install-and-authenticate  
+      - install-and-authenticate
 ```
 
 See the [CircleCI documentation](https://circleci.com/docs/openid-connect-tokens/#format-of-the-openid-connect-id-token) to learn more about using OpenID Connect tokens in CircleCI jobs.
-
 
 ## Authenticating with Microsoft Entra ID OIDC Token
 
@@ -222,7 +218,7 @@ If you use the authorization code flow (recommended), request the `openid` scope
 
 Retrieve and save an ID token as a local environment variable. The following examples use `MS_ENTRA_ID_OIDC_TOKEN`.
 
-Next, use `chainctl` to create an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). Replace `{tenant}` with your Entra ID tenant ID (GUID). Modify the subject pattern regular expression to reduce access from all users from that issuer to a more appropriate scope for your needs.
+Next, use `chainctl` to create an [assumed identity](/platform/administration/assumable-ids/assumable-ids/#managing-identities-with-chainctl). Replace `{tenant}` with your Entra ID tenant ID (GUID). Modify the subject pattern regular expression to reduce access from all users from that issuer to a more appropriate scope for your needs.
 
 ```sh
 chainctl iam identities create entraid-identity \
@@ -268,7 +264,7 @@ workflows:
   version: 2
   chainctl-workflow:
     jobs:
-      - install-and-authenticate  
+      - install-and-authenticate
 ```
 
 Refer to the [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc) to learn more about using OpenID Connect tokens on the Microsoft Entra ID platform. Of special note is their warning about reading and validating their tokens:
@@ -276,7 +272,6 @@ Refer to the [Microsoft documentation](https://learn.microsoft.com/en-us/entra/i
 > Don't attempt to validate or read tokens for any API you don't own, including the tokens in this example, in your code. Tokens for Microsoft services can use a special format that will not validate as a JWT, and may also be encrypted for consumer (Microsoft account) users. While reading tokens is a useful debugging and learning tool, do not take dependencies on this in your code or assume specifics about tokens that aren't for an API you control.
 
 Chainguard does not require you to parse or validate the Microsoft-issued token yourself. Instead, just pass the token to `chainctl` as shown above.
-
 
 ## Authenticating with Kubernetes
 
@@ -288,8 +283,8 @@ After that, you can create a Kubernetes secret based on those credentials, follo
 
 ```sh
 kubectl create secret generic regcred \
-	--from-file=.dockerconfigjson=<path/to/.docker/config.json> \
-	--type=kubernetes.io/dockerconfigjson
+ --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+ --type=kubernetes.io/dockerconfigjson
 ```
 
 > **Important Note:** this will also make any other credentials you have configured in your Docker config available in the secret. Ensure only the necessary credentials are included.
@@ -304,7 +299,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-	image: cgr.dev/chainguard/nginx:latest
+ image: cgr.dev/chainguard/nginx:latest
   imagePullSecrets:
   - name: regcred
 ```
@@ -316,4 +311,4 @@ kubectl apply -f cgr-example.yaml
 kubectl get pod cgr-example
 ```
 
-Learn more in our [sign in guidance](/chainguard/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/#logging-in).
+Learn more in our [sign in guidance](/platform/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/#logging-in).

--- a/content/chainguard/chainguard-images/chainguard-registry/overview.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/overview.md
@@ -28,7 +28,7 @@ You can check the status of Chainguard's registry at [https://status.cgr.dev](ht
 
 ## Network Requirements
 
-Refer to our [Network Requirements](/chainguard/administration/network-requirements/) reference page for details about how to ensure access to Chainguard's registry in environments using firewalls, access control lists, and proxies.
+Refer to our [Network Requirements](/chainguard/chainguard-images/network-requirements/) reference page for details about how to ensure access to Chainguard's registry in environments using firewalls, access control lists, and proxies.
 
 ## Using a Caching Proxy with Chainguard's registry
 
@@ -36,8 +36,8 @@ Chainguard does not offer an SLA for uptime for the Chainguard's registry. In or
 
 We currently provide documentation on how you can set up a pull-through cache for the Chainguard's registry on the following platforms:
 
-* [Amazon ECR](/chainguard/chainguard-registry/pull-through-guides/ecr-pull-through/)
-* [Google Artifact Registry](/chainguard/chainguard-registry/pull-through-guides/artifact-registry-pull-through/)
-* [JFrog Artifactory](/chainguard/chainguard-registry/pull-through-guides/artifactory/)
-* [Sonatype Nexus](/chainguard/chainguard-registry/pull-through-guides/nexus-pull-through/)
-* [Cloudsmith](/chainguard/chainguard-registry/pull-through-guides/cloudsmith-pull-through/)
+* [Amazon ECR](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/ecr-pull-through/)
+* [Google Artifact Registry](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifact-registry-pull-through/)
+* [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/)
+* [Sonatype Nexus](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/nexus-pull-through/)
+* [Cloudsmith](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/cloudsmith-pull-through/)

--- a/content/open-source/wolfi/wolfi-with-dockerfiles.md
+++ b/content/open-source/wolfi/wolfi-with-dockerfiles.md
@@ -30,7 +30,8 @@ In this article, we'll learn how to leverage Wolfi to create safer runtime envir
 You'll need Docker to build and run the application.
 
 ## Step 1: Obtaining the Demo Application
-We'll use the same demo application from the [Getting Started with the Python Chainguard Image](/chainguard/chainguard-images/getting-started/python//) tutorial to demonstrate how to build a Wolfi Python image with a Dockerfile. The application files are available in the [edu-images-demos](https://github.com/chainguard-dev/edu-images-demos) repository. We'll start by cloning that repository in a temporary folder so that we can obtain the relevant application files to run the **second** demo from that tutorial.
+
+We'll use the same demo application from the [Getting Started with the Python Chainguard Image](/chainguard/chainguard-images/getting-started/python/) tutorial to demonstrate how to build a Wolfi Python image with a Dockerfile. The application files are available in the [edu-images-demos](https://github.com/chainguard-dev/edu-images-demos) repository. We'll start by cloning that repository in a temporary folder so that we can obtain the relevant application files to run the **second** demo from that tutorial.
 
 The following command will clone the demos repository in your `/tmp` folder:
 
@@ -97,7 +98,7 @@ ARG version=3.12
 WORKDIR /app
 
 RUN apk add python-${version} py${version}-pip && \
-	chown -R nonroot:nonroot /app/
+ chown -R nonroot:nonroot /app/
 
 USER nonroot
 COPY requirements.txt linky.png linky.py /app/
@@ -109,7 +110,6 @@ ENTRYPOINT [ "python", "/app/linky.py" ]
 This Dockerfile uses a variable called `version` to define which Python version is going to be installed in the resulting image. You can change this to one of the Python versions available in Wolfi. To find out which versions are available, please refer to the [Searching for Packages](https://edu.chainguard.dev/chainguard/migration/migrating-to-chainguard-images/#searching-for-packages) section of our migration guide.
 
 Save the file when you're done. In the next step, we'll build and run the image with `docker`.
-
 
 ## Step 3: Building and Running the Image
 
@@ -160,7 +160,7 @@ ENV PATH="/app/venv/bin:$PATH"
 WORKDIR /app
 
 RUN apk update && apk add python-$version py${version}-pip && \
-	chown -R nonroot:nonroot /app/
+ chown -R nonroot:nonroot /app/
 USER nonroot
 RUN python -m venv /app/venv
 
@@ -216,6 +216,3 @@ In this tutorial, we've demonstrated how to build a Python image from scratch us
 If your application runtime requires system dependencies that are not already included within a distroless variant available in our [images directory](https://images.chainguard.dev), you can still use a builder image (identified by the `-dev` suffix) or the `wolfi-base` image in a standard Dockerfile to build a suitable runtime. These images come with `apk` and a shell, allowing for further customization based on your application's requirements.
 
 If you can't find an image that is a good match for your use case, or if your build has dependencies that cannot be met with the regular catalog, [get in touch with us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) for alternative options.
-
-
-

--- a/content/platform/administration/assumable-ids/assumable-ids.md
+++ b/content/platform/administration/assumable-ids/assumable-ids.md
@@ -23,7 +23,6 @@ In such cases, you can create a Chainguard identity for these systems to assume,
 
 This guide provides a general overview of assumable identities in Chainguard, outlining how they work and how to create them.
 
-
 ## About Assumable Identities
 
 Chainguard's *assumable identities* are identities that can be assumed by workflows in order to complete tasks without manual authorization. In many ways, these are similar to AWS roles or Google Service accounts, as Chainguard identities allow you to delegate access to your Chainguard resources to external applications or services.
@@ -34,20 +33,19 @@ Assumable identities essentially reverse the lookup process of literal identitie
 
 This enables you to create identities that can only be assumed by specific automated workflows, providing greater security for your build and deployment processes. We have a number of examples of how to create assumable identities for specific providers.
 
-* [GitHub](/chainguard/administration/assumable-ids/identity-examples/github-identity/)
-* [GitLab](/chainguard/administration/assumable-ids/identity-examples/gitlab-identity/)
-* [AWS](/chainguard/administration/assumable-ids/identity-examples/aws-identity-oidc/)
-* [AWS (Legacy)](/chainguard/administration/assumable-ids/identity-examples/aws-identity/)
-* [Jenkins with Terraform](/chainguard/administration/assumable-ids/identity-examples/jenkins-terraform/) or [Jenkins with chainctl](/chainguard/administration/assumable-ids/identity-examples/jenkins-chainctl/)
-* [Buildkite](/chainguard/administration/assumable-ids/identity-examples/buildkite-identity/)
-* [Bitbucket](/chainguard/administration/assumable-ids/identity-examples/bitbucket-identity/)
+* [GitHub](/platform/administration/assumable-ids/identity-examples/github-identity/)
+* [GitLab](/platform/administration/assumable-ids/identity-examples/gitlab-identity/)
+* [AWS](/platform/administration/assumable-ids/identity-examples/aws-identity-oidc/)
+* [AWS (Legacy)](/platform/administration/assumable-ids/identity-examples/aws-identity/)
+* [Jenkins with Terraform](/platform/administration/assumable-ids/identity-examples/jenkins-terraform/) or [Jenkins with chainctl](/platform/administration/assumable-ids/identity-examples/jenkins-chainctl/)
+* [Buildkite](/platform/administration/assumable-ids/identity-examples/buildkite-identity/)
+* [Bitbucket](/platform/administration/assumable-ids/identity-examples/bitbucket-identity/)
 
-A notable difference between registered users and identities in Chainguard's IAM model is that identities are tied to a specific [IAM organization](/chainguard/administration/iam-organizations/overview-of-chainguard-iam-model/). When you create an identity, you must specify a Chainguard organization under which the identity will be created.
+A notable difference between registered users and identities in Chainguard's IAM model is that identities are tied to a specific [IAM organization](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/). When you create an identity, you must specify a Chainguard organization under which the identity will be created.
 
 However, an identity won't automatically have access to the other resources associated with that organization. In order for an identity to be able to interact with a organization's resources — including the containers, repositories, and users associated with the organization — it must be granted the permissions it needs to do so. To do this, you must also tie the identity to a role. Chainguard comes with a few built-in roles, including `viewer`, `editor`, and `owner`. You can also create custom role-bindings with `chainctl`. Check out the [`chainctl iam role-bindings` documentation](/chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings/) for more details.
 
 Now that you have a better understanding of what assumable identities are, let's go over how you can set up an assumable identity. There are currently two main ways you can create an identity: with Terraform and with `chainctl`. Let's first go over how to set up an identity with Terraform.
-
 
 ## Terraform
 
@@ -56,7 +54,7 @@ To set up an assumable identity with Terraform, you will need to add a few speci
 ```hcl
 resource "chainguard_identity" "<id-ref>" {
   parent_id   = <chainguard organization ID>
-  name   	 = "<identity name>"
+  name     = "<identity name>"
   description = <<EOF
     This is an example description for an identity.
   EOF
@@ -76,9 +74,9 @@ This example provides literal values for both the `issuer` and `subject` fields.
 
 ```hcl
   claim_match {
-	issuer_pattern = ".*"
-	subject_pattern = ".*"
-	audience_pattern = ".*"
+ issuer_pattern = ".*"
+ subject_pattern = ".*"
+ audience_pattern = ".*"
   }
 ```
 
@@ -112,8 +110,7 @@ resource "chainguard_rolebinding" "view-stuff" {
 
 This means that the identity this Terraform configuration will create will only be able to view the resources tied to the same organization the identity is tied to.
 
-Applying this configuration will create the assumable identity. You can follow any of our [identity examples](/chainguard/administration/iam-organizations/identity-examples/) to create an assumable identity that can be used by a continuous integration workflow to interact with Chainguard. The Terraform files used in the linked tutorials are based closely on the template outlined here.
-
+Applying this configuration will create the assumable identity. You can follow any of our [identity examples](/platform/administration/assumable-ids/identity-examples/) to create an assumable identity that can be used by a continuous integration workflow to interact with Chainguard. The Terraform files used in the linked tutorials are based closely on the template outlined here.
 
 ## Managing identities with `chainctl`
 
@@ -134,7 +131,7 @@ Be aware that you can use regular expressions to create an identity that matches
 
 ```shell
 chainctl iam identities create <identity-name> \
-    --identity-issuer-pattern="https://*.mycompany\.com" \ 
+    --identity-issuer-pattern="https://*.mycompany\.com" \
     --subject-pattern="^\d{4}$"
 ```
 
@@ -159,7 +156,6 @@ chainctl iam identities delete <identity-name>
 
 For more detailed information on managing identities with `chainctl`, we encourage you to check out the [`chainctl` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities/).
 
-
 ## Assuming an Identity
 
 Whether you create an identity with `chainctl` or with Terraform, Chainguard will generate a UIDP (unique identifier path) tied to the identity. You can retrieve a list of all the identities you've created — along with their UIDPs — with the following command.
@@ -167,6 +163,7 @@ Whether you create an identity with `chainctl` or with Terraform, Chainguard wil
 ```sh
 chainctl iam identities ls -o table
 ```
+
 ```output
                              ID                             |      NAME      |    TYPE     | DESCRIPTION |         ROLES         |                   ISSUER                    | EXPIRES
 ------------------------------------------------------------+----------------+-------------+-------------+-----------------------+---------------------------------------------+----------
@@ -180,7 +177,7 @@ There are a few different ways to do this.
 ### Using `chainctl`
 
 On some platforms, such as
-[GitHub](/chainguard/administration/assumable-ids/identity-examples/github-identity/)
+[GitHub](/platform/administration/assumable-ids/identity-examples/github-identity/)
 or Google Cloud Platform, `chainctl` is able to detect your credentials
 transparently. This means you only need to provide the identity's UIDP to log in, as in this example:
 
@@ -214,7 +211,7 @@ curl -sSf \
 
 ### Using the Chainguard API
 
-If you want to interact with the API directly without using `chainctl`, 
+If you want to interact with the API directly without using `chainctl`,
 you can exchange your platform's OIDC token for a Chainguard API token
 like in the following example. Be sure to substitute `<identity-id>` and `<identity-token>` with the
 identity's UIDP and the OIDC token, respectively:
@@ -241,4 +238,4 @@ will need to fetch a new token after it has expired.
 
 ## Learn More
 
-As mentioned previously, we've published a few tutorials that outline how you can [set up an identity for a CI/CD workflow to assume](/chainguard/administration/iam-organizations/identity-examples/). We strongly encourage you to follow these guides to better understand how assumable identities work in Chainguard.
+As mentioned previously, we've published a few tutorials that outline how you can [set up an identity for a CI/CD workflow to assume](/platform/administration/assumable-ids/identity-examples/). We strongly encourage you to follow these guides to better understand how assumable identities work in Chainguard.

--- a/content/platform/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard.md
+++ b/content/platform/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard.md
@@ -20,7 +20,7 @@ weight: 010
 toc: true
 ---
 
-Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. This guide outlines how to manage Chainguard's IAM structures with the [`chainctl` command line tool](/chainguard/chainctl/). 
+Chainguard provides a rich Identity and Access Management (IAM) model similar to those used by AWS and GCP. This guide outlines how to manage Chainguard's IAM structures with the [`chainctl` command line tool](/chainguard/chainctl/).
 
 > **Note**: You should work with Chainguard's Customer Success team to create or delete organizations. This will help to ensure that no users lose access to resources and that your IAM structure is configured correctly.
 
@@ -33,7 +33,6 @@ chainctl auth login
 ```
 
 A web browser window will open to prompt you to log in via your chosen OIDC flow. Select an account with which you wish to register. Once authenticated, you can set up an organization.
-
 
 ## Listing Organizations
 
@@ -55,8 +54,9 @@ You can retrieve your organizations' UIDPs by adding the `-o table` option to th
 ```sh
 chainctl iam organizations list -o table
 ```
+
 ```output
-          ID          |     NAME     |  	DESCRIPTION
+          ID          |     NAME     |   DESCRIPTION
 ----------------------+--------------+---------------------------------
   <Organization UIDP> | tutorial-org | This is a shared IAM
                       |              | organization for tutorials.
@@ -65,7 +65,6 @@ chainctl iam organizations list -o table
 ```
 
 Some other `chainctl` functions require you to know an organization's UIDP, making this a useful option to remember.
-
 
 ## Inviting Others to an Organization
 
@@ -77,7 +76,7 @@ To do so, run the following command, making sure to replace `$ORGANIZATION` with
 chainctl iam invite create $ORGANIZATION
 ```
 
-You will be prompted for the scope that the invite code will be granted. After selecting the [role-bindings](/chainguard/administration/iam-organizations/roles-role-bindings/), this command will generate both an invite code and an invite link.  If you ever lose the invite code, you can retrieve a list of active invite codes with the following `chainctl` command:
+You will be prompted for the scope that the invite code will be granted. After selecting the [role-bindings](/platform/administration/iam-organizations/roles-role-bindings/), this command will generate both an invite code and an invite link.  If you ever lose the invite code, you can retrieve a list of active invite codes with the following `chainctl` command:
 
 ```sh
 chainctl iam invite list
@@ -86,9 +85,9 @@ chainctl iam invite list
 This will provide output in the form of a table with the organization ID, a timestamp indicating when the invitation to the organization will expire, the invite code's key ID, and the selected role.
 
 ```output
-          ID          |        EXPIRATION        |     KEYID     |          	ROLE          	 
+          ID          |        EXPIRATION        |     KEYID     |           ROLE
 ----------------------+--------------------------+---------------+---------------------------------
-  <Organization UIDP> | 2024-03-23T00:55:04.813Z | <Invite code> | [editor] Editor            	 
+  <Organization UIDP> | 2024-03-23T00:55:04.813Z | <Invite code> | [editor] Editor
 ```
 
 Note that this invite code found under the `KEYID` column will be shorter than the one returned in the output of the `chainctl iam invite create` command, but they are effectively the same.
@@ -109,9 +108,8 @@ chainctl iam invite create $ORGANIZATION --email linky@example.com --ttl 24h
 
 In this example, the invitation is scoped to a user with the email address `linky@example.com`. If someone with a different email address tries to use the code it will not work. The `--ttl` option in this example means that the code will expire in 24 hours.
 
-
 ## Learn more
 
-In addition to inviting other users to your organization, you can set up [assumable identities](/chainguard/administration/iam-organizations/assumable-ids/) to allow automation systems — like Buildkite or GitHub Actions — to perform certain administrative tasks for your organization. To learn more, we encourage you to check out our [Overview of Assumable Identities](/chainguard/administration/iam-organizations/assumable-ids/) as well as our collection of [Assumable Identity Examples](/chainguard/administration/iam-organizations/identity-examples/).
+In addition to inviting other users to your organization, you can set up [assumable identities](/platform/administration/assumable-ids/assumable-ids/) to allow automation systems — like Buildkite or GitHub Actions — to perform certain administrative tasks for your organization. To learn more, we encourage you to check out our [Overview of Assumable Identities](/platform/administration/assumable-ids/assumable-ids/) as well as our collection of [Assumable Identity Examples](/platform/administration/assumable-ids/identity-examples/).
 
-You may also be interested in setting up a [Custom Identity Provider](/chainguard/administration/custom-idps/custom-idps/) for your organization. By default, users can log in with GitHub GitLab, and Google, but a Custom IDP can allow members of your organization to log in to Chainguard with a corporate identity provider like [Okta](/chainguard/administration/custom-idps/okta/), [Microsoft Entra ID](/chainguard/administration/custom-idps/ms-entra-id/), or [Ping Identity](/chainguard/administration/custom-idps/ping-id/).
+You may also be interested in setting up a [Custom Identity Provider](/platform/administration/custom-idps/custom-idps/) for your organization. By default, users can log in with GitHub GitLab, and Google, but a Custom IDP can allow members of your organization to log in to Chainguard with a corporate identity provider like [Okta](/platform/administration/custom-idps/idp-providers/okta/), [Microsoft Entra ID](/platform/administration/custom-idps/idp-providers/ms-entra-id/), or [Ping Identity](/platform/administration/custom-idps/idp-providers/ping-id/).

--- a/content/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
+++ b/content/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
@@ -14,21 +14,19 @@ images: []
 weight: 005
 ---
 
-In the context of Chainguard, an *identity* represents an individual user within an organization. Chainguard's IAM model allows administrators to assign identities to specialized *roles* which define the level of access that an identity has to the organization's resources. You assign a role by creating a *role-binding*, which is what ties an identity to a given role. 
+In the context of Chainguard, an *identity* represents an individual user within an organization. Chainguard's IAM model allows administrators to assign identities to specialized *roles* which define the level of access that an identity has to the organization's resources. You assign a role by creating a *role-binding*, which is what ties an identity to a given role.
 
-This guide serves as an overview of what roles and role-bindings are within the context of Chainguard. It also outlines how you can manage roles and role-bindings with `chainctl`. 
-
+This guide serves as an overview of what roles and role-bindings are within the context of Chainguard. It also outlines how you can manage roles and role-bindings with `chainctl`.
 
 ## Prerequisites
 
-This guide includes several examples of how you can manage roles and role-bindings with `chainctl`, the Chainguard command-line tool. To set up `chainctl`, follow our guide on [how to install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you haven't done so already.
-
+This guide includes several examples of how you can manage roles and role-bindings with `chainctl`, the Chainguard command-line tool. To set up `chainctl`, follow our guide on [how to install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/) if you haven't done so already.
 
 ## Roles
 
 There are a number of built-in roles in Chainguard's IAM model that customers can assign to identities within their organization. Most users within your organization will likely have one of the following roles with broadly-defined privileges: `owner`, `editor`, `viewer`, or `console_viewer`.
 
-`owner` is the role with the most privileges. An owner can create, delete, view (list), and modify (update) organizations, account associations, role-bindings, organization invitations, custom roles, role-bindings, and subscriptions. 
+`owner` is the role with the most privileges. An owner can create, delete, view (list), and modify (update) organizations, account associations, role-bindings, organization invitations, custom roles, role-bindings, and subscriptions.
 
 `editor` is the role with read access and limited creation and modification access. As opposed to the owner role, an editor can view images, policies, records, organizations, organization invites, roles, and account associations but cannot create or make changes to these resources. It can modify the state of event subscriptions, but cannot grant roles or permissions. Editors can also push and pull images, libraries, and APKs.
 
@@ -42,20 +40,20 @@ The remaining roles are for more specialized functions. For example, `registry.p
 
 The `owner`, `editor`, and `viewer` roles are useful for user profiles that require broad, but clearly defined capabilities. The registry, container, and library roles have limited permissions, allowing them to manage only one specific Chainguard resource. These specialized, resource-specific roles grant minimal required access.
 
-Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `apk.pull` role only grants `list` access for APK packages and groups. This means identities with this role can pull the organization's APK packages and retrieve information about the organization, but won't have general access to the organization's [Chainguard registry](/chainguard/chainguard-images/chainguard-registry/overview/) access. 
+Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `apk.pull` role only grants `list` access for APK packages and groups. This means identities with this role can pull the organization's APK packages and retrieve information about the organization, but won't have general access to the organization's [Chainguard registry](/chainguard/chainguard-images/chainguard-registry/overview/) access.
 
 Chainguard's built-in default roles serve as building blocks and can be complemented with custom roles for specific use cases. Custom roles can extend or restrict default role capabilities, and offer or your organization greater flexibility, allowing you to mix default and custom roles based on your team's structure and needs.
 
 When assigning a role, do so based on the principle of least privilege; assign only the role needed for the indentity's function. For example, CI systems should have a role like `registry.pull`, not `editor`.
 
-You can run `chainctl iam roles list` to retrieve a list of all the roles available to your organization and review each of their specific capabilities. This command will list all the built-in roles as well as any custom roles created for your organization. The next section outlines how to create and manage such custom roles. 
-
+You can run `chainctl iam roles list` to retrieve a list of all the roles available to your organization and review each of their specific capabilities. This command will list all the built-in roles as well as any custom roles created for your organization. The next section outlines how to create and manage such custom roles.
 
 ## Managing custom roles
 
 There are two options for managing custom roles:
+
 - with [`chainctl`](#manage-custom-roles-with-chainctl), or
-- directly [in the Chainguard Console](#manage-custom-roles-in-the-chainguard-console). 
+- directly [in the Chainguard Console](#manage-custom-roles-in-the-chainguard-console).
 
 ### Manage custom roles with chainctl
 
@@ -67,7 +65,7 @@ chainctl iam roles create my-role
 
 After running this command, an interactive prompt will appear asking you to select what capabilities the new role should have and the organization under which the role should be created.
 
-You can avoid using the interactive prompt by including the `--parent` and `--capabilities` options in this command. 
+You can avoid using the interactive prompt by including the `--parent` and `--capabilities` options in this command.
 
 ```sh
 chainctl iam roles create new-role --parent=example-org --capabilities=roles.list
@@ -83,15 +81,15 @@ chainctl iam roles create puller-role --parent=example-org --capabilities=apk.li
 
 This example command creates a role named `puller-role` that has the following capabilities:
 
-* `apk.list`
-* `groups.list`
-* `manifest.list`
-* `manifest.metadata.list`
-* `record_signatures.list`
-* `repo.list`
-* `sboms.list`
-* `tag.list`
-* `vuln.list`
+- `apk.list`
+- `groups.list`
+- `manifest.list`
+- `manifest.metadata.list`
+- `record_signatures.list`
+- `repo.list`
+- `sboms.list`
+- `tag.list`
+- `vuln.list`
 
 This essentially combines the capabilities of the `registry.pull` and `apk.pull` roles, allowing any identities bound to this role to be able to pull both Chainguard Containers and APKs.
 
@@ -105,7 +103,7 @@ Note that you cannot delete any of the built-in roles. Attempting to do so will 
 
 ### Manage custom roles in the Chainguard Console
 
-In addition to using `chainctl` to manage roles, you can also create, view, and edit custom roles directly in the [Chainguard Console](https://console.chainguard.dev). 
+In addition to using `chainctl` to manage roles, you can also create, view, and edit custom roles directly in the [Chainguard Console](https://console.chainguard.dev).
 
 #### Create  a custom role
 
@@ -128,12 +126,11 @@ After creating a role, you can attach it to a user. Learn more under [Managing r
 
 Both the Console and `chainctl` operate on the same underlying roles and role-bindings; changes made in either place are immediately reflected everywhere.
 
-
 ## Managing role-bindings
 
 ### Manage role bindings with chainctl
 
-You can assign a role — and all of its capabilities — to a given user by creating a role-binding and tying it to that user's identity. 
+You can assign a role — and all of its capabilities — to a given user by creating a role-binding and tying it to that user's identity.
 
 You can run a command like the following example to create a role-binding.
 
@@ -141,7 +138,7 @@ You can run a command like the following example to create a role-binding.
 chainctl iam role-bindings create
 ```
 
-This will start an interactive prompt where you can enter the appropriate details for this new role-binding. Specifically, you'll be prompted to specify the identity to bind, the role you want the identity bound to, and the organization that the role-binding should belong to. 
+This will start an interactive prompt where you can enter the appropriate details for this new role-binding. Specifically, you'll be prompted to specify the identity to bind, the role you want the identity bound to, and the organization that the role-binding should belong to.
 
 To avoid using the interactive prompt, you can add these details to the command by including the `--identity`, `--role`, and `--parent` options.
 
@@ -149,7 +146,7 @@ To avoid using the interactive prompt, you can add these details to the command 
 chainctl iam role-bindings create --identity=example-id --role=viewer --parent=example-org
 ```
 
-This example creates a role-binding for the identity `example-id` with the built-in `viewer` role in an organization named `example-org`. 
+This example creates a role-binding for the identity `example-id` with the built-in `viewer` role in an organization named `example-org`.
 
 Note that in order to use the `--identity` option like this, you will need to know the given identity's UIDP. You can find a list of all your identities' UIDPs by running `chainctl iam identities ls`. The identities' UIDPs will appear in the resulting `ID` column.
 
@@ -162,6 +159,6 @@ Note that in order to use the `--identity` option like this, you will need to kn
 
 ## Learn more
 
-You can create a Chainguard identity for an automation system (such as Buildkite or GitHub Actions) to assume. This process involves choosing a role for the assumable identity and then creating a role-binding for it. Check out our [overview of assumable identities](/chainguard/administration/iam-organizations/assumable-ids/) — as well as our [collection of assumable identity examples](/chainguard/administration/iam-organizations/identity-examples/) — to learn more.
+You can create a Chainguard identity for an automation system (such as Buildkite or GitHub Actions) to assume. This process involves choosing a role for the assumable identity and then creating a role-binding for it. Check out our [overview of assumable identities](/platform/administration/assumable-ids/assumable-ids/) — as well as our [collection of assumable identity examples](/platform/administration/assumable-ids/identity-examples/) — to learn more.
 
-If you'd like to learn more about Chainguard's IAM model and structures, we encourage you to read our [Overview of the Chainguard IAM Model](/chainguard/administration/iam-organizations/overview-of-enforce-iam-model/).
+If you'd like to learn more about Chainguard's IAM model and structures, we encourage you to read our [Overview of the Chainguard IAM Model](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/).

--- a/content/platform/administration/terraform-provider/index.md
+++ b/content/platform/administration/terraform-provider/index.md
@@ -21,13 +21,11 @@ weight: 008
 
 [The Chainguard Terraform provider](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest) enables users to manage resources on the Chainguard Platform, such as identities, role-bindings, custom roles, and more. This guide provides a brief introduction to the Chainguard Terraform provider, including how to configure it and use it to manage your Chainguard resources.
 
-
 ## Prerequisites
 
 In order to use the Chainguard Terraform provider, you will need to [install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) on your local machine.
 
-Also, while it isn't necessary for using the Chainguard Terraform provider, this guide assumes you have [`chainctl` installed](/chainguard/chainctl-usage/how-to-install-chainctl/) in order to retrieve some information about your Chainguard resources.
-
+Also, while it isn't necessary for using the Chainguard Terraform provider, this guide assumes you have [`chainctl` installed](/platform/chainctl-usage/how-to-install-chainctl/) in order to retrieve some information about your Chainguard resources.
 
 ## Configuring the Chainguard Terraform provider
 
@@ -38,22 +36,22 @@ To use the Chainguard Terraform provider, add it to the block of required provid
 ```hcl
 terraform {
   required_providers {
-	chainguard = { source = "chainguard-dev/chainguard" }
+ chainguard = { source = "chainguard-dev/chainguard" }
   }
 }
 ```
 
 If you don't have an active Chainguard token when you apply the configuration, the provider will automatically launch a browser to complete the Oauth 2 flow with one of the default identity providers: GitHub, GitLab, or Google. This means the Terraform provider does not require `chainctl` to be installed to manage authentication with Chainguard.
 
-You can customize the behavior of the authentication flow in a number of ways. For example, you can specify an identity to assume, or a [verified organization](/chainguard/administration/iam-organizations/verified-orgs/) name in order to use a previously-configured custom identity provider:
+You can customize the behavior of the authentication flow in a number of ways. For example, you can specify an identity to assume, or a [verified organization](/platform/administration/iam-organizations/verified-orgs/) name in order to use a previously-configured custom identity provider:
 
 ```hcl
 provider "chainguard" {
   login_options {
-	organization_name = "my-org.com"
-	# identity_id is the exact ID of an assumable identity.
-	# Get this ID with chainctl iam identities list
-	identity_id = "1f127a7c0609329f04b43d845cf80eea4247a07c/d6305475446bbef6"
+ organization_name = "my-org.com"
+ # identity_id is the exact ID of an assumable identity.
+ # Get this ID with chainctl iam identities list
+ identity_id = "1f127a7c0609329f04b43d845cf80eea4247a07c/d6305475446bbef6"
   }
 }
 ```
@@ -63,9 +61,9 @@ You can also configure the provider to use an OIDC token, either by supplying it
 ```hcl
 provider "chainguard" {
   login_options {
-	# Disable the automatic browser authentication flow.
-	disabled   	= true
-	identity_token = "/path/to/oidc/token"
+ # Disable the automatic browser authentication flow.
+ disabled    = true
+ identity_token = "/path/to/oidc/token"
   }
 }
 ```
@@ -74,15 +72,15 @@ You can find more information about authenticating with the Chainguard Terraform
 
 ## Defining Organization References
 
-Terraform was designed to allow users to manage various resources declaratively. In practice, this means that you define the state you want your resources to be in and then you let Terraform and the provider handle the details of bringing that state to reality. 
+Terraform was designed to allow users to manage various resources declaratively. In practice, this means that you define the state you want your resources to be in and then you let Terraform and the provider handle the details of bringing that state to reality.
 
-Resources on the Chainguard platform are organized in a hierarchical structure consisting of [**Organizations** and **Folders**](/chainguard/administration/iam-organizations/overview-of-chainguard-iam-model/#organizations-and-folders). An organization is a customer or group of customers working with the same Chainguard resources, while a folder is a collection of resources within a Chainguard organization. Most users will only need to work at the organization level.
+Resources on the Chainguard platform are organized in a hierarchical structure consisting of [**Organizations** and **Folders**](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/#organizations-and-folders). An organization is a customer or group of customers working with the same Chainguard resources, while a folder is a collection of resources within a Chainguard organization. Most users will only need to work at the organization level.
 
 ![Diagram outlining hierarchical structure of Chainguard resources. The diagram has two halves: one labeled "Organization" and another labeled "Chainguard". Under Organization is a box labeled "Tags" with an arrow pointing toward another box labeled "Repos." Under both halves is a box labeled "Role Bindings" which has four arrows pointing from it. Two arrows point to boxes (labeled "Identities" and "Custom Roles") under Organization and the other two point to boxes (labeled "User Identities" and "roles) under Chainguard.](tf-diagram.png)
 
 All user-managed resources are defined in relation to the organization to which they belong. This means developers need to be able to reference their organization throughout their configuration. We'll outline two ways to define this kind of reference: using local values and data sources. For more details on referencing an organization, please refer to the [`chainguard_group` resource documentation](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs/resources/group) for more information.
 
-> **Note:** Chainguard organizations were previously called "groups," with a "root group" representing what is now referred to as an organization and "subgroups" referring to folders. As of this writing, the Chainguard Terraform provider still refers to "groups" instead of organizations. To align with our other [IAM resources](/chainguard/administration/iam-organizations/), this document uses the new nomenclature wherever possible.
+> **Note:** Chainguard organizations were previously called "groups," with a "root group" representing what is now referred to as an organization and "subgroups" referring to folders. As of this writing, the Chainguard Terraform provider still refers to "groups" instead of organizations. To align with our other [IAM resources](/platform/administration/iam-organizations/), this document uses the new nomenclature wherever possible.
 
 ### Defining local values
 
@@ -114,12 +112,11 @@ If you know the exact name of your organization, you can use a data resource to 
 data "chainguard_group" "org" {
   # This indicates the group is an organization.
   parent_id = "/"
-  name  	= "[organization name]"
+  name   = "[organization name]"
 }
 ```
 
 To refer to the organization's ID in other parts of your Terraform configuration, you would use the reference `data.chainguard_group.org.id`. The rest of the examples in this document will use this for referring to the organization's ID.
-
 
 ## Managing users
 
@@ -137,7 +134,7 @@ data "chainguard_role" "default_role" {
 
 resource "chainguard_identity_provider" "idp" {
   parent_id   = data.chainguard_group.org.id
-  name    	= "[identity provider service]"
+  name     = "[identity provider service]"
   description = "My org's identity provider"
   # Role data sources return list of matched roles.
   # Don't use data.chainguard_role.default_role.id here, as that
@@ -145,20 +142,20 @@ resource "chainguard_identity_provider" "idp" {
   default_role = data.chainguard_role.default_role.items.0.id
 
   oidc {
-	issuer    	= "[URL of identity provider issuer]"
-	client_id 	= "[identity provider client ID]"
-	client_secret = "[identity provider client secret]"
+ issuer     = "[URL of identity provider issuer]"
+ client_id  = "[identity provider client ID]"
+ client_secret = "[identity provider client secret]"
 
-	# openid scope is always requested, add additional scopes
-	# your identity provider provides (e.g. email, profile)
-	additional_scopes = ["email"]
+ # openid scope is always requested, add additional scopes
+ # your identity provider provides (e.g. email, profile)
+ additional_scopes = ["email"]
   }
 }
 ```
 
-As this example shows, you also have the option of including a `description` of the identity provider. 
+As this example shows, you also have the option of including a `description` of the identity provider.
 
-If you're not bringing your own identity provider, but rather relying on one of the default OIDC providers, you can still pre-bind users to roles within your organization so they can log in and access your organization's resources right away. 
+If you're not bringing your own identity provider, but rather relying on one of the default OIDC providers, you can still pre-bind users to roles within your organization so they can log in and access your organization's resources right away.
 
 As an example, say you want your users to log in with their GitHub account. To pre-bind users to a role within your organization, you will need to know their GitHub IDs and add them to a Terraform configuration like the following:
 
@@ -166,16 +163,16 @@ As an example, say you want your users to log in with their GitHub account. To p
 # Create a custom role in this example for first time users.
 resource "chainguard_role" "default_role" {
   parent_id   = data.chainguard_group.org.id
-  name    	= "org-default-role"
+  name     = "org-default-role"
   description = "The role new users are bound to on first login."
 
   # A full list of all capabilities you can assign to a role
   # are available with chainctl iam roles capabilities list
   capabilities = [
-	"groups.list",
-	"repo.list",
-	"tag.list",
-	...
+ "groups.list",
+ "repo.list",
+ "tag.list",
+ ...
   ]
 }
 
@@ -189,7 +186,7 @@ data "chainguard_identity" "users" {
   # The issuer is always the same when using the default
   # OIDC providers.
   issuer  = "https://auth.chainguard.dev/"
- 
+
   # Subjects are prepended with the name of the OIDC provider
   # when using the default provider: github, gitlab, or google-oauth2
   subject = "github|${each.key}”
@@ -199,18 +196,16 @@ data "chainguard_identity" "users" {
 resource "chainguard_rolebinding" "default_bindings" {
   for_each = var.github_ids
 
-  group 	= data.chainguard_group.org.id
+  group  = data.chainguard_group.org.id
   identity  = data.chainguard_identity.users[each.key].id
-  role  	= chainguard_role.default_role.id
+  role   = chainguard_role.default_role.id
 }
 ```
 
 After applying this Terraform configuration, any user whose GitHub ID was included can log in and will already be bound to the default role.
 
-
 ## Learn more
 
 The [Chainguard Terraform provider documentation](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest/docs) includes examples of how you can use it to manage your Chainguard resources.
 
-For more information on setting up custom identity providers, we encourage you to check out our documentation on setting up [custom IDPs](/chainguard/administration/custom-idps/custom-idps/), as well as our examples for [Okta](/chainguard/administration/custom-idps/okta/), [Ping Identity](/chainguard/administration/custom-idps/ping-id/), and [Microsoft Entra ID](/chainguard/administration/custom-idps/ms-entra-id/). Additionally, [our tutorial](/chainguard/administration/iam-organizations/rolebinding-terraform-gh/) on using the Terraform provider to grant members of a GitHub team access to the resources managed by a Chainguard organization provides more context and information to the method outlined in this guide.
-
+For more information on setting up custom identity providers, we encourage you to check out our documentation on setting up [custom IDPs](/platform/administration/custom-idps/custom-idps/), as well as our examples for [Okta](/platform/administration/custom-idps/idp-providers/okta/), [Ping Identity](/platform/administration/custom-idps/idp-providers/ping-id/), and [Microsoft Entra ID](/platform/administration/custom-idps/idp-providers/ms-entra-id/). Additionally, [our tutorial](/platform/administration/iam-organizations/roles-role-bindings/rolebinding-terraform-gh/) on using the Terraform provider to grant members of a GitHub team access to the resources managed by a Chainguard organization provides more context and information to the method outlined in this guide.

--- a/content/platform/chainctl-usage/_index.md
+++ b/content/platform/chainctl-usage/_index.md
@@ -19,18 +19,18 @@ Like most control commands that end with `ctl`, such as `systemctl` or `loginctl
 
 This page lists a curated set of `chainctl` resources to help you get started.
 
-To install `chainctl`, follow our <ins>[installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/)</ins>.
+To install `chainctl`, follow our <ins>[installation guide](/platform/chainctl-usage/how-to-install-chainctl/)</ins>.
 
 Once installed, these will help you on your path to success:
 
 * <ins>[Get Started with chainctl](/get-started/getting-started-with-chainctl/)</ins>
-* <ins>[Authenticate to Chainguard's Registry](/chainguard/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
-* <ins>[Manage Your chainctl Configuration](/chainguard/chainctl-usage/manage-chainctl-config/)</ins>
-* <ins>[Find and Update Your chainctl Release Version](/chainguard/chainctl-usage/chainctl-version-update/)</ins>
-* <ins>[Compare Chainguard Images with chainctl diff](/chainguard/chainctl-usage/comparing-images/)</ins>
+* <ins>[Authenticate to Chainguard's Registry](/chainguard/chainguard-images/chainguard-registry/authenticating/)</ins> - This page includes links to register for a Chainguard account, which is needed to do anything with `chainctl`. You must authenticate to Chainguard to use `chainctl`.
+* <ins>[Manage Your chainctl Configuration](/platform/chainctl-usage/manage-chainctl-config/)</ins>
+* <ins>[Find and Update Your chainctl Release Version](/platform/chainctl-usage/chainctl-version-update/)</ins>
+* <ins>[Compare Chainguard Images with chainctl diff](/platform/chainctl-usage/comparing-images/)</ins>
 * <ins>[Using chainctl to Manage Custom Assembly Resources](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/)
 * <ins>[Automating with chainctl](/platform/chainctl-usage/automating-chainctl/)</ins>
-* <ins>[chainctl events](/chainguard/chainctl-usage/chainctl-events/)</ins>
-* <ins>[chainctl iam](/chainguard/chainctl-usage/chainctl-iam/)</ins>
-* <ins>[chainctl images](/chainguard/chainctl-usage/chainctl-images/)</ins>
-* <ins>[chainctl images](/chainguard/chainctl-usage/chainctl-images-history/)</ins>
+* <ins>[chainctl events](/platform/chainctl-usage/chainctl-events/)</ins>
+* <ins>[chainctl iam](/platform/chainctl-usage/chainctl-iam/)</ins>
+* <ins>[chainctl images](/platform/chainctl-usage/chainctl-images/)</ins>
+* <ins>[chainctl images](/platform/chainctl-usage/chainctl-images/)</ins>

--- a/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
+++ b/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
@@ -19,13 +19,11 @@ toc: true
 
 Chainguard provides two powerful interfaces for managing container security resources: the web-based Console for visual exploration and the `chainctl` CLI for automation and scripting. Understanding when to use each tool maximizes your efficiency in managing Chainguard's security-hardened containers and access controls.
 
-
 ## Prerequisites
 
 To access the [Chainguard Console](/platform/console/images-directory/) you need to [create an account and sign in](https://console.chainguard.dev/auth/login). The Console is accessible to everyone, including users who aren't Chainguard customers.
 
 To use `chainctl`, start by [installing chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/). See [Get Started with chainctl](/get-started/getting-started-with-chainctl/) to help you begin using it; the examples on this page assume you have `chainctl` installed and are authenticated.
-
 
 ## High-level Comparison
 
@@ -34,7 +32,6 @@ The Console is especially useful for one-off information searches, such as when 
 If you know specifically what you are looking for or what you want to accomplish, `chainctl` is a powerful way to do so. It can perform some additional tasks that are not yet available in the Console, such as [comparing images with a diff](/chainguard/chainctl-usage/comparing-images/).
 
 This guide will take the reader through a few use cases to illustrate.
-
 
 ## Find Available Images
 
@@ -48,16 +45,14 @@ To find the images available to you in the Console, do this:
 1. On the Overview page that opens, click **Organization Images** in the sidebar.
 ![Screenshot showing the Organization Images page in the Console, which lists all of the images available along with data for each including Status, Latest tag, Pull URL, and when the image was last updated.](console-org-images.png)
 
-
 ### Find Available Images with chainctl
 
 To find the images available to you using `chainctl`, use this command. The list of available images is likely to be long and will scroll past you quickly in the terminal, so it may be more useful to you by piping the output into a grep search or redirecting the output into a file.
 
-```
+```sh
 chainctl images list
 
 ```
-
 
 ## Invite Users
 
@@ -77,12 +72,11 @@ To invite a user using the Console, follow these steps:
 
 1. Enter the **Email address** of the user you are inviting and use the dropdown menu to assign a **Role** for this user. Click **Invite**.
 
-
 ### Invite Users using chainctl
 
 To invite a user using `chainctl`, use this command, substituting your organization name for ORGANIZATION along with setting the role, email address, length of time for the invite to be valid, and whether this invite may only be used once:
 
-```
+```sh
 chainctl iam invite create ORGANIZATION
 --role=viewer
 --email=sample@organization.dev
@@ -90,7 +84,6 @@ chainctl iam invite create ORGANIZATION
 --single-use
 
 ```
-
 
 ## Review Container Image History
 
@@ -105,18 +98,17 @@ To examine the history of an image using the Console:
 
 This list contains columns with data about each image release, like the Pull URL, Digest, and when it was last changed. Click the other tabs to learn more about the *latest* release version of this image.
 
-
 ### Review Container Image History using chainctl
 
 To examine the history of an image using `chainctl`, enter this, replacing ORGANIZATION with your organization:
 
-```
+```sh
 chainctl image history kubectl:latest --parent=ORGANIZATION
 ```
 
 This will return a reverse-chronological history of when a specific tag was update to point to a new manifest digest. This list can be long. Here's an excerpt:
 
-```
+```yaml
 - time: 2025-05-29 03:08:31 UTC
   digest: sha256:34798f562dffc3746cb69bab49b93ff83aa57bea393a07997e87c37bc83a62db
   architectures:
@@ -141,18 +133,16 @@ This will return a reverse-chronological history of when a specific tag was upda
 
 The details that are returned here and the details found in the Console vary in focus, but where the same details are provided they should match. See [Examine the History of Container Images](/chainguard/chainctl-usage/chainctl-images/#examine-the-history-of-container-images) for more information about this command.
 
-
 ## Learn more
 
 To learn more about `chainctl`, see:
 
 * [chainctl Usage](/chainguard/chainctl-usage/)
-* [chainctl Reference](/chainguard/chainctl/chainctl-docs/)
+* [chainctl Reference](/chainguard/chainctl/)
 
 To learn more about the Chainguard Console, see:
 
 * [Using the Chainguard Directory and Console](/platform/console/images-directory/).
-
 
 ### Compare a Chainguard Container to a non-Chainguard Alternative in the Console
 

--- a/content/platform/integrations/cursor.md
+++ b/content/platform/integrations/cursor.md
@@ -12,20 +12,21 @@ draft: false
 weight: 010
 ---
 
-AI coding agents write code and install dependencies faster than any security team can review them manually. Every `pip install`, `npm install`, or `docker pull` an agent kicks off is a trust decision being made on your behalf against public registries. 
+AI coding agents write code and install dependencies faster than any security team can review them manually. Every `pip install`, `npm install`, or `docker pull` an agent kicks off is a trust decision being made on your behalf against public registries.
 
-The [Chainguard and Cursor partnership](https://www.chainguard.dev/partners/cursor) follows a clear separation of responsibilities: Cursor is where your developers and agents plan, write, and review code. Chainguard is where developers reach for open source artifacts: Python, Java, and JavaScript libraries plus 2,300+ container images, all rebuilt from verifiable sources in the Chainguard Factory. 
+The [Chainguard and Cursor partnership](https://www.chainguard.dev/partners/cursor) follows a clear separation of responsibilities: Cursor is where your developers and agents plan, write, and review code. Chainguard is where developers reach for open source artifacts: Python, Java, and JavaScript libraries plus 2,300+ container images, all rebuilt from verifiable sources in the Chainguard Factory.
 
 This page explains how to start using Chainguard artifacts in Cursor.
 
 ## Prerequisites
 
 Before you begin, you'll need:
+
 * A [Cursor](https://cursor.com/) account
 * A [Chainguard account](https://console.enforce.dev/) and organization in domain format (for example, `acme-corp.com`).
-* [`chainctl` installed and authenticated](/chainguard/administration/how-to-install-chainctl/)
-    * Chainguard authentication should be configured in the environment where Cursor runs commands.
-    * Your Chainguard pull token credentials should be injected via environment variables, and not hard-coded in source.
+* [`chainctl` installed and authenticated](/platform/chainctl-usage/how-to-install-chainctl/)
+  * Chainguard authentication should be configured in the environment where Cursor runs commands.
+  * Your Chainguard pull token credentials should be injected via environment variables, and not hard-coded in source.
 
 ## Install the Chainguard Plugin
 
@@ -35,14 +36,14 @@ The Chainguard integration is delivered as an official plugin through the Cursor
 1. On the Chainguard plugin screen, click **Add to Cursor**.
 1. In your Cursor settings, navigate to the **Tools & MCPs** section. Connect all Chainguard MCP servers to your account.
 
-You will be prompted to authenticate Chainguard MCPs. After authenticating, Cursor displays an overview of how the plugin works. 
+You will be prompted to authenticate Chainguard MCPs. After authenticating, Cursor displays an overview of how the plugin works.
 
 ## Migrate a project to use Chainguard
 
 After installing the plugin, open a project in Cursor. When writing prompts, tell Cursor to use Chainguard libraries and images:
 
 ```prompt
-I'd like to migrate this project to use Chainguard images and libraries. 
+I'd like to migrate this project to use Chainguard images and libraries.
 ```
 
 Cursor will update your Dockerfiles to reference Chainguard container images and reconfigure your build files to pull dependencies from Chainguard Libraries.
@@ -56,6 +57,7 @@ You can also reference specific Chainguard library skills in prompts. For exampl
 > **Note**: Cursor's output is prompt-driven and may vary depending on your project's structure and complexity. Review all changes before running a build or deploying to production.
 
 ### Using Chainguard container images
+
 Chainguard provides thousands of minimal, CVE-free container images. When Cursor updates a Dockerfile to use Chainguard images, it will reference the images like the following example:
 
 ```dockerfile
@@ -63,44 +65,49 @@ FROM cgr.dev/chainguard/python:latest-dev AS builder
 FROM cgr.dev/chainguard/python:latest
 ```
 
-You can browse available images and their tags in the [Chainguard Images directory](https://images.chainguard.dev/). 
+You can browse available images and their tags in the [Chainguard Images directory](https://images.chainguard.dev/).
 
 This Dockerfile references both the `python` image's `latest` and `latest-dev` variants. Learn more about Chainguard image variants in [Chainguard’s container variants docs](/chainguard/chainguard-images/about/differences-development-production/).
 
-> **Note**: `latest` tags are not recommended for production workloads. For production, we recommend pinning to a specific version or digest to ensure reproducible builds. 
+> **Note**: `latest` tags are not recommended for production workloads. For production, we recommend pinning to a specific version or digest to ensure reproducible builds.
 
 Learn more about Chainguard's container images in the [Containers documentation](/chainguard/chainguard-images/).
 
 ### Using Chainguard libraries
 
-[Chainguard Libraries](/chainguard/libraries/) provide malware-resistant Python, Java, and JavaScript packages. When Cursor migrates a project, it reconfigures your build files to pull dependencies from Chainguard instead of public registries. 
+[Chainguard Libraries](/chainguard/libraries/) provide malware-resistant Python, Java, and JavaScript packages. When Cursor migrates a project, it reconfigures your build files to pull dependencies from Chainguard instead of public registries.
 
-You can browse available packages in the [Chainguard Console](https://console.chainguard.dev/), under the **Libraries** section. 
+You can browse available packages in the [Chainguard Console](https://console.chainguard.dev/), under the **Libraries** section.
 
 > **Note**: Chainguard Libraries does not mirror every package available on public registries. If a required package is unavailable, your build may fail. See [Package not found / build fails after migration](#package-not-found--build-fails-after-migration) for ecosystem-specific fallback options.
 
-Learn more about configuring libraries in the documentation for each ecosystem: 
-- [Chainguard Libraries for JavaScript](/chainguard/libraries/javascript/)
-- [Chainguard Libraries for Python](/chainguard/libraries/python/)
-- [Chainguard Libraries for Java](/chainguard/libraries/java/)
+Learn more about configuring libraries in the documentation for each ecosystem:
+
+* [Chainguard Libraries for JavaScript](/chainguard/libraries/javascript/)
+* [Chainguard Libraries for Python](/chainguard/libraries/python/)
+* [Chainguard Libraries for Java](/chainguard/libraries/java/)
 
 ## Troubleshooting
 
 ### Authentication errors on install
 
 If you see a 401 or 403 when running `npm install`, `pip install`, or a Maven build after Cursor configures your project:
+
 * Confirm the pull token was created for the correct ecosystem (`java`, `python`, or `javascript`).
 * Check that the token hasn't expired. The default TTL is 720 hours (30 days).
 * For npm: verify your `.npmrc` has both the registry line and the auth line for the correct host.
 
 ### Image not found / tag doesn't exist
+
 If Cursor references an image tag that doesn't exist:
+
 * Check available tags for the image in the [Chainguard Images directory](https://images.chainguard.dev/). Ensure that you have access to the tag.
 * Use `latest` or `latest-dev` as a reliable starting point. Image digests are also available for production use.
 
 ### Package not found / build fails after migration
 
 If your build fails because a package is unavailable from Chainguard:
-- **JavaScript**: The Chainguard Repository includes a configurable upstream fallback for npm packages; [enable fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) if you want to pull from upstream when a package isn't available from Chainguard. 
-- **Python**: To enable fallback to PyPI for unavailable packages, add `extra-index-url = https://pypi.org/simple/` to your `pip.conf` or `pyproject.toml`.
-- **Java**: To enable upstream fallback, add `mavenCentral()` after the Chainguard Libraries for Java repository in your Gradle configuration, or add Maven Central as a second `repository` entry in your `pom.xml`.
+
+* **JavaScript**: The Chainguard Repository includes a configurable upstream fallback for npm packages; [enable fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls) if you want to pull from upstream when a package isn't available from Chainguard.
+* **Python**: To enable fallback to PyPI for unavailable packages, add `extra-index-url = https://pypi.org/simple/` to your `pip.conf` or `pyproject.toml`.
+* **Java**: To enable upstream fallback, add `mavenCentral()` after the Chainguard Libraries for Java repository in your Gradle configuration, or add Maven Central as a second `repository` entry in your `pom.xml`.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -192,7 +192,7 @@
             </a>
           </div>
           <div class="basics-card">
-            <a href="/chainguard/chainguard-images/features/fips/fips-images/">
+            <a href="/platform/fips/fips-images/">
               <div style="display: flex; gap: 12px;">
                 <div class="d-block">
                   <div class="form-check-input">


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Repoint 430 internal links across 134 content pages to their current canonical paths after the IA reorg
- Fix links that omitted a subfolder added during the move (e.g. `custom-idps/ping-id` → `custom-idps/idp-providers/ping-id`)
- Correct three genuinely dead links (FIPS, pull-through guides, a malformed `python//`)

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Fix internal documentation links that broke after the information-architecture reorganization.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The IA reorg moved content from `/chainguard/...` into `/get-started/`, `/platform/`, and reshuffled subfolders. Internal cross-references still pointed at the old locations — some returning 404s, others surviving only via alias redirects, and several missing a newly added subfolder. This repoints every affected link at its real current path so links no longer depend on redirects.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The links a teammate reported (custom IDPs, `rolebinding-terraform-gh`, `identity-examples`, `how-to-install-chainctl`, `network-requirements`) resolve directly without redirects
- No internal link resolves to a nonexistent page or relies on an alias
- Frontmatter `aliases:` are unchanged, so old external URLs still redirect

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Navigate to the previously broken pages (e.g. `/platform/administration/custom-idps/idp-providers/ping-id/`, `/platform/administration/iam-organizations/roles-role-bindings/rolebinding-terraform-gh/`) and confirm the links land directly on the target page
