### PR TITLE
fix(js): resolve eslint errors in theme JavaScript

### DIFF
--- a/assets/js/cookie-banner-override.js
+++ b/assets/js/cookie-banner-override.js
@@ -2,36 +2,36 @@
 // This is a workaround for HubSpot's aggressive inline styles that CSS can't override
 
 (function() {
-  'use strict';
+  "use strict";
 
   // Create or update backdrop overlay
   function createBackdrop() {
-    let backdrop = document.getElementById('cookie-banner-backdrop');
+    let backdrop = document.getElementById("cookie-banner-backdrop");
     if (!backdrop) {
-      backdrop = document.createElement('div');
-      backdrop.id = 'cookie-banner-backdrop';
+      backdrop = document.createElement("div");
+      backdrop.id = "cookie-banner-backdrop";
       document.body.appendChild(backdrop);
     }
 
-    backdrop.style.setProperty('position', 'fixed', 'important');
-    backdrop.style.setProperty('top', '0', 'important');
-    backdrop.style.setProperty('left', '0', 'important');
-    backdrop.style.setProperty('right', '0', 'important');
-    backdrop.style.setProperty('bottom', '0', 'important');
-    backdrop.style.setProperty('background-color', 'rgba(0, 0, 0, 0.5)', 'important');
-    backdrop.style.setProperty('z-index', '9999', 'important');
-    backdrop.style.setProperty('pointer-events', 'none', 'important');
-    backdrop.style.setProperty('display', 'block', 'important');
+    backdrop.style.setProperty("position", "fixed", "important");
+    backdrop.style.setProperty("top", "0", "important");
+    backdrop.style.setProperty("left", "0", "important");
+    backdrop.style.setProperty("right", "0", "important");
+    backdrop.style.setProperty("bottom", "0", "important");
+    backdrop.style.setProperty("background-color", "rgba(0, 0, 0, 0.5)", "important");
+    backdrop.style.setProperty("z-index", "9999", "important");
+    backdrop.style.setProperty("pointer-events", "none", "important");
+    backdrop.style.setProperty("display", "block", "important");
 
     return backdrop;
   }
 
   // Function to apply custom styles
   function applyCustomStyles() {
-    const isDarkMode = document.documentElement.hasAttribute('data-dark-mode');
+    const isDarkMode = document.documentElement.hasAttribute("data-dark-mode");
 
     // Target the parent container - check if it exists FIRST
-    const bannerParent = document.getElementById('hs-banner-parent');
+    const bannerParent = document.getElementById("hs-banner-parent");
 
     // Only create backdrop if banner actually exists
     if (!bannerParent) {
@@ -39,128 +39,128 @@
     }
 
     // Create backdrop overlay only after confirming banner exists
-    const backdrop = createBackdrop();
+    createBackdrop();
 
     if (bannerParent) {
-      bannerParent.style.setProperty('position', 'fixed', 'important');
-      bannerParent.style.setProperty('bottom', '0', 'important');
-      bannerParent.style.setProperty('top', 'auto', 'important');
-      bannerParent.style.setProperty('left', '0', 'important');
-      bannerParent.style.setProperty('right', '0', 'important');
-      bannerParent.style.setProperty('transform', 'none', 'important');
-      bannerParent.style.setProperty('opacity', '1', 'important');
-      bannerParent.style.setProperty('z-index', '10000', 'important');
-      bannerParent.style.setProperty('pointer-events', 'auto', 'important');
+      bannerParent.style.setProperty("position", "fixed", "important");
+      bannerParent.style.setProperty("bottom", "0", "important");
+      bannerParent.style.setProperty("top", "auto", "important");
+      bannerParent.style.setProperty("left", "0", "important");
+      bannerParent.style.setProperty("right", "0", "important");
+      bannerParent.style.setProperty("transform", "none", "important");
+      bannerParent.style.setProperty("opacity", "1", "important");
+      bannerParent.style.setProperty("z-index", "10000", "important");
+      bannerParent.style.setProperty("pointer-events", "auto", "important");
     }
 
     // Target the main banner confirmation element
-    const confirmation = document.getElementById('hs-eu-cookie-confirmation');
+    const confirmation = document.getElementById("hs-eu-cookie-confirmation");
     if (confirmation) {
-      confirmation.style.setProperty('opacity', '1', 'important');
-      confirmation.style.setProperty('pointer-events', 'auto', 'important');
+      confirmation.style.setProperty("opacity", "1", "important");
+      confirmation.style.setProperty("pointer-events", "auto", "important");
       if (isDarkMode) {
-        confirmation.style.setProperty('background-color', 'rgb(26, 26, 46)', 'important');
-        confirmation.style.setProperty('background', 'rgb(26, 26, 46)', 'important');
+        confirmation.style.setProperty("background-color", "rgb(26, 26, 46)", "important");
+        confirmation.style.setProperty("background", "rgb(26, 26, 46)", "important");
       } else {
-        confirmation.style.setProperty('background-color', 'rgb(255, 255, 255)', 'important');
-        confirmation.style.setProperty('background', 'rgb(255, 255, 255)', 'important');
+        confirmation.style.setProperty("background-color", "rgb(255, 255, 255)", "important");
+        confirmation.style.setProperty("background", "rgb(255, 255, 255)", "important");
       }
 
       // Fix all text colors in the banner
-      const allTextElements = confirmation.querySelectorAll('p, span, a, div, h1, h2, h3, h4, h5, h6');
+      const allTextElements = confirmation.querySelectorAll("p, span, a, div, h1, h2, h3, h4, h5, h6");
       allTextElements.forEach(function(el) {
-        if (!el.closest('button')) { // Don't style text inside buttons
+        if (!el.closest("button")) { // Don't style text inside buttons
           if (isDarkMode) {
-            el.style.setProperty('color', '#e0e0e0', 'important');
+            el.style.setProperty("color", "#e0e0e0", "important");
           } else {
-            el.style.setProperty('color', '#1a1a1a', 'important');
+            el.style.setProperty("color", "#1a1a1a", "important");
           }
         }
       });
     }
 
     // Target the cookie settings modal
-    const cookieSettings = document.getElementById('hs-eu-cookie-settings');
+    const cookieSettings = document.getElementById("hs-eu-cookie-settings");
     if (cookieSettings) {
-      cookieSettings.style.setProperty('opacity', '1', 'important');
-      cookieSettings.style.setProperty('z-index', '10001', 'important');
-      cookieSettings.style.setProperty('pointer-events', 'auto', 'important');
+      cookieSettings.style.setProperty("opacity", "1", "important");
+      cookieSettings.style.setProperty("z-index", "10001", "important");
+      cookieSettings.style.setProperty("pointer-events", "auto", "important");
       if (isDarkMode) {
-        cookieSettings.style.setProperty('background-color', 'rgb(26, 26, 46)', 'important');
-        cookieSettings.style.setProperty('background', 'rgb(26, 26, 46)', 'important');
+        cookieSettings.style.setProperty("background-color", "rgb(26, 26, 46)", "important");
+        cookieSettings.style.setProperty("background", "rgb(26, 26, 46)", "important");
       } else {
-        cookieSettings.style.setProperty('background-color', 'rgb(255, 255, 255)', 'important');
-        cookieSettings.style.setProperty('background', 'rgb(255, 255, 255)', 'important');
+        cookieSettings.style.setProperty("background-color", "rgb(255, 255, 255)", "important");
+        cookieSettings.style.setProperty("background", "rgb(255, 255, 255)", "important");
       }
 
       // Fix all text colors in the modal
-      const allModalText = cookieSettings.querySelectorAll('p, span, a, div, h1, h2, h3, h4, h5, h6, label');
+      const allModalText = cookieSettings.querySelectorAll("p, span, a, div, h1, h2, h3, h4, h5, h6, label");
       allModalText.forEach(function(el) {
-        if (!el.closest('button')) { // Don't style text inside buttons
+        if (!el.closest("button")) { // Don't style text inside buttons
           if (isDarkMode) {
-            el.style.setProperty('color', '#e0e0e0', 'important');
+            el.style.setProperty("color", "#e0e0e0", "important");
           } else {
-            el.style.setProperty('color', '#1a1a1a', 'important');
+            el.style.setProperty("color", "#1a1a1a", "important");
           }
         }
       });
     }
 
     // Target the Accept button
-    const acceptButton = document.getElementById('hs-eu-confirmation-button');
+    const acceptButton = document.getElementById("hs-eu-confirmation-button");
     if (acceptButton) {
-      acceptButton.style.setProperty('background-color', '#7545fb', 'important');
-      acceptButton.style.setProperty('background', '#7545fb', 'important');
-      acceptButton.style.setProperty('color', '#ffffff', 'important');
-      acceptButton.style.setProperty('border', 'none', 'important');
-      acceptButton.style.setProperty('opacity', '1', 'important');
-      acceptButton.style.setProperty('pointer-events', 'auto', 'important');
-      acceptButton.style.setProperty('cursor', 'pointer', 'important');
+      acceptButton.style.setProperty("background-color", "#7545fb", "important");
+      acceptButton.style.setProperty("background", "#7545fb", "important");
+      acceptButton.style.setProperty("color", "#ffffff", "important");
+      acceptButton.style.setProperty("border", "none", "important");
+      acceptButton.style.setProperty("opacity", "1", "important");
+      acceptButton.style.setProperty("pointer-events", "auto", "important");
+      acceptButton.style.setProperty("cursor", "pointer", "important");
     }
 
     // Target the Cookie Settings button
-    const settingsButton = document.getElementById('hs-eu-cookie-settings-button');
+    const settingsButton = document.getElementById("hs-eu-cookie-settings-button");
     if (settingsButton) {
       if (isDarkMode) {
-        settingsButton.style.setProperty('background-color', '#2a2a3e', 'important');
-        settingsButton.style.setProperty('background', '#2a2a3e', 'important');
-        settingsButton.style.setProperty('color', '#e0e0e0', 'important');
-        settingsButton.style.setProperty('border', '2px solid #444458', 'important');
+        settingsButton.style.setProperty("background-color", "#2a2a3e", "important");
+        settingsButton.style.setProperty("background", "#2a2a3e", "important");
+        settingsButton.style.setProperty("color", "#e0e0e0", "important");
+        settingsButton.style.setProperty("border", "2px solid #444458", "important");
       } else {
-        settingsButton.style.setProperty('background-color', '#f5f5f5', 'important');
-        settingsButton.style.setProperty('background', '#f5f5f5', 'important');
-        settingsButton.style.setProperty('color', '#1a1a1a', 'important');
-        settingsButton.style.setProperty('border', '2px solid #e0e0e0', 'important');
+        settingsButton.style.setProperty("background-color", "#f5f5f5", "important");
+        settingsButton.style.setProperty("background", "#f5f5f5", "important");
+        settingsButton.style.setProperty("color", "#1a1a1a", "important");
+        settingsButton.style.setProperty("border", "2px solid #e0e0e0", "important");
       }
-      settingsButton.style.setProperty('opacity', '1', 'important');
-      settingsButton.style.setProperty('pointer-events', 'auto', 'important');
-      settingsButton.style.setProperty('cursor', 'pointer', 'important');
+      settingsButton.style.setProperty("opacity", "1", "important");
+      settingsButton.style.setProperty("pointer-events", "auto", "important");
+      settingsButton.style.setProperty("cursor", "pointer", "important");
     }
 
     // Target the Decline button (if present)
-    const declineButton = document.getElementById('hs-eu-decline-button');
+    const declineButton = document.getElementById("hs-eu-decline-button");
     if (declineButton) {
       if (isDarkMode) {
-        declineButton.style.setProperty('background-color', '#2a2a3e', 'important');
-        declineButton.style.setProperty('background', '#2a2a3e', 'important');
-        declineButton.style.setProperty('color', '#e0e0e0', 'important');
-        declineButton.style.setProperty('border', '2px solid #444458', 'important');
+        declineButton.style.setProperty("background-color", "#2a2a3e", "important");
+        declineButton.style.setProperty("background", "#2a2a3e", "important");
+        declineButton.style.setProperty("color", "#e0e0e0", "important");
+        declineButton.style.setProperty("border", "2px solid #444458", "important");
       } else {
-        declineButton.style.setProperty('background-color', '#f5f5f5', 'important');
-        declineButton.style.setProperty('background', '#f5f5f5', 'important');
-        declineButton.style.setProperty('color', '#1a1a1a', 'important');
-        declineButton.style.setProperty('border', '2px solid #e0e0e0', 'important');
+        declineButton.style.setProperty("background-color", "#f5f5f5", "important");
+        declineButton.style.setProperty("background", "#f5f5f5", "important");
+        declineButton.style.setProperty("color", "#1a1a1a", "important");
+        declineButton.style.setProperty("border", "2px solid #e0e0e0", "important");
       }
-      declineButton.style.setProperty('opacity', '1', 'important');
-      declineButton.style.setProperty('pointer-events', 'auto', 'important');
-      declineButton.style.setProperty('cursor', 'pointer', 'important');
+      declineButton.style.setProperty("opacity", "1", "important");
+      declineButton.style.setProperty("pointer-events", "auto", "important");
+      declineButton.style.setProperty("cursor", "pointer", "important");
     }
 
     // Ensure all buttons and links in banner are clickable
-    const allButtons = document.querySelectorAll('#hs-eu-cookie-confirmation button, #hs-eu-cookie-settings button, #hs-eu-cookie-confirmation a, #hs-eu-cookie-settings a');
+    const allButtons = document.querySelectorAll("#hs-eu-cookie-confirmation button, #hs-eu-cookie-settings button, #hs-eu-cookie-confirmation a, #hs-eu-cookie-settings a");
     allButtons.forEach(function(btn) {
-      btn.style.setProperty('pointer-events', 'auto', 'important');
-      btn.style.setProperty('cursor', 'pointer', 'important');
+      btn.style.setProperty("pointer-events", "auto", "important");
+      btn.style.setProperty("cursor", "pointer", "important");
     });
 
     return !!(bannerParent || acceptButton || settingsButton);
@@ -168,7 +168,7 @@
 
   // Remove backdrop when banner is closed
   function removeBackdrop() {
-    const backdrop = document.getElementById('cookie-banner-backdrop');
+    const backdrop = document.getElementById("cookie-banner-backdrop");
     if (backdrop) {
       backdrop.remove();
     }
@@ -176,7 +176,7 @@
 
   // Check if banner is still visible
   function isBannerVisible() {
-    const bannerParent = document.getElementById('hs-banner-parent');
+    const bannerParent = document.getElementById("hs-banner-parent");
     return bannerParent && bannerParent.offsetParent !== null;
   }
 
@@ -210,16 +210,16 @@
 
   // Watch for HubSpot re-applying inline styles
   function setupMutationObserver() {
-    const bannerParent = document.getElementById('hs-banner-parent');
-    const confirmation = document.getElementById('hs-eu-cookie-confirmation');
-    const cookieSettings = document.getElementById('hs-eu-cookie-settings');
-    const acceptButton = document.getElementById('hs-eu-confirmation-button');
-    const settingsButton = document.getElementById('hs-eu-cookie-settings-button');
-    const declineButton = document.getElementById('hs-eu-decline-button');
+    const bannerParent = document.getElementById("hs-banner-parent");
+    const confirmation = document.getElementById("hs-eu-cookie-confirmation");
+    const cookieSettings = document.getElementById("hs-eu-cookie-settings");
+    const acceptButton = document.getElementById("hs-eu-confirmation-button");
+    const settingsButton = document.getElementById("hs-eu-cookie-settings-button");
+    const declineButton = document.getElementById("hs-eu-decline-button");
 
     const observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
-        if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+        if (mutation.type === "attributes" && mutation.attributeName === "style") {
           applyCustomStyles();
         }
       });
@@ -242,12 +242,12 @@
 
   darkModeObserver.observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ['data-dark-mode']
+    attributeFilter: ["data-dark-mode"],
   });
 
   // Start when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', waitForBanner);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", waitForBanner);
   } else {
     waitForBanner();
   }

--- a/assets/js/copypage.js
+++ b/assets/js/copypage.js
@@ -1,28 +1,28 @@
-document.addEventListener('DOMContentLoaded', function() {
-  const copyButton = document.querySelector('.copy-page-btn');
-  const tooltip = document.querySelector('.copy-tooltip');
-  
+document.addEventListener("DOMContentLoaded", function() {
+  const copyButton = document.querySelector(".copy-page-btn");
+  const tooltip = document.querySelector(".copy-tooltip");
+
   if (!copyButton) return;
-  
-  copyButton.addEventListener('click', async function() {
+
+  copyButton.addEventListener("click", async function() {
     const content = await getPageAsMarkdown();
-    
+
     if (content && await copyToClipboard(content)) {
       // Show success state
-      copyButton.classList.add('copy-success');
-      tooltip.classList.add('show');
-      
+      copyButton.classList.add("copy-success");
+      tooltip.classList.add("show");
+
       // Update button text
-      const textElement = copyButton.querySelector('.copy-btn-text');
-      const originalText = textElement ? textElement.textContent : '';
+      const textElement = copyButton.querySelector(".copy-btn-text");
+      const originalText = textElement ? textElement.textContent : "";
       if (textElement) {
-        textElement.textContent = 'Copied to clipboard!';
+        textElement.textContent = "Copied to clipboard!";
       }
-      
+
       // Reset after 2 seconds
       setTimeout(() => {
-        copyButton.classList.remove('copy-success');
-        tooltip.classList.remove('show');
+        copyButton.classList.remove("copy-success");
+        tooltip.classList.remove("show");
         if (textElement) {
           textElement.textContent = originalText;
         }
@@ -32,173 +32,177 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 async function getPageAsMarkdown() {
-  const article = document.querySelector('main.docs-content');
-  if (!article) return '';
-  
+  const article = document.querySelector("main.docs-content");
+  if (!article) return "";
+
   // Get page title
-  const title = document.querySelector('h1')?.textContent || document.title;
-  
+  const title = document.querySelector("h1")?.textContent || document.title;
+
   // Get page description
-  const description = document.querySelector('meta[name="description"]')?.content || '';
-  
+  const description = document.querySelector("meta[name=\"description\"]")?.content || "";
+
   // Get main content
   let mainContent = article.cloneNode(true);
-  
+
   // Remove elements that shouldn't be included
   const elementsToRemove = [
-    '.back-button',
-    '.contributors',
-    '.tag-container',
-    '.page-footer-meta',
-    '.copy-page-btn',
-    '.copy-tooltip',
-    '.notice',
-    '.rumble-comparison',
-    '.rumble-vuln',
-    '.tooltip-container',
-    '.tooltip',
-    '.top-container',
-    '.expand-btn-container',
-    'nav',
-    'script',
-    'style'
+    ".back-button",
+    ".contributors",
+    ".tag-container",
+    ".page-footer-meta",
+    ".copy-page-btn",
+    ".copy-tooltip",
+    ".notice",
+    ".rumble-comparison",
+    ".rumble-vuln",
+    ".tooltip-container",
+    ".tooltip",
+    ".top-container",
+    ".expand-btn-container",
+    "nav",
+    "script",
+    "style",
   ];
-  
+
   elementsToRemove.forEach(selector => {
     mainContent.querySelectorAll(selector).forEach(el => el.remove());
   });
-  
+
   // Build markdown
   let markdown = `# ${title}\n\n`;
-  
+
   if (description) {
     markdown += `${description}\n\n`;
   }
-  
+
   markdown += `Source: ${window.location.href}\n\n---\n\n`;
   markdown += convertHtmlToMarkdown(mainContent);
-  
+
   return markdown;
 }
 
 function convertHtmlToMarkdown(element) {
-  let markdown = '';
-  
+  let markdown = "";
+
   const processNode = (node, listLevel = 0) => {
     if (node.nodeType === Node.TEXT_NODE) {
       // Skip whitespace-only text nodes
       const text = node.textContent;
-      if (text.trim() === '') {
-        return '';
+      if (text.trim() === "") {
+        return "";
       }
       return text;
     }
-    
+
     if (node.nodeType === Node.ELEMENT_NODE) {
       const tagName = node.tagName.toLowerCase();
-      let content = '';
-      
+      let content = "";
+
       // Process children
       node.childNodes.forEach(child => {
-        content += processNode(child, tagName === 'ul' || tagName === 'ol' ? listLevel + 1 : listLevel);
+        content += processNode(child, tagName === "ul" || tagName === "ol" ? listLevel + 1 : listLevel);
       });
-      
+
       // Skip empty elements (except self-closing tags like img, hr, br)
-      const selfClosingTags = ['img', 'hr', 'br'];
-      if (!selfClosingTags.includes(tagName) && content.trim() === '') {
-        return '';
+      const selfClosingTags = ["img", "hr", "br"];
+      if (!selfClosingTags.includes(tagName) && content.trim() === "") {
+        return "";
       }
-      
+
       // Convert based on tag
       switch (tagName) {
-        case 'h1': return `# ${content.trim()}\n\n`;
-        case 'h2': return `## ${content.trim()}\n\n`;
-        case 'h3': return `### ${content.trim()}\n\n`;
-        case 'h4': return `#### ${content.trim()}\n\n`;
-        case 'h5': return `##### ${content.trim()}\n\n`;
-        case 'h6': return `###### ${content.trim()}\n\n`;
-        case 'p': return `${content.trim()}\n\n`;
-        case 'strong':
-        case 'b': return `**${content.trim()}**`;
-        case 'em':
-        case 'i': return `*${content.trim()}*`;
-        case 'code':
-          if (node.parentElement?.tagName.toLowerCase() === 'pre') {
+        case "h1": return `# ${content.trim()}\n\n`;
+        case "h2": return `## ${content.trim()}\n\n`;
+        case "h3": return `### ${content.trim()}\n\n`;
+        case "h4": return `#### ${content.trim()}\n\n`;
+        case "h5": return `##### ${content.trim()}\n\n`;
+        case "h6": return `###### ${content.trim()}\n\n`;
+        case "p": return `${content.trim()}\n\n`;
+        case "strong":
+        case "b": return `**${content.trim()}**`;
+        case "em":
+        case "i": return `*${content.trim()}*`;
+        case "code":
+          if (node.parentElement?.tagName.toLowerCase() === "pre") {
             return content;
           }
           return `\`${content.trim()}\``;
-        case 'pre':
-          const codeElement = node.querySelector('code');
+        case "pre": {
+          const codeElement = node.querySelector("code");
           if (codeElement) {
-            const lang = codeElement.className.match(/language-(\w+)/)?.[1] || '';
-            const codeContent = codeElement.textContent || '';
+            const lang = codeElement.className.match(/language-(\w+)/)?.[1] || "";
+            const codeContent = codeElement.textContent || "";
             return `\`\`\`${lang}\n${codeContent.trim()}\n\`\`\`\n\n`;
           }
           return `\`\`\`\n${content.trim()}\n\`\`\`\n\n`;
-        case 'a':
-          const href = node.getAttribute('href');
-          if (href && !href.startsWith('#')) {
+        }
+        case "a": {
+          const href = node.getAttribute("href");
+          if (href && !href.startsWith("#")) {
             return `[${content.trim()}](${href})`;
           }
           return content;
-        case 'ul': return content + '\n';
-        case 'ol': return content + '\n';
-        case 'li':
-          const listPrefix = node.parentElement?.tagName.toLowerCase() === 'ol' 
+        }
+        case "ul": return content + "\n";
+        case "ol": return content + "\n";
+        case "li": {
+          const listPrefix = node.parentElement?.tagName.toLowerCase() === "ol"
             ? `${Array.from(node.parentElement.children).indexOf(node) + 1}. `
-            : '- ';
-          const indent = '  '.repeat(listLevel - 1);
+            : "- ";
+          const indent = "  ".repeat(listLevel - 1);
           return `${indent}${listPrefix}${content.trim()}\n`;
-        case 'blockquote':
-          return content.split('\n').map(line => `> ${line}`).join('\n') + '\n\n';
-        case 'img':
-          const alt = node.getAttribute('alt') || '';
-          const src = node.getAttribute('src') || '';
+        }
+        case "blockquote":
+          return content.split("\n").map(line => `> ${line}`).join("\n") + "\n\n";
+        case "img": {
+          const alt = node.getAttribute("alt") || "";
+          const src = node.getAttribute("src") || "";
           return `![${alt}](${src})\n\n`;
-        case 'hr': return '---\n\n';
-        case 'br': return '\n';
-        case 'table': return processTable(node) + '\n\n';
+        }
+        case "hr": return "---\n\n";
+        case "br": return "\n";
+        case "table": return processTable(node) + "\n\n";
         default: return content;
       }
     }
-    
-    return '';
+
+    return "";
   };
-  
+
   element.childNodes.forEach(child => {
     markdown += processNode(child);
   });
-  
+
   // Clean up excessive newlines and trim each line
   return markdown
-    .split('\n')
+    .split("\n")
     .map(line => line.trimEnd())
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 
 function processTable(table) {
-  const rows = table.querySelectorAll('tr');
-  if (rows.length === 0) return '';
-  
-  let markdown = '';
-  
+  const rows = table.querySelectorAll("tr");
+  if (rows.length === 0) return "";
+
+  let markdown = "";
+
   // Process header row
-  const headerCells = rows[0].querySelectorAll('th, td');
+  const headerCells = rows[0].querySelectorAll("th, td");
   if (headerCells.length > 0) {
-    markdown += '| ' + Array.from(headerCells).map(cell => cell.textContent.trim()).join(' | ') + ' |\n';
-    markdown += '|' + Array.from(headerCells).map(() => ' --- ').join('|') + '|\n';
+    markdown += "| " + Array.from(headerCells).map(cell => cell.textContent.trim()).join(" | ") + " |\n";
+    markdown += "|" + Array.from(headerCells).map(() => " --- ").join("|") + "|\n";
   }
-  
+
   // Process data rows
   for (let i = headerCells.length > 0 ? 1 : 0; i < rows.length; i++) {
-    const cells = rows[i].querySelectorAll('td');
+    const cells = rows[i].querySelectorAll("td");
     if (cells.length > 0) {
-      markdown += '| ' + Array.from(cells).map(cell => cell.textContent.trim()).join(' | ') + ' |\n';
+      markdown += "| " + Array.from(cells).map(cell => cell.textContent.trim()).join(" | ") + " |\n";
     }
   }
-  
+
   return markdown;
 }
 
@@ -206,20 +210,20 @@ async function copyToClipboard(text) {
   try {
     await navigator.clipboard.writeText(text);
     return true;
-  } catch (err) {
+  } catch {
     // Fallback for older browsers
-    const textArea = document.createElement('textarea');
+    const textArea = document.createElement("textarea");
     textArea.value = text;
-    textArea.style.position = 'absolute';
-    textArea.style.left = '-9999px';
+    textArea.style.position = "absolute";
+    textArea.style.left = "-9999px";
     document.body.appendChild(textArea);
     textArea.select();
-    
+
     try {
-      document.execCommand('copy');
+      document.execCommand("copy");
       document.body.removeChild(textArea);
       return true;
-    } catch (err) {
+    } catch {
       document.body.removeChild(textArea);
       return false;
     }

--- a/assets/js/feedback-widget.js
+++ b/assets/js/feedback-widget.js
@@ -7,20 +7,20 @@ class FeedbackWidget {
   constructor(container) {
     this.container = container;
     this.data = this.loadFeedbackData();
-    this.currentState = 'initial'; // initial, thanks, form
+    this.currentState = "initial"; // initial, thanks, form
     this.retryCount = 0;
     this.maxRetries = 2;
-    
+
     this.elements = {
-      prompt: container.querySelector('.feedback-prompt'),
-      thanks: container.querySelector('.feedback-thanks'),
-      form: container.querySelector('.feedback-form'),
-      yesBtn: container.querySelector('[data-feedback="yes"]'),
-      noBtn: container.querySelector('[data-feedback="no"]'),
-      textarea: container.querySelector('.feedback-textarea'),
-      charCount: container.querySelector('.char-count'),
-      submitBtn: container.querySelector('.feedback-submit-btn'),
-      cancelBtn: container.querySelector('.feedback-cancel-btn')
+      prompt: container.querySelector(".feedback-prompt"),
+      thanks: container.querySelector(".feedback-thanks"),
+      form: container.querySelector(".feedback-form"),
+      yesBtn: container.querySelector("[data-feedback=\"yes\"]"),
+      noBtn: container.querySelector("[data-feedback=\"no\"]"),
+      textarea: container.querySelector(".feedback-textarea"),
+      charCount: container.querySelector(".char-count"),
+      submitBtn: container.querySelector(".feedback-submit-btn"),
+      cancelBtn: container.querySelector(".feedback-cancel-btn"),
     };
 
     this.bindEvents();
@@ -31,21 +31,21 @@ class FeedbackWidget {
     // Check if user has already provided feedback for this page
     const pageKey = `feedback-${this.data.pageUrl}`;
     const existingFeedback = localStorage.getItem(pageKey);
-    
+
     if (existingFeedback) {
       const feedbackData = JSON.parse(existingFeedback);
       const daysSinceFeedback = (Date.now() - feedbackData.timestamp) / (1000 * 60 * 60 * 24);
-      
+
       // Show existing feedback state if less than 30 days old
       if (daysSinceFeedback < 30) {
-        if (feedbackData.type === 'positive') {
-          this.updateButtonState(this.elements.yesBtn, '👍');
+        if (feedbackData.type === "positive") {
+          this.updateButtonState(this.elements.yesBtn, "👍");
           this.disableButton(this.elements.noBtn);
-        } else if (feedbackData.type === 'negative') {
-          this.updateButtonState(this.elements.noBtn, '👎');
+        } else if (feedbackData.type === "negative") {
+          this.updateButtonState(this.elements.noBtn, "👎");
           this.disableButton(this.elements.yesBtn);
         }
-        this.setState('thanks');
+        this.setState("thanks");
       } else {
         // Clear old feedback
         localStorage.removeItem(pageKey);
@@ -57,60 +57,60 @@ class FeedbackWidget {
     const pageKey = `feedback-${this.data.pageUrl}`;
     const feedbackData = {
       type: type,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
     try {
       localStorage.setItem(pageKey, JSON.stringify(feedbackData));
     } catch (e) {
-      console.warn('Failed to save feedback state:', e);
+      console.warn("Failed to save feedback state:", e);
     }
   }
 
   loadFeedbackData() {
-    const dataScript = document.getElementById('feedback-data');
+    const dataScript = document.getElementById("feedback-data");
     if (dataScript) {
       try {
         return JSON.parse(dataScript.textContent);
       } catch (e) {
-        console.error('Failed to parse feedback data:', e);
+        console.error("Failed to parse feedback data:", e);
       }
     }
     return {
       pageTitle: document.title,
       pageUrl: window.location.href,
-      appsScriptUrl: 'YOUR_APPS_SCRIPT_URL_HERE' // Will be replaced with actual URL
+      appsScriptUrl: "YOUR_APPS_SCRIPT_URL_HERE", // Will be replaced with actual URL
     };
   }
 
   bindEvents() {
     // Feedback button clicks
-    this.elements.yesBtn?.addEventListener('click', () => this.handlePositiveFeedback());
-    this.elements.noBtn?.addEventListener('click', () => this.handleNegativeFeedback());
+    this.elements.yesBtn?.addEventListener("click", () => this.handlePositiveFeedback());
+    this.elements.noBtn?.addEventListener("click", () => this.handleNegativeFeedback());
 
     // Form interactions
-    this.elements.textarea?.addEventListener('input', (e) => this.updateCharCount(e.target.value));
-    this.elements.submitBtn?.addEventListener('click', () => this.submitNegativeFeedback());
-    this.elements.cancelBtn?.addEventListener('click', () => this.cancelFeedback());
+    this.elements.textarea?.addEventListener("input", (e) => this.updateCharCount(e.target.value));
+    this.elements.submitBtn?.addEventListener("click", () => this.submitNegativeFeedback());
+    this.elements.cancelBtn?.addEventListener("click", () => this.cancelFeedback());
 
     // Keyboard accessibility
-    this.elements.textarea?.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') {
+    this.elements.textarea?.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
         this.cancelFeedback();
       }
     });
   }
 
   handlePositiveFeedback() {
-    this.updateButtonState(this.elements.yesBtn, '👍');
+    this.updateButtonState(this.elements.yesBtn, "👍");
     this.disableButton(this.elements.noBtn);
-    this.setState('thanks');
+    this.setState("thanks");
     this.submitPositiveFeedback();
   }
 
   handleNegativeFeedback() {
-    this.updateButtonState(this.elements.noBtn, '👎');
+    this.updateButtonState(this.elements.noBtn, "👎");
     this.disableButton(this.elements.yesBtn);
-    this.setState('form');
+    this.setState("form");
     // Focus the textarea for better UX
     setTimeout(() => {
       this.elements.textarea?.focus();
@@ -119,67 +119,67 @@ class FeedbackWidget {
 
   updateButtonState(button, emoji) {
     if (button) {
-      button.classList.add('feedback-selected');
-      const textSpan = button.querySelector('.feedback-btn-text');
+      button.classList.add("feedback-selected");
+      const textSpan = button.querySelector(".feedback-btn-text");
       if (textSpan) {
         textSpan.textContent = emoji;
       }
-      button.setAttribute('aria-pressed', 'true');
+      button.setAttribute("aria-pressed", "true");
     }
   }
 
   disableButton(button) {
     if (button) {
       button.disabled = true;
-      button.classList.add('feedback-disabled');
-      button.style.opacity = '0.5';
-      button.style.cursor = 'not-allowed';
+      button.classList.add("feedback-disabled");
+      button.style.opacity = "0.5";
+      button.style.cursor = "not-allowed";
     }
   }
 
   enableButton(button) {
     if (button) {
       button.disabled = false;
-      button.classList.remove('feedback-disabled');
-      button.style.opacity = '';
-      button.style.cursor = '';
+      button.classList.remove("feedback-disabled");
+      button.style.opacity = "";
+      button.style.cursor = "";
     }
   }
 
   setState(newState) {
     this.currentState = newState;
-    
+
     // Always keep prompt visible
-    this.elements.prompt.style.display = 'block';
-    
+    this.elements.prompt.style.display = "block";
+
     // Hide secondary sections with fade out
     const sections = [this.elements.thanks, this.elements.form];
     sections.forEach(section => {
       if (section) {
-        section.style.display = 'none';
-        section.classList.remove('feedback-fade-in');
+        section.style.display = "none";
+        section.classList.remove("feedback-fade-in");
       }
     });
 
     // Show the appropriate section below the prompt with fade in
     let targetElement = null;
     switch (newState) {
-      case 'initial':
+      case "initial":
         // Only prompt is visible
         break;
-      case 'thanks':
+      case "thanks":
         targetElement = this.elements.thanks;
         break;
-      case 'form':
+      case "form":
         targetElement = this.elements.form;
         break;
     }
-    
+
     if (targetElement) {
-      targetElement.style.display = 'block';
+      targetElement.style.display = "block";
       // Trigger reflow to ensure animation plays
       void targetElement.offsetWidth;
-      targetElement.classList.add('feedback-fade-in');
+      targetElement.classList.add("feedback-fade-in");
     }
   }
 
@@ -188,7 +188,7 @@ class FeedbackWidget {
     if (this.elements.charCount) {
       this.elements.charCount.textContent = count;
     }
-    
+
     // Update submit button state
     if (this.elements.submitBtn) {
       this.elements.submitBtn.disabled = count === 0 || count > 1000;
@@ -200,21 +200,21 @@ class FeedbackWidget {
       await this.submitToAppsScript({
         pageTitle: this.data.pageTitle,
         pageUrl: this.data.pageUrl,
-        feedbackType: 'positive',
-        feedbackText: ''
+        feedbackType: "positive",
+        feedbackText: "",
       });
-      this.saveFeedbackState('positive');
+      this.saveFeedbackState("positive");
     } catch (error) {
-      console.error('Failed to submit positive feedback:', error);
+      console.error("Failed to submit positive feedback:", error);
       // Don't show error for positive feedback since user already saw success
       // Still save the state locally even if submission failed
-      this.saveFeedbackState('positive');
+      this.saveFeedbackState("positive");
     }
   }
 
   async submitNegativeFeedback() {
     const feedbackText = this.elements.textarea?.value?.trim();
-    
+
     if (!feedbackText) {
       this.elements.textarea?.focus();
       return;
@@ -227,69 +227,69 @@ class FeedbackWidget {
       const result = await this.submitToAppsScriptWithRetry({
         pageTitle: this.data.pageTitle,
         pageUrl: this.data.pageUrl,
-        feedbackType: 'negative',
-        feedbackText: feedbackText
+        feedbackType: "negative",
+        feedbackText: feedbackText,
       });
-      
+
       if (result.success) {
-        this.saveFeedbackState('negative');
+        this.saveFeedbackState("negative");
         this.hideLoadingState();
-        this.setState('thanks');
+        this.setState("thanks");
       } else {
         // Even if submission fails, thank the user and save state locally
-        this.saveFeedbackState('negative');
+        this.saveFeedbackState("negative");
         this.hideLoadingState();
-        this.setState('thanks');
+        this.setState("thanks");
       }
     } catch (error) {
-      console.error('Failed to submit negative feedback:', error);
+      console.error("Failed to submit negative feedback:", error);
       // Even if submission fails, thank the user and save state locally
-      this.saveFeedbackState('negative');
+      this.saveFeedbackState("negative");
       this.hideLoadingState();
-      this.setState('thanks');
+      this.setState("thanks");
     }
   }
 
   showLoadingState() {
     if (this.elements.submitBtn) {
       this.elements.submitBtn.disabled = true;
-      this.elements.submitBtn.textContent = 'Submitting...';
+      this.elements.submitBtn.textContent = "Submitting...";
     }
   }
 
   hideLoadingState() {
     if (this.elements.submitBtn) {
       this.elements.submitBtn.disabled = false;
-      this.elements.submitBtn.textContent = 'Submit';
+      this.elements.submitBtn.textContent = "Submit";
     }
   }
 
   async submitToAppsScriptWithRetry(data) {
     this.retryCount = 0;
-    
+
     while (this.retryCount <= this.maxRetries) {
       try {
         const result = await this.submitToAppsScript(data);
         return result;
       } catch (error) {
         this.retryCount++;
-        
+
         if (this.retryCount > this.maxRetries) {
           throw error;
         }
-        
+
         // Wait before retrying (exponential backoff)
         const delay = Math.min(1000 * Math.pow(2, this.retryCount - 1), 4000);
         await new Promise(resolve => setTimeout(resolve, delay));
-        
+
         console.log(`Retrying submission (attempt ${this.retryCount + 1}/${this.maxRetries + 1})...`);
       }
     }
   }
 
   async submitToAppsScript(data) {
-    if (!this.data.appsScriptUrl || this.data.appsScriptUrl === 'YOUR_APPS_SCRIPT_URL_HERE' || this.data.appsScriptUrl === '') {
-      throw new Error('Apps Script URL not configured');
+    if (!this.data.appsScriptUrl || this.data.appsScriptUrl === "YOUR_APPS_SCRIPT_URL_HERE" || this.data.appsScriptUrl === "") {
+      throw new Error("Apps Script URL not configured");
     }
 
     // Create an AbortController for timeout
@@ -298,29 +298,29 @@ class FeedbackWidget {
 
     try {
       const response = await fetch(this.data.appsScriptUrl, {
-        method: 'POST',
-        mode: 'cors',
+        method: "POST",
+        mode: "cors",
         headers: {
-          'Content-Type': 'text/plain;charset=utf-8',
+          "Content-Type": "text/plain;charset=utf-8",
         },
         body: JSON.stringify(data),
-        redirect: 'follow',
-        signal: controller.signal
+        redirect: "follow",
+        signal: controller.signal,
       });
 
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        throw new Error('Failed to submit feedback. Please try again.');
+        throw new Error("Failed to submit feedback. Please try again.");
       }
 
       const result = await response.json();
       return result;
     } catch (error) {
       clearTimeout(timeoutId);
-      
-      if (error.name === 'AbortError') {
-        throw new Error('Request timeout - please try again');
+
+      if (error.name === "AbortError") {
+        throw new Error("Request timeout - please try again");
       }
       throw error;
     }
@@ -329,45 +329,45 @@ class FeedbackWidget {
   cancelFeedback() {
     // Reset form
     if (this.elements.textarea) {
-      this.elements.textarea.value = '';
+      this.elements.textarea.value = "";
     }
-    this.updateCharCount('');
-    
+    this.updateCharCount("");
+
     // Reset button states
-    this.elements.yesBtn?.classList.remove('feedback-selected');
-    this.elements.noBtn?.classList.remove('feedback-selected');
-    this.elements.yesBtn?.setAttribute('aria-pressed', 'false');
-    this.elements.noBtn?.setAttribute('aria-pressed', 'false');
-    
+    this.elements.yesBtn?.classList.remove("feedback-selected");
+    this.elements.noBtn?.classList.remove("feedback-selected");
+    this.elements.yesBtn?.setAttribute("aria-pressed", "false");
+    this.elements.noBtn?.setAttribute("aria-pressed", "false");
+
     // Re-enable both buttons
     this.enableButton(this.elements.yesBtn);
     this.enableButton(this.elements.noBtn);
-    
+
     // Reset button text
-    const yesText = this.elements.yesBtn?.querySelector('.feedback-btn-text');
-    const noText = this.elements.noBtn?.querySelector('.feedback-btn-text');
-    if (yesText) yesText.textContent = 'Yes';
-    if (noText) noText.textContent = 'No';
-    
+    const yesText = this.elements.yesBtn?.querySelector(".feedback-btn-text");
+    const noText = this.elements.noBtn?.querySelector(".feedback-btn-text");
+    if (yesText) yesText.textContent = "Yes";
+    if (noText) noText.textContent = "No";
+
     // Return to initial state
-    this.setState('initial');
+    this.setState("initial");
   }
 
 }
 
 // Initialize feedback widgets when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-  const feedbackWidgets = document.querySelectorAll('.feedback-widget');
-  
+document.addEventListener("DOMContentLoaded", function() {
+  const feedbackWidgets = document.querySelectorAll(".feedback-widget");
+
   feedbackWidgets.forEach(widget => {
     new FeedbackWidget(widget);
   });
 });
 
 // Handle page navigation for single-page apps (if applicable)
-window.addEventListener('popstate', function() {
+window.addEventListener("popstate", function() {
   // Reinitialize if needed
-  const feedbackWidgets = document.querySelectorAll('.feedback-widget');
+  const feedbackWidgets = document.querySelectorAll(".feedback-widget");
   feedbackWidgets.forEach(widget => {
     if (!widget.feedbackWidget) {
       widget.feedbackWidget = new FeedbackWidget(widget);

--- a/assets/js/rumble/base.js
+++ b/assets/js/rumble/base.js
@@ -19,7 +19,7 @@ const severityColours = {
     Medium: "#1F2892",
     Low: "#16C0D7",
     Negligible: "#C5C5C5",
-    Unknown: "#8C8C8C"
+    Unknown: "#8C8C8C",
 }
 
 // used on image comparison and vulnerability info page search fields
@@ -32,7 +32,7 @@ if (searchFilter !== null) {
         filterTable("rumble-images-external", filter);
         filterTable("rumble-images-chainguard", filter);
         if (severityPicker != null) {
-            severityPicker.querySelector("label span").innerHTML = `<span>Severity<span class="bi-chevron-down" style="padding-left: 2rem;"></span></span>`;
+            severityPicker.querySelector("label span").innerHTML = "<span>Severity<span class=\"bi-chevron-down\" style=\"padding-left: 2rem;\"></span></span>";
         }
     });
 }
@@ -45,7 +45,7 @@ function filterTable(tableId, filter) {
     for (i = 1; i < tr.length; i++) {
         tr[i].style.display = "none";
         const tdArray = tr[i].getElementsByTagName("td");
-        for (var j = 0; j < tdArray.length; j++) {
+        for (j = 0; j < tdArray.length; j++) {
             const cellValue = tdArray[j];
             if (cellValue && cellValue.innerHTML.toLowerCase().indexOf(filter) > -1) {
                 tr[i].style.display = "";

--- a/assets/js/rumble/comparison.js
+++ b/assets/js/rumble/comparison.js
@@ -98,7 +98,7 @@ function makeTable(id, sortedData, vulnIDs) {
     .html(function (d) { return d.value; });
 
   if (vulnIDs.length == 0) {
-    document.querySelector(id).insertAdjacentHTML("beforeend", `<p style="margin: 0; padding: 24px 8px;">No vulnerabilities detected</p>`);
+    document.querySelector(id).insertAdjacentHTML("beforeend", "<p style=\"margin: 0; padding: 24px 8px;\">No vulnerabilities detected</p>");
     return;
   }
 };
@@ -106,9 +106,9 @@ function makeTable(id, sortedData, vulnIDs) {
 // toggles between absolute and ?id= URLs for each page when rendering table links
 function getEnvUrl() {
   let host = document.location.host;
-  if (host.match(`.+netlify.com.+`)) {
+  if (host.match(".+netlify.com.+")) {
     return false
-  } else if (host.match(`localhost:1313`)) {
+  } else if (host.match("localhost:1313")) {
     return false
   } else {
     return true
@@ -120,14 +120,14 @@ severityPicker.addEventListener("click", function (event) {
     return;
   }
   severityPicker.querySelector(".dropdown-content").visiblity = "hidden";
-  severityPicker.querySelector('input[type = "checkbox"]').checked = false;
+  severityPicker.querySelector("input[type = \"checkbox\"]").checked = false;
 
   let filter = event.target.dataset.severity.toLowerCase();
   filterTable("rumble-images-external", filter);
   filterTable("rumble-images-chainguard", filter);
 
   if (event.target.dataset.severity == "") {
-    severityPicker.querySelector("label span").innerHTML = `<span>Severity<span class="bi-chevron-down" style="padding-left: 2rem;"></span></span>`;
+    severityPicker.querySelector("label span").innerHTML = "<span>Severity<span class=\"bi-chevron-down\" style=\"padding-left: 2rem;\"></span></span>";
     return;
   }
 
@@ -137,7 +137,7 @@ severityPicker.addEventListener("click", function (event) {
 });
 severityPicker.addEventListener("mouseleave", function (event) {
   // severityPicker.querySelector(".dropdown-content").visiblity = "hidden";
-  severityPicker.querySelector('input[type = "checkbox"]').checked = false;
+  severityPicker.querySelector("input[type = \"checkbox\"]").checked = false;
 });
 
 const tds = document.querySelectorAll("#rumble .tables table tbody tr td");

--- a/assets/js/rumble/vulnerability.js
+++ b/assets/js/rumble/vulnerability.js
@@ -12,7 +12,7 @@ showVuln();
 function getVulnID() {
   let id = "";
   let host = document.location.host;
-  if (host.match(`.+netlify.app:443`) || host == "localhost:1313") {
+  if (host.match(".+netlify.app:443") || host == "localhost:1313") {
     id = new URLSearchParams(document.location.search).get("id");
   } else {
     id = document.location.pathname.replace(/\/$/, "").split("/").pop();
@@ -41,13 +41,13 @@ function updateTitleAndURLs() {
   const link = document.querySelector("head link[rel=canonical]");
   link.href += id;
 
-  const ogTitle = document.querySelector('head meta[property="og:title"]');
+  const ogTitle = document.querySelector("head meta[property=\"og:title\"]");
   ogTitle.content = `${ogTitle.content} - ${id}`;
 
-  const ogURL = document.querySelector('head meta[property="og:url"]');
+  const ogURL = document.querySelector("head meta[property=\"og:url\"]");
   ogURL.content += id;
 
-  const twitterTitle = document.querySelector('head meta[name="twitter:title"]');
+  const twitterTitle = document.querySelector("head meta[name=\"twitter:title\"]");
   twitterTitle.content = `${twitterTitle.content} - ${id}`;
 }
 
@@ -80,7 +80,7 @@ function makeTable(id, images) {
       return 0;
     });
   } else {
-    document.querySelector(id).innerHTML = `<p style="margin: 0; padding: 24px 8px;">No vulnerabilities detected</p>`;
+    document.querySelector(id).innerHTML = "<p style=\"margin: 0; padding: 24px 8px;\">No vulnerabilities detected</p>";
     return;
   }
 
@@ -130,4 +130,3 @@ function makeTable(id, images) {
     .append("td")
     .html(function (d) { return d.value; });
 };
-

--- a/assets/js/titles.js
+++ b/assets/js/titles.js
@@ -1,10 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll("h2, .page-links a").forEach((h2) => {
-    const match = /Step (\d+) [—–]/.exec(h2.innerHTML);
+    const match = /Step (\d+) ([—–])/.exec(h2.innerHTML);
     if (match) {
       h2.innerHTML = `<div class="step-container">${h2.innerHTML.replace(
         match[0],
-        `Step <span class="step">${stepNumber}</span> ${dash}`
+        `Step <span class="step">${match[1]}</span> ${match[2]}`
       )}</div>`;
     }
   });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,7 @@ module.exports = [
   {
     files: ["assets/js/**/*.js", "config/**/*.js"],
     languageOptions: {
-      ecmaVersion: 2018,
+      ecmaVersion: 2022,
       sourceType: "module",
       globals: {
         ...globals.browser,
@@ -43,6 +43,17 @@ module.exports = [
           functions: "ignore",
         },
       ],
+    },
+  },
+  {
+    // The rumble scripts are concatenated at build time (Hugo resources.Concat
+    // of base.js + comparison.js / vulnerability.js), so symbols defined in one
+    // fragment are referenced from another. eslint lints each file in isolation
+    // and cannot see that, so disable the cross-file rules for these fragments.
+    files: ["assets/js/rumble/**/*.js"],
+    rules: {
+      "no-unused-vars": "off",
+      "no-undef": "off",
     },
   },
 ];


### PR DESCRIPTION
## Type of change

Lint / bug fix for the theme's JavaScript.

### What should this PR do?

Clear all eslint findings under `assets/js` and `config`:
- Autofix formatting (double-quotes, comma-dangle)
- Bump `eslint.config.js` `ecmaVersion` 2018 → 2022 (the code uses optional chaining and top-level await, which 2018 can't parse)
- Fix a real bug in `titles.js`
- Behavior-neutral cleanups: `switch`-case braces and optional catch binding in `copypage.js`, an unused-variable removal in `cookie-banner-override.js`, and a `var` redeclare in `rumble/base.js`
- Add an eslint override for `assets/js/rumble/**`

### Why are we making this change?

`assets/js` carried the eslint backlog. Most was mechanical; a few were genuine issues that only surfaced once the parser was modernized.

### What are the acceptance criteria?

- `eslint assets/js config` reports zero errors.
- No behavior regressions in the affected UI.

### How should this PR be tested?

Verified locally in the Hugo dev server:
- **`titles.js` (real fix):** step-numbered headings referenced undefined `stepNumber`/`dash` and threw a `ReferenceError`, so the step styling never applied. Now they use the regex captures — confirmed the "Step **N** — …" badge renders (e.g. the policy-controller how-to pages).
- **Rumble tool:** the d3 comparison chart renders and the table filter works (image-comparison + vulnerability pages).
- **Cookie banner** and **copy-page-as-markdown** behave as before.
- `hugo` builds all 1563 pages.

### Notes

- **`rumble/**` override** disables `no-unused-vars` / `no-undef` for those files: Hugo concatenates `base.js` with `comparison.js` / `vulnerability.js` at build time (`resources.Concat`), so symbols defined in one fragment (`d3`, `fetchAdvisories`, `severityColours`) are used in another. eslint lints each file in isolation and can't see that, so the "unused"/"undefined" reports are false positives — the symbols are live, and deleting them would break the tool.

---

**Risk**: low-medium. Mostly mechanical/formatting plus one genuine bug fix and behavior-neutral cleanups; rendering verified locally.

**Review focus**:
1. `titles.js` regex-capture fix (renders step numbers — verified in browser).
2. The `rumble/**` eslint override vs deleting the "unused" symbols.