### PR TITLE
ci(pre-commit): preserve markdown hard line breaks in trailing-whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,9 @@ repos:
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
+        # Preserve two-space hard line breaks in Markdown; strip other trailing
+        # whitespace as usual.
+        args: ['--markdown-linebreak-ext=md']
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files


### PR DESCRIPTION
## Type of change

pre-commit config tweak.

### What should this PR do?

Add `--markdown-linebreak-ext=md` to the `trailing-whitespace` hook so it preserves two-space hard line breaks in Markdown instead of stripping them.

### Why are we making this change?

The `trailing-whitespace` hook stripped all trailing whitespace, including the two spaces Markdown uses for a hard line break (`<br>`) — which markdownlint (MD009) explicitly allows. That conflict risked silently dropping intentional line breaks whenever a `.md` file was touched (it bit us a couple times during the lint cleanup). This flag reconciles the two tools.

### What are the acceptance criteria?

- Two-space hard breaks in `.md` files survive the hook.
- Other trailing whitespace (including on blank lines) is still cleaned up.

### How should this PR be tested?

Verified locally: a two-space break mid-paragraph is preserved after running the hook, while whitespace-only blank lines are still stripped.

---

**Risk**: low. Single hook-argument change; only affects how trailing whitespace is handled in Markdown.

**Review focus**: confirm preserving two-space Markdown breaks is the desired behavior (it matches markdownlint MD009).