### PR TITLE
style(markdown): lint-clean libraries docs (batch 2); disable MD036

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,6 +6,9 @@
     "MD026": false,
     "MD033": false,
     "MD034": false,
+    "MD036": false,
+    // Nested list items use 4-space indentation in this repo's docs.
+    "MD007": { "indent": 4 },
     "MD040": false,
     // Table style rules disabled: they enforce cosmetic pipe alignment/style
     // that is high-churn and not autofixable, without improving rendering.

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -22,7 +22,7 @@ system. This guide explains how to access (download) Chainguard library artifact
 
 ### Prerequisites
 
-- Ensure you have access to Chainguard Libraries. 
+- Ensure you have access to Chainguard Libraries.
     - If you are not a Chainguard user yet, a new Chainguard account must be
 created and you must [add an entitlement to Chainguard Libraries](/chainguard/libraries/access/#manage-library-entitlements).
 - Confirm the name of your organization so you can use it with the `--parent`
@@ -31,13 +31,13 @@ parameter to specify your organization when running commands with `chainctl`.
 ### Direct access vs. artifact manager
 
 There are two approaches to access: Using an artifact manager or
-direct access. 
+direct access.
 
 **Artifact manager**
 
 If your organization uses an artifact manager such as Cloudsmith, JFrog Artifactory, or Sonatype Nexus, you can set up and configure credentials once per language ecosystem. Then, all projects and developers automatically inherit
 the configuration. This option is recommended for organizations with multiple
-teams, and provides centralized access controls and consistent uptime. 
+teams, and provides centralized access controls and consistent uptime.
 
 **Direct access**
 
@@ -47,11 +47,11 @@ allow for global configuration. It requires configuration per project and
 workstation, which creates more overhead as you scale across teams and projects.
 
 Both approaches require pull tokens for authentication; see [Pull token
-characteristics and use](#pull-token-characteristics-and-use) for more information. 
+characteristics and use](#pull-token-characteristics-and-use) for more information.
 
 > NOTE: For Python users, the [Chainguard keyring
 provider](#python-keyring-provider) uses short-lived credentials and is the
-preferred method where your environment supports it. 
+preferred method where your environment supports it.
 
 ### Initial authentication
 
@@ -77,7 +77,8 @@ Valid! Id: 8a4141a........7d9904d98c
 ## Creating pull tokens for libraries
 
 Pull tokens authenticate requests to download library artifacts from Chainguard. You can create the pull tokens:
-- With [the chainctl command](#creating-pull-tokens-with-chainctl), or 
+
+- With [the chainctl command](#creating-pull-tokens-with-chainctl), or
 - [Using the Chainguard
   console](#creating-pull-tokens-with-the-chainguard-console).
 
@@ -100,14 +101,14 @@ command:
 chainctl auth pull-token --repository=java --parent=example --ttl=8670h
 ```
 
-* `--repository=java`: retrieve the token for use with [Chainguard Libraries for
+- `--repository=java`: retrieve the token for use with [Chainguard Libraries for
   Java](/chainguard/libraries/java/overview/). Use `python` for a token to use
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/) and
   `javascript` for a token to use [Chainguard Libraries for
   JavaScript](/chainguard/libraries/javascript/overview/).
-* `--parent=example`: specify the parent organization for your account as
+- `--parent=example`: specify the parent organization for your account as
   provided when requesting access to Chainguard Libraries and replace `example`.
-* `--ttl=8670h`: set the duration for the validity of the token, defaults to
+- `--ttl=8670h`: set the duration for the validity of the token, defaults to
   `720h` (equivalent to 30 days), maximum valid value is `8760h` (equivalent to
   365 days), valid unit strings range from nanoseconds to hours and are `ns`,
   `us`, `ms`, `s`, `m`, and `h`.
@@ -171,14 +172,16 @@ for basic authentication. Note that the actual returned values are much longer.
 > your own artifact repository whenever possible.
 
 For artifact manager setup, see the global configuration guides:
-* [Java](/chainguard/libraries/java/global-configuration/)
-* [JavaScript](/chainguard/libraries/javascript/global-configuration/)
-* [Python](/chainguard/libraries/python/global-configuration/)
+
+- [Java](/chainguard/libraries/java/global-configuration/)
+- [JavaScript](/chainguard/libraries/javascript/global-configuration/)
+- [Python](/chainguard/libraries/python/global-configuration/)
 
 For direct access, see the build configuration guides:
-* [Java](/chainguard/libraries/java/build-configuration/)
-* [JavaScript](/chainguard/libraries/javascript/build-configuration/)
-* [Python](/chainguard/libraries/python/build-configuration/)
+
+- [Java](/chainguard/libraries/java/build-configuration/)
+- [JavaScript](/chainguard/libraries/javascript/build-configuration/)
+- [Python](/chainguard/libraries/python/build-configuration/)
 
 <a name="env"></a>
 
@@ -203,6 +206,7 @@ calling `chainctl`:
 ```shell
 eval $(chainctl auth pull-token --output env --repository=java --parent=example)
 ```
+
 Equivalent commands for Python and JavaScript are supported and result in values
 for the `CHAINGUARD_PYTHON_IDENTITY_ID`/`CHAINGUARD_PYTHON_TOKEN` and
 `CHAINGUARD_JAVASCRIPT_IDENTITY_ID`/`CHAINGUARD_JAVASCRIPT_TOKEN` variables.
@@ -217,11 +221,11 @@ Running this command as part of a login script or some other automation allows
 your organization to replace actual username and password values in your build
 tool configuration with environment variable placeholders:
 
-* [Java build tool
+- [Java build tool
   configuration](/chainguard/libraries/java/build-configuration/)
-* [JavaScript build tool
+- [JavaScript build tool
   configuration](/chainguard/libraries/javascript/build-configuration/)
-* [Python build tool
+- [Python build tool
   configuration](/chainguard/libraries/python/build-configuration/)
 
 <a id="netrc"></a>
@@ -270,14 +274,14 @@ Use the credentials for manual testing in a browser or with a script and curl if
 you know the URL for a specific library artifact. Refer to the following
 sections for more details:
 
-* [Technical details and manual testing for Java
+- [Technical details and manual testing for Java
   libraries](/chainguard/libraries/java/overview/#technical-details)
-* [Technical details and manual testing for JavaScript
+- [Technical details and manual testing for JavaScript
   libraries](/chainguard/libraries/javascript/overview/#technical-details)
-* [Technical details and manual testing for Python
+- [Technical details and manual testing for Python
   libraries](/chainguard/libraries/python/overview/#technical-details)
-* [Use environment variables](#env)
-* [.netrc for authentication](#netrc)
+- [Use environment variables](#env)
+- [.netrc for authentication](#netrc)
 
 <a id="python-keyring"></a>
 
@@ -359,30 +363,30 @@ otherwise do not cause any issues and continue to exist until you delete them.
 
 Inspect all pull tokens for your organization in the Chainguard console:
 
-* Use your authentication details to access the console at
+- Use your authentication details to access the console at
   [https://console.chainguard.dev/](https://console.chainguard.dev/).
-* Select **Overview** in the left-hand navigation.
-* Select the **Manage pull tokens** tab.
-  * Alternatively, select **Settings** in the left-hand navigation, and select
+- Select **Overview** in the left-hand navigation.
+- Select the **Manage pull tokens** tab.
+    - Alternatively, select **Settings** in the left-hand navigation, and select
     **Pull Tokens** in the menu on the settings page.
 
 The list includes the following columns:
 
-* **Name** - the name of the pull token, expired pull token are identified by a
+- **Name** - the name of the pull token, expired pull token are identified by a
   red **Expired** warning.
-* **Description** - the description of the pull token
-* **Created** - the date when the pull token was created
-* **Expiration** - string description of the expiration status of the token,
+- **Description** - the description of the pull token
+- **Created** - the date when the pull token was created
+- **Expiration** - string description of the expiration status of the token,
   such as *in 8 months* or *4 days ago*.
-* **Actions** - menu button to perform actions on the pull token, only a Delete
+- **Actions** - menu button to perform actions on the pull token, only a Delete
   action is available.
 
 Use the action to remove a pull token:
 
-* Locate the row of the desired pull token, typically an expired token.
-* Use the menu button in the **Actions** column of the same row and select
+- Locate the row of the desired pull token, typically an expired token.
+- Use the menu button in the **Actions** column of the same row and select
   **Delete**.
-* Confirm the deletion in the dialog by pressing **Delete pull token**.
+- Confirm the deletion in the dialog by pressing **Delete pull token**.
 
 Alternatively use chainctl with the [auth
 pull-token](/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/) and
@@ -397,16 +401,16 @@ chainctl auth pull-token list
 
 The displayed list includes the following columns:
 
-* **ID** - the identifying username of the pull token
-* **NAME** - the name of the pull token
-* **DESCRIPTION** - the description of the pull token
-* **ROLES** - the assigned organization and role for the pull token. The value
+- **ID** - the identifying username of the pull token
+- **NAME** - the name of the pull token
+- **DESCRIPTION** - the description of the pull token
+- **ROLES** - the assigned organization and role for the pull token. The value
   shows the name of the organization separate from the role with a colon. Valid
   roles are all pull authorization from for apk packages `apk.pull`, container
   images `registry.pull`, Python libraries `libraries.python.pull`, Java
   libraries `libraries.java.pull`, and JavaScript libraries
   `libraries.javascript.pull` .
-* **EXPIRES** - the number of days until the end of the TTL period. Negative
+- **EXPIRES** - the number of days until the end of the TTL period. Negative
   values indicate expired tokens.
 
 List all pull tokens for Chainguard Libraries for Java that are not yet expired:
@@ -460,7 +464,7 @@ To update the upstream fallback policy on an existing entitlement, rerun the `cr
 
 ### Remove entitlements
 
-You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/): 
+You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/):
 
 ```shell
 chainctl libraries entitlements delete --ecosystem=JAVASCRIPT --parent=example
@@ -496,7 +500,7 @@ You can create, disable, and list library policies using [`chainctl libraries po
 
 ### Create and enable a cooldown policy
 
-When upstream fallback is enabled, users with the Owner role can create and enable a cooldown policy with `chainctl`. The cooldown period provides an additional layer of defense on top of malware and greyware scanning, giving the broader security community time to surface threats that may not be immediately detectable. 
+When upstream fallback is enabled, users with the Owner role can create and enable a cooldown policy with `chainctl`. The cooldown period provides an additional layer of defense on top of malware and greyware scanning, giving the broader security community time to surface threats that may not be immediately detectable.
 
 In the following example, a 10-day cooldown policy is created, then it is enforced on the JavaScript ecosystem:
 
@@ -505,11 +509,11 @@ chainctl libraries policy create --name=js-cooldown --cooldown-days=10
 chainctl libraries policy enable --policy=js-cooldown --ecosystem=JAVASCRIPT --mode=ENFORCE
 ```
 
-The default cooldown period is 7 days. 
+The default cooldown period is 7 days.
 
 #### Preview a cooldown policy
 
-To understand the impact before enforcing a policy, use `--mode=PREVIEW`. In preview mode, installs continue to succeed, but Chainguard records what _would have been blocked_ if the policy were enforced.
+To understand the impact before enforcing a policy, use `--mode=PREVIEW`. In preview mode, installs continue to succeed, but Chainguard records what *would have been blocked* if the policy were enforced.
 
 ### Disable cooldown
 
@@ -534,4 +538,4 @@ To verify which policy is active and its cooldown settings, run the following:
 chainctl libraries policy binding list
 ```
 
-Prior to `chainctl` version 0.2.291, cooldown policies were enabled via the `chainctl entitlements command`. Cooldown policies configured prior to this version of `chainctl` are migrated under the new `chainctl libraries policies` system. 
+Prior to `chainctl` version 0.2.291, cooldown policies were enabled via the `chainctl entitlements command`. Cooldown policies configured prior to this version of `chainctl` are migrated under the new `chainctl libraries policies` system.

--- a/content/chainguard/libraries/cve-remediation.md
+++ b/content/chainguard/libraries/cve-remediation.md
@@ -56,7 +56,7 @@ For Java, remediated artifacts use a `-0.cgr.N` suffix appended to the base vers
 
 ### Remediation and transitive dependencies
 
-**Python** 
+**Python**
 
 For Python, installing a `+cgr.N` package doesn't automatically remediate its entire dependency tree. Chainguard publishes a `+cgr.N` version only for a package that has a remediation to deliver, and it leaves that package's own dependency declarations unchanged.
 
@@ -86,22 +86,22 @@ package level, no advisory entry is published in the VEX feed for these
 versions. However, scanners that inspect vendored binaries will reflect the fix
 in their results.
 
-
 ## Browse libraries with CVE remediation
 
 Remediated libraries are published in dedicated repositories:
+
 - Python: In a PyPI-compatible index at `https://libraries.cgr.dev/python-remediated/` - the simple index is at `https://libraries.cgr.dev/python-remediated/simple/`
 - Java: In a repository at `https://libraries.cgr.dev/java-remediated/` - a companion to the standard Chainguard Libraries for Java repository at `https://libraries.cgr.dev/java/`
 
 You can:
+
 - Browse them in the Chainguard Console
 - Use the public VEX feed to understand what has been remediated
     - This feed does not include [vendored dependencies](#cve-remediation-for-vendored-dependencies).
 - View them in a browser at the simple index URL
     - Learn more in [Python Overview > Manual access](/chainguard/libraries/python/overview/#manual-access) and in [Java Overview > Manual access](/chainguard/libraries/java/overview/#manual-access).
-- Expose them to your developers via a repo manager 
+- Expose them to your developers via a repo manager
     - Learn more in the global configuration docs for [Python](/chainguard/libraries/python/global-configuration/) and [Java](/chainguard/libraries/java/global-configuration/).
-
 
 ### Browse remediated libraries in the Chainguard Console
 
@@ -119,7 +119,7 @@ a public VEX feed at
 Supported scanners and your own custom tooling can use this feed to identify and
 recognize remediated versions.
 
-To view more details on the CVE and versions of a library that have been remediated, identify the library then navigate to the URL. For example: `https://libraries.cgr.dev/openvex/v1/pypi/urllib3.openvex.json`. 
+To view more details on the CVE and versions of a library that have been remediated, identify the library then navigate to the URL. For example: `https://libraries.cgr.dev/openvex/v1/pypi/urllib3.openvex.json`.
 
 ## Scanning remediated libraries
 
@@ -131,4 +131,3 @@ dependencies.
 Find more general information and specifics for supported scanners in
 [Vulnerability Scanners and Chainguard
 Libraries](/chainguard/libraries/scanners/).
-

--- a/content/chainguard/libraries/faq.md
+++ b/content/chainguard/libraries/faq.md
@@ -42,7 +42,7 @@ of the software supply chain for libraries across different language ecosystems:
 
 * This May 2025 attack uploaded compromised packages to PyPI and npm that enable remote shell access and uploading files to compromised machines
 * Chainguard Libraries would have protected against this attack. First, the packages have invalid upstream source URLs so there was no source repository. In the case of the lone exception (a package with a valid source repository link), no code was present for Chainguard to build a valid package.
-- [The Hacker News](https://thehackernews.com/2025/06/new-supply-chain-malware-operation-hits.html) blog post on the attack
+* [The Hacker News](https://thehackernews.com/2025/06/new-supply-chain-malware-operation-hits.html) blog post on the attack
 
 {{< /details >}}
 
@@ -124,12 +124,12 @@ list](https://github.com/chainguard-dev/ssc-reading-list).
 
 {{< /details >}}
 
-
 ## Why do the Chainguard library checksums differ from those published by upstream repositories?
 
-Chainguard rebuilds libraries from source in a controlled environment to improve supply-chain security. As a result, while functionality remains the same, build metadata and generated content, such as SBOMs, differs from upstream distributions. Whether Chainguard library checksums match upstream depends on the ecosystem and build process. 
+Chainguard rebuilds libraries from source in a controlled environment to improve supply-chain security. As a result, while functionality remains the same, build metadata and generated content, such as SBOMs, differs from upstream distributions. Whether Chainguard library checksums match upstream depends on the ecosystem and build process.
 
 During initial migration to Chainguard Libraries, some common causes of checksum errors include:
+
 * Artifacts were previously cached from upstream repositories
     * Example: Maven's `.m2` or Gradle's cache.
 * Dependencies are pinned to upstream checksums or hashes
@@ -139,7 +139,7 @@ During initial migration to Chainguard Libraries, some common causes of checksum
 
 ## Does Chainguard Libraries for Java include CVE remediation fixes?
 
-Short answer: 
+Short answer:
 
 No. Libraries are built from source code in the secured and hardened Chainguard
 infrastructure. This eliminates any build and distribution stage
@@ -151,7 +151,7 @@ Chainguard cannot patch Java libraries and create binaries with the same
 identifier because the complete behavior and API surface of every library
 affects the use. That use however is part of the application development of each
 customer. It varies widely and any change potentially creates incompatibilities,
-different behavior or even new security issues. 
+different behavior or even new security issues.
 
 Chainguard collaborates with many upstream projects and can collaborate with
 customers to increase and accelerate the creation and adoption of fixes and the
@@ -178,9 +178,10 @@ backports High and Critical vulnerability fixes from newer upstream releases to
 older versions that customers are still using, particularly when upstream
 maintainers no longer ship patches for those older versions. Remediated versions
 are:
-- Published in a separate Python index (e.g.,
+
+* Published in a separate Python index (e.g.,
   https://libraries.cgr.dev/python-remediated/simple/).
-- Given a local version suffix like +cgr.N (for example, 2.0.0+cgr.1) so
+* Given a local version suffix like +cgr.N (for example, 2.0.0+cgr.1) so
   dependency resolvers can distinguish them from non‑remediated upstream
   versions while still preferring the remediated build during resolution.
 
@@ -189,21 +190,22 @@ are:
 For JavaScript, Chainguard offers the [Chainguard
 Repository](/chainguard/chainguard-repository/) as a unified, managed endpoint
 at `https://libraries.cgr.dev/javascript/`. This single endpoint:
-- Serves Chainguard‑built packages first, rebuilt from source.
-- Optionally falls back to upstream npm for packages or versions that are not
+
+* Serves Chainguard‑built packages first, rebuilt from source.
+* Optionally falls back to upstream npm for packages or versions that are not
   yet available from Chainguard.
-- Applies security controls on the upstream fallback, including a cooldown
+* Applies security controls on the upstream fallback, including a cooldown
   window and malware detection that blocks packages associated with known
   malware IDs from public OSV feeds.
 
 Because of those controls, you can still see 404s or failed fetches even when
 fallback is enabled, for example when:
 
-- A package or version is blocked by malware detection and therefore
+* A package or version is blocked by malware detection and therefore
   intentionally not served from upstream.
-- A recently published version is still in the cooldown period, so the
+* A recently published version is still in the cooldown period, so the
   repository will not yet proxy it from npm.
-- The requested package/version truly does not exist in either Chainguard’s
+* The requested package/version truly does not exist in either Chainguard’s
   catalog or upstream.
 
 Fallback respects security policies first, then mirrors safe content from npm.
@@ -214,4 +216,4 @@ though a version appears in the public registry.
 
 Chibbies is the internal codename for the Chainguard Libraries. It evolved from
 Chainguard Libraries being shortened to Chainguard Libbies, and then [finally to
-Chibbies](https://www.youtube.com/watch?v=adfU9LJg3I0&t=2843s). 
+Chibbies](https://www.youtube.com/watch?v=adfU9LJg3I0&t=2843s).

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -40,10 +40,10 @@ optional measures:
 * Remove all cached artifacts in the proxy repository of Maven Central and other
   repositories. This step allows you to validate which libraries are not
   available from Chainguard Libraries and proceed with potential next steps with
-  Chainguard and your own development efforts. 
+  Chainguard and your own development efforts.
 * Remove any repositories that are no longer desired or necessary. Depending on
   your library requirements this step can result in removal of some proxy
-  repositories or even removal of all proxy repositories. 
+  repositories or even removal of all proxy repositories.
 
 Adopting the use of a repository manager is the recommended approach, however if
 your organization does not use a repository manager, you can still use
@@ -53,7 +53,7 @@ configure and control. Refer to the [direct access documentation for build
 tools](/chainguard/libraries/java/build-configuration/#direct-access) for more
 information.
 
-### Considerations for fallback approach
+## Considerations for fallback approach
 
 Before configuring your repo manager, consider how you want to handle packages that aren't
 yet available in the Chainguard Libraries repository. If you configure a fallback to Maven Central, packages sourced from that registry are not covered by Chainguard's
@@ -74,7 +74,7 @@ by defining multiple upstream repositories.
 ### Initial configuration
 
 Use the following steps to add a repository with the Maven Central Repository
-and the Chainguard Libraries for Java repository as Maven upstream repositories. 
+and the Chainguard Libraries for Java repository as Maven upstream repositories.
 
 Configure a `java-all` repository:
 
@@ -83,10 +83,10 @@ Configure a `java-all` repository:
 1. On the **Repositories** page, click the **+ New repository** button.
 1. Enter the name `java-all` for your new repository. The name should
    include `java` to identify the ecosystem. This convention helps
-   avoid confusion since repositories in Cloudsmith are multi-format. 
+   avoid confusion since repositories in Cloudsmith are multi-format.
 1. Select a storage region that is appropriate for your organization and
    infrastructure.
-1. Click **+Create Repository**. 
+1. Click **+Create Repository**.
 
 Configure an upstream proxy for the Maven Central Repository:
 
@@ -175,7 +175,7 @@ Before configuring the repositories, you must create a secret with the [password
 value as retrieved with chainctl](/chainguard/libraries/access/):
 
 1. Navigate to the **Secret Manager**
-1. Click **Create secret**. 
+1. Click **Create secret**.
 1. Set the **Name** to `chainguard-libraries-java`.
 1. Set the **Secret** value to the password from your `chainctl` output.
 1. Click **Create secret**.
@@ -220,13 +220,13 @@ Combine the repositories in a new virtual repository:
 1. Under **Virtual upstream repositories**, click **Add upstream repository**.
 1. Use the **Browse** button to locate and select the `java-chainguard`
    repository as **Repository 1** and set the **Policy name 1** to
-   `java-chainguard`. 
+   `java-chainguard`.
 1. Use the **Browse** button to locate and select the `java-public` repository
    as **Repository 1** and set the **Policy name 1** to `java-public`.
 1. Under **Virtual upstream repositories**, click **Add upstream repository**.
 1. Set the **Priority** value for the `java-chainguard` policy name to a higher
    value than the `java-public` priority value.
-   * If you are using the remediated repository, add the `java-chainguard-remediated` repository and ensure it is the first in the displayed list. If not, ensure the `java-chainguard` repository is first. 
+   * If you are using the remediated repository, add the `java-chainguard-remediated` repository and ensure it is the first in the displayed list. If not, ensure the `java-chainguard` repository is first.
 1. Under **Location type**, choose the same suitable **Region** for your development as configured for the `java-public` repository.
 1. Click **Create**.
 
@@ -299,7 +299,7 @@ Combine the repositories in a new virtual repository:
 1. Scroll down to the **Repositories** section.
 1. Add the `java-chainguard` and `java-public` repositories. Drag and drop repositories into the
    desired position.
-    * If you are using the remediated repository, add the `java-chainguard-remediated` repository and ensure it is the first in the displayed list. If not, ensure the `java-chainguard` repository is first. 
+    * If you are using the remediated repository, add the `java-chainguard-remediated` repository and ensure it is the first in the displayed list. If not, ensure the `java-chainguard` repository is first.
 1. Click **Create Virtual Repository**.
 
 Use this setup for initial testing with Chainguard Libraries for Java. For
@@ -321,7 +321,7 @@ curl -sSf -L \
   | sha256sum
 ```
 
-2. Fetch the same artifact through the Artifactory remote repository and compute its checksum:
+1. Fetch the same artifact through the Artifactory remote repository and compute its checksum:
 
 ```bash
 curl -sSf -L \
@@ -329,13 +329,14 @@ curl -sSf -L \
   https://<artifactory-host>/artifactory/java-chainguard/junit/junit/4.13.2/junit-4.13.2.jar \
   | sha256sum
 ```
+
 Replace `artifactory-host` with your Artifactory instance hostname.
 
-The checksums returned by the commands must match. 
+The checksums returned by the commands must match.
 
 If the checksum from the Artifactory remote repository differs from the direct fetch, or if the Artifactory fetch fails entirely, review the following before proceeding:
 
-* URL: The remote repository URL must be set to `https://libraries.cgr.dev/java/`. 
+* URL: The remote repository URL must be set to `https://libraries.cgr.dev/java/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=java` and update the Artifactory repository credentials. Expired tokens fail silently.
 * Advanced configuration: Ensure all recommended Advanced settings from the [remote repository configuration steps](#initial-configuration-2) have been applied.
 
@@ -360,8 +361,8 @@ for accessing the repository:
    replaced with the name of your organization.
 
 Use the URL of the virtual repository in the [build
-configuration](/chainguard/libraries/java/build-configuration/) and build a 
-first test project. In a working setup the chainguard remote repository contains 
+configuration](/chainguard/libraries/java/build-configuration/) and build a
+first test project. In a working setup the chainguard remote repository contains
 all libraries retrieved from Chainguard.
 
 <a name="nexus"></a>
@@ -410,7 +411,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * **HTTP - Authentication** Select the `username` **Authentication type**, and
    provide the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).
-1. Click **Create repository**. 
+1. Click **Create repository**.
 1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 
 Combine a new repository group and add the repositories:
@@ -431,7 +432,7 @@ for accessing the repository:
 1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top
    navigation bar.
 1. Locate the **URL** column for the `java-all` repository group and click
-   **Copy**. 
+   **Copy**.
      * For example, `https://repo.example.com/repository/java-all/` (with
    `repo.example.com` replaced with the hostname of your repository manager).
 1. Use your configured username and password, unless **Security > Anonymous
@@ -441,7 +442,6 @@ for accessing the repository:
 Use the URL of the repository group, such as
 `https://repo.example.com/repository/java-all/` or
 `https://repo.example.com/repository/maven-public/` in the [build
-configuration](/chainguard/libraries/java/build-configuration/) and build a 
+configuration](/chainguard/libraries/java/build-configuration/) and build a
 first test project. In a working setup the `java-chainguard` proxy repository contains
 all libraries retrieved from Chainguard.
-

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -14,7 +14,7 @@ weight: 051
 toc: true
 ---
 
-Chainguard Libraries for Java provides enhanced security for the Java ecosystem by rebuilding dependencies from Maven Central and other common repositories with the latest patches and comprehensive supply chain protection. This service addresses critical vulnerabilities in the vast Java/JVM ecosystem that spans hundreds of projects from organizations like the Apache Software Foundation, Eclipse Foundation, and numerous independent maintainers. 
+Chainguard Libraries for Java provides enhanced security for the Java ecosystem by rebuilding dependencies from Maven Central and other common repositories with the latest patches and comprehensive supply chain protection. This service addresses critical vulnerabilities in the vast Java/JVM ecosystem that spans hundreds of projects from organizations like the Apache Software Foundation, Eclipse Foundation, and numerous independent maintainers.
 
 Chainguard Libraries for Java provides access to all open source libraries
 commonly used. New releases of common libraries or artifacts requested by
@@ -45,7 +45,7 @@ CERN,
 Note that coverage is not exhaustive for any single repository; the index
 continues to grow, and any request for a missing library or version
 automatically triggers a process to provision the artifacts from relevant
-sources if available. 
+sources if available.
 
 ## Runtime requirements
 
@@ -59,7 +59,7 @@ Libraries for Java.
 
 You must use the [username and password retrieved with
 chainctl](/chainguard/libraries/access/) to access the Chainguard
-Libraries for Java repository. 
+Libraries for Java repository.
 
 The URL for the repository is:
 
@@ -106,7 +106,7 @@ the Chainguard Libraries repository.
 
 Typically the access is [configured globally on a repository manager for your
 organization](/chainguard/libraries/java/global-configuration/). This approach
-is strongly recommended. 
+is strongly recommended.
 
 Alternatively, you can use the token for direct access from a build tool as
 discussed in [Build
@@ -116,7 +116,7 @@ configuration](/chainguard/libraries/java/build-configuration/).
 
 Chainguard Libraries for Java includes the [CVE
 Remediation](/chainguard/libraries/cve-remediation/) feature, available in beta for Spring Boot. Remediated
-libraries include an appended local version identifier of `-0.cgr.N`. 
+libraries include an appended local version identifier of `-0.cgr.N`.
 
 For example, if `org.apache.commons:commons-lang3:3.18.0` has a remediated build, that build is published as `org.apache.commons:commons-lang3:3.18.0-0.cgr.1`. If Chainguard publishes another remediated iteration for the same base version, the trailing number increases, such as `-0.cgr.2` or `-0.cgr.3`.
 
@@ -161,7 +161,6 @@ structure follows the [Maven repository
 format](https://maven.apache.org/repository/layout.html). The `groupId` and
 `artifactId` of a library is used to create a nested directory structure,
 similar to the package structure within Java projects.
-
 
 For example, the Maven coordinates for [Apache Commons
 Lang](https://commons.apache.org/proper/commons-lang/) are the following:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -27,8 +27,7 @@ applications or otherwise downloads and uses relevant libraries.
 
 If you are migrating an existing project to Chainguard Libraries, follow the
 [JavaScript migration guide](/chainguard/libraries/javascript/migration/) for a
-step-by-step walkthrough. 
-
+step-by-step walkthrough.
 
 ## JFrog Artifactory
 
@@ -94,10 +93,10 @@ which requires authentication. Choose whichever fits your environment:
   automatically. (`chainctl auth configure-npm` also sets up this
   libraries-scoped session as part of configuring npm.)
 - **CI or non-interactive**:
-  - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
+    - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
     token must be scoped to the libraries registry; mint one with
     `chainctl auth token --audience=libraries.cgr.dev`.
-  - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
+    - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
     secret), pass it as basic auth: `--username <identity> --password <secret>`,
     or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
 - **From `~/.netrc`**: Credentials for the registry host are read from `~/.netrc`
@@ -109,7 +108,6 @@ Artifactory or JFrog), authenticate with **that** registry's credentials —
 `--username`/`--password`, the `CHAINCTL_REGISTRY_USERNAME` /
 `CHAINCTL_REGISTRY_PASSWORD` environment variables, or a matching `~/.netrc`
 entry. Chainguard-scoped tokens are never sent to third-party hosts.
-
 
 <a id="npm"></a>
 
@@ -148,7 +146,7 @@ shows a minimal example with a couple of dependencies each:
 By default, npm retrieves packages from the npm Registry at
 `https://registry.npmjs.org` and stores them locally in the `node_modules`
 directory of the project after running `npm install`. This operation also
-creates the `package-lock.json` file. 
+creates the `package-lock.json` file.
 
 Note that dependency versions are typically declared with the `^` before the
 version string. This indicates higher, compatible versions, following the
@@ -165,17 +163,16 @@ each module.
 **Direct access: Point registry to Chainguard**
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to Chainguard in your user `.npmrc` file: 
+URL to point to Chainguard in your user `.npmrc` file:
 
 ```bash
 npm config set registry https://libraries.cgr.dev/javascript/
 ```
 
-
 ### Using a repository manager
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to your repository manager in your user `.npmrc` file: 
+URL to point to your repository manager in your user `.npmrc` file:
 
 ```shell
 npm config set registry https://repo.example.com:8443/repository/javascript-all/
@@ -194,9 +191,9 @@ configuring authentication.
 
 Example URLs:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all/`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all/`
-* Direct access: `https://libraries.cgr.dev/javascript/`
+- JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all/`
+- Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all/`
+- Direct access: `https://libraries.cgr.dev/javascript/`
 
 ### Apply registry changes
 
@@ -204,7 +201,7 @@ To apply the registry changes, remove the `node_modules` directory, [update the 
 packages from Chainguard and updates the lockfile in place with updated hashes:
 
 ```bash
-rm -rf node_modules 
+rm -rf node_modules
 chainctl libraries update-hashes
 npm install
 ```
@@ -264,13 +261,12 @@ After adding this line, verify your lockfile reflects the
 correct resolved URLs: scoped packages should resolve to `registry.npmjs.org`
 and all other packages should resolve to `libraries.cgr.dev/javascript`.
 
-
 <a id="npm-minimal"></a>
 
 ### Minimal example project
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#env). 
+detailed in the [access documentation](/chainguard/libraries/access/#env).
 
 **1. Create a JavaScript project**
 
@@ -285,7 +281,7 @@ npm init -y
 
 **2. Configure the .npmrc file**
 
-Once the environment variables are set, configure the `.npmrc` file. 
+Once the environment variables are set, configure the `.npmrc` file.
 
 Run the following command to configure registry
 access and authentication in the `.npmrc` file in the current project
@@ -323,6 +319,7 @@ coreutils versions included in most operating systems.
 registry=https://libraries.cgr.dev/javascript/
 //libraries.cgr.dev/javascript/:_auth=aWRlbnRpdHktaWQ6dG9rZW4=
 ```
+
 The value of `auth` is the base64 encoding of `identity-id:token`, including the `/` character in the username.
 
 **3. Verify authentication with npm ping**
@@ -334,6 +331,7 @@ npm ping --userconfig .npmrc
 ```
 
 A successful respoonse looks like:
+
 ```bash
 npm notice PING https://libraries.cgr.dev/javascript/
 npm notice PONG 1065ms
@@ -404,7 +402,7 @@ shows a minimal example with a couple of dependencies each:
 By default, pnpm retrieves the packages the npm Registry at
 `https://registry.npmjs.org` and stores them locally in the `node_modules`
 directory of the project after running `pnpm install`. This operation also
-creates the `pnpm-lock.yaml` file. 
+creates the `pnpm-lock.yaml` file.
 
 Note that dependency versions are typically declared with the `^` before the
 version string. This indicates higher, compatible versions, following the
@@ -458,10 +456,10 @@ registry=https://libraries.cgr.dev/javascript/
 //libraries.cgr.dev/javascript-upstream/:_auth=<base64-encoded-token>
 ```
 
-### Using a repository manager 
+### Using a repository manager
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to your repository manager in your user `.npmrc` file: 
+URL to point to your repository manager in your user `.npmrc` file:
 
 ```shell
 pnpm config set registry https://repo.example.com:8443/repository/javascript-all/
@@ -480,9 +478,9 @@ configuring authentication.
 
 Example URLs:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all/`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all/`
-* Direct access: `https://libraries.cgr.dev/javascript/`
+- JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all/`
+- Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all/`
+- Direct access: `https://libraries.cgr.dev/javascript/`
 
 ### Apply registry changes
 
@@ -490,7 +488,7 @@ To apply the registry changes, remove the `node_modules` directory, [update the 
 packages from Chainguard and updates the lockfile in place with updated hashes:
 
 ```bash
-rm -rf node_modules 
+rm -rf node_modules
 chainctl libraries update-hashes
 pnpm install
 ```
@@ -527,15 +525,15 @@ To find and manually remove the full store:
 pnpm store path
 ```
 
-Then delete the directory that command outputs: 
+Then delete the directory that command outputs:
 
-On macOS/Linux - 
+On macOS/Linux -
 
 ```bash
 rm -rf "$(pnpm store path)"
 ```
 
-On Windows - 
+On Windows -
 
 Use the path returned by `pnpm store path` and delete it via File Explorer or `rmdir`.
 
@@ -549,7 +547,7 @@ If you are migrating an existing project and want to preserve your current
 lockfile, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
 to update only the integrity hashes in place instead.
 
-Now you can proceed with your development and testing. 
+Now you can proceed with your development and testing.
 
 <a id="pnpm-minimal"></a>
 
@@ -565,7 +563,7 @@ pnpm init
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/access/#env). 
+detailed in the [access documentation](/chainguard/libraries/access/#env).
 
 To create pull token credentials and set them as environment variables, run:
 
@@ -627,7 +625,7 @@ projects, offering fast, reliable, and secure dependency management as an
 alternative to npm. It is widely used for managing
 project dependencies, scripts, and workflows in Node.js and other JavaScript
 development environments. For more details, refer to the [Yarn
-documentation](https://yarnpkg.com/getting-started). 
+documentation](https://yarnpkg.com/getting-started).
 
 This section applies to modern versions of Yarn, also known as Yarn Berry, with
 versions 2.x and higher. If you are using Yarn 1.x refer to the [Yarn Classic
@@ -653,6 +651,7 @@ dependencies. The following block shows a minimal example with `react` and
   }
 }
 ```
+
 By default, Yarn retrieves the packages from the registry at
 `https://registry.yarnpkg.com` and stores them locally in the `.yarn` folder in the user's
 home directory after running `yarn`. Specific packages are linked into the
@@ -671,7 +670,7 @@ values in the `checksum` field.
 **Direct access: Point registry to Chainguard**
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to Chainguard in your user `.yarnrc` file: 
+URL to point to Chainguard in your user `.yarnrc` file:
 
 ```bash
 yarn config set npmRegistryServer https://libraries.cgr.dev/javascript/
@@ -680,7 +679,7 @@ yarn config set npmRegistryServer https://libraries.cgr.dev/javascript/
 ### Using a repository manager
 
 To change a project to use Chainguard Libraries for JavaScript, set the registry
-URL to point to your repository manager in your project `.yarnrc.yml` file: 
+URL to point to your repository manager in your project `.yarnrc.yml` file:
 
 ```shell
 yarn config set npmRegistryServer https://repo.example.com:8443/repository/javascript-all
@@ -697,9 +696,9 @@ more details such as authentication support.
 
 Example URLs:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all`
-* Direct access: `https://libraries.cgr.dev/javascript`
+- JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all`
+- Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all`
+- Direct access: `https://libraries.cgr.dev/javascript`
 
 ### Apply registry changes
 
@@ -726,7 +725,7 @@ to update only the integrity hashes in place instead.
 
 #### Using Chainguard Libraries with `yarn install --immutable`
 
-Yarn Berry's `--immutable` flag prevents changes to `yarn.lock` during installation. Migrating to Chainguard Libraries requires a lockfile preparation step before your normal `--immutable` workflow can resume. 
+Yarn Berry's `--immutable` flag prevents changes to `yarn.lock` during installation. Migrating to Chainguard Libraries requires a lockfile preparation step before your normal `--immutable` workflow can resume.
 
 Yarn Berry's lockfile stores both resolved `__archiveUrl` entries and Yarn-specific checksums (used by `--immutable` to detect tampering). Run the following command to update both:
 
@@ -816,9 +815,9 @@ yarn config set 'npmRegistries["//libraries.cgr.dev/javascript"].npmAlwaysAuth' 
 
 Note the following details:
 
-* The `authInfo` token is passed as authentication identity `npmAuthIdent` and only uses 
+- The `authInfo` token is passed as authentication identity `npmAuthIdent` and only uses
   the username and password values from the pull token separated by colon without any further encoding.
-* Setting `npmAlwaysAuth` is required.
+- Setting `npmAlwaysAuth` is required.
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:
@@ -892,7 +891,7 @@ To change a project to use Chainguard Libraries for JavaScript, first export you
 export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 ```
 
-Then, set auth and set the registry URL to point to Chainguard in your user `.npmrc` file: 
+Then, set auth and set the registry URL to point to Chainguard in your user `.npmrc` file:
 
 ```bash
 cat > .npmrc << 'EOF'
@@ -917,10 +916,9 @@ EOF
 
 Example URLs:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all`
-* Direct access: `https://libraries.cgr.dev/javascript`
-
+- JFrog Artifactory: `https://example.jfrog.io/artifactory/javascript-all`
+- Sonatype Nexus: `https://repo.example.com:8443/repository/javascript-all`
+- Direct access: `https://libraries.cgr.dev/javascript`
 
 ### Apply registry changes
 
@@ -937,12 +935,12 @@ To apply the registry changes, remove the `node_modules` directory, [update the 
 packages from Chainguard and updates the lockfile in place with updated hashes:
 
 ```bash
-rm -rf node_modules 
+rm -rf node_modules
 chainctl libraries update-hashes
 yarn install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `yarn-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes. 
+As an alternative, you can remove the `node_modules` directory _and_ the `yarn-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes.
 
 Another option, after deleting `node_modules` and `yarn-lock.json`, is to run `yarn upgrade`. This updates all dependencies to their latest allowed
 versions and regenerates the lock file with updated hashes.
@@ -972,7 +970,7 @@ the environment variables are set, the following steps configure registry access
 with authentication in the `.npmrc` file directory:
 
 ```shell
-export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0) 
+export token=$(echo -n "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}:${CHAINGUARD_JAVASCRIPT_TOKEN}" | base64 -w 0)
 cat > .npmrc << EOF
 registry=https://libraries.cgr.dev/javascript/
 //libraries.cgr.dev/javascript/:_auth="$token"
@@ -982,15 +980,15 @@ EOF
 
 Note the following details:
 
-* Using yarn configuration files such as `.yarnrc` and commands like `yarn
+- Using yarn configuration files such as `.yarnrc` and commands like `yarn
   config set registry` does not work with authentication details, and the
-  proposed approach with `.npmrc` file is preferable. 
-* The `token` token is passed as authentication token `_auth` and uses the
+  proposed approach with `.npmrc` file is preferable.
+- The `token` token is passed as authentication token `_auth` and uses the
   username and password values from the pull token separated by colon in
   `base64` encoding. Note that the `-w 0` option for `base64` is required and
-  supported by the GNU coreutils versions included in most operating systems. 
-* Setting `always-auth` is required.
-* The trailing slash in the registry URL and authentication references to it is required.
+  supported by the GNU coreutils versions included in most operating systems.
+- Setting `always-auth` is required.
+- The trailing slash in the registry URL and authentication references to it is required.
 
 Add dependencies for your project into the `package.json` file to test retrieval
 from Chainguard Libraries, build the project, and list the dependencies:
@@ -1052,7 +1050,7 @@ compatible newer releases under semantic versioning. For example, `^22.18.0` for
 Any dependency or version changes require running `bun install` again, which
 updates the lockfile.
 
-### Using a repository manager 
+### Using a repository manager
 
 To switch a project to use Chainguard Libraries for JavaScript, point Bun at
 your repository manager. Add the [registry
@@ -1077,9 +1075,9 @@ Refer to [Bun documentation](https://bun.com/docs) for additional registry and a
 
 Example registry URLs:
 
-* JFrog Artifactory: https://example.jfrog.io/artifactory/javascript-all/
-* Sonatype Nexus: https://repo.example.com:8443/repository/javascript-all/
-* Direct access: https://libraries.cgr.dev/javascript/
+- JFrog Artifactory: https://example.jfrog.io/artifactory/javascript-all/
+- Sonatype Nexus: https://repo.example.com:8443/repository/javascript-all/
+- Direct access: https://libraries.cgr.dev/javascript/
 
 ### Apply registry changes
 
@@ -1087,12 +1085,12 @@ To apply the registry changes, remove the `node_modules` directory, [update the 
 packages from Chainguard and updates the lockfile in place with updated hashes:
 
 ```bash
-rm -rf node_modules 
+rm -rf node_modules
 chainctl libraries update-hashes
 bun install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `bun-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes. 
+As an alternative, you can remove the `node_modules` directory _and_ the `bun-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes.
 
 <a id="bun-minimal"></a>
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -53,7 +53,8 @@ At a high level, adopting the use of Chainguard Libraries consists of the follow
 
 Adopting the use of a repository manager is the recommended approach to minimize complexity. If your organization does not use a repository manager, refer to the [direct access documentation](/chainguard/libraries/javascript/build-configuration/) for build tools.
 
-### Manually managing fallback
+## Manually managing fallback
+
 Chainguard recommends using the Chainguard Repository's built-in [upstream
 fallback](/chainguard/libraries/javascript/overview/#upstream-fallback-policy-and-controls)
 rather than configuring a public registry fallback in your repo manager.
@@ -69,7 +70,7 @@ this page follow this pattern.
 ### Updating lockfile hashes
 
 If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
-for all supported JavaScript lockfile formats. 
+for all supported JavaScript lockfile formats.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 
@@ -79,7 +80,7 @@ chainctl libraries update-hashes \
   --token "$REPO_TOKEN"
 ```
 
-After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes. 
+After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
 Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
@@ -97,11 +98,11 @@ by defining multiple upstream repositories.
 
 ### Initial configuration
 
-Use the following steps to configure a repository with the Chainguard Libraries for 
+Use the following steps to configure a repository with the Chainguard Libraries for
 JavaScript repository as an upstream.
 
-Configure a *javascript-all* repository. This repository acts as a single access point 
-for JavaScript packages and may also include private packages or additional upstream 
+Configure a *javascript-all* repository. This repository acts as a single access point
+for JavaScript packages and may also include private packages or additional upstream
 sources, depending on your configuration.
 
 1. Log in as a user with administrator privileges.
@@ -136,7 +137,6 @@ proxy for the public npm registry with a lower priority than
 Use this setup for initial testing with Chainguard Libraries for JavaScript. For
 production usage, add the `javascript-chainguard` upstream proxy to your production
 repository.
-
 
 ### Build tool access
 
@@ -200,10 +200,8 @@ repository:
 1. Click the **Advanced** configuration tab, then check the box next to **Disable URL Normalization**.
 1. Click **Create Remote Repository**.
 
-
-
 Create a virtual repository, or add the remote repository to an existing
-virtual repository used for npm packages. A virtual repository may also include private npm packages or 
+virtual repository used for npm packages. A virtual repository may also include private npm packages or
 additional upstream sources, depending on your configuration.
 
 1. Click **Create a Repository** → **Virtual**.
@@ -230,16 +228,16 @@ To prevent this:
 
 1. Apply the following settings to your Artifactory `javascript-chainguard`
    remote repository, within in the **Advanced** tab:
-    - **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD
+    * **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD
       requests that may not be handled correctly by redirect-based registries.
-    - **Disable Lenient Host Authentication** — disabling this setting ensures
-      credentials are not forwarded across the redirect. 
-    - **Enable Cookie Management** - this setting is optional, but recommended
+    * **Disable Lenient Host Authentication** — disabling this setting ensures
+      credentials are not forwarded across the redirect.
+    * **Enable Cookie Management** - this setting is optional, but recommended
       by JFrog for remote repositories that involve redirects.
 2. Clear the corrupted cached tarballs: in Artifactory, right-click the
    `javascript-chainguard` repository and click **Zap Caches**, then re-run your
    install.
-    - Alternatively, you could delete specific corrupted `.tgz` artifacts from
+    * Alternatively, you could delete specific corrupted `.tgz` artifacts from
       the remote cache, rather than deleting all, before re-running the install.
 
 ### Validate the remote repository
@@ -257,7 +255,7 @@ curl -sSf -L \
   | openssl dgst -sha512 -binary | base64
 ```
 
-2. Fetch the same artifact through the Artifactory remote repository and compute its checksum:
+1. Fetch the same artifact through the Artifactory remote repository and compute its checksum:
 
 ```bash
 curl -sSf -L \
@@ -265,9 +263,10 @@ curl -sSf -L \
   https://<artifactory-host>/artifactory/api/npm/javascript-chainguard/picocolors/-/picocolors-1.1.1.tgz \
   | openssl dgst -sha512 -binary | base64
 ```
+
 Replace `artifactory-host` with your Artifactory instance hostname, and replace `${ARTIFACTORY_TOKEN}` with your Artifactory identity token.
 
-3. If your configuration includes a virtual repository combining `javascript-chainguard` with a public npm fallback, test that as well:
+1. If your configuration includes a virtual repository combining `javascript-chainguard` with a public npm fallback, test that as well:
 
 ```bash
 curl -sSf -L \
@@ -276,16 +275,15 @@ curl -sSf -L \
   | openssl dgst -sha512 -binary | base64
 ```
 
-The checksums returned by the commands must match. 
+The checksums returned by the commands must match.
 
 If the checksum from the Artifactory remote or virtual repository differ from the direct fetch, or if the Artifactory fetch fails entirely, review the following before proceeding:
 
-* URL: The remote repository URL must be set to `https://libraries.cgr.dev/javascript/`. 
+* URL: The remote repository URL must be set to `https://libraries.cgr.dev/javascript/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=javascript` and update the Artifactory repository credentials. Expired tokens fail silently.
-* [Advanced tab settings](#advanced-settings-for-redirect-handling): Confirm that **Bypass HEAD Requests** is enabled and **Lenient Host Authentication** is disabled. 
+* [Advanced tab settings](#advanced-settings-for-redirect-handling): Confirm that **Bypass HEAD Requests** is enabled and **Lenient Host Authentication** is disabled.
 
 Do not proceed to virtual repository setup or build configuration until the checksums match.
-
 
 ### Build tool access
 
@@ -322,7 +320,7 @@ npm](https://help.sonatype.com/en/npm-registry.html).
 
 ### Initial configuration
 
-For initial testing and adoption it is advised to create a separate proxy repository 
+For initial testing and adoption it is advised to create a separate proxy repository
 for the Chainguard Libraries for JavaScript repository, and include it in a repository group:
 
 1. Log in as a user with administrator privileges.
@@ -341,7 +339,7 @@ repository:
 1. In **HTTP - Authentication** with the **Authentication type** *Username*,
    provide the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).
-1. Click **Create repository**. 
+1. Click **Create repository**.
 
 Create a repository group, or add to an existing repository group:
 
@@ -350,7 +348,7 @@ Create a repository group, or add to an existing repository group:
 1. Select the **npm (group)** recipe.
 1. Provide a new name *javascript-all*.
 1. In the section **Group - Member repositories**, move the new repository
-   `javascript-chainguard` to the right to include it in the group. Position 
+   `javascript-chainguard` to the right to include it in the group. Position
    `javascript-chainguard` at the top of the list using the arrow controls.
 
 Repository groups can include multiple repositories, such as hosted
@@ -387,6 +385,7 @@ repository contains all libraries retrieved from Chainguard.
 Google Artifact Registry (GAR) is not an officially supported repository manager for Chainguard Libraries for JavaScript. However, it has been shown to work with the following configuration.
 
 Configure two GAR remote repositories, with upstream validation disabled on the second:
+
 * First remote repository: `javascript-chainguard` pointing to `https://libraries.cgr.dev/javascript` with upstream validation enabled
 * Second remote repository: `javascript-chainguard-upstream` pointing to `https://libraries.cgr.dev/javascript-upstream` with upstream validation disabled.
 
@@ -449,7 +448,6 @@ export CGR_TOKEN="your-chainguard-token"
 ### Step 2: Mirror packages from a lockfile
 
 This guide uses a script named `npm-codeartifact-mirror.sh`. Access the bash script and learn more about it in [Chainguard's example on GitHub](https://github.com/chainguard-demo/platform-examples/tree/main/library-copy-aws-code-artifact).
-
 
 Before running the script, save it to a local working directory and make it executable:
 
@@ -563,5 +561,3 @@ If packages remain unavailable after all retry passes, Chainguard may still be i
 #### pnpm parsing issues
 
 If you use pnpm and the workflow reports zero packages or fails because of `yq`, make sure you are using the Go `mikefarah` build of `yq` v4 rather than the Python `kislyuk` implementation.
-
-

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -34,7 +34,7 @@ Repository](/chainguard/libraries/chainguard-repository/), which provides a
 single endpoint for package retrieval and supports configurable security
 policies for both Chainguard-built and upstream packages.
 
-### Background
+## Background
 
 The main public repository for JavaScript packages is the [npm
 Registry](https://npmjs.com/). Launched in 2010, the npm Registry has grown to
@@ -49,7 +49,7 @@ It is the default repository in all commonly used build tools from the
 JavaScript community, including [npm](https://www.npmjs.com/),
 [pnpm](https://pnpm.io/), [Yarn](https://classic.yarnpkg.com/), and [Yarn
 Berry](https://yarnpkg.com/), and uses the npm repository format. Chainguard
-Libraries for JavaScript covers many of the open source artifacts found in the 
+Libraries for JavaScript covers many of the open source artifacts found in the
 npm Registry.
 
 You can use Chainguard Libraries for Javascript with [your repository
@@ -93,16 +93,17 @@ Configure this endpoint [globally through a repository manager](/chainguard/libr
 
 ## Updating lockfile hashes
 
-Existing JavaScript lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/). 
+Existing JavaScript lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/).
 
 If you install through a repository manager, see [Global configuration](/chainguard/libraries/javascript/global-configuration/#updating-lockfile-hashes/).
 
 ## Provenance and attestations
-Chainguard Libraries for JavaScript include SLSA provenance with signed attestations. 
-These attestations cryptographically link each package to the Chainguard 
-Factory build environment, providing verifiable proof of where and how each package 
-was produced. Provenance attestations follow the npm attestation standard. The 
-Chainguard publisher identity is verifiable via the Sigstore signing certificate 
+
+Chainguard Libraries for JavaScript include SLSA provenance with signed attestations.
+These attestations cryptographically link each package to the Chainguard
+Factory build environment, providing verifiable proof of where and how each package
+was produced. Provenance attestations follow the npm attestation standard. The
+Chainguard publisher identity is verifiable via the Sigstore signing certificate
 embedded in the attestation bundle, which links back to https://issuer.enforce.dev,  
 the Chainguard OIDC issuer.
 
@@ -116,11 +117,12 @@ See [Verification](/chainguard/libraries/verification/) for setup and usage deta
 
 ### Verify attestation manually
 
-Alternatively, you can verify a specific package's provenance attestation manually using `cosign`, which is useful for debugging or integrating individual steps into custom workflows. In the following commands, replace `PACKAGE` 
-and `VERSION` with the package name and version (for example, `axios-mock-adapter` 
+Alternatively, you can verify a specific package's provenance attestation manually using `cosign`, which is useful for debugging or integrating individual steps into custom workflows. In the following commands, replace `PACKAGE`
+and `VERSION` with the package name and version (for example, `axios-mock-adapter`
 and `1.17.0`):
 
 **Download the tarball**
+
 ```
 curl -L -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.dev)" \
   "https://libraries.cgr.dev/javascript/PACKAGE/-/PACKAGE-VERSION.tgz" \
@@ -128,6 +130,7 @@ curl -L -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr
 ```
 
 **Extract the SLSA provenance bundle**
+
 ```
 curl -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.dev)" \
   "https://libraries.cgr.dev/javascript/-/npm/v1/attestations/PACKAGE@VERSION" | \
@@ -136,6 +139,7 @@ curl -H "Authorization: Bearer $(chainctl auth token --audience=libraries.cgr.de
 ```
 
 **Verify the attestation was signed by Chainguard**
+
 ```
 cosign verify-blob-attestation \
   --bundle PACKAGE-provenance.sigstore.json \
@@ -149,16 +153,17 @@ cosign verify-blob-attestation \
 If this command returns an error, ensure you are using the latest version of `cosign`.
 
 A successful verification returns:
+
 ```
 Verified OK
 ```
 
-The `--certificate-oidc-issuer` and `--certificate-identity-regexp` flags confirm 
-the attestation was signed by Chainguard. 
+The `--certificate-oidc-issuer` and `--certificate-identity-regexp` flags confirm
+the attestation was signed by Chainguard.
 
 ### Retrieve SBOMs
 
-Chainguard Libraries for JavaScript also include Software Bills of Materials (SBOMs) in SPDX format. 
+Chainguard Libraries for JavaScript also include Software Bills of Materials (SBOMs) in SPDX format.
 
 To check whether an SBOM is available for a package, use npm show with the dist.sboms field:
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -1,8 +1,8 @@
 ---
 title: "Chainguard Libraries overview"
 linktitle: "Libraries overview"
-description: "Learn about Chainguard Libraries, providing enhanced security for 
-    Java, JavaScript, and Python dependencies through automated patching and 
+description: "Learn about Chainguard Libraries, providing enhanced security for
+    Java, JavaScript, and Python dependencies through automated patching and
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
@@ -94,7 +94,7 @@ Chainguard Libraries is available for the following library ecosystems:
 * Java and the larger Java Virtual Machine (JVM) ecosystem with
   [Chainguard Libraries for Java](/chainguard/libraries/java/overview/)
 * JavaScript and the larger ecosystem around JavaScript, TypeScript, npm, React,
-  and others with 
+  and others with
   [Chainguard Libraries for JavaScript](/chainguard/libraries/javascript/overview/)
 * Python and the larger ecosystem with
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/)
@@ -120,7 +120,7 @@ Our current minimum supported toolchains are:
 
 * **Python**: Python 3.10 and higher.
 * **Java**: Java 8 and higher.
-* **JavaScript**: Any supported, non-EOL version of Node.js. 
+* **JavaScript**: Any supported, non-EOL version of Node.js.
 
 We will attempt to rebuild any libraries that meet the [licensing and source availability criteria](#licensing-and-source-availability) using the supported toolchains.
 
@@ -129,9 +129,10 @@ We will attempt to rebuild any libraries that meet the [licensing and source ava
 When a library version reaches end of life (EOL) upstream, Chainguard Libraries continues to build packages and provide security fixes for that version for six months beyond the upstream EOL date.
 
 After that six-month window closes, Chainguard Libraries will:
-- No longer build new packages that require the EOL version
-- No longer provide security fixes for packages built against the EOL version
-- Continue to serve previously built packages
+
+* No longer build new packages that require the EOL version
+* No longer provide security fixes for packages built against the EOL version
+* Continue to serve previously built packages
 
 ## Upstream fallback and controls
 
@@ -148,13 +149,13 @@ subject to additional security controls before being served.
 
 To enable or change upstream fallback configuration, use the [`chainctl
 libraries entitlements`
-command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/). 
+command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/).
 
 For example, the following command creates or updates an entitlement to Chainguard Libraries
 for JavaScript, and adds the npm upstream fallback policy. Enabling upstream fallback includes a 7-day cooldown by default, which can also be configured:
 
 ```bash
-chainctl libraries entitlements create --ecosystems=JAVASCRIPT --policy=CHAINGUARD_AND_UPSTREAM 
+chainctl libraries entitlements create --ecosystems=JAVASCRIPT --policy=CHAINGUARD_AND_UPSTREAM
 ```
 
 For JavaScript, you can also enable upstream fallback in the Chainguard Console. For Java and Python, you cannot currently enable fallback or view upstream vs. Chainguard-built packages via the Chainguard Console; you must use `chainctl` to enable fallback for Java and Python.
@@ -162,6 +163,7 @@ For JavaScript, you can also enable upstream fallback in the Chainguard Console.
 ### Fallback options
 
 The following options are available:
+
 * **No upstream fallback (default)**: Only Chainguard-built packages are served.
 * **Upstream fallback enabled with default 7-day cooldown**: Upstream packages are available after passing a configurable cooldown period and malware scan. The same cooldown period is enforced across Chainguard-built packages and upstream packages, so that dependency trees resolve consistently across both sources.
 
@@ -173,7 +175,7 @@ identifies and blocks malicious and greyware packages in Chainguard Libraries
 via the Chainguard Repository. This includes packages that are publicly reported
 as malicious (including packages associated with OSV malware IDs) and packages
 that Chainguard determines are unsafe through its own malware source code
-scanning, even when no public malware advisory exists yet. 
+scanning, even when no public malware advisory exists yet.
 
 Malware detection is continuous. If a version that was previously cached is
 later identified as malicious, it is added to the block list and will be blocked
@@ -181,23 +183,23 @@ on subsequent requests.
 
 Chainguard's scanning evaluates multiple signal types, including:
 
-- **Maintainer behavior**: Flags anomalies in publisher accounts, release
+* **Maintainer behavior**: Flags anomalies in publisher accounts, release
   history, and package metadata, checking to see if a maintainer account was
   recently transferred, if a version was quietly yanked and republished, or if a
   publish timestamp falls outside any normal window. It also monitors for
   changes in publishing policy, process, or toolchain as these updates can be an
-  indicator of ownership takeover. 
-- **Package contents**: Downloads and scans the actual package that was
+  indicator of ownership takeover.
+* **Package contents**: Downloads and scans the actual package that was
   published for obfuscated code, embedded C2 domains, modified binaries, and
   other indicators that something fishy was inserted into the package before it
   hit the registry. It also triggers on newly added dependencies and significant
   changes in code or binary size.
-- **Publishing signals**: Compares the published package against its source
+* **Publishing signals**: Compares the published package against its source
   code, providing extra protection for all of the packages served via
   Chainguard’s upstream fallback. It also monitors for items such as a release
   not being tagged or being signed with an unknown key. Other publish signals
   include force pushing a tag or a commit hash not being in the event log.
-- **Dynamic execution**: Runs install scripts in a sandboxed, network-blocked
+* **Dynamic execution**: Runs install scripts in a sandboxed, network-blocked
   environment to see if there are attempts to call out to an external server,
   read system files, or execute hidden payloads.
 
@@ -205,7 +207,7 @@ Use Chainguard's [malware API endpoint](/chainguard/api/spec-api-v1/#tag/malware
 
 ### Cooldown period
 
-When fallback is enabled, upstream packages are subject to a cooldown period from their publication date before the Chainguard Repository will serve them. The cooldown is an additional layer of security that provides a window for the security community to identify and report malicious packages before your builds can pull them. 
+When fallback is enabled, upstream packages are subject to a cooldown period from their publication date before the Chainguard Repository will serve them. The cooldown is an additional layer of security that provides a window for the security community to identify and report malicious packages before your builds can pull them.
 
 The cooldown applies globally across Chainguard-built packages and upstream packages served through the fallback. This prevents installs from failing when a Chainguard-built package depends on an upstream dependency that is still under the cooldown window.
 
@@ -244,4 +246,3 @@ Blog posts
 * [Mitigating Malware in the Python Ecosystem with Chainguard Libraries](https://www.chainguard.dev/unchained/mitigating-malware-in-the-python-ecosystem-with-chainguard-libraries)
 * [Announcing Chainguard Libraries for Python: Malware-Resistant Dependencies Built Securely from Source](https://www.chainguard.dev/unchained/announcing-chainguard-libraries-for-python-malware-resistant-dependencies-built-securely-from-source)
 * [Announcing Chainguard Libraries: Guarded Java Language Dependencies Built from Source](https://www.chainguard.dev/unchained/announcing-chainguard-libraries-guarded-java-language-dependencies-built-from-source)
-

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -33,7 +33,7 @@ Repository](/chainguard/chainguard-repository/overview/) endpoint for Python. By
 default, it serves only Chainguard-built artifacts. When [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled for your organization, the same endpoint can also serve requested
-versions from PyPI under Chainguard security controls. 
+versions from PyPI under Chainguard security controls.
 
 See the [minimal example projects](#minimal-example-projects) on this page for demonstrations using `uv` and `pip`.
 
@@ -60,7 +60,7 @@ for accessing your organization's Cloudsmith repository manager.
    URL `...` is replaced with a default token or your personal token depending
    on your selection and `exampleorg` is replaced with the name of your
    organization. The URL contains both the name of the repository `python-all`
-   as well as `python` as an identifier for the format. 
+   as well as `python` as an identifier for the format.
 1. Alternatively, use the **API Key** and copy the URL to use in your build tool
    - for example
    `https://username:{{apiKey}}@dl.cloudsmith.io/basic/exampleorg/python-all/python/simple/`.
@@ -124,11 +124,11 @@ for accessing your organization's Sonatype Nexus repository group.
 The build configuration to retrieve artifacts **directly** from the Chainguard
 Libraries for Python repositories requires authentication with username and
 password from a pull token as detailed in [access
-documentation](/chainguard/libraries/access/#pull-token). 
+documentation](/chainguard/libraries/access/#pull-token).
 
 Note that there are multiple repositories:
 
-- `https://libraries.cgr.dev/python/` with the simple index at `https://libraries.cgr.dev/python/simple` 
+- `https://libraries.cgr.dev/python/` with the simple index at `https://libraries.cgr.dev/python/simple`
 - `https://libraries.cgr.dev/python-remediated` with the simple index at `https://libraries.cgr.dev/python-remediated/simple`
 
 Configuration for multiple index use and authentication varies for each
@@ -143,7 +143,7 @@ Once you have credentials and the index URL from your organization's repository
 manager, you're ready to set up specific build tools for local development or
 CI/CD.
 
-The recommended configuration is to use the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint rather than manually configuring fallback to upstream PyPI. 
+The recommended configuration is to use the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint rather than manually configuring fallback to upstream PyPI.
 
 ### Authentication
 
@@ -192,10 +192,10 @@ which requires authentication. Choose whichever fits your environment:
   `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
   automatically.
 - **CI or non-interactive**:
-  - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
+    - For a session token, pass `--token <token>` or set `CHAINCTL_AUTH_TOKEN`. The
     token must be scoped to the libraries registry; mint one with
     `chainctl auth token --audience=libraries.cgr.dev`.
-  - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
+    - For a [pull token](/chainguard/libraries/access/#pull-token) (an identity and
     secret), pass it as basic auth: `--username <identity> --password <secret>`,
     or set `CHAINCTL_REGISTRY_USERNAME` / `CHAINCTL_REGISTRY_PASSWORD`.
 - **From `~/.netrc`**: Credentials for the registry host are read from `~/.netrc`
@@ -209,7 +209,7 @@ Artifactory or JFrog), authenticate with **that** registry's credentials —
 entry. Chainguard-scoped tokens are never sent to third-party hosts.
 
 By default, Chainguard hashes are appended alongside existing upstream hashes. After updating the lockfiles, to switch your environment to use Chainguard packages, configure your tool to use the Chainguard index and reinstall. The command will output
-a "Next steps" section that includes the tool-specific command for reinstalling. 
+a "Next steps" section that includes the tool-specific command for reinstalling.
 
 <a id="pip"></a>
 
@@ -269,9 +269,9 @@ When using [direct access](#direct-access) to the Chainguard Libraries for
 Python repository with `pip`, you must ensure the following are set in your
 configuration file:
 
-* Replace any `/` in the username value `CG_PULLTOKEN_USERNAME` with `_`.
-* Ensure the `simple` context is used for the URL.
-* The password value `CG_PULLTOKEN_PASSWORD` remains unchanged.
+- Replace any `/` in the username value `CG_PULLTOKEN_USERNAME` with `_`.
+- Ensure the `simple` context is used for the URL.
+- The password value `CG_PULLTOKEN_PASSWORD` remains unchanged.
 
 Example for `requirements.txt`:
 
@@ -292,7 +292,7 @@ with `extra-index-url` without any specific prioritization beyond resolving
 semantic versions. The following example uses authentication from a local
 `.netrc` file and places the remediated repository first as the primary source,
 falling back to the standard Chainguard Libraries repository when a remediated
-version is not available: 
+version is not available:
 
 ```
 --index-url https://libraries.cgr.dev/python-remediated/simple/
@@ -350,8 +350,8 @@ poetry source add python-all https://repo.example.com/../python-all/simple/
 
 Example URLs including the required `simple` context:
 
-* JFrog Artifactory: `https://example.jfrog.io/artifactory/api/pypi/python-all/simple/`
-* Sonatype Nexus: `https://repo.example.com:8443/repository/python-all/simple/`
+- JFrog Artifactory: `https://example.jfrog.io/artifactory/api/pypi/python-all/simple/`
+- Sonatype Nexus: `https://repo.example.com:8443/repository/python-all/simple/`
 
 The following configuration is added:
 
@@ -436,7 +436,7 @@ name = "PyPI"
 ```
 
 The [Poetry documentation](https://python-poetry.org/docs/) contains more
-information about your project build, dependencies, versions, and other aspects. 
+information about your project build, dependencies, versions, and other aspects.
 
 ### uv
 
@@ -444,7 +444,7 @@ information about your project build, dependencies, versions, and other aspects.
 written in Rust. It uses PyPI by default, but also [supports the use of
 alternative package indexes](https://docs.astral.sh/uv/configuration/indexes/).
 
-#### Using a repository manager 
+#### Using a repository manager
 
 To update your global configuration to use your organization's repository
 manager with `uv`, create or edit the `~/.config/uv/uv.toml` configuration file.
@@ -560,7 +560,7 @@ dependency to `flask` version `2.0.0` results in the use of version `2.0.0+cgr.1
 Use the following steps to create a minimal example project for uv with
 Chainguard Libraries for Python. For testing purposes, you can use direct access
 and environment variables as detailed in the [access
-documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials). 
+documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-token-credentials).
 
 > **Migrating an existing project?** If you have an existing uv lockfile with
 > upstream hashes, use [`chainctl libraries update-hashes`](#updating-lockfile-hashes)
@@ -578,12 +578,13 @@ password ${CHAINGUARD_PYTHON_TOKEN}
 EOF
 chmod 600 ~/.netrc
 ```
+
 > **Note**: The `machine libraries.cgr.dev` entry is shared across ecosystems.
 > Make sure your entry is using a pull token with Python entitlement.
 
 In this example, the global uv index is set to the Chainguard Python repositories
 without embedded credentials, allowing uv to authenticate automatically using
-`.netrc`. 
+`.netrc`.
 
 Create the global index file `~/.config/uv/uv.toml` then open it in a text
 editor such as `nano`:
@@ -592,6 +593,7 @@ editor such as `nano`:
 mkdir -p ~/.config/uv
 nano ~/.config/uv/uv.toml
 ```
+
 Update it to include the remediated and standard Chainguard indexes:
 
 ```toml
@@ -694,7 +696,7 @@ documentation](/chainguard/libraries/access/#use-environment-variables-for-pull-
 
 **1. Update your configuration to point to Chainguard**
 
-Once the environment variables are set, update `~/.pip/pip.conf` to point to Chainguard Libraries. 
+Once the environment variables are set, update `~/.pip/pip.conf` to point to Chainguard Libraries.
 
 You may need to create the `~/.pip` directory first:
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -31,12 +31,12 @@ manager with a single upstream pointed at `https://libraries.cgr.dev/python/`. T
 Chainguard Repository handles fallback and policy enforcement; your repository
 manager handles local caching and access control. Chainguard proxies and serves
 packages from the public PyPI repository on your behalf when upstream
-fallback is enabled. All packages served from Chainguard are protected with 
+fallback is enabled. All packages served from Chainguard are protected with
 malware scanning and a configurable cooldown policy.
 
 At a high level, adopting the use of Chainguard Libraries consists of the following steps:
 
-* Configure your environment to use `https://libraries.cgr.dev/python/` as the single upstream source for Python package retrieval. 
+* Configure your environment to use `https://libraries.cgr.dev/python/` as the single upstream source for Python package retrieval.
 * Add the public [PyPI](https://pypi.org/) repository as a remote repository.
 * Create a group, virtual, or polyglot repository combining these repository
   sources with any desired internal repositories. Configure the Chainguard
@@ -50,7 +50,7 @@ You should also:
   assists technical evaluation and adoption of Chainguard Libraries.
 * Remove any repositories that are no longer desired or necessary. Depending on
   your library requirements, this step can result in removal of some proxy
-  repositories or even removal of all proxy repositories. 
+  repositories or even removal of all proxy repositories.
 
 If your organization does not use a repository manager, you can still use
 Chainguard Libraries. However, this approach requires configuration of multiple
@@ -60,7 +60,7 @@ approach. Refer to the [direct access documentation for build
 tools](/chainguard/libraries/python/build-configuration/#direct-access) for more
 information.
 
-### Manually managing fallback 
+## Manually managing fallback
 
 Chainguard recommends using the [Chainguard Repository built-in upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) rather than configuring a public PyPI fallback in your repository manager. Configuring your own fallback bypasses the protection and policy behavior provided by Chainguard Repository.
 
@@ -69,7 +69,7 @@ However, if you intentionally want to manage fallback ordering yourself, you can
 ### Updating lockfile hashes
 
 If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
-for all supported JavaScript lockfile formats. 
+for all supported JavaScript lockfile formats.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 
@@ -79,7 +79,7 @@ chainctl libraries update-hashes \
   --token "$REPO_TOKEN"
 ```
 
-After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes. 
+After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
 Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
@@ -93,7 +93,7 @@ with compatible formats. Refer to the [Cloudsmith Python Repository
 documentation](https://help.cloudsmith.io/docs/python-repository) and the
 [Cloudsmith documentation for creating a
 repository](https://help.cloudsmith.io/docs/create-a-repository) for more
-information. 
+information.
 
 ### Initial configuration
 
@@ -108,10 +108,10 @@ First, create a repository:
 1. At the new repository form, enter the name *python-all* for your new
    repository. The name should include *python* to identify the repository
    format. This convention helps avoid confusion, since repositories in
-   Cloudsmith are multi-format. 
+   Cloudsmith are multi-format.
 1. Select a storage region that is appropriate for your organization and
    infrastructure.
-1. Select **+Create Repository**. 
+1. Select **+Create Repository**.
 
 Next, configure the upstream proxies:
 
@@ -119,12 +119,12 @@ Next, configure the upstream proxies:
    to configure it.
 1. Access the **Upstreams** tab and click **+ Add Upstream Proxy**.
 1. Configure an upstream proxy with the format **python** and the following
-   details: 
+   details:
     * **Name**: `python-chainguard`
     * **Priority**: `1`
     * **Upstream URL**: `https://libraries.cgr.dev/python/`
     * **Mode**: `Cache and Proxy`
-   * Add the **Username** and **Password** value from [Chainguard Libraries
+    * Add the **Username** and **Password** value from [Chainguard Libraries
       access](/chainguard/libraries/access/) in **Authentication Settings**
 1. Select **Create Upstream Proxy**.
 1. If you want to use the separate repository with
@@ -173,7 +173,7 @@ Before configuring the repositories, you must create a secret with the [password
 value as retrieved with chainctl](/chainguard/libraries/access/):
 
 1. Navigate to the **Secret Manager**
-1. Click **Create secret**. 
+1. Click **Create secret**.
 1. Set the **Name** to `chainguard-libraries-python`.
 1. Use the **Password** from chainctl output to set the **Secret value**.
 1. Click **Create secret**.
@@ -200,7 +200,7 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI.
 
 Combine the repositories in a new virtual repository:
 
@@ -261,7 +261,7 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI index. 
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI index.
 
 Combine the repositories in a new virtual repository:
 
@@ -273,7 +273,7 @@ Combine the repositories in a new virtual repository:
 
 At this point, you have a virtual repository set up in Artifactory that allows
 you or others in your organization to access Chainguard Libraries for Python,
-optionally including remediated versions, with your chosen tools. 
+optionally including remediated versions, with your chosen tools.
 
 ### Validate the remote repository
 
@@ -290,7 +290,7 @@ curl -sSf \
   | grep -o 'https://[^"]*\.whl' | head -1
 ```
 
-2. Fetch a package file directly from `libraries.cgr.dev` and compute its checksum:
+1. Fetch a package file directly from `libraries.cgr.dev` and compute its checksum:
 
 ```bash
 curl -sSf -L \
@@ -299,7 +299,7 @@ curl -sSf -L \
   | sha256sum
 ```
 
-3. Fetch the same file through the Artifactory remote repository and compute its checksum:
+1. Fetch the same file through the Artifactory remote repository and compute its checksum:
 
 ```bash
 curl -sSfL \
@@ -307,13 +307,14 @@ curl -sSfL \
   "https://<artifactory-host>/artifactory/<python-remote-repository>/${path-to-wheel}" \
   | sha256sum
 ```
+
 Replace `artifactory-host` with your Artifactory instance hostname and replace `python-remote-repository` with your remote repository name. Replace `path-to-wheel` with the path component of the URL from step 1 (for example: `/files/15f7d141c3b76b85/37e321caa85a8f41/urllib3/urllib3-1.26.9-py2.py3-none-any.whl`)
 
-The checksums returned by the commands must match. 
+The checksums returned by the commands must match.
 
 If the checksum from the Artifactory remote repository differs from the direct fetch, or if the Artifactory fetch fails entirely, review the following before proceeding:
 
-* URL: The remote repository URL must be set to `https://libraries.cgr.dev/python/`. 
+* URL: The remote repository URL must be set to `https://libraries.cgr.dev/python/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=python` and update the Artifactory repository credentials. Expired tokens fail silently.
 * Advanced Configuration: Ensure all recommended Advanced settings from the [initial configuration steps](#initial-configuration-2) have been applied.
 
@@ -356,7 +357,7 @@ Next, configure a remote repository for Chainguard Libraries for Python reposito
 1. In **HTTP - Authentication**, set the **Authentication type** to *username*
    and enter the the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).
-1. Select **Create repository**. 
+1. Select **Create repository**.
 
 If you want to use the separate repository with [remediated Python
 libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
@@ -364,7 +365,7 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI. 
+If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI.
 
 Finally, create a new repository group and add the repositories:
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -31,7 +31,7 @@ request for a library or library version missing in Chainguard Libraries
 automatically triggers a process to provision the artifacts from relevant
 sources if available. In combination with third-party software repository
 managers, you can use Chainguard Libraries for Python as a secure source of
-truth for your development process. 
+truth for your development process.
 
 ## Technical details
 
@@ -58,9 +58,9 @@ source, without remediated versions. The second index provides remediated
 libraries with high and critical CVE fixes applied to older versions. The
 separate indexes provide you the option to make remediated versions available
 for your development or to opt out of using these versions completely and
-continue to use non-remediated versions only. The third index refers to 
-CUDA version-specific indexes which include libraries with 
-GPU-accelerated Python wheels. You can find more details in the [CUDA 
+continue to use non-remediated versions only. The third index refers to
+CUDA version-specific indexes which include libraries with
+GPU-accelerated Python wheels. You can find more details in the [CUDA
 Enabled Libraries](#cuda-enabled-libraries) section.
 
 The Chainguard Libraries for Python repository does not include all packages
@@ -102,15 +102,15 @@ the version `3.9.1+cgr.2`.
 
 ## CUDA-enabled libraries
 
-Chainguard Libraries for Python includes libraries optimized for specific CUDA 
-versions. These libraries are GPU‑accelerated Python wheels that are built 
-and tested against specific NVIDIA CUDA versions. An example is `torch` built 
-for CUDA 12.8, available via the `https://libraries.cgr.dev/cu128/simple/` index. 
-These libraries are published to CUDA‑specific indexes to ensure your Python build 
-tools resolve the correct wheel versions, mirroring how other CUDA-optimized 
+Chainguard Libraries for Python includes libraries optimized for specific CUDA
+versions. These libraries are GPU‑accelerated Python wheels that are built
+and tested against specific NVIDIA CUDA versions. An example is `torch` built
+for CUDA 12.8, available via the `https://libraries.cgr.dev/cu128/simple/` index.
+These libraries are published to CUDA‑specific indexes to ensure your Python build
+tools resolve the correct wheel versions, mirroring how other CUDA-optimized
 ecosystems are commonly distributed.
 
-Chainguard Libraries for Python includes the following repositories for 
+Chainguard Libraries for Python includes the following repositories for
 GPU‑accelerated libraries, built for specific CUDA versions:
 
 ```
@@ -119,25 +119,25 @@ https://libraries.cgr.dev/cu128/simple/
 https://libraries.cgr.dev/cu129/simple/
 ```
 
-Many Python package managers and repository managers support configuring 
-multiple package indexes. You can generally treat Chainguard’s CUDA indexes 
-the same way you use other CUDA-specific indexes (for example, the PyTorch 
+Many Python package managers and repository managers support configuring
+multiple package indexes. You can generally treat Chainguard’s CUDA indexes
+the same way you use other CUDA-specific indexes (for example, the PyTorch
 CUDA wheels at https://download.pytorch.org/whl/cu128).
 
 If you use a repository manager as described in the [Global Configuration
-documentation](/chainguard/libraries/python/global-configuration/), configure 
-a remote repository that points at the appropriate Chainguard CUDA index, and 
+documentation](/chainguard/libraries/python/global-configuration/), configure
+a remote repository that points at the appropriate Chainguard CUDA index, and
 use it in place of any CUDA-specific index you previously proxied.
 
-If you choose to pull directly without an artifact manager, you can similarly 
-replace the CUDA index you previously used with the corresponding 
-Chainguard CUDA index, with your existing package management tools like 
-`pip`, `uv`, or `poetry`. 
+If you choose to pull directly without an artifact manager, you can similarly
+replace the CUDA index you previously used with the corresponding
+Chainguard CUDA index, with your existing package management tools like
+`pip`, `uv`, or `poetry`.
 
-Note that the CUDA-enabled libraries in these repositories are not dependency 
-complete, since they do not include packages from the NVIDIA CUDA toolkit. You 
-must configure your package manager to pull NVIDIA components from an 
-upstream source such as NVIDIA's index at https://pypi.nvidia.com, or from PyPI 
+Note that the CUDA-enabled libraries in these repositories are not dependency
+complete, since they do not include packages from the NVIDIA CUDA toolkit. You
+must configure your package manager to pull NVIDIA components from an
+upstream source such as NVIDIA's index at https://pypi.nvidia.com, or from PyPI
 where NVIDIA publishes them directly.
 
 ## Python version support
@@ -242,7 +242,6 @@ however, uses a suitable package from Chainguard Libraries. When using CVE remed
 this also means that remediated packages with native binaries are only used on
 Linux.
 
-
 <a id="manual"></a>
 
 ## Manual access
@@ -318,9 +317,9 @@ The option `-L` is required to follow redirects for the actual file locations.
 
 Because Chainguard rebuilds Python packages from source rather than mirroring upstream PyPI artifacts, it is expected that checksums for Chainguard-built packages differ from their PyPI counterparts, even for identical package versions. This affects any tool that pins or verifies hashes:
 
-- Tools such as `pip` verify that downloaded files match the hashes specified in requirements.txt when using `--require-hashes` or when hashes are pinned
-- Tools such as `pip`, `Poetry`, and `uv` generate lock files that include SHA-256 hashes
-- Repository managers such as JFrog Artifactory or Sonatype Nexus may have cached upstream PyPI wheels and continue serving them instead of Chainguard versions, even after you have reconfigured to use Chainguard Libraries
+* Tools such as `pip` verify that downloaded files match the hashes specified in requirements.txt when using `--require-hashes` or when hashes are pinned
+* Tools such as `pip`, `Poetry`, and `uv` generate lock files that include SHA-256 hashes
+* Repository managers such as JFrog Artifactory or Sonatype Nexus may have cached upstream PyPI wheels and continue serving them instead of Chainguard versions, even after you have reconfigured to use Chainguard Libraries
 
 Resolving these issues requires two steps: [clearing cached artifacts](#clearing-caches-before-migration) at every layer of your build pipeline, and [updating lock files or requirements files](#updating-lockfile-hashes) so they reflect Chainguard's checksums.
 
@@ -332,7 +331,7 @@ Cached packages can exist at multiple layers:
 
 **Local developer machines**
 
-Common cache locations for Python tools include `~/.cache/pip/`, `~/.cache/uv/`, and `~/.cache/pypoetry/`. 
+Common cache locations for Python tools include `~/.cache/pip/`, `~/.cache/uv/`, and `~/.cache/pypoetry/`.
 
 Clear the cache for your tool:
 
@@ -366,7 +365,7 @@ If you install through a repository manager, see [Global configuration](/chaingu
 
 #### Update lockfiles manually
 
-Alternatively, you can use the following instructions to manually update your lockfiles: 
+Alternatively, you can use the following instructions to manually update your lockfiles:
 
 {{< details "Manually updating lockfiles" >}}
 
@@ -374,12 +373,13 @@ Before regenerating lock files, ensure your tool is configured to use Chainguard
 
 To update your lock files and requirements with Chainguard's checksums:
 
-**pip with `--require-hashes`:** 
+**pip with `--require-hashes`:**
 
 If your `requirements.txt` was generated using PyPI hashes, installation will
 fail with a hash mismatch after switching to Chainguard. Once pip is configured
 to use Chainguard as the index, regenerate your requirements file to update the
 hashes:
+
 ```bash
   pip-compile --generate-hashes requirements.in -o requirements.txt
 ```
@@ -399,7 +399,7 @@ The credentials from your Chainguard pull token must be embedded in the index UR
 url = "https://<PULLTOKEN_USERNAME_PART1>%2F<PULLTOKEN_USERNAME_PART2>:<PULLTOKEN_PASSWORD>@libraries.cgr.dev/python/simple/"
 authenticate = "always"
 ```
-  
+
 **Poetry:**
 
 When the configured source changes, Poetry detects that `pyproject.toml` has changed significantly and refuses to install until the lock file is regenerated. Regenerate your lock file to update the hashes:
@@ -410,15 +410,15 @@ Poetry 1.x:
   poetry lock --no-update
 ```
 
-Poetry 2.x: 
+Poetry 2.x:
 
 ```bash
   poetry lock
 ```
 
-**Repository managers:** 
+**Repository managers:**
 
-Repository managers such as JFrog Artifactory or Sonatype Nexus may continue serving cached PyPI artifacts even after the upstream index is changed. Clear the cache or invalidate the artifact to ensure the Chainguard-built package is fetched. 
+Repository managers such as JFrog Artifactory or Sonatype Nexus may continue serving cached PyPI artifacts even after the upstream index is changed. Clear the cache or invalidate the artifact to ensure the Chainguard-built package is fetched.
 
 Before regenerating lock files, ensure your tool is configured to use Chainguard as the package index by following the [global configuration](/chainguard/libraries/python/global-configuration/) or [direct access](/chainguard/libraries/python/build-configuration/#direct-access) documentation.
 
@@ -444,8 +444,9 @@ specification](https://peps.python.org/pep-0770/) for software composition
 analytis (SCA) using the SPDX format.
 
 A wheel file contains two directories:
-- The main code directory that uses the name of the library only, and 
-- The version-specific distribution info directory `.dist.info`.
+
+* The main code directory that uses the name of the library only, and
+* The version-specific distribution info directory `.dist.info`.
 
 For example, the wheel archive for Flask version 2.0.0
 includes a directory `flask-2.0.0.dist.info`. You can also find this directory
@@ -520,7 +521,7 @@ to verify the authenticity and integrity of a signed artifact.
 A Sigstore bundle file is available
 as `bundle.json` from the integrity context at
 `https://libraries.cgr.dev/python/integrity/PACKAGE/VERSION/FILE/bundle.json`
-specifically for each package, version, and file. 
+specifically for each package, version, and file.
 
 ## Upstream fallback policy and controls
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -46,14 +46,16 @@ Before getting started:
    ```bash
    chainctl auth login
    ```
+
 * Entitle access for yourself to Chainguard Libraries.
     * Chainguard Libraries are available to Catalog Starter and Free tier users,
-      and trial users. 
+      and trial users.
     * Run the following [chainctl libraries](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements/) command to create an entitlement for libraries:
 
 ```bash
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT
 ```
+
 The available `ecosystems` are `JAVASCRIPT`, `JAVA`, and `PYTHON`.
 
 Alternatively, you can create an entitlement and pull token in the Chainguard Console: while viewing a library ecosystem page, follow the prompts to create an access token.
@@ -68,10 +70,10 @@ Configure credentials once in a tool like JFrog Artifactory, Sonatype Nexus, or 
 
 If you [configure upstream fallback](/chainguard/libraries/overview/#upstream-fallback-policy-and-controls), the same ecosystem endpoint can serve both:
 
-- Libraries rebuilt from source by Chainguard, and
-- Eligible packages from the upstream public registry when Chainguard has not built that package or version yet 
+* Libraries rebuilt from source by Chainguard, and
+* Eligible packages from the upstream public registry when Chainguard has not built that package or version yet
 
-Upstream packages served through the Chainguard Repository are subject to configurable policy controls such as cooldown and malware protection. It is strongly recommended that you follow this approach. 
+Upstream packages served through the Chainguard Repository are subject to configurable policy controls such as cooldown and malware protection. It is strongly recommended that you follow this approach.
 
 Alternatively, you can configure your repository manager to fallback to the upstream public repositories for packages not available from Chainguard Libraries, as described in the global configuration docs for each ecosystem. Packages sourced from public registries are **not** covered by Chainguard's
 malware-resistance guarantees. If you choose this option, we strongly recommend
@@ -86,18 +88,17 @@ Configure authentication directly in each project's build configuration.
 
 This option is faster to set up initially, but requires per-project and
 per-workstation configuration. This increases the risk of credentials being
-committed to source control or going stale. 
+committed to source control or going stale.
 
 Learn how to set up direct access in the build configuration documentation for
 [Python](/chainguard/libraries/python/build-configuration/),
 [JavaScript](/chainguard/libraries/javascript/build-configuration/), and
-[Java](/chainguard/libraries/java/build-configuration/). 
+[Java](/chainguard/libraries/java/build-configuration/).
 
 ## Step 2: Create a pull token
 
 [Pull tokens](/chainguard/libraries/access/#creating-pull-tokens-for-libraries)
 are required for authentication. You can create one using `chainctl`:
-
 
 {{< tabs >}}
 
@@ -125,17 +126,16 @@ chainctl auth pull-token --repository=javascript --ttl=720h
 
 {{% /tab %}}
 
-
 {{< /tabs >}}
 
 > The default TTL is `720h` (30 days); the maximum is `8760h` (365 days).
 
 The command returns a username and password for basic authentication. Store
-these securely, as they won't be shown again. 
+these securely, as they won't be shown again.
 
 You can also [create pull tokens via the Chainguard
 Console](/chainguard/libraries/access/#creating-pull-tokens-with-the-chainguard-console)
-under **Overview > Manage pull tokens > Create access token**. 
+under **Overview > Manage pull tokens > Create access token**.
 
 Learn more about pull tokens, and using environment variables for pull token credentials, in the [Libraries Access documentation](/chainguard/libraries/access/).
 
@@ -143,20 +143,19 @@ Learn more about pull tokens, and using environment variables for pull token cre
 
 Once you have a pull token, you can configure your build tool. Configuration
 steps vary by build tool and ecosystem. See the ecosystem-specific documentation
-pages for instructions. 
+pages for instructions.
 
 If you configure [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-policy-and-controls), the same endpoint can serve both Chainguard-built artifacts and upstream arfifacts through the Chainguard Repository.
-
 
 {{< tabs >}}
 
 {{% tab title="Java" %}}
 
-### Java 
+### Java
 
 * [Repository manager](/chainguard/libraries/java/global-configuration/): Configure your repository manager or build tool to use
   `https://libraries.cgr.dev/java/` as the first repository for artifact
-  resolution. 
+  resolution.
 * [Direct access](/chainguard/libraries/java/build-configuration/): Configure
   your tool to retrieve artifacts directly from the Chainguard Libraries for
   Java repository at `https://libraries.cgr.dev/java/`. Use direct access for
@@ -166,13 +165,12 @@ If you configure [upstream fallback](/chainguard/libraries/overview/#upstream-fa
 In addition to malware-resistance, Chainguard Libraries for Java includes
 CVE remediation for select libraries. These patched versions help reduce known
 risk while you plan your next major version upgrade. You can view which
-libraries have CVE remediation available in the Chainguard Console. 
-  
+libraries have CVE remediation available in the Chainguard Console.
+
 Check out minimal example projects for
 [Maven](/chainguard/libraries/java/build-configuration/#minimal-example-project)
 and
 [Gradle](/chainguard/libraries/java/build-configuration/#minimal-example-project-1) to understand how to use these repositories.
-
 
 {{% /tab %}}
 
@@ -181,12 +179,13 @@ and
 ### Python
 
 * [Repository manager](/chainguard/libraries/python/global-configuration/): Add Chainguard Libraries as a remote repository in your
-  repository manager. 
+  repository manager.
 * [Direct access](/chainguard/libraries/python/build-configuration/): Configure
   your tool to retrieve artifacts directly from the Chainguard Libraries for
-  Python. 
+  Python.
 
 Note that there are multiple repositories:
+
 * `https://libraries.cgr.dev/python/` with the simple index at
   `https://libraries.cgr.dev/python/simple`
 * `https://libraries.cgr.dev/python-remediated` with the simple index at
@@ -196,7 +195,7 @@ Note that there are multiple repositories:
 In addition to malware-resistance, Chainguard Libraries for Python includes
 CVE remediation for select libraries. These patched versions help reduce known
 risk while you plan your next major version upgrade. You can view which
-libraries have CVE remediation available in the Chainguard Console. 
+libraries have CVE remediation available in the Chainguard Console.
 
 Check out minimal example projects for
 [uv](/chainguard/libraries/python/build-configuration/#uv-minimal) and [pip](/chainguard/libraries/python/build-configuration/#pip-minimal) to understand how to use these repositories.
@@ -215,8 +214,8 @@ Check out minimal example projects for
 * [Repository
   manager](/chainguard/libraries/javascript/global-configuration/): Add the Chainguard Libraries registry as a remote repository
   and configure it as the first choice for package resolution, with npm as a
-  fallback only where necessary. 
-* [Direct access](/chainguard/libraries/javascript/build-configuration/): Configure your `.npmrc` to use `https://libraries.cgr.dev/javascript/` as the registry. 
+  fallback only where necessary.
+* [Direct access](/chainguard/libraries/javascript/build-configuration/): Configure your `.npmrc` to use `https://libraries.cgr.dev/javascript/` as the registry.
 
 <a id="upstream-note"></a>
 
@@ -256,7 +255,6 @@ and
 > guide](/chainguard/libraries/javascript/migration/) for instructions.
 
 {{% /tab %}}
-
 
 {{< /tabs >}}
 

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -156,7 +156,7 @@ chainctl libraries verify example-application.tar.gz
 
 Note that if your deployment archive is a fat JAR, uber JAR, or shaded JAR,
 verification returns 0% coverage. This is expected behavior; see [Java fat JAR limitations](#java-fat-jar-limitations) for the recommended verification
-approach. 
+approach.
 
 For other archive types such as tarballs that contain individual unmodified JAR
 files, scanning can take a significant amount of time if numerous libraries are
@@ -165,7 +165,7 @@ for more information about the performed verification steps, and potentially
 pipe the output into a file.
 
 ```sh
-chainctl libraries verify --detailed commons-lang3-3.17.0.jar > run.log 
+chainctl libraries verify --detailed commons-lang3-3.17.0.jar > run.log
 ```
 
 Use the `--verbose` flag for even more details.
@@ -249,7 +249,7 @@ chainctl libraries verify ~/.m2/repository/net/logstash/logback/logstash-logback
 ```
 
 To integrate this into your build pipeline, add the verification step after
-dependency resolution and before the packaging phase. 
+dependency resolution and before the packaging phase.
 
 ### Analyze JavaScript packages
 
@@ -267,8 +267,9 @@ Verify an npm package tarball to confirm it was built by Chainguard:
 ```sh
 chainctl libraries verify PACKAGE-VERSION.tgz
 ```
-Replace `PACKAGE` 
-and `VERSION` with the package name and version (for example, `@eslint-js` 
+
+Replace `PACKAGE`
+and `VERSION` with the package name and version (for example, `@eslint-js`
 and `9.0.0`)
 
 Verification uses SLSA provenance attestations. `chainctl` computes a SHA-512 digest of the tarball locally, fetches the signed attestation bundle, and uses `cosign` to confirm that the signature is valid, the certificate chains to the Sigstore root, the signer identity matches the Chainguard JavaScript builder, and the digest matches what was attested at build time.
@@ -293,7 +294,7 @@ chainctl libraries verify /tmp/my-pnpm-store
 pnpm v9 and earlier are not supported. Verification works by comparing
 the tarball hash recorded in your local store against the hash in Chainguard's
 signed SLSA attestation. pnpm v10 records this hash in the index file path;
-pnpm v9 does not. 
+pnpm v9 does not.
 
 Note that in `pnpm-lock.yaml`, packages resolved from Chainguard have only a
 `resolution:` entry with an integrity hash:
@@ -326,7 +327,6 @@ chainctl libraries verify yarn:~/Library/Caches/Yarn/v6
 
 Unlike npm and pnpm, Yarn Classic requires the `yarn:` prefix because its
 cache directory layout cannot be reliably auto-detected.
-
 
 #### Verify a `node_modules` directory
 
@@ -412,7 +412,7 @@ chainctl help libraries verify
 
 ## Troubleshooting
 
-#### Why might I see 0% coverage when verifying Java artifacts?
+### Why might I see 0% coverage when verifying Java artifacts?
 
 A 0% coverage result is expected when verifying a fat JAR, uber JAR, or shaded JAR. Those packaging formats merge dependency contents into a single archive, so `chainctl libraries verify` cannot trace merged classes back to the original JARs.
 


### PR DESCRIPTION
## Type of change

Markdown lint cleanup — batch 2 (`content/chainguard/libraries`).

### What should this PR do?

Make 13 `libraries` docs fully markdownlint-clean and disable `MD036` (emphasis-as-heading) in `.markdownlint-cli2.jsonc`.

- Autofixes: trailing whitespace, list style/indent, blanks around lists/headings/fences, EOF
- Manual: heading-increment (`MD001`) promotions and one list-indent (`MD005`) fix
- Disable `MD036`: it flags intentional `**bold**` labels used throughout the reference/config docs; converting the ~68 repo-wide instances to real headings would be invasive (changes structure, TOC, and heading anchors) for little benefit

### Why are we making this change?

Continuing the markdown lint backlog cleanup in reviewable, per-section batches.

### What are the acceptance criteria?

- Every changed file is markdownlint-clean.
- No rendering changes.

### How should this PR be tested?

- `markdownlint-cli2` reports zero errors on every changed file.
- `hugo` builds all pages; no hard line breaks lost (literal `<br>` counts match `main`, incl. `quickstart.md`).
- `MD001` fixes change only heading levels, so heading anchors are unchanged (derived from text).

### Notes / scope

- **Deferred to a follow-up** (reverted here): `java/build-configuration.md` and `javascript/migration.md`, whose only remaining errors are `MD051` link-fragments. Those need verification against Hugo's actual anchor IDs (its slugger differs from markdownlint's), so I'm handling the anchor fixes separately rather than guessing.

---

**Risk**: low. Mechanical autofix + heading-level/list-indent corrections + one rule disable; rendering verified unchanged.

**Review focus**:
1. Disabling `MD036` (keep intentional bold labels vs convert to headings).
2. The `MD001` heading-level promotions read correctly.