### PR TITLE
fix(pre-commit): make content tag validation advisory, not blocking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         pass_filenames: false
 
       # Content tag validation against the approved taxonomy (TAG_GUIDELINES.md).
-      # Blocking; runs locally and in CI.
+      # Advisory (warnings only, never blocks); runs locally and in CI.
       - id: content-tags
         name: Validate content tags
         entry: python3 scripts/hooks/content_checks.py --mode tags

--- a/scripts/hooks/content_checks.py
+++ b/scripts/hooks/content_checks.py
@@ -3,9 +3,9 @@
 
 Two modes, selected with --mode:
 
-  tags   Validate frontmatter tags against the approved taxonomy. Blocks the
-         commit on errors (e.g. an all-caps tag that is not a known acronym).
-         Runs locally and in CI.
+  tags   Validate frontmatter tags against the approved taxonomy. Advisory:
+         it warns (unapproved tag, too many tags, non-acronym all-caps) but
+         never blocks. Runs locally and in CI.
 
   spell  Spell-check prose with aspell, skipping code blocks, shortcodes and
          URLs. Advisory only: it reports misspellings but never fails. Runs
@@ -252,13 +252,18 @@ def extract_tags(filepath):
 
 
 def validate_tags(paths):
-    """Return exit code: 1 if any blocking tag errors found, else 0."""
-    had_error = False
+    """Report tag issues as advisory warnings. Never blocks (always returns 0).
+
+    All-caps tags are only warned about, not blocked: many legitimate tags are
+    acronyms (FIPS, TLS, API, ...), and maintaining an exhaustive allowlist of
+    them is impractical. ACRONYM_TAGS still suppresses the warning for known
+    acronyms to keep the signal useful.
+    """
     for filepath in content_markdown(paths):
         tags = extract_tags(filepath)
         if not tags:
             continue
-        warnings, errors = [], []
+        warnings = []
         if len(tags) > 5:
             warnings.append(
                 f"  ⚠️  Too many tags ({len(tags)}). Maximum recommended: 5"
@@ -267,17 +272,12 @@ def validate_tags(paths):
             if tag not in APPROVED_TAGS and tag not in ACRONYM_TAGS:
                 warnings.append(f"  ⚠️  Tag not in approved list: '{tag}'")
             if tag not in ACRONYM_TAGS and tag.isupper():
-                errors.append(f"  ❌  Tag should use Title Case: '{tag}'")
-        if warnings or errors:
+                warnings.append(f"  ⚠️  Non-acronym tag should use Title Case: '{tag}'")
+        if warnings:
             print(f"\n📄 {filepath}")
             print(f"   Tags: {', '.join(tags)}")
-            for line in warnings + errors:
+            for line in warnings:
                 print(line)
-        if errors:
-            had_error = True
-    if had_error:
-        print("\n❌ Commit blocked due to tag errors. See TAG_GUIDELINES.md.")
-        return 1
     return 0
 
 


### PR DESCRIPTION
## Type of change

Bug fix to the pre-commit content-tags hook.

### What should this PR do?

Downgrade the `content-tags` hook's all-caps check from a blocking error to a warning, so tag validation is advisory (warns but never blocks a commit or the required CI check).

### Why are we making this change?

The hook treated any all-caps tag not in a fixed acronym allowlist as a blocking error. Legitimate acronym tags in existing content — `FIPS`, `TLS`, `API`, `MD5` — are not in that list, so any PR touching a file using them fails the now-required `pre-commit` check. Maintaining an exhaustive acronym allowlist is impractical, so all-caps tags now warn instead of block.

### What are the acceptance criteria?

- `content-tags` no longer fails on legitimate acronym tags.
- Tag issues (unapproved, too many, non-acronym all-caps) still surface as warnings.

### How should this PR be tested?

Running the hook on a file tagged `FIPS`/`API`/`SHOUTY` passes (exit 0) and prints warnings rather than blocking. `ACRONYM_TAGS` still suppresses the warning for known acronyms.

---

**Risk**: low. Softens one hook from blocking to advisory; no other behavior change.

**Review focus**: confirm advisory-only tag validation is the desired policy (warns but does not block merges).