### PR TITLE
style(markdown): lint-clean chainguard-images docs (batch 1); disable table style rules

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,7 +6,11 @@
     "MD026": false,
     "MD033": false,
     "MD034": false,
-    "MD040": false
+    "MD040": false,
+    // Table style rules disabled: they enforce cosmetic pipe alignment/style
+    // that is high-churn and not autofixable, without improving rendering.
+    "MD055": false,
+    "MD060": false
   },
   "ignores": [
     "node_modules",

--- a/content/chainguard/chainguard-images/about/images-testing.md
+++ b/content/chainguard/chainguard-images/about/images-testing.md
@@ -22,7 +22,6 @@ Chainguard Containers are minimal, distroless container images that you can use 
 
 This article provides a high-level overview of Chainguard's approach to testing when building new container images to ensure their security and consistency with comparable container images.
 
-
 ## Build requirements for new container images
 
 Chainguard has a set of requirements in place that new container images must meet in order to be included in our [Containers Directory](https://images.chainguard.dev?utm=docs). These requirements fall into two categories:
@@ -30,31 +29,29 @@ Chainguard has a set of requirements in place that new container images must mee
 * Container image standards
 * Comprehensive testing
 
-
 ### Container image standards
 
 When building a new container image, Chainguard will take steps to ensure it meets the following standards:
 
-| **Requirement** 	  |  **Explanation**     |
+| **Requirement**    |  **Explanation**     |
 | --- | --- |
 | **Size**     |  Any new Chainguard Containers should be smaller than their external counterparts, though exceptions may occur.    |
-|  **CVEs**     | When scanned with a CVE scanning tool like Grype, new container images should return zero CVEs. If a container image does return CVEs in its scan results it should include an explanation, though some reported CVEs may be false positives. Refer to our [Security Advisories](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-images-testing) for more information.	  |
+|  **CVEs**     | When scanned with a CVE scanning tool like Grype, new container images should return zero CVEs. If a container image does return CVEs in its scan results it should include an explanation, though some reported CVEs may be false positives. Refer to our [Security Advisories](https://images.chainguard.dev/security?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-images-testing) for more information.   |
 |  **Kubernetes accessibility**     | Containers used for Kubernetes-based deployments must be able to run inside of a Kubernetes cluster.     |
 |  **Architecture**     | Chainguard Containers must be built for both the `x86_64` and `aarch64` architectures.      |
 
 Chainguard also performs the following checks on new container images to ensure that the applications contained within them meet the needs of most use cases:
 
-| **Requirement** 	  |  **Explanation**     |
+| **Requirement**    |  **Explanation**     |
 | --- | --- |
 |  **Functionality**     | The application is tested to comply with its upstream counterpart's core feature set.   |
 |  **Builder Containers**     | Chainguard's builder containers can in fact build new, functional container images.     |
-
 
 ### Comprehensive testing
 
 Chainguard builds a wide variety of different container images, with differing core functionalities and expected installation methods. This means we must vary our testing across container images to test the right things. It can be helpful to think about the various layers in a container image build process and what would be useful to test for each layer:
 
-| **Layer**  | **Test** | **Applies to**  |
+| **Layer** | **Test** | **Applies to** |
 | --- | --- | --- |
 | Deployment | Upstream accepted, documented deployment methods | All services and controllers |
 | Runtime security | Non-root, no extra capacities, read-only rootfs | All |
@@ -62,7 +59,6 @@ Chainguard builds a wide variety of different container images, with differing c
 | Persistence | Correct file and directory permissions, read/write, restarts cleanly | Stateful, such as databases |
 | UI | Smoke test and auth | UI apps, such as Argo |
 | Metrics and logging | Metrics emitted or exposed if the app exposes them, logs are written to expected locations if they are emitted | Almost all containers intended for production environments |
-
 
 In addition, Chainguard performs a number of automatic checks for new container images as part of our CI/CD process.
 
@@ -73,7 +69,6 @@ When applicable, Chainguard will develop functional tests for container images. 
 Our goal for these tests is that they fully evaluate the container image's deployment in a representative environment; for example, container images running Kubernetes applications are tested in a Kubernetes cluster and builder or toolchain applications are tested with a `docker run` command or part of a `docker build` process. This means that our container images work with the existing upstream deployment methods, such as Helm charts or Kustomize manifests, helping us to ensure that a container image is as close to a drop-in replacement as possible.
 
 Additionally, Chainguard performs automated tests on every *package* included in our container images. These tests run on every new package build within an ephemeral container environment before the package build is published. This allows us to validate the representative functionality of each package well before packages are assembled into container images.
-
 
 ## Learn more
 

--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -57,18 +57,18 @@ Chainguard Containers are built on open source software, so understanding how
 Chainguard manages releases starts with understanding how open source projects
 version and release software. Generally, projects follow one of two approaches:
 
-- **Multiple release track**: Popular open source
+* **Multiple release track**: Popular open source
 projects often provide maintenance for a number of release tracks concurrently.
 For example, Java, Go, Postgres, and Kubernetes patch multiple release versions,
-each on their own defined maintenance schedule. 
-    - For these types of projects, Chainguard will maintain every version track of the
+each on their own defined maintenance schedule.
+  * For these types of projects, Chainguard will maintain every version track of the
 upstream software that receives updates from the project.
-- **Single release track**: Many open source projects support only a single stream of releases that are
+* **Single release track**: Many open source projects support only a single stream of releases that are
 continuously incremented; often, this is simply the latest release. In the case
 of a single release track, any security fix that is published will only be
 applied to the most recent release of the project, and the project release tags
-will be updated to indicate a new version is available. 
-    - For this type of project, Chainguard only warrants that the latest release of
+will be updated to indicate a new version is available.
+  * For this type of project, Chainguard only warrants that the latest release of
 the software and its corresponding version tags have the most up-to-date patches
 available.
 
@@ -89,24 +89,24 @@ an actively maintained version.
 
 The table provides some example scenarios to help illustrate our approach.
 
-| **Category**	| **Example** | **Maintained Upstream Releases** | **Chainguard Patches** | **Chainguard No Longer Patches** |
-|---------------|-------------|----------------------------------|------------------------|----------------------------------|
-| **Multiple Release Tracks** | [Go](https://images.chainguard.dev/directory/image/go/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)       | 1.23, 1.22                 | `:latest`, 1, 1.23, 1.22 | 1.23.old, 1.22.old, 1.21 and below |
-|                             | [Python](https://images.chainguard.dev/directory/image/python/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 3.13, 3.12, 3.11, 3.10, 3.9 | `:latest`, 3, 3.9 and above | 3.8 and below, 3.8.old, 3.9.old, 3.10.old, 3.11.old, 3.12.old |
-|                             | [Postgres](https://images.chainguard.dev/directory/image/postgres/version?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 17, 16, 15, 14, 13         | `:latest`, 17, 16, 15, 14, 13 | 12 (EOL November 21, 2024) and below |
-| **Single Release Track**    | [Cosign](https://images.chainguard.dev/directory/image/cosign/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement)   | 2                          | `:latest`, 2, 2.4 | 2.3, 2.2, 2.1, 2.0, 1.x, 0.x |
-|                             | [Bank-Vaults](https://images.chainguard.dev/directory/image/bank-vaults/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 1 | `:latest`, 1 | Any previous version tag
-| **No Release Track**        | [envoyproxy/ratelimit](https://images.chainguard.dev/directory/image/envoy-ratelimit/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | No versioned releases | `:latest` | Any previous version tag |
+| **Category** | **Example** | **Maintained Upstream Releases** | **Chainguard Patches** | **Chainguard No Longer Patches** |
+| --------------- | ------------- | ---------------------------------- | ------------------------ | ---------------------------------- |
+| **Multiple Release Tracks** | [Go](https://images.chainguard.dev/directory/image/go/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 1.23, 1.22 | `:latest`, 1, 1.23, 1.22 | 1.23.old, 1.22.old, 1.21 and below |
+| | [Python](https://images.chainguard.dev/directory/image/python/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 3.13, 3.12, 3.11, 3.10, 3.9 | `:latest`, 3, 3.9 and above | 3.8 and below, 3.8.old, 3.9.old, 3.10.old, 3.11.old, 3.12.old |
+| | [Postgres](https://images.chainguard.dev/directory/image/postgres/version?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 17, 16, 15, 14, 13 | `:latest`, 17, 16, 15, 14, 13 | 12 (EOL November 21, 2024) and below |
+| **Single Release Track** | [Cosign](https://images.chainguard.dev/directory/image/cosign/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 2 | `:latest`, 2, 2.4 | 2.3, 2.2, 2.1, 2.0, 1.x, 0.x |
+| | [Bank-Vaults](https://images.chainguard.dev/directory/image/bank-vaults/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | 1 | `:latest`, 1 | Any previous version tag
+| **No Release Track** | [envoyproxy/ratelimit](https://images.chainguard.dev/directory/image/envoy-ratelimit/versions?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) | No versioned releases | `:latest` | Any previous version tag |
 
 > **Note**: The "Maintained Upstream Releases" column is current as of December 2024.
 
 ### Daily rebuilds and proactive patching
 
-[Actively maintained](#list-active-tags) Chainguard Containers are rebuilt on a daily 
-cadence, so you can be sure the container image you are using is up to date. 
+[Actively maintained](#list-active-tags) Chainguard Containers are rebuilt on a daily
+cadence, so you can be sure the container image you are using is up to date.
 
-In some 
-cases, Chainguard will fix vulnerabilities in tools without waiting for the external 
+In some
+cases, Chainguard will fix vulnerabilities in tools without waiting for the external
 project to release patches. Learn more about this under [Epoch tags](#epoch-tags).
 
 ### Maintaining Wolfi packages in Chainguard Containers
@@ -152,7 +152,7 @@ more versions. The Chainguard approach is as follows:
 
 ## Floating tags and epoch tags
 
-Chainguard Containers use *floating tags*. This means that a container image's
+Chainguard Containers use _floating tags_. This means that a container image's
 tag always points to the most recent build or version within a version stream,
 rather than a fixed, immutable image. For example, `python:3.13` will always
 point to the latest version of that version stream (`3.13.9`, as of this
@@ -178,7 +178,7 @@ and tooling. Epoch tags make it easy to track these incremental updates in a
 clear, human-readable way — particularly useful when changes affect the main
 package or involve security fixes.
 
-**How epoch tags work**
+#### How epoch tags work
 
 Once a newer epoch tag is available, the previous one stops being updated. For
 example, the tag `1.14.5-r3` will no longer be updated once `1.14.5-r4` is
@@ -195,7 +195,7 @@ for Chainguard's `python` container image is `python:3.14.0-r6`, then
 to the same container image. However, you could still specify `python:3.14.0-r5`
 should you need.
 
-**How epoch tags affect other packages**
+#### How epoch tags affect other packages
 
 Bear in mind that Chainguard's Containers, although minimal, will almost always
 contain more than one package. At the time of writing this, the Go image has
@@ -219,7 +219,6 @@ instead.
 You can learn more about our approach by reviewing our [blog on Chainguard's
 container image tagging
 philosophy](https://www.chainguard.dev/unchained/chainguards-image-tagging-philosophy-enabling-high-velocity-updates-pt-1-of-3?utm=docs).
-
 
 ## SLAs
 
@@ -256,7 +255,6 @@ longer updated.
 No EOL notice will be provided for single-release applications where the only
 supported release is the `:latest` or corresponding version tag.
 
-
 ### EOL grace period
 
 There are cases where an organization may want to continue using a container
@@ -278,13 +276,13 @@ lifecycle of your Chainguard Containers.
 
 ### List Active Tags
 
-**Active tags in the Chainguard Console**
+#### Active tags in the Chainguard Console
 
 You can view tag statuses in the Chainguard Console. In the Console under
 **Images > Organization**, under the **Status** column, you can see:
 
-- `Active` status for images you are entitled to
-- `Expired` status for images you are no longer entitled to
+* `Active` status for images you are entitled to
+* `Expired` status for images you are no longer entitled to
 
 If you use Chainguard Production Containers, it is also possible to view the
 statuses of different tag versions for an image. Click into an image to see the
@@ -295,10 +293,11 @@ name to indicate that it's inactive.
 >**Note**: This feature is not applicable to customers who use [Unique
 >tags](/chainguard/chainguard-images/features/unique-tags/).
 
-**List active tags with chainctl**
+#### List active tags with chainctl
 
 You can use `chainctl` to retrieve the list of tags that are being actively
 maintained for a Chainguard container image by running:
+
 ```shell
 chainctl image repo list
 ```
@@ -309,6 +308,7 @@ For instance, the following command lists the tags that are currently active for
 ```sh
 chainctl image repo list --repo=python -o json | jq -r '.items[].activeTags'
 ```
+
 ```output
 [
   "3",
@@ -366,6 +366,7 @@ package:
 ```sh
 chainctl package versions list python --show-active
 ```
+
 ```output
  VERSION |  EOL DATE  | EOL GRACE PERIOD END DATE
 ---------|------------|---------------------------

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
@@ -17,20 +17,21 @@ toc: true
 
 Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) is a tool that allows customers to create customized container images with extra packages and annotations added. This enables customers to reduce their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs. It can be managed in the [Chainguard Console](/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/), [with chainctl](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/), [with the API](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/), or via CI/CD.
 
-This guide shows how to use Chainguard Custom Assembly as code via CI/CD, storing your configuration in Git and using automation to apply changes and trigger builds. The examples in this guide focus on GitHub Actions, as seen in [Chainguard's custom-assembly-as-code demo repository](https://github.com/chainguard-demo/custom-assembly-as-code). 
+This guide shows how to use Chainguard Custom Assembly as code via CI/CD, storing your configuration in Git and using automation to apply changes and trigger builds. The examples in this guide focus on GitHub Actions, as seen in [Chainguard's custom-assembly-as-code demo repository](https://github.com/chainguard-demo/custom-assembly-as-code).
 
-> **NOTE**: `chainctl` is an API client that handles common tasks like authentication and applying configuration files. You can manage Custom Assembly [interactively using `chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/). Running `chainctl` non-interactively is a common pattern for implementing GitOps workflows. 
+> **NOTE**: `chainctl` is an API client that handles common tasks like authentication and applying configuration files. You can manage Custom Assembly [interactively using `chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-api-demo/). Running `chainctl` non-interactively is a common pattern for implementing GitOps workflows.
 
 ## Prerequisites
 
 Before getting started, you should have:
+
 * A Chainguard organization with access to Custom Assembly
 * Permission to manage Custom Assembly configuration for your organization/repository
 * A CI/CD platform in place
-    * In this guide, we use GitHub Actions as an example.
+  * In this guide, we use GitHub Actions as an example.
 * A Git repository to host your apko configuration files
 * A configured assumable identity for your CI workload
-    * If you have not yet set up CI identities, see [Chainguard's tutorials for creating and assuming identities](/chainguard/administration/assumable-ids/identity-examples/).
+  * If you have not yet set up CI identities, see [Chainguard's tutorials for creating and assuming identities](/chainguard/administration/assumable-ids/identity-examples/).
 * The full IDs for your [catalog_syncer and apko_builder identities](/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/#chainguards-signing-identities/).
 
 Also note that Chainguard's [demo workflow](https://github.com/chainguard-demo/custom-assembly-as-code) uses [octo-sts](https://www.chainguard.dev/unchained/the-end-of-github-pats-you-cant-leak-what-you-dont-have), a tool that generates short-lived GitHub tokens instead of using long-lived Personal Access Tokens (PATs). While octo-sts is optional for Custom Assembly builds, it's recommended for workflows that need GitHub API access alongside Chainguard operations.
@@ -39,7 +40,7 @@ Also note that Chainguard's [demo workflow](https://github.com/chainguard-demo/c
 
 Custom Assembly uses apko overlay YAML files to customize images. You can use them to define changes such as additional packages to install, environment variables, and annotations.
 
-This example overlay file shows the configuration options available for customizing Chainguard images: 
+This example overlay file shows the configuration options available for customizing Chainguard images:
 
 ```yaml
 contents:
@@ -108,7 +109,6 @@ chainctl iam identities create github-actions-identity \
 
 This creates an identity that GitHub Actions workflows in `your-org/your-repo` can assume when triggered by push events.
 
-
 ## Step 2: Grant permissions
 
 The identity needs permission to build Custom Assembly images. You can create a [least-privilege custom role](/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements/) that contains the `repo.update` and `repo.create` permissions, then grant the necessary permission using `chainctl`:
@@ -135,20 +135,22 @@ chainctl iam identities list -o table
 ## Trigger builds via chainctl in CI/CD workflows
 
 Regardless of which CI/CD platform you use, Custom Assembly builds are triggered with the same chainctl command:
+
 ```bash
 chainctl images repos build apply --file ca-images-iac/custom-jre.yaml \
   --parent your-parent-group \
   --repo your-repo \
   --yes
 ```
+
 This command follows the example repo structure that appears earlier on this page, where `ca-images-iac` is the directory that contains the apko overlay files.
 
 This command:
-- Reads your apko overlay configuration from the YAML file
-- Applies it to build a custom image
-- Pushes the result to your Chainguard registry
-- Skips the interactive confirmation via the `--yes` flag, making it suitable for automated workflows
 
+* Reads your apko overlay configuration from the YAML file
+* Applies it to build a custom image
+* Pushes the result to your Chainguard registry
+* Skips the interactive confirmation via the `--yes` flag, making it suitable for automated workflows
 
 ### GitHub Actions example
 
@@ -184,40 +186,40 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           egress-policy: audit
-      
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
-      
+
       - name: Setup Go environment
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           cache: false
-      
+
       # Use octo-sts for GitHub authentication (no PAT needed)
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
         id: octo-sts
         with:
           scope: your-org/your-repo
           identity: build
-      
+
       - name: Install Crane
         run: go install github.com/google/go-containerregistry/cmd/crane@latest
-      
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-      
+
       # Authenticate to Chainguard using assumable identity
       - uses: chainguard-dev/setup-chainctl@8d93dcbef466d3cf3533f67084f52eb74ef9d262 # v0.2.4
         with:
           identity: "your-org-id/your-identity-id"
-      
+
       - name: 'Auth to Registry'
         run: |
           chainctl auth configure-docker
           chainctl auth status
-      
+
       # Verify existing image signature before rebuilding. Find these identity IDs in your organization's "Assumed Identities" settings.
       - name: Verify signature && pull existing image
         id: cosign-verify
@@ -231,7 +233,7 @@ jobs:
             --certificate-oidc-issuer=https://issuer.enforce.dev \
             --certificate-identity-regexp="https://issuer.enforce.dev/(${CATALOG_SYNCER}|${APKO_BUILDER})" \
             $CUSTOM_IMAGE:latest | jq
-      
+
       # Extract and display packages from the SBOM attestation.
       - name: Print created time and list packages
         id: crane-config
@@ -249,7 +251,7 @@ jobs:
             jq -r .payload | base64 -d | jq '.predicate' | \
             jq '.packages[] | select(.externalRefs[]?.referenceCategory == "PACKAGE_MANAGER") | \
             .externalRefs[] | select(.referenceCategory == "PACKAGE_MANAGER") | .referenceLocator'
-      
+
       # Apply the apko configuration file to trigger the build. The --yes flag skips the confirmation prompt.
       - name: Trigger custom build
         id: start-custom-build
@@ -266,13 +268,14 @@ Before deploying your CI/CD workflow to production, test it thoroughly to ensure
 ### Testing the GitHub Action example
 
 Before using the GitHub action in this guide, make sure to update the placeholders:
-- `your-org/your-repo`: Your GitHub repository (e.g., `acme/infrastructure`)
-- `your-org-id/your-identity-id`: Your full Chainguard identity ID
-- `CUSTOM_IMAGE: "cgr.dev/your-org/your-image"`: Your image registry path
-- `CATALOG_SYNCER="your-org-id/catalog-syncer-id"`: Your catalog syncer identity
-- `APKO_BUILDER="your-org-id/apko-builder-id"`: Your APKO builder identity
-- `--parent your-parent-group --repo your-repo`: Your Chainguard group and repo names
-- `ca-images-iac/custom-jre.yaml`: Your repo's directory that holds the apko overlay files, and the overlay file name
+
+* `your-org/your-repo`: Your GitHub repository (e.g., `acme/infrastructure`)
+* `your-org-id/your-identity-id`: Your full Chainguard identity ID
+* `CUSTOM_IMAGE: "cgr.dev/your-org/your-image"`: Your image registry path
+* `CATALOG_SYNCER="your-org-id/catalog-syncer-id"`: Your catalog syncer identity
+* `APKO_BUILDER="your-org-id/apko-builder-id"`: Your APKO builder identity
+* `--parent your-parent-group --repo your-repo`: Your Chainguard group and repo names
+* `ca-images-iac/custom-jre.yaml`: Your repo's directory that holds the apko overlay files, and the overlay file name
 
 To test your GitHub Action:
 
@@ -280,13 +283,10 @@ To test your GitHub Action:
 2. View the detailed logs for each step.
 3. Confirm that the images appear in your Chainguard registry.
 
-
 ## Additional resources
 
-- [Custom Assembly Overview](/chainguard/chainguard-images/features/ca-docs/custom-assembly/)
-- [apko Overview](/open-source/build-tools/apko/overview/)
-- [Assumable Identity Documentation](/chainguard/administration/assumable-ids/assumable-ids/)
-- [Demo Repository: custom-assembly-as-code](https://github.com/chainguard-demo/custom-assembly-as-code)
-- [Chainguard Support](https://support.chainguard.dev)
-
-
+* [Custom Assembly Overview](/chainguard/chainguard-images/features/ca-docs/custom-assembly/)
+* [apko Overview](/open-source/build-tools/apko/overview/)
+* [Assumable Identity Documentation](/chainguard/administration/assumable-ids/assumable-ids/)
+* [Demo Repository: custom-assembly-as-code](https://github.com/chainguard-demo/custom-assembly-as-code)
+* [Chainguard Support](https://support.chainguard.dev)

--- a/content/chainguard/chainguard-images/getting-started/istio.md
+++ b/content/chainguard/chainguard-images/getting-started/istio.md
@@ -2,7 +2,7 @@
 title: "Getting Started with the Chainguard Istio Containers"
 type: "article"
 linktitle: "Istio"
-aliases: 
+aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-istio
 description: "Learn how to deploy Istio service mesh using Chainguard's security-hardened Istio images with reduced vulnerabilities and minimal attack surface"
 date: 2023-12-14T00:00:00+00:00
@@ -50,12 +50,12 @@ This will return output similar to the following:
 
 ```output
 Creating cluster "kind" ...
- ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 
- ✓ Preparing nodes 📦  
- ✓ Writing configuration 📜 
- ✓ Starting control-plane 🕹️ 
- ✓ Installing CNI 🔌 
- ✓ Installing StorageClass 💾 
+ ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
 Set kubectl context to "kind-kind"
 You can now use your cluster with:
 
@@ -70,14 +70,15 @@ Following that, you can install the Istio Chainguard Containers with `istioctl`.
 
 We will be using the `istioctl` command to install Istio. In order to use the
 Chainguard Containers, we will need to set these following values:
-- `hub = cgr.dev/$ORGANIZATION`
+
+* `hub = cgr.dev/$ORGANIZATION`
 
 > **Note**: Be aware that you will need to change `cgr.dev/$ORGANIZATION` to reflect the name of your organization's repository within Chainguard's registry.
 
-- `tag = latest`
-- `values.pilot.image = istio-pilot`
-- `values.global.proxy.image = istio-proxy`
-- `values.global.proxy_init.image = istio-proxy`
+* `tag = latest`
+* `values.pilot.image = istio-pilot`
+* `values.global.proxy.image = istio-proxy`
+* `values.global.proxy_init.image = istio-proxy`
 
 We can set these values with the following `istioctl` command:
 
@@ -88,18 +89,20 @@ istioctl install --set tag=latest --set hub=cgr.dev/$ORGANIZATION \
   --set values.global.proxy_init.image=istio-proxy
 ```
 
-The Istio Chainguard Container is now running on the kind cluster you created previously. 
-In the next section, you'll set up an Istio gateway and a VirtualService to test out 
+The Istio Chainguard Container is now running on the kind cluster you created previously.
+In the next section, you'll set up an Istio gateway and a VirtualService to test out
 this container.
 
-## Stand up a Gateway and a VirtualService 
+## Stand up a Gateway and a VirtualService
 
 To see the Istio installation in action, we will create two Istio resources:
+
 * An Istio gateway serving the "http://hello.example.com" domain
 * A VirtualService to always reply with "Hello, world!" to requests to the
-  "http://hello.example.com" domain 
+  "http://hello.example.com" domain
 
-Create a YAML manifest file with the following contents to define the Istio resources: 
+Create a YAML manifest file with the following contents to define the Istio resources:
+
 ```sh
 cat > example.yaml <<EOF
 apiVersion: networking.istio.io/v1alpha3
@@ -149,9 +152,10 @@ In another terminal, send a request to the Istio Ingress Gateway:
 ```sh
 curl -H "Host: hello.example.com" localhost:8080
 ```
+
 This will return `Hello, world!` to the terminal output.
 
-## Clean up your kind cluster 
+## Clean up your kind cluster
 
 Once you are done, you can delete your kind cluster:
 
@@ -162,4 +166,5 @@ kind delete cluster
 This will delete the default cluster context, `kind`.
 
 ## Advanced Usage
+
 {{< blurb/images-advanced image="Istio" >}}

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -35,7 +35,6 @@ The following is an instructional guide for Chainguard users that are looking fo
 
 You can use these Helm charts with Chainguard FIPS container images, but you will need to adjust the charts as they use the non-FIPS images by default. We build a single chart per application and validate that both FIPS and non-FIPS Chainguard Images work with it.
 
-
 ## Configuration Requirements
 
 If you are pulling container images directly from Chainguard, then you must set a `global.org` value. You don't need this if you are pulling from your own internal registry.
@@ -71,16 +70,15 @@ volumePermissions:
     digest: sha256:... # Use specific digest instead of tag
 ```
 
-
 ## Authentication
 
 You will need to authenticate to pull charts. These instructions explain how to use charts and images with the `cgr.dev` repository. If you have mirrored or copied the charts and images to an organization-specific registry, you will need to adapt these instructions to authenticate to your registry, as appropriate.
 
 This section presents multiple authentication methods:
+
 - Use Helm values with `global.imagePullSecrets`
 - Deploy a Chainguard Helm chart using a Kubernetes pull secret
 - Use cluster node-scoped registry permissions
-
 
 ### Use Helm values with `global.imagePullSecrets`
 
@@ -91,7 +89,6 @@ global:
   imagePullSecrets:
     - name: chainguard-pull-secret
 ```
-
 
 ### Deploy a Chainguard Helm chart using a Kubernetes pull secret
 
@@ -112,7 +109,7 @@ Find the username and password that are contained in the pull token, as in this 
 
 ```sh
 chainctl auth configure-docker --pull-token --save --ttl=24h
-                                    
+
   ✔ Selected folder chainguard.edu.
 
 To use this pull token in another environment, run this command:
@@ -131,7 +128,7 @@ HELMUSER=45a0c61ea6fd977f050c5fb9ac06a69eed764595/095b0c7ea9d68679
 HELMPASS=eyJhbGciOiJSUzI1NiJ9.eyJhdWQ... # Token truncated
 ```
 
-Create your Kubernetes secret using the variables you just created.	
+Create your Kubernetes secret using the variables you just created.
 
 ```sh
 kubectl create secret docker-registry chainguard-pull-secret \
@@ -156,7 +153,6 @@ helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
   --set "global.org=$ORGANIZATION" \
   --set "global.imagePullSecrets[0].name=chainguard-pull-secret"
 ```
-
 
 When the install is successful, it returns a confirmation message, like this:
 
@@ -202,7 +198,6 @@ WARNING: There are "resources" sections in the chart not set. Using "resourcesPr
 +info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 ```
 
-
 ### Use cluster node-scoped registry permissions
 
 If you manage access and permissions at cluster-wide and node-specific levels, these are some best practices to consider.
@@ -212,13 +207,12 @@ If you manage access and permissions at cluster-wide and node-specific levels, t
 **Pin to Digest:** While charts follow the same tagging scheme as Chainguard images, always pin to a specific chart **digest** to prevent unexpected updates:
 
 ```sh
-helm install rabbitmq \ 
+helm install rabbitmq \
 oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq@sha256:DIGEST \
      --set "global.org=$ORGANIZATION"
 ```
 
 **Review Default Values:** The chart provides security-minded defaults that are sensible but may not suit all use cases. Review the chart's `values.yaml` for the full range of configuration options and adjust as needed.
-
 
 ## Helm chart usage examples
 
@@ -276,7 +270,7 @@ helm install rabbitmq oci://cgr.dev/$ORGANIZATION/iamguarded-charts/rabbitmq \
   --set "persistence.storageClass=gp3-automode"
 ```
 
-## Troubleshooting 
+## Troubleshooting
 
 To check the Helm configuration, you can run `helm install` with `--dry-run` flag. This will output the generated Kubernetes YAML. Double check the values for the image and `imagePullSecrets` to ensure they point to the correct registry and authentication is in place.
 

--- a/content/chainguard/chainguard-images/how-to-use/use-with-openshift.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-with-openshift.md
@@ -23,8 +23,7 @@ Using Chainguard Containers in your OpenShift deployment significantly reduces C
 
 When [Using Chainguard Containers](/chainguard/chainguard-images/how-to-use/how-to-use-chainguard-images/) with OpenShift, there are some adjustments that need to be made to the usual process. This guide provides guidance. See the [OpenShift docs](https://docs.redhat.com/en/documentation/openshift_container_platform/) for more details.
 
-
-# Adjust Ownership and Permissions
+## Adjust Ownership and Permissions
 
 By default, OpenShift Container Platform runs containers using an arbitrarily assigned User ID (UID), as described in the [Red Hat documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/creating-images#use-uid_create-images).
 
@@ -40,7 +39,7 @@ RUN chgrp -R 0 /some/directory && \
     chmod -R g=u /some/directory
 ```
 
-# Create `/app` Directory and `HOME`
+## Create `/app` Directory and `HOME`
 
 When running on OpenShift clusters, you will find that the OpenShift user cannot create config files inside their home directory. This is because [OpenShift is designed to start container instances using a random User ID](https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids).
 
@@ -75,15 +74,13 @@ ENV HOME=/app
 ENTRYPOINT ["dotnet", "Sample.Service.dll"]
  ```
 
-
-# Use Special Container Images for Hard-coded User IDs
+## Use Special Container Images for Hard-coded User IDs
 
 There are cases where Red Hat hard codes UIDs for specific applications, for example, the user for Postgres is set to UID 26. See the [Red Hat documentation](https://access.redhat.com/solutions/6996195) for more details.
 
 In this instance, Chainguard has built a special image for Postgres on OpenShift with a different release tag. Where the Postgres release version is `17.5` and the regular Chainguard Container would be released with the tag `17.5`, there is another image released with the tag `17.5-openshift`.
 
-
-# Understand Security Context Constraints (SCCs)
+## Understand Security Context Constraints (SCCs)
 
 OpenShift Container Platform includes [security context constraints](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/authentication_and_authorization/index#managing-pod-security-policies) (SCCs) that you can use to control permissions for the pods in your cluster. SCCs determine the actions that a pod can perform and what resources it can access.
 

--- a/content/chainguard/chainguard-images/staying-secure/security-advisories/managing-advisories/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/security-advisories/managing-advisories/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using wolfictl to Manage Security Advisories"
 linktitle: "Managing Advisories"
-aliases: 
+aliases:
 - /chainguard/chainguard-images/working-with-images/security-advisories/managing-advisories/
 type: "article"
 description: "Guide on how to use the wolfictl tool to create, update, and manage security advisories"
@@ -17,18 +17,17 @@ weight: 030
 toc: true
 ---
 
-> **Note**: This document is deprecated as of June 2025. 
+> **Note**: This document is deprecated as of June 2025.
 
 Chainguard operates its own [Security Advisories](https://images.chainguard.dev/security/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-managing-advisories) page to alert users about the status of vulnerabilities found in Chainguard Containers. To maintain this database, we use [`wolfictl`](https://github.com/wolfi-dev/wolfictl/), a tool developed for working with the [Wolfi un-distro](https://github.com/wolfi-dev/).
 
-In this guide, you will walk through using `wolfictl` to create an advisory for a vulnerable package. You’ll also learn how to update this advisory as more information about the vulnerability is disclosed over time. To follow along, you will need to have [`git`](https://git-scm.com/) and the [Go programming language](https://go.dev/dl/) installed on your machine. 
+In this guide, you will walk through using `wolfictl` to create an advisory for a vulnerable package. You’ll also learn how to update this advisory as more information about the vulnerability is disclosed over time. To follow along, you will need to have [`git`](https://git-scm.com/) and the [Go programming language](https://go.dev/dl/) installed on your machine.
 
 This guide will focus on the packages and advisories issued for Wolfi.
 
-
 ## How to Install `wolfictl`
 
-To work with security advisories, you will need to install the `wolfictl` tool onto your machine. First, execute the following command in your terminal to clone the `wolfictl` repository locally, and navigate to it. 
+To work with security advisories, you will need to install the `wolfictl` tool onto your machine. First, execute the following command in your terminal to clone the `wolfictl` repository locally, and navigate to it.
 
 ```sh
 git clone git@github.com:wolfi-dev/wolfictl.git wolfictl && cd $_
@@ -39,6 +38,7 @@ Then, using `go`, install the `wolfictl` tool:
 ```sh
 go install
 ```
+
 If you encounter any errors during installation, your installed version of `go` may be out of date. You can check what version of `go` you have installed by running `go version` in your terminal. Check the [`go.mod` file](https://github.com/wolfi-dev/wolfictl/blob/main/go.mod) in the `wolfictl` repository to determine what version of `go` you will need, and be sure to update `go` to this version or a later release to continue. Alternatively, you may need to add the `wolfictl` binary to your `$PATH` after installation if your system does not recognize the command.
 
 You can verify that you have successfully installed `wolfictl` by executing the `wolfictl version` command in your terminal.
@@ -46,7 +46,8 @@ You can verify that you have successfully installed `wolfictl` by executing the 
 ```sh
 wolfictl version
 ```
-A successful installation of `wolfictl` will display output similar to the following. Note that the exact output will vary over time as new `wolfictl` versions are released. 
+
+A successful installation of `wolfictl` will display output similar to the following. Note that the exact output will vary over time as new `wolfictl` versions are released.
 
 ```Output
  __        __   ___    _       _____   ___    ____   _____   _
@@ -74,18 +75,18 @@ Before you can interact with security advisories, the  `wolfictl` tool will need
 You will need to clone two additional repositories: the [`wolfi-dev/os`](https://github.com/wolfi-dev/os) repository and the [`wolfi-dev/advisories`](https://github.com/wolfi-dev/advisories) repository. Execute the following commands to clone each of these repositories to your machine and then navigate to the `advisories` directory.
 
 ```sh
-git clone git@github.com:wolfi-dev/os.git 
+git clone git@github.com:wolfi-dev/os.git
 git clone git@github.com:wolfi-dev/advisories.git && cd advisories
 ```
 
 With `wolfictl` installed and these two repositories cloned locally, you are now ready to interact with the security advisory database.
 
-
 ## Viewing Existing Advisories
 
-First we will take a look at the existing advisories issued for packages in Wolfi. Keep in mind that the results shown here, and on your own machine, are snapshots in time. You should regularly check for changes to the upstream repository as new packages and advisories are issued. 
+First we will take a look at the existing advisories issued for packages in Wolfi. Keep in mind that the results shown here, and on your own machine, are snapshots in time. You should regularly check for changes to the upstream repository as new packages and advisories are issued.
 
 You will be using the `wolfictl advisory list` command to view existing advisories. There are a variety of flags which you can append to assist in your search.
+
 * `-p` lists all advisories for a given package name.
 * `-V` lists all advisories for a given CVE ID, across all packages.
 * `-t` lists all advisories by their most recent event type.
@@ -94,13 +95,14 @@ You will be using the `wolfictl advisory list` command to view existing advisori
 
 You can combine multiple flags together to conduct a more granular search. For a complete listing of available command options, you can run the `wolfictl advisory list -h` command in your terminal.
 
-For example, let’s say you want to find advisories for the `glibc` package as well as the full history of these advisories. 
+For example, let’s say you want to find advisories for the `glibc` package as well as the full history of these advisories.
 
 ```sh
 wolfictl advisory list -p glibc --history
 ```
 
 The following shows a small sample of output from this command at the time of this writing. Note that the output of this command may change as vulnerability entries are added and updated over time.
+
 ```Output
 glibc CGA-49g3-q5cv-7m6g (CVE-2023-4527, GHSA-hmf7-f8gf-8f4p)    2023-09-22T14:14:01Z fixed (2.38-r2)
       CGA-573p-mg38-75fh (CVE-2019-1010024, GHSA-3q29-89cr-qgvj) 2023-03-06T13:22:06Z false positive (vulnerability-record-analysis-contested)
@@ -121,27 +123,28 @@ We encourage you to experiment with these flags to find what information you can
 To begin creating and updating security advisories, you will need to navigate back to the Wolfi package repository you cloned.
 
 ```sh
-cd ../os 
+cd ../os
 ```
 
 Here, you will run the `wolfictl advisory create` command to begin the process of adding a new advisory. This command will respond with a few prompts in the terminal requesting input of information used to create the advisory.
 
 First, you will be asked to enter the package in which the CVE was found. For this demonstration we will use the `glibc` package. Then, you will be asked for the vulnerability ID that you wish to make an advisory for. This ID must be a CVE, CGA, GHSA, or Go vulnerability ID. Finally, you will be asked what the status for the advisory should be, from one of the following options:
-- `detection` (Under investigation)
-- `true-positive-determination` (Affected)
-- `fixed` (Fixed)
-- `false-positive-determination` (Not affected)
-- `fix-not-planned` (Fix not planned)
-- `pending-upstream-fix` (Pending upstream fix)
+
+* `detection` (Under investigation)
+* `true-positive-determination` (Affected)
+* `fixed` (Fixed)
+* `false-positive-determination` (Not affected)
+* `fix-not-planned` (Fix not planned)
+* `pending-upstream-fix` (Pending upstream fix)
 
 To learn more about the meanings of each of these identifiers, please refer to our [documentation on event types](https://github.com/wolfi-dev/advisories/blob/main/docs/event_types.md). The following shows an example of the `wolfictl advisory create` command in action. **Please note that the vulnerability referenced is an arbitrary CVE ID for demonstration purposes and does not reflect an actual vulnerability found in the `glibc` package.**
 
 ```sh
 Auto-detected distro: Wolfi
 
-Package: glibc 
-Vulnerability: CVE-2024-57230 
-Type: 
+Package: glibc
+Vulnerability: CVE-2024-57230
+Type:
   detection
 ```
 
@@ -167,18 +170,18 @@ Let’s say that you upgrade a vulnerable package to a newer, patched version. Y
 ```sh
 Auto-detected distro: Wolfi
 
-Package: glibc 
+Package: glibc
 Vulnerability: CVE-2024-57230
-Type: 
+Type:
   fixed
-Fixed Version: 2.39-r7 
+Fixed Version: 2.39-r7
 ```
 
-The same process can be followed for other status updates, whether you wish to mark a vulnerability as “Not affected” in the case of a [false positive finding](/chainguard/chainguard-images/recommended-practices/false-results/), “Fix not planned”, or another applicable status. 
+The same process can be followed for other status updates, whether you wish to mark a vulnerability as “Not affected” in the case of a [false positive finding](/chainguard/chainguard-images/recommended-practices/false-results/), “Fix not planned”, or another applicable status.
 
 ## Further Reading
 
 In this guide, you learned how to use the `wolfictl` tool to interact with Chainguard’s Security Advisories feed. You used `wolfictl` to explore existing advisories, and also created and updated a new security advisory. The steps shown in this guide allowed you to make local changes to your advisory feed. If you wish to contribute to the open-source Wolfi OS advisory feed, please read through our [How To Patch CVEs](
 https://github.com/wolfi-dev/os/blob/main/HOW_TO_PATCH_CVES.md) guide and our [How Chainguard Issues Security Advisories](/chainguard/chainguard-images/staying-secure/security-advisories/how-chainguard-issues/) article first.
 
-Be sure to routinely check [our Security Advisories page](https://images.chainguard.dev/security/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-managing-advisories) when your scanners pick up new CVEs in your images. If you want to learn more about how you can interpret a security advisory and what its status means for your security, read our [article on using advisories](/chainguard/chainguard-images/staying-secure/security-advisories/how-to-use/). 
+Be sure to routinely check [our Security Advisories page](https://images.chainguard.dev/security/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-security-advisories-managing-advisories) when your scanners pick up new CVEs in your images. If you want to learn more about how you can interpret a security advisory and what its status means for your security, read our [article on using advisories](/chainguard/chainguard-images/staying-secure/security-advisories/how-to-use/).

--- a/content/chainguard/chainguard-images/staying-secure/updating-images/digestabot.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/digestabot.md
@@ -65,7 +65,8 @@ We use Digestabot internally at Chainguard, and this pattern nicely balances the
 So please try it out and let me know if you have any questions.
 
 ## Relevant Resources
-- [Reproducible Dockerfiles with Frizbee and Digestabot](/chainguard/chainguard-images/how-to-use/digestabot_frizbee/) (Video)
-- [Reproducibility and Chainguard Containers](/chainguard/chainguard-images/videos/repro/) (Video)
-- [Considerations for Keeping Containers Up to Date](/chainguard/chainguard-images/recommended-practices/considerations-for-image-updates/) (Article)
-- [Strategies and Tooling for Updating Containers](/chainguard/chainguard-images/recommended-practices/strategies-tools-updating-images/) (Article)
+
+* [Reproducible Dockerfiles with Frizbee and Digestabot](/chainguard/chainguard-images/how-to-use/digestabot_frizbee/) (Video)
+* [Reproducibility and Chainguard Containers](/chainguard/chainguard-images/videos/repro/) (Video)
+* [Considerations for Keeping Containers Up to Date](/chainguard/chainguard-images/recommended-practices/considerations-for-image-updates/) (Article)
+* [Strategies and Tooling for Updating Containers](/chainguard/chainguard-images/recommended-practices/strategies-tools-updating-images/) (Article)

--- a/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
+++ b/content/chainguard/chainguard-images/troubleshooting/debugging-distroless-images.md
@@ -32,18 +32,17 @@ The development variants of [Chainguard Containers](/chainguard/chainguard-image
 
 For example, the following table shows a comparison between the development variants of the PHP image, and which packages are included with each variant:
 
-
-|                      	| latest | latest-dev | latest-fpm |
+|                       | latest | latest-dev | latest-fpm |
 |--------------------------|--------|------------|------------|
-| `wolfi-baselayout`   	| X  	| X      	| X      	|
-| `ca-certificates-bundle` | X  	| X      	| X      	|
-| `php`                	| X  	| X      	| X      	|
-| `apk-tools`          	|    	| X      	|        	|
-| `bash`               	|    	| X      	|        	|
-| `busybox`            	|    	| X      	|        	|
-| `git`                	|    	| X      	|        	|
-| `composer`           	|    	| X      	|        	|
-| `php-fpm`            	|    	|        	| X      	|
+| `wolfi-baselayout`    | X   | X       | X       |
+| `ca-certificates-bundle` | X   | X       | X       |
+| `php`                 | X   | X       | X       |
+| `apk-tools`           |     | X       |         |
+| `bash`                |     | X       |         |
+| `busybox`             |     | X       |         |
+| `git`                 |     | X       |         |
+| `composer`            |     | X       |         |
+| `php-fpm`             |     |         | X       |
 
 You can find similar detailed package information for all [Chainguard Containers](https://images.chainguard.dev) in their respective image details pages under the SBOM section.
 
@@ -56,11 +55,13 @@ docker run -it --entrypoint /bin/sh cgr.dev/chainguard/php:latest-dev
 Having a package manager and the ability to log into the image to debug any issues is very important at development time, but becomes unnecessary (and less safe) when talking about production environments. That's why we recommend using a distroless variant for production workloads.
 
 ### Chainguard Containers in production
+
 Although the development image variants have similar security features as their distroless versions, such as complete SBOMs and signatures, they feature additional software that is typically not necessary in production environments. The general recommendation is to use the development variants to build the application and then copy all application artifacts into a distroless image, which will result in a final container image that has a minimal attack surface and won't allow package installations or logins.
 
 That being said, it's worth noting that the `-dev` variants of Chainguard Containers are still **more secure** than many popular container images based on fully-featured operating systems such as Debian and Ubuntu, because they carry less software, follow a more frequent patch cadence, and offer attestations for what is included.
 
 ### Language ecosystem guides
+
 The following guides show how to use these development images in combination with their distroless variants in order to build a final image that is also distroless, but contains everything the application needs to run:
 
 - [Getting Started with the Python Chainguard Container](/chainguard/chainguard-images/getting-started/python/)
@@ -70,7 +71,6 @@ The following guides show how to use these development images in combination wit
 - [Getting Started with the PHP Chainguard Container](/chainguard/chainguard-images/getting-started/php/)
 
 Check also the guide on [Creating Wolfi Container Images with Dockerfiles](/open-source/wolfi/wolfi-with-dockerfiles/) for guidance on how to build a custom image that can be used for development and debugging.
-
 
 ## 2. Using ephemeral debug containers
 
@@ -154,11 +154,13 @@ Kubernetes does not currently offer a built-in way to automatically replicate vo
 To work around this issue, you can manually create a copy of the pod definition with a new debug container that replicates the necessary volume mounts.
 
 Proxy the Kubernetes API:
+
 ```
 kubectl proxy
 ```
 
 Patch the pod to add an ephemeral container:
+
 ```
 curl http://localhost:8001/api/v1/namespaces/default/pods/<pod-name>/ephemeralcontainers \
 -X PATCH \
@@ -186,6 +188,7 @@ curl http://localhost:8001/api/v1/namespaces/default/pods/<pod-name>/ephemeralco
   }
 }'
 ```
+
 - Replace `<pod-name>` and `<container-name>` with your actual values.
 - Be sure to match the `volumeMounts` spec to those in your target container.
 
@@ -244,6 +247,7 @@ cat /proc/1/root/var/log/app/app.log
 This requires the ephemeral container to run as the same UID as the target process, which is why the `securityContext` fix above is a prerequisite. If security policies in your environment block `/proc/<pid>/root` access (for example, strict seccomp or AppArmor profiles), use the explicit `volumeMounts` approach instead.
 
 Attach to the debug container:
+
 ```
 kubectl attach <pod-name> -c debugger -ti
 ```
@@ -254,7 +258,7 @@ For more strategies on how to debug production distroless containers, check the 
 
 ## Resources to learn more
 
-- [Minimal Container Images: Towards a More Secure Future ](https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future) - Chainguard Blog
+- [Minimal Container Images: Towards a More Secure Future](https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future) - Chainguard Blog
 - [Why Distroless](/chainguard/chainguard-images/overview/) - Chainguard Container Documentation
 - [Ephemeral Containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) - Official Kubernetes Documentation
 - [Introducing Ephemeral Containers](https://opensource.googleblog.com/2022/01/Introducing%20Ephemeral%20Containers.html) - Google Open Source Blog


### PR DESCRIPTION
## Type of change

Markdown lint cleanup — first batch (`content/chainguard/chainguard-images`).

### What should this PR do?

Make nine `chainguard-images` docs fully markdownlint-clean, and disable the `MD060`/`MD055` table-style rules in `.markdownlint-cli2.jsonc`.

- Autofixes: trailing whitespace, list style/indent, blanks around lists/headings, EOF
- Manual heading fixes: `versions.md` bold-as-heading → `####` (under their `###` parents); `use-with-openshift.md` body `#` headings → `##` (single-h1)
- Disable `MD060` (table-column-style / pipe alignment) and `MD055` (table-pipe-style): cosmetic, not autofixable, high-churn, no rendering benefit — matches earlier reviewer feedback on table rules

### Why are we making this change?

Working through the pre-existing markdown lint backlog in reviewable batches. Only files that end up fully clean are included; anything needing riskier manual work is deferred.

### What are the acceptance criteria?

- Every changed file is markdownlint-clean.
- No rendering changes.
- Autogenerated `chainctl-docs` remain excluded from linting.

### How should this PR be tested?

- `markdownlint-cli2` reports zero errors on every changed file.
- `hugo` builds all 1563 pages; no hard line breaks lost (literal `<br>` counts match `main`, and stripped whitespace was blank-line/end-of-paragraph only).

### Notes / scope

- **Deferred to a follow-up** (reverted here, not touched): files with broken anchor links (`MD051`), a heading-increment restructure (`MD001`), a nested-list indented code block (`MD046`), non-descriptive link text (`MD059`), and an emphasis-as-quote (`MD036`). `MD051` in particular needs verification against Hugo's actual anchor IDs (its slugger differs from markdownlint's), so those are handled carefully separately rather than guessed.

---

**Risk**: low. Mechanical autofix + two heading-level corrections; rendering verified unchanged.

**Review focus**:
1. The `versions.md` / `use-with-openshift.md` heading-level changes read correctly.
2. Disabling `MD060`/`MD055` table style rules.