### PR TITLE
Fix active sidebar item style

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1288,7 +1288,7 @@ header .search-container {
     }
 }
 
-.sidebar-item-list-item-selected>.sidebar-subcategory,
+.sidebar-subcategory.active,
 .sidebar-item-list-item-selected>.sidebar-item,
 // Beat _buttons.scss
 .sidebar-item.sidebar-item:hover,


### PR DESCRIPTION
Simplify the active styles to use `.active` for both top-level items and subitems.