### PR TITLE
style(markdown): lint-clean remaining chainguard-images docs (batch 3)

### DIFF
--- a/content/chainguard/chainguard-images/about/catalog-starter.md
+++ b/content/chainguard/chainguard-images/about/catalog-starter.md
@@ -54,11 +54,11 @@ Catalog Starter allows users to try out Chainguard Containers, but it comes with
 
 * You can select up to five non-FIPS images. Once chosen, these images cannot be swapped or replaced during the lifetime of the free plan.
 * The following types of Chainguard Containers are not included in the Catalog Starter plan:
-  * [FIPS-validated images](/chainguard/fips/fips-images/)
-  * Images that fall under the [EOL Grace Period](/chainguard/chainguard-images/features/eol-gp-overview/#understanding-chainguards-eol-grace-period)
-  * Images whose software is part of [Chainguard EmeritOSS](https://github.com/chainguard-forks/)
+    * [FIPS-validated images](/chainguard/fips/fips-images/)
+    * Images that fall under the [EOL Grace Period](/chainguard/chainguard-images/features/eol-gp-overview/#understanding-chainguards-eol-grace-period)
+    * Images whose software is part of [Chainguard EmeritOSS](https://github.com/chainguard-forks/)
 * Teams using Chainguard Catalog Starter will not have access to the support services available to paying customers: they will not be added to Chainguard's support platform, be able to create support tickets, or have access to root cause analysis (RCA) or phone escalations.
-  * Catalog Starter users will still have access to Chainguard resources like our [documentation](https://edu.chainguard.dev/), [courses](https://courses.chainguard.dev/), the [Community Slack channel](https://www.chainguard.dev/unchained/the-chainguard-slack-community-is-here), and the [public support knowledge base](https://support.chainguard.dev/hc/en-us).
+    * Catalog Starter users will still have access to Chainguard resources like our [documentation](https://edu.chainguard.dev/), [courses](https://courses.chainguard.dev/), the [Community Slack channel](https://www.chainguard.dev/unchained/the-chainguard-slack-community-is-here), and the [public support knowledge base](https://support.chainguard.dev/hc/en-us).
 * [Chainguard's CVE SLA](https://www.chainguard.dev/legal/cve-policy) does not apply to container images obtained through Catalog Starter.
 * The free plan does not support user management or role-based access control (RBAC). Chainguard can add newer users from the same company to your organization after they sign up for Catalog Starter, but you cannot add them yourself. Any additional users in your organization will have access to the five images selected by the first user and cannot change them after the fact.
 * Users in a Catalog Starter organization are assigned the `limited_owner` role, which allows them to browse the Console, pull images, and create pull tokens, but does not include permission to invite other users to the organization or access features like [Custom Assembly](/chainguard/chainguard-images/features/custom-assembly/).

--- a/content/chainguard/chainguard-images/about/images-compiled-programs/glibc-vs-musl.md
+++ b/content/chainguard/chainguard-images/about/images-compiled-programs/glibc-vs-musl.md
@@ -23,7 +23,6 @@ When developing [Wolfi](/open-source/wolfi/overview/), the "undistro" on which a
 
 > **Note**: Several sections of this guide present data about the differences between glibc and musl across various categories. You can recreate some of these examples used to find this data with the Dockerfiles and C program files hosted in the `glibc-vs-musl` directory of the [Chainguard Academy Containers Demos repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/glibc-vs-musl).
 
-
 ## High-level Differences between glibc and musl
 
 The GNU C Library ([glibc](https://www.gnu.org/software/libc/)), driven by the [GNU Project](https://www.gnu.org/gnu/thegnuproject.en.html), was first released in 1988. glibc aims to provide a consistent interface for developers to help them write software that will work across multiple platforms. Today, glibc has become the default implementation of the C standard library across the majority of Linux distributions, including Ubuntu, Debian, Fedora, and even Chainguard's Wolfi.
@@ -32,24 +31,23 @@ The GNU C Library ([glibc](https://www.gnu.org/software/libc/)), driven by the [
 
 The following table highlights some of the main differences between glibc and musl.
 
-| Criteria        	| glibc                                                      	| musl                                                               	|
+| Criteria         | glibc                                                       | musl                                                                |
 | ------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| First Release   	| 1988                                                       	| 2011                                                               	|
-| License         	| GNU Lesser General Public License (LGPL)                   	| MIT License (more permissive)                                      	|
-| Binary Size     	| Larger Binaries                                            	| Smaller Binaries                                                   	|
-| Runtime Performance | Optimized for performance                                  	| Slower performance                                                 	|
-| Build Performance   | Slower                                                     	| Faster                                                             	|
+| First Release    | 1988                                                        | 2011                                                                |
+| License          | GNU Lesser General Public License (LGPL)                    | MIT License (more permissive)                                       |
+| Binary Size      | Larger Binaries                                             | Smaller Binaries                                                    |
+| Runtime Performance | Optimized for performance                                   | Slower performance                                                  |
+| Build Performance   | Slower                                                      | Faster                                                              |
 | Compatibility | POSIX Compliant + GNU Extensions | POSIX Compliant
-| Memory Usage    	| Efficient, higher memory usage                             	| Potential performance issues with large memory allocations (e.g. Rust) |
-| Dynamic Linking 	| Supports lazy binding, unloads libraries                   	| No lazy binding, libraries loaded permanently                      	|
-| Portability Issues  | Fewer portability issues, widely used                      	| Potential issues due to different system call behaviors            	|
-| Python Support  	| Fast build times, supports precompiled wheels              	| Slower build times, often requires source compilation              	|
-| NVIDIA Support  	| Supported by NVIDIA for CUDA                               	| Not supported by NVIDIA for CUDA                                   	|
+| Memory Usage     | Efficient, higher memory usage                              | Potential performance issues with large memory allocations (e.g. Rust) |
+| Dynamic Linking  | Supports lazy binding, unloads libraries                    | No lazy binding, libraries loaded permanently                       |
+| Portability Issues  | Fewer portability issues, widely used                       | Potential issues due to different system call behaviors             |
+| Python Support   | Fast build times, supports precompiled wheels               | Slower build times, often requires source compilation               |
+| NVIDIA Support   | Supported by NVIDIA for CUDA                                | Not supported by NVIDIA for CUDA                                    |
 
 Be aware that binaries are not compatible between Alpine and Wolfi. You **should not** attempt to copy Alpine binaries into a Wolfi-based container image.
 
 > **Note**: As mentioned previously, several of the remaining sections in this guide present data about the differences between glibc and musl across various categories. You can recreate some of these examples by following the same procedure of setting creating and testing container images based on the Dockerfiles and program files relevant to the example you're exploring. You can find the appropriate files in the `glibc-vs-musl` directory of the [Chainguard Academy Containers Demos repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/glibc-vs-musl).
-
 
 ## Library and Binary Size
 
@@ -61,18 +59,16 @@ You might notice the decreased binary size for musl in a simple `hello world` pr
 
 The following table shows the difference in binary size of statically and dynamically linked `hello world` programs:
 
-| Distro                	| Static linking | Dynamic linking |
+| Distro                 | Static linking | Dynamic linking |
 | ------------------------- | -------------- | --------------- |
-| Alpine (musl) binary size | 132K       	| 12K         	|
-| Wolfi (glibc) binary size | 892K       	| 16K         	|
+| Alpine (musl) binary size | 132K        | 12K          |
+| Wolfi (glibc) binary size | 892K        | 16K          |
 
 The smaller the binary size, the better the system is at debloating. You can find the Dockerfiles used in this setup in the [`binary-bloat` directory of this guide's example's repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/glibc-vs-musl/binary-bloat).
-
 
 ## Portability of Applications
 
 The *portability* of an application refers to its ability to run on various hardware or software environments without requiring significant modifications. In practice, many developers target glibc specifically rather than a generic POSIX C library, much like writing scripts for bash rather than a POSIX-compliant shell. Consequently, developers can encounter portability issues when moving an application from one libc implementation to another. That said, [Hyrum's Law](https://www.hyrumslaw.com/) reminds us that achieving perfect portability is tough. Even when you design an application to be portable, it might still unintentionally depend on certain quirks of the environment or libc implementation.
-
 
 ## Building from Source Performance
 
@@ -80,16 +76,16 @@ We've compared the build from source performance for individual projects using t
 
 The following table highlights the results of this comparison by highlighting the compilation times between Wolfi (glibc) and musl-gcc. The shorter the build time, the better the system's performance.
 
-| Repository   | Wolfi compilation time | musl-gcc compilation | Build successful with musl? 	|
+| Repository   | Wolfi compilation time | musl-gcc compilation | Build successful with musl?  |
 | ------------ | ---------------------- | -------------------- | ------------------------------- |
-| binutils-gdb | 18m 3.11s          	| *   <br>         	| No - C++17 features unsupported |
-| Little-CMS   | 29.44s             	| 24.13s           	| Yes                         	|
-| zlib     	| 11.48s             	| 9.37s            	| Yes                         	|
-| libpcap  	| 8.19s              	| 5.61s            	| Yes                         	|
-| gmp      	| 98.91s             	| 99.38s           	| Yes                         	|
-| openssl  	| 849.08s            	| 671.92s          	| Yes                         	|
-| curl     	| 92.33s             	| 79.15s           	| Yes                         	|
-| usrsctp  	| 55.39s             	| 48.38s           	| Yes                         	|
+| binutils-gdb | 18m 3.11s           | *   <br>          | No - C++17 features unsupported |
+| Little-CMS   | 29.44s              | 24.13s            | Yes                          |
+| zlib      | 11.48s              | 9.37s             | Yes                          |
+| libpcap   | 8.19s               | 5.61s             | Yes                          |
+| gmp       | 98.91s              | 99.38s            | Yes                          |
+| openssl   | 849.08s             | 671.92s           | Yes                          |
+| curl      | 92.33s              | 79.15s            | Yes                          |
+| usrsctp   | 55.39s              | 48.38s            | Yes                          |
 
 You can find the Dockerfiles used in this setup in the [`build-comparison` directory of this guide's example's repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/glibc-vs-musl/build-comparison).
 
@@ -105,11 +101,11 @@ This also means you must determine every system library dependency needed to bui
 
 The following table shows PIP install times across Alpine (musl) and Wolfi (glibc). You can find the Dockerfiles used in this setup in the [`python-build-comparison` directory of this guide's example's repository](https://github.com/chainguard-dev/edu-images-demos/tree/main/glibc-vs-musl/python-build-comparison).
 
-| Python Package 	| Alpine (musl) | Wolfi (glibc) |
+| Python Package  | Alpine (musl) | Wolfi (glibc) |
 | ------------------ | ------------- | ------------- |
-| Matplotlib, pandas | 21m 30.196s   | 0m 24.3s  	|
-| tensorflow     	| 104m 21.904s  | 2m  54.5s 	|
-| pwntools       	| 29m 45.952s   | 21.5s     	|
+| Matplotlib, pandas | 21m 30.196s   | 0m 24.3s   |
+| tensorflow      | 104m 21.904s  | 2m  54.5s  |
+| pwntools        | 29m 45.952s   | 21.5s      |
 
 As this table shows, this results in long build times whenever you want to use Python-based applications with musl.
 
@@ -140,11 +136,11 @@ As this Dockerfile shows, `pwntools` requires a set of other packages. These in 
 
 ## Runtime Performance
 
-Time is critical. One common bottleneck occurs when allocating large chunks of memory repeatedly. We compare this memory allocation performance between Wolfi and the latest Alpine [here](https://github.com/chainguard-dev/edu-images-demos/blob/main/glibc-vs-musl/musl-performance-issues/allocations-slowdown.sh). The benchmark uses JSON dumping, a highly memory intensive operation.
+Time is critical. One common bottleneck occurs when allocating large chunks of memory repeatedly. We compare this memory allocation performance between Wolfi and the latest Alpine [this benchmark script](https://github.com/chainguard-dev/edu-images-demos/blob/main/glibc-vs-musl/musl-performance-issues/allocations-slowdown.sh). The benchmark uses JSON dumping, a highly memory intensive operation.
 
-| Runtime                  	| Alpine (musl) | Wolfi (glibc) |
+| Runtime                   | Alpine (musl) | Wolfi (glibc) |
 | ---------------------------- | ------------- | ------------- |
-| Memory Allocations Benchmark | 102.25 sec	| 51.01 sec 	|
+| Memory Allocations Benchmark | 102.25 sec | 51.01 sec  |
 
 This table highlights how excessive memory allocations can cause musl (used by Alpine) to perform up to **2x slower** than glibc (used by Wolfi). A memory-intensive application needs to be wary of performance issues when migrating to the musl-alpine ecosystem.
 
@@ -152,20 +148,18 @@ Apart from memory allocations, multi-threading has also been problematic for mus
 
 We used a Rust script (referenced from the [GitHub issue](https://github.com/rust-lang/rust/issues/70108)) to test single-thread and multi-thread performance on Alpine (musl) and Wolfi (glibc). The next table shows performance benchmarks across single-threaded and multi-threaded Rust applications.
 
-| Runtime                   	| Alpine (musl) | Wolfi (glibc) |
+| Runtime                    | Alpine (musl) | Wolfi (glibc) |
 | ----------------------------- | ------------- | ------------- |
-| Single-thread (avg of 5 runs) | 1735 ms   	| 1300 ms   	|
-| Multi-thread (avg of 5 runs)  | 1178 ms   	| 293 ms    	|
+| Single-thread (avg of 5 runs) | 1735 ms    | 1300 ms    |
+| Multi-thread (avg of 5 runs)  | 1178 ms    | 293 ms     |
 
 Alpine (musl) has the worse performance out of the two, taking around 4x more time for multi-thread when compared to Wolfi (glibc). As discussed previously, the real source of thread contention is in the `malloc` implementation of musl. Multiple threads may allocate memory at once, or free memory may be allocated to other threads. Therefore, the thread synchronization logic is a bottleneck for performance.
-
 
 ## Conclusion
 
 glibc and musl both serve well as C implementations. Our goal for this article is to explain Chainguard's rationale for choosing to use glibc for Wolfi. We believe that's what made the most sense for our project, but you should continue your own research to determine if one C implementation would suit your needs better than another.
 
 If you spot anything we've overlooked regarding glibc or musl or have additional insights to contribute, please feel free to raise the issue in [chainguard-dev/edu](https://github.com/chainguard-dev/edu). We welcome further discussion on weaknesses in glibc, such as its larger codebase and complexity compared to musl. Additionally, insights into the intricacies of compiler toolchains for cross-compilation are welcomed, especially when dealing with glibc and musl.
-
 
 ## Additional References
 

--- a/content/chainguard/chainguard-images/about/versions.md
+++ b/content/chainguard/chainguard-images/about/versions.md
@@ -61,14 +61,14 @@ version and release software. Generally, projects follow one of two approaches:
 projects often provide maintenance for a number of release tracks concurrently.
 For example, Java, Go, Postgres, and Kubernetes patch multiple release versions,
 each on their own defined maintenance schedule.
-  * For these types of projects, Chainguard will maintain every version track of the
+    * For these types of projects, Chainguard will maintain every version track of the
 upstream software that receives updates from the project.
 * **Single release track**: Many open source projects support only a single stream of releases that are
 continuously incremented; often, this is simply the latest release. In the case
 of a single release track, any security fix that is published will only be
 applied to the most recent release of the project, and the project release tags
 will be updated to indicate a new version is available.
-  * For this type of project, Chainguard only warrants that the latest release of
+    * For this type of project, Chainguard only warrants that the latest release of
 the software and its corresponding version tags have the most up-to-date patches
 available.
 

--- a/content/chainguard/chainguard-images/about/what-chainguard-will-build.md
+++ b/content/chainguard/chainguard-images/about/what-chainguard-will-build.md
@@ -22,11 +22,11 @@ If you would like a Chainguard Container that is not yet available, or inquire a
 * The source code is freely available in a Source Code Manager (SCM) system such as GitHub or GitLab.
 * The project is licensed under a FOSS license. Non-FOSS licenses are reviewed on a case-by-case basis.
 * The project is actively maintained with supported versions. That is:
-  * There are recent commits and releases.
-  * The project has not reached its end of life (EOL).
-  * The project has maintained active versions.
-  * The project does not rely on outdated or unmaintained dependencies; for example, unsupported versions of Python, OpenSSL etc.
-  * There is usually a lead or owner.
+    * There are recent commits and releases.
+    * The project has not reached its end of life (EOL).
+    * The project has maintained active versions.
+    * The project does not rely on outdated or unmaintained dependencies; for example, unsupported versions of Python, OpenSSL etc.
+    * There is usually a lead or owner.
 * There are no technical blockers preventing us from building the container image as we’ve determined as part of an initial analysis process.
 
 If the software project or container image you have in mind meets the above criteria, please [contact us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) for more information.

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifact-registry-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifact-registry-pull-through/index.md
@@ -28,7 +28,7 @@ In order to complete this tutorial, you will need the following:
 * Docker installed on your local machine. Follow the [official installation instructions](https://docs.docker.com/engine/install/) to set this up.
 * Administrative privileges over a Google Cloud Platform project. This project will also need to have the [Artifact Registry API](https://cloud.google.com/artifact-registry/docs/reference/rest) enabled.
 * If you plan to set up an Artifact Registry repository to serve as a pull through cache for Production containers, then you will also need to have privileges to create a pull token from Chainguard.
-  * Additionally, you'll need `chainctl` installed to create the pull token. If you haven't already installed this, follow the [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
+    * Additionally, you'll need `chainctl` installed to create the pull token. If you haven't already installed this, follow the [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
 
 ## Setting up Google Artifact Registry as a Pull Through for Free Containers
 

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/index.md
@@ -190,7 +190,7 @@ Enter the following details for the two remote repositories:
 
 * **Repository Key** — This is the name used to identify your remote repository. Again, you can choose whatever names you like here but this guide's examples use the names `cg-chainguard` and `cg-extras`.
 * **URL** — This must be set to `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/chainguard` for the `chainguard` repository and `https://virtualapk.cgr.dev/<ORGANIZATION-ID>/extra-packages` for the `extra-packages` repository.
-  * For both of these URLs, you need to replace the `<ORGANIZATION-ID>` placeholder with your Chainguard organization's UID. You can find this by running the `chainctl iam organizations list -o table`; the UID is the value in your organization's `ID` column. Alternatively, you can find it by checking the **Settings** ⇒ **General** page in the [Chainguard Console](https://console.chainguard.dev).
+    * For both of these URLs, you need to replace the `<ORGANIZATION-ID>` placeholder with your Chainguard organization's UID. You can find this by running the `chainctl iam organizations list -o table`; the UID is the value in your organization's `ID` column. Alternatively, you can find it by checking the **Settings** ⇒ **General** page in the [Chainguard Console](https://console.chainguard.dev).
 
 You **do not** need to set any values for the **User Name** or **Password / Access Token** fields, as the public repositories do not require authentication.
 
@@ -256,7 +256,7 @@ If you run into issues when trying to pull from Chainguard's package repositorie
 * You may run into issues if your Artifactory username is an email address; specifically, the `@` sign can lead to errors. Be sure that you're using a user profile with a name that only contains letters and numbers. If you must use a profile with an email address for a name, try percent-encoding the `@` sign by replacing it with `%40`.
 * Ensure that all [network requirements](/chainguard/chainguard-images/network-requirements/) are met.
 * When configuring a remote Artifactory repository, ensure that the **URL** field is set correctly.
-  * If necessary, ensure that you've set the correct UID for your organization in the URL field.
+    * If necessary, ensure that you've set the correct UID for your organization in the URL field.
 * It may help to [clear the Artifactory cache](https://jfrog.com/help/r/artifactory-cleanup-best-practices/clearing-an-oversized-cache).
 * It could be that your Artifactory repository was misconfigured. In this case, create and configure a new Remote Artifactory repository to test with.
 * If your output returns `package mentioned in index not found`, it usually means Artifactory or a CDN is normalizing or rewriting APK URLs (often by stripping query strings, collapsing path segments, or altering tokens). To prevent this, ensure that Artifactory's **Disable URL Normalization** option is checked in order to preserve exact filenames and tokens.

--- a/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/cloudsmith-pull-through/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/pull-through-guides/cloudsmith-pull-through/index.md
@@ -28,7 +28,7 @@ In order to complete this tutorial, you will need the following:
 * Docker installed on your local machine. Follow the [official installation instructions](https://docs.docker.com/engine/install/) to set this up.
 * Administrative privileges over a Cloudsmith project. You can set up an account by visiting the [Cloudsmith website](https://cloudsmith.com/).
 * If you plan to set up a Cloudsmith repository to serve as a pull through cache for Production container images, then you will also need to have privileges to create a pull token from Chainguard.
-  * Additionally, you'll need `chainctl` installed to create the pull token. If you haven't already installed this, follow the [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
+    * Additionally, you'll need `chainctl` installed to create the pull token. If you haven't already installed this, follow the [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
 
 ## Setting up Cloudsmith as a Pull Through for Free Containers
 

--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -19,17 +19,21 @@ toc: true
 Learn answers to your questions about [Chainguard Containers](https://www.chainguard.dev/chainguard-images?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement). Chainguard provides container images designed with security as the primary focus, featuring zero known CVEs, minimal attack surface, and built-in SBOMs for every image.
 
 ## Which Linux distribution is used as base for Chainguard Containers?
+
 Chainguard Containers are based on [Wolfi](/open-source/wolfi/), a Linux _undistro_ we built specifically to address software supply chain security issues. We call it an undistro because it doesn't contain certain software you'd normally find in a traditional Linux distribution such as Debian or Alpine. Wolfi is a minimal Linux distribution designed specifically to be used as a base for stripped-down container images.
 
 ## How do Chainguard Containers relate to the Google Distroless Container Images?
+
 The [Google distroless](https://github.com/GoogleContainerTools/distroless) images follow a similar philosophy to many of our images: they are minimal images that don't include package managers or shells. The main difference is in the implementation. The Google distroless images are built with [Bazel](https://bazel.build) and based on the Debian distribution, whereas Chainguard Containers are built with [apko](/open-source/apko/) and based on [Wolfi](/open-source/wolfi/). We believe our approach is more maintainable and extensible.
 
 ## Which images are available?
-There are currently over a thousand Chainguard Containers available, which are segmented as **Free** or **Production**. You can read more about this in the [next question](#what-options-do-i-have-to-use-chainguard-images).
+
+There are currently over a thousand Chainguard Containers available, which are segmented as **Free** or **Production**. You can read more about this in the [next question](#what-options-do-i-have-to-use-chainguard-containers).
 
 Chainguard Containers are primarily available from [Chainguard's registry](/chainguard/chainguard-registry/overview/), but a selection of Free images is also available on [Docker Hub](https://hub.docker.com/u/chainguard). You can find the complete list of available Chainguard Containers in our public [Containers Directory](https://images.chainguard.dev/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-faq) or within the [Chainguard Console](https://console.chainguard.dev/).
 
 ## What options do I have to use Chainguard Containers?
+
 You can get free Chainguard Containers for your organization. You can also upgrade for more versions, SLAs, and dedicated support.
 
 Free | Production
@@ -46,17 +50,21 @@ You can read more about the differences between Free and Production Containers i
 Yes, Chainguard Free Container images are available on [Docker Hub](https://hub.docker.com/u/chainguard?utm_source=academy&utm_medium=referral&utm_campaign=FY25-DockerHub-Orgprofile). As a Docker Verified Publisher, Chainguard has met Docker's stringent standards for security, quality, and transparency. This status signifies that our container images are trusted, reliable, and have undergone rigorous verification processes. If you wish to use Production Containers, you will use [Chainguard's registry](/chainguard/chainguard-registry/overview/).
 
 ## What is an SBOM and why is it important?
+
 An SBOM is a Software Bill of Materials, which is a list containing detailed information about all software that is included within a software artifact, whether it's an application, a container image, or a physical appliance.
 
 SBOMs provide visibility into the software you depend on. They can allow automated systems to quickly identify issues such as unpatched vulnerabilities, since SBOMs typically include the version of each dependency listed.
 
 ## Who maintains Chainguard Containers?
+
 [Chainguard Containers](https://www.chainguard.dev/chainguard-images?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement) are officially maintained by [Chainguard](https://chainguard.dev) engineers.
 
 ## How often are Chainguard Containers updated?
+
 Chainguard Containers are rebuilt every night to ensure that new package versions and security updates in upstream Wolfi are quickly applied.
 
 ## Can I simply replace my current base image with a Chainguard Container and it will work out of the box?
+
 Chainguard Containers are designed to be minimal, and many of them don't come with a package manager. Depending on your stack and specific dependencies, you may need to include additional software by combining `-dev` container images and our [distroless](/chainguard/chainguard-images/getting-started-distroless/) images in a multi-stage Docker build.
 
 ## What packages are available in Chainguard Containers?
@@ -67,22 +75,24 @@ Starting in March of 2024, Chainguard will maintain one version of each Wolfi pa
 
 This change ensures that Chainguard can provide the most up-to-date patches to all packages for our customers. Note that specific package versions can be made available in Production containers. If you have a request for a specific package version, please [contact us](https://www.chainguard.dev/contact?utm=docs).
 
-
 ## How do I add packages to a Chainguard Container?
 
 {{< blurb/why_ca >}}
 
-
 ## What does Chainguard do when a CVE is published, but a patch is not available from the owner of the OSS code?
+
 Chainguard investigates the CVE and marks relevant images as affected or not. If Chainguard can identify a patch that's unreleased, Chainguard may apply a patch before it lands upstream. In either case, when the patch lands upstream, Chainguard picks it up and rolls it out.
 
 ## Why are some CVEs persistent in select Chainguard Containers?
+
 There are several Chainguard Containers container images--such as Druid and Spark--with a notable number of CVEs that are marked `pending-upstream-fix.` The reasons that these CVEs can't be remediated by standard engineering procedures include: some vulnerabilities can only be patched through major version upgrades, which often break compatibility through broken builds or tests; many of these CVEs (over fifty percent by one internal Chainguard analysis) stem from "shaded" JARs, JAR files that bundle their dependencies internally; and a small portion of these CVEs simply have no fix available. The Chainguard engineering team continually investigates new approaches to fixing these persistent CVEs.
 
 ## I added software on top of one of Chainguard's base container images, why are there CVEs?
+
 Chainguard is not responsible for CVEs in software you add on top of base images.
 
 ## Do I need to authenticate into Chainguard to use Chainguard Containers?
+
 Logging in is optional if you are only using Free containers. That being said, there are benefits for all users who authenticate to Chainguard's registry, as Chainguard provides notifications of version updates, breaking changes, or critical security updates.
 
 To learn how to authenticate into Chainguard's registry, you can review our [authentication documentation](/chainguard/chainguard-registry/authenticating/) . You can read more about the thought process behind authentication in our blog post, [Scaling Chainguard Containers with a growing catalog and proactive security updates](https://www.chainguard.dev/unchained/scaling-chainguard-images-with-a-growing-catalog-and-proactive-security-updates).

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-certs.md
@@ -25,12 +25,12 @@ Before getting started, you'll need the following:
 
 * Access to Chainguard's Custom Assembly tool, which is available to any organization with access to Production Chainguard Containers.
 * Permissions in your Chainguard organization to use Custom Assembly.
-  * Review the [Custom Assembly Permissions Requirements](https://edu.chainguard.dev/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements) for more information
+    * Review the [Custom Assembly Permissions Requirements](https://edu.chainguard.dev/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements) for more information
 * [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) installed and configured.
 * One or more PEM-encoded certificate files that you want to add to your container.
-  * Each certificate must be a PEM-encoded string of an x509v3 certificate.
-  * Private keys must not be passed as a certificate, and will be rejected.
-  * The total size of all inlined certificates must not exceed 50 KB. Please reach out to your account team if there are any issues with this limit.
+    * Each certificate must be a PEM-encoded string of an x509v3 certificate.
+    * Private keys must not be passed as a certificate, and will be rejected.
+    * The total size of all inlined certificates must not exceed 50 KB. Please reach out to your account team if there are any issues with this limit.
 
 Additionally, be aware of the following limitations when adding custom certificates:
 

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/index.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-console/index.md
@@ -42,7 +42,7 @@ You can scroll through the list and select or deselect packages to tailor the im
 After selecting your chosen packages, click the **Continue** button. After doing so, Custom Assembly will prompt you to select one of the two following options for how you want to apply the customizations:
 
 * **Create a new image**: This option will create a new container image, based on the current image you've chosen to customize.
-  * This option requires you to select a new name for the container image. Note that whatever name you select can only contain lowercase alphanumeric characters, `-`, or `_`.
+    * This option requires you to select a new name for the container image. Note that whatever name you select can only contain lowercase alphanumeric characters, `-`, or `_`.
 * **Customize current image**: This option overrides the existing container image with your customizations. Note that any customizations applied to this image will also apply to any users in your organization that are already consuming it.
 
 <center><img src="ca-3.png" alt="Screenshot of the Customize Image display, showing the two customization options. The 'Create new image' option is selected, with the name 'customized_node' entered into the naming field." style="width:650px;"></center>

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
@@ -28,10 +28,10 @@ Before getting started, you should have:
 * A Chainguard organization with access to Custom Assembly
 * Permission to manage Custom Assembly configuration for your organization/repository
 * A CI/CD platform in place
-  * In this guide, we use GitHub Actions as an example.
+    * In this guide, we use GitHub Actions as an example.
 * A Git repository to host your apko configuration files
 * A configured assumable identity for your CI workload
-  * If you have not yet set up CI identities, see [Chainguard's tutorials for creating and assuming identities](/chainguard/administration/assumable-ids/identity-examples/).
+    * If you have not yet set up CI identities, see [Chainguard's tutorials for creating and assuming identities](/chainguard/administration/assumable-ids/identity-examples/).
 * The full IDs for your [catalog_syncer and apko_builder identities](/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/#chainguards-signing-identities/).
 
 Also note that Chainguard's [demo workflow](https://github.com/chainguard-demo/custom-assembly-as-code) uses [octo-sts](https://www.chainguard.dev/unchained/the-end-of-github-pats-you-cant-leak-what-you-dont-have), a tool that generates short-lived GitHub tokens instead of using long-lived Personal Access Tokens (PATs). While octo-sts is optional for Custom Assembly builds, it's recommended for workflows that need GitHub API access alongside Chainguard operations.

--- a/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
+++ b/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
@@ -62,20 +62,20 @@ After a grace period ends, your organization will retain access to the last succ
 To maximize the value of a grace period, we recommend the following:
 
 * **Before the grace period starts**:
-  * Identify all dependent applications and services using the container image
-  * Create an upgrade plan with realistic timelines
-  * Document any known issues or compatibility requirements
-  * Set up monitoring for the container images
+    * Identify all dependent applications and services using the container image
+    * Create an upgrade plan with realistic timelines
+    * Document any known issues or compatibility requirements
+    * Set up monitoring for the container images
 * **During the grace period**:
-  * Test newer versions of the image in a development environment
-  * Track and resolve any compatibility issues
-  * Begin deploying updated versions to non-critical environments
-  * Monitor for any build failures or dependency conflicts
+    * Test newer versions of the image in a development environment
+    * Track and resolve any compatibility issues
+    * Begin deploying updated versions to non-critical environments
+    * Monitor for any build failures or dependency conflicts
 * **Before expiration**:
-  * Complete all necessary testing of the new version
-  * Schedule the production upgrade
-  * Document any configuration changes needed
-  * Prepare rollback procedures if needed
+    * Complete all necessary testing of the new version
+    * Schedule the production upgrade
+    * Document any configuration changes needed
+    * Prepare rollback procedures if needed
 
 ## Using the EOL Grace Period API
 
@@ -149,17 +149,17 @@ This example output is derived from an API call made on a `node` image repositor
 * `id`: this is the UID of the specific image this block of data represents
 * `name`: the given container image's tag
 * `tagStatus`: whether the tag can support a grace period, with the following possible statuses:
-  * `TAG_ACTIVE`: the tag is continuing to be built, but is not in a grace period
-  * `TAG_IN_GRACE`: tag is in a grace period
-  * `TAG_INACTIVE`: the tag is not in a grace period and no longer being built
+    * `TAG_ACTIVE`: the tag is continuing to be built, but is not in a grace period
+    * `TAG_IN_GRACE`: tag is in a grace period
+    * `TAG_INACTIVE`: the tag is not in a grace period and no longer being built
 * `mainPackageVersion`: this section shows some information about the main package itself:
-  * `eolDate`: the date on which the image's main package reached EOL
-  * `lts`: the date on which this version of the main package entered its long-term support period
-  * `releaseDate`: the date on which the main package's version was released
+    * `eolDate`: the date on which the image's main package reached EOL
+    * `lts`: the date on which this version of the main package entered its long-term support period
+    * `releaseDate`: the date on which the main package's version was released
 * `graceStatus`: the status of whether or not the given container image is in an active grace period
-  * `GRACE_ACTIVE`, as shown in this example, indicates the image is in an active grace period
-  * any images that are not currently in a grace period but may be in the future will show `GRACE_ELIGIBLE`
-  * any container images that will never enter a grace period will show `GRACE_NOT_ELIGIBLE`
+    * `GRACE_ACTIVE`, as shown in this example, indicates the image is in an active grace period
+    * any images that are not currently in a grace period but may be in the future will show `GRACE_ELIGIBLE`
+    * any container images that will never enter a grace period will show `GRACE_NOT_ELIGIBLE`
 * `gracePeriodExpiryDate`: the date on which the image's grace period will end
 
 Of course, you won't use `curl` to interact with the Chainguard API in most scenarios. Instead, you'll likely have some kind of application that can ingest and process this EOL data. For example, your organization could create a Slackbot that fetches data from the Chainguard EOL grace period API and posts messages about EOL tags approaching their grace period expiration to a specified Slack channel. Chainguard's [API documentation](/chainguard/api/spec/) includes request samples for many languages and platforms, including Go, Python, and Java.

--- a/content/chainguard/chainguard-images/features/image-stigs.md
+++ b/content/chainguard/chainguard-images/features/image-stigs.md
@@ -98,7 +98,6 @@ _END_DOCKER_RUN
 
 Results are written to a new `out/` subdirectory in the current working directory. The `report.html` file contains a human-readable report of the scan results; `results.xml` contains the raw results.
 
-
 ## What are STIGs?
 
 "STIG" stands for Security Technical Implementation Guide. A STIG is a technology-specific implementation of a Security Requirements Guide (SRG) that a security administrator follows to ensure that a given piece of software has been hardened against cybersecurity threats.
@@ -106,7 +105,6 @@ Results are written to a new `out/` subdirectory in the current working director
 A STIG is typically written by the developer or vendor of the given piece of software against a published DOD Security Requirements Guide (SRG). STIGs are presented in the XCCDF (Extensible Configuration Checklist Description Format), allowing them to be ingested into a SCAP-validated tool to validate that a given target is in compliance with them.
 
 After drafting the STIG, the vendor will submit it to the [Defense Information Systems Agency (DISA)](https://www.disa.mil/), an agency within the DoD. One of DISA's responsibilities is publishing and maintaining STIGs on the [DoD Cyber Exchange website](https://www.cyber.mil/stigs/downloads/), and the process from a STIG being submitting to it being published by DISA can take years. As of this writing, DISA has published over 450 STIGs for a wide variety of software applications.
-
 
 ## How STIGs can be used to harden container images
 
@@ -131,7 +129,6 @@ controls and benefits from infrastructure to host OS-level remediation requireme
 
 Deploying containers on a STIG hardened host provides many of the security features that are difficult or sometimes impossible to implement inside a container. What's left then is the application-level security configuration — in particular vulnerability remediation — which Chainguard provides through our guaranteed vulnerability remediation SLAs.
 
-
 ## False positives and the General Purpose OS STIG
 
 Here we've assembled several explanations for requirements from Chainguard's General Purpose Operating System STIG that are likely to cause false positives when scanning containers, as well as the rationale for those requirements. By disambiguating these false positives, the following sections should be helpful to any administrators deploying containers in environments where STIG hardening is necessary both as a means to understand where to expend effort performing hardening and for discussions with assessors and compliance personnel.
@@ -144,13 +141,11 @@ Linux containers use their host's kernel, making it impossible to install and op
 
 Once configured, logs of container actions are written to the host's audit log files and are readable only by the host superuser account. These logs must be collected from the host for incident response and reporting. Storage capacity limits, audit process monitoring, remote upload of logs, and associated alerts are the responsibility of the host where the containers are running.
 
-
 ### Isolation
 
 Containers provide process isolation by executing their applications in a constrained environment using the Linux Namespace and cgroup subsystems. Inside the namespace, container processes are only permitted to access a limited set of system resources defined when the container is launched. Processes are further restricted by limits imposed through the cgroup for access to system resources such as system memory or CPU use.
 
 Together, namespaces and cgroups isolate security functions of the host operating system from non-security functions of applications running inside the container. This separation makes it possible for container failures to not directly impact the operation of the host and its security functions when caused through processing of invalid inputs or other runtime errors. In the event of a container failure during initialization or shutdown, for example, the host operating system's security capabilities will continue to function as configured.
-
 
 ### Minimal container images
 
@@ -160,36 +155,29 @@ This limited implementation means that only the necessary software to operate ca
 
 The host's container execution environment further reduces the risk of unauthorized modification of software through Linux container isolation capabilities including namespaces and cgroups. These restrictions prevent unauthorized modification of the host operating system environment.
 
-
 ### Address Space Layout Randomization (ASLR)
 
 ASLR configuration is the responsibility of the host operating system on which containers run. Applications running within a container on a host that has ASLR enabled will automatically be protected by the configuration. No additional action is needed to ensure that container-based applications are protected.
-
 
 ### Host firewall
 
 Linux containers inherit the firewall configuration of their host operating system which dictates which ports on the container can be accessed from the network. Selection of which ports to make accessible on the applications running on the container is the responsibility of the host firewall configuration — an additional application-level firewall inside the container is not necessary.
 
-
 ### Host filesystem
 
 Linux containers use the host's filesystem for storage of their files and configuration. To protect data at rest inside containers from unauthorized access or modification, you must modify the host operating system's configuration. As an example, you might set up encrypted virtual filesystems. The host filesystem is also responsible for the size, utilization, and capacity of the physical disks that are used by containers running on that host.
-
 
 ### Vulnerability scanning
 
 The team deploying the container is also responsible for scanning it for vulnerabilities. This scanning can be executed from the host operating system or against the container image when it is stored in a registry. Continuous scanning can be used to detect vulnerabilities that have been identified / announced since the previous scan and determine when updated images should be built and deployed in the environment.
 
-
 ### Time
 
 Linux containers inherit the system time from the underlying host; likewise, containers don't operate their own separate time services. The host owner is responsible for configuring the host's time service to generate the timestamp used by its auditing system, perform periodic synchronization, and ensure that only authorized time servers are used as the authoritative source. Time synchronization of the host clock is automatically reflected in the time used by the container.
 
-
 ### STIGs
 
 These containers can be validated against the General Purpose Operating System STIG and other applicable STIGs using the [OpenSCAP toolset](http://www.open-scap.org/tools/). OpenSCAP can validate configuration of container images by reviewing the configuration of the image filesystem and can perform interactive checks by executing commands against running containers.
-
 
 ## Learn more
 

--- a/content/chainguard/chainguard-images/features/incert-custom-certs.md
+++ b/content/chainguard/chainguard-images/features/incert-custom-certs.md
@@ -33,7 +33,7 @@ To follow along with this tutorial, you will need to have the following tools in
 * `incert`, a Go program that appends CA certificates to Docker images and pushes the modified image to a specified registry. You can install this by following [the instructions](https://github.com/chainguard-dev/incert#installation) listed in the project's GitHub repository.
 * Docker, the open-source containerization platform. Set this up by following [the platform-specific instructions](https://docs.docker.com/get-docker/) on the project's website.
 * A tool for creating a self-signed certificate. This guide highlights using `cfssl`, a public key infrastructure toolkit from CloudFlare, but alternatives like `openssl` could also be used for this purpose. Follow [the `cfssl` installation instructions](https://github.com/cloudflare/cfssl#installation) to set this up.
-  * Note that if you use `cfssl`, you will also need the `cfssljson` utility installed as well.
+    * Note that if you use `cfssl`, you will also need the `cfssljson` utility installed as well.
 
 ## Creating a self-signed certificate
 

--- a/content/chainguard/chainguard-images/features/packages/package-model.md
+++ b/content/chainguard/chainguard-images/features/packages/package-model.md
@@ -115,8 +115,8 @@ The public Wolfi and Extra repositories currently retain non-latest package vers
 Retention rules for public repositories:
 
 * Non-latest package versions older than 12 months are removed unless:
-  * They are required by other Wolfi packages.
-  * They are required by Chainguard Container images.
+    * They are required by other Wolfi packages.
+    * They are required by Chainguard Container images.
 * Additionally, Chainguard removes latest package versions if the corresponding package definition has been removed from the Wolfi source repository (`https://github.com/wolfi-dev/os`), unless they meet one of these exceptions.
 
 If you pin specific package versions, ensure those versions remain within the retention window or mirror them internally.

--- a/content/chainguard/chainguard-images/features/request-resources/index.md
+++ b/content/chainguard/chainguard-images/features/request-resources/index.md
@@ -36,14 +36,14 @@ To begin, navigate to the [**Requests** section of the Chainguard Console](https
 Each of these tabs contains a table with the following columns:
 
 * A column at the far left where you can upvote requests by clicking the upward-pointing arrow.
-  * Click the arrow again to remove an upvote.
+    * Click the arrow again to remove an upvote.
 * The **Name** of the resource requested.
 * The request's **Status**. This can be one of the following:
-  * **Future**
-  * **In progress**
-  * **Paused**
-  * **Reviewing**
-  * **Won't build**
+    * **Future**
+    * **In progress**
+    * **Paused**
+    * **Reviewing**
+    * **Won't build**
 * If the original requester included them, **Project Details** that describe the resource being requested
 
 Additionally, the **Community requests** tab includes a **Demand** column, showing what demand percentile the request falls into. Also, the **Active builds** tab includes an **Estimated delivery** column that shows when Chainguard expects the resource to be available.
@@ -77,7 +77,7 @@ The Chainguard team will then review the request and prioritize it based on dema
 There are a few limitations you should consider before submitting a new request:
 
 * Chainguard will not build resources based on proprietary code.
-  * Note that some projects distributed under open source licenses have strict terms that prevent Chainguard from building artifacts based on them.
+    * Note that some projects distributed under open source licenses have strict terms that prevent Chainguard from building artifacts based on them.
 * If a project is no longer receiving updates or releases, Chainguard typically won't build it since there aren't reliable security fixes upstream.
 * There are cases where Chainguard cannot fulfill a FIPS request and be FIPS compliant. In such cases the standard variant can often still be built but the FIPS variant will get marked as **Won't build**.
 

--- a/content/chainguard/chainguard-images/getting-started/python.md
+++ b/content/chainguard/chainguard-images/getting-started/python.md
@@ -2,7 +2,7 @@
 title: "Getting Started with the Python Chainguard Container"
 type: "article"
 linktitle: "Python"
-aliases: 
+aliases:
 - /chainguard/chainguard-images/getting-started/getting-started-python
 description: "Learn how to use Chainguard's Python container images for secure Python applications with minimal CVEs, distroless design, and comprehensive supply chain security features"
 date: 2023-02-28T11:07:52+02:00
@@ -150,7 +150,7 @@ And you should get output similar to what you got before, with a random octopus 
 Octopuses can breathe and see through their skin.
 ```
 
-You have successfully completed the single-stage Python Chainguard Container. At this point, you can continue to the [multi-stage example](#example-2-multi-stage-build-for-python-chainguard-image) or [advanced usage](#advanced-usage).
+You have successfully completed the single-stage Python Chainguard Container. At this point, you can continue to the [multi-stage example](#example-2-multi-stage-build-for-python-chainguard-container) or [advanced usage](#advanced-usage).
 
 ## Example 2 — Multi-Stage Build for Python Chainguard Container
 
@@ -237,12 +237,12 @@ The following Dockerfile will:
 
 1. Start a new build stage based on the `python:latest-dev` container image and call it `builder`;
 2. Create a new virtual environment to cleanly hold the application's dependencies;
-2. Copy `requirements.txt` from the current directory to the `/linky` location in the container;
-3. Run `pip install --no-cache-dir -r requirements.txt` to install dependencies;
-4. Start a new build stage based on the `python:latest` image;
-5. Copy the dependencies in the virtual environment from the builder stage, and the source code from
+3. Copy `requirements.txt` from the current directory to the `/linky` location in the container;
+4. Run `pip install --no-cache-dir -r requirements.txt` to install dependencies;
+5. Start a new build stage based on the `python:latest` image;
+6. Copy the dependencies in the virtual environment from the builder stage, and the source code from
    the current directory;
-6. Set up the application as the entry point for this container.
+7. Set up the application as the entry point for this container.
 
 Copy this configuration to your own Dockerfile:
 
@@ -279,7 +279,7 @@ Save the file when you’re finished.
 You can now build the container image. If you receive a permission error, try running under `sudo`.
 
 ```shell
-docker build . --pull -t linky 
+docker build . --pull -t linky
 ```
 
 Once the build is finished, run the image with:

--- a/content/chainguard/chainguard-images/getting-started/pytorch/index.md
+++ b/content/chainguard/chainguard-images/getting-started/pytorch/index.md
@@ -78,9 +78,9 @@ In this section, we'll download prepared data to your environment, download a mo
 
 First check that `curl` and `tar` are available on your system, and install them if necessary. [Docker Engine](https://docs.docker.com/engine/install/) will also need to be installed.
 
-Run the following to download necessary files and train the model. If there is an issue with the command, see the [manual step-by-step instructions](#a-namemanuala-manual-steps-to-fine-tune-the-model) below.
+Run the following to download necessary files and train the model. If there is an issue with the command, see the [manual step-by-step instructions](#manual-steps-to-fine-tune-the-model) below.
 
-Note: if you're following this tutorial in an environment without access to GPU, remove the ` --gpus all \` line below before running.
+Note: if you're following this tutorial in an environment without access to GPU, remove the `--gpus all \` line below before running.
 
 ```bash
 mkdir image_classification && cd image_classification
@@ -125,7 +125,7 @@ In the below steps, the prompt of your host machine will be denoted as `(host) $
     (host) $ cd pytorch-getting-started
     ```
 
-3. Run the below command to start an interactive session in a running `pytorch` Chainguard Container with root access. If your environment doesn't have access to GPU, remove the ` --gpus all \` line before running. Note the volume option, which creates a volume on the container based on the current working directory, allowing access to our training script and data inside the container. Remember that this guide assumes you are training the model in a controlled development environment—do not use root access in any production scenario.
+3. Run the below command to start an interactive session in a running `pytorch` Chainguard Container with root access. If your environment doesn't have access to GPU, remove the `--gpus all \` line before running. Note the volume option, which creates a volume on the container based on the current working directory, allowing access to our training script and data inside the container. Remember that this guide assumes you are training the model in a controlled development environment—do not use root access in any production scenario.
 
     ```bash
     (host) $ docker run --user root --rm -it \

--- a/content/chainguard/chainguard-images/how-to-use/dev-containers/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/dev-containers/index.md
@@ -17,7 +17,7 @@ weight: 100
 toc: true
 ---
 
-[Development Containers](https://containers.dev/) — sometimes known as "dev containers" — allow you to use a container as a development environment where you can run applications and separate tools, libraries, or runtimes. Dev containers can also help with testing and continuous integration. 
+[Development Containers](https://containers.dev/) — sometimes known as "dev containers" — allow you to use a container as a development environment where you can run applications and separate tools, libraries, or runtimes. Dev containers can also help with testing and continuous integration.
 
 With a few changes, the images based on Wolfi and maintained by Chainguard provide distroless images that can be used as dev containers. This guide outlines how you can set up a Chainguard image as a dev container in VS Code.
 
@@ -33,7 +33,6 @@ With a few changes, the images based on Wolfi and maintained by Chainguard provi
 {{< blurb/images >}}
 {{< /details >}}
 
-
 ## Prerequisites
 
 To follow along with this guide, you will need to have the following:
@@ -43,7 +42,6 @@ To follow along with this guide, you will need to have the following:
 * A Docker server to connect to. A local installation of Docker Desktop will usually suffice for demonstration purposes, but you can find full instructions in this guide on [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) in the VS Code documentation.
 * This guide's first example assumes that you have a GitHub repository named `empty`. You can follow GitHub's [Quickstart for repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/quickstart-for-repositories) for information on setting this up.
 
-
 ## What are Dev Containers?
 
 A development container is a container in which a user can develop an application. Development containers are isolated environments that allow developers to work on applications with all the necessary dependencies, tools, and configurations pre-packaged. These containers ensure that the development environment is consistent across different systems, avoiding the "works on my machine" problem.
@@ -52,8 +50,7 @@ In order to run a dev container, the given project must contain a file named `de
 
 Although there are many reasons why production images should be secure, the reasons for concern about the security of development environments are less clear. Put briefly: the code you've written and tested in your development environment will eventually make it into your production environment. If you've been hacked during development, then perhaps the hackers' code goes into production as well.
 
-Chainguard offers minimal runtime images designed for running production workloads, and development images that contain a shell and some development tooling. With that said, both development and production images are slimmed down and updated regularly to be free of CVEs. Because of their minimal and secure-by-default nature, Chainguard Containers are ideal for use in a secure development process. 
-
+Chainguard offers minimal runtime images designed for running production workloads, and development images that contain a shell and some development tooling. With that said, both development and production images are slimmed down and updated regularly to be free of CVEs. Because of their minimal and secure-by-default nature, Chainguard Containers are ideal for use in a secure development process.
 
 ## Building a Go Dev Container using an Example Repository
 
@@ -106,18 +103,17 @@ git push -fu origin main
 Following that, if you open VS Code on this directory you will be prompted to open the project in a dev container.
 
 <center><img src="dev-containers-1.png" alt="Screenshot of a VS Code window showing the prompt to reopen the project in a dev container." style="width:1000px;"></center>
-<br /> 
+<br />
 
 If you do reopen the project in a dev container it may take a minute or so to build the first time you use it. Open a terminal and you can run the sample project, even if you don't have Go installed on your local machine:
 
 <center><img src="dev-containers-2.png" alt="Screenshot of a VS Code window with the example Go program being run in the terminal." style="width:1000px;"></center>
-<br /> 
+<br />
 
 If you run a webserver in your dev container you will be asked if you want to open the port in a local browser. Exactly as if you were running in a local container:
 
 <center><img src="dev-containers-1.png" alt="Screenshot of a VS Code window running helloserver and prompting the user to open the application in the browser." style="width:1000px;"></center>
-<br /> 
-
+<br />
 
 ## Building a Dev Container in other languages
 
@@ -138,18 +134,18 @@ Next, create a dev container configuration file named `devcontainer.json` with t
 ```shell
 cat > devcontainer.json <<EOF
 {
-	"name": "my-devcontainer",
-	"build": {
-    	"dockerfile": "Dockerfile",
-    	"args": {}
-	},
-	"customizations": {
-    	"vscode": {
-        	"extensions": [ "ms-python.python" ]
-    	}
-	},
-	"postCreateCommand": "pip install -r requirements.txt",
-	"remoteUser": "nonroot"
+ "name": "my-devcontainer",
+ "build": {
+     "dockerfile": "Dockerfile",
+     "args": {}
+ },
+ "customizations": {
+     "vscode": {
+         "extensions": [ "ms-python.python" ]
+     }
+ },
+ "postCreateCommand": "pip install -r requirements.txt",
+ "remoteUser": "nonroot"
 }
 
 EOF
@@ -184,6 +180,7 @@ Here's what each line of this Dockerfile does:
         ```shell
         docker run -it --entrypoint id chainguard/python:latest-dev
         ```
+
         ```Output
         uid=65532(nonroot) gid=65532(nonroot) groups=65532(nonroot)
         docker run -it --entrypoint id chainguard/go:latest-dev
@@ -210,14 +207,14 @@ RUN apk add sudo-rs shadow && echo "nonroot ALL = (ALL:ALL) NOPASSWD:ALL" >> /et
 
 ## Usage Notes
 
-[GitHub CodeSpaces](https://github.com/features/codespaces) support dev containers. However, at present they only work when the config is stored at the root directory. 
+[GitHub CodeSpaces](https://github.com/features/codespaces) support dev containers. However, at present they only work when the config is stored at the root directory.
 
 The IDE should pass your keys through to the dev container using `ssh-agent` and `gpg-agent`. For this reason, you may need to install GPG or SSH tools inside the container.
 
 Please refer to the VS Code page on [advanced usage](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) for more information.
 
-
 ## Conclusion
+
 You should now have a development environment that does not require packages to be installed on your local machine and will run the same for anyone working on your project.
 
 You may want to add things like linting rules or other components to your dev container config. The [VS Code website](https://code.visualstudio.com/docs/devcontainers/containers) has many resources on working with dev containers which you may find useful.

--- a/content/chainguard/chainguard-images/how-to-use/install-apks-in-distroless-variants.md
+++ b/content/chainguard/chainguard-images/how-to-use/install-apks-in-distroless-variants.md
@@ -44,10 +44,9 @@ Here are three options that you may be considering and our thoughts about them b
 - **Bind mount** — In a multi-stage build, mount APK and other required development resources from a development image, then install needed APKs using these mounted resources. This approach can work for a single point in time but can be difficult to maintain as the APK resources needed to copy over change over time.
 - **Chroot (recommended)** — In a multi-stage build, install any build-time dependencies and build any required software artifacts such as binaries. Use a second base image to install runtime dependencies to a directory specified with chroot for later copying. In a final step, copy built software artifacts and the chroot installation directory to scratch and set the desired entrypoint. This method is recommended.
 
-
 ## Using chroot
 
-> **Note**: If you’re working to a deadline, you can skip to this short [appendix with full code example](#appendix-b:-example-code-for-chroot-method-\(c-binary\)).
+> **Note**: If you’re working to a deadline, you can skip to this short [appendix with full code example](#appendix-b-example-code-for-chroot-method-c-binary).
 
 This workflow allows you to install APKs to a distroless image during a Dockerfile build by generating required software artifacts in a development environment, preparing a directory structure with runtime dependencies installed using chroot, then assembling these components back in the distroless image. The steps are as follows:
 
@@ -82,13 +81,13 @@ from MySQLdb import _mysql
 print(_mysql.__version__)
 ```
 
-2. Create a `requirements.txt` file with `mysqlclient` as the only listed Python dependency:
+1. Create a `requirements.txt` file with `mysqlclient` as the only listed Python dependency:
 
 ```plaintext
 mysqlclient
 ```
 
-3. Create a Dockerfile. Here's the full file, followed by line-by-line explanations.
+1. Create a Dockerfile. Here's the full file, followed by line-by-line explanations.
 
 ```Dockerfile
 # syntax=docker/dockerfile:1
@@ -189,13 +188,13 @@ Finally, set the entrypoint:
 
 `ENTRYPOINT ["python", "run.py"]`
 
-4. Once you have your Dockerfile, `run.py`, and `requirements.txt`, build the image:
+1. Once you have your Dockerfile, `run.py`, and `requirements.txt`, build the image:
 
 `docker build . --pull --no-cache -t mariadb-distroless`
 
 Here, `--pull` ensures we receive the latest images, even if one is locally stored, and `--no-cache` ensures that we receive the latest versions of packages.
 
-5. Once the build completes, run the container:
+1. Once the build completes, run the container:
 
 `docker run mariadb-distroless`
 

--- a/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/retrieve-image-sboms/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How to Retrieve SBOMs and attestations for Chainguard Containers"
 linktitle: "Retrieve SBOMs"
-aliases: 
+aliases:
 - /chainguard/chainguard-images/retrieve-image-sboms
 - /chainguard/chainguard-images/images-features/retrieve-image-sboms
 - /chainguard/chainguard-images/working-with-images/retrieve-image-sboms/
@@ -28,7 +28,8 @@ Even though they contain the minimum number of packages, there may come a time w
 ## Retrieve a container image's attestation
 
 You can retrieve a container image's attestation in two ways:
-- [Using Cosign](#retrieve-a-container-image-attestation-via-cosign)
+
+- [Using Cosign](#retrieve-a-container-image-attestation-using-cosign)
     - [Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/) — a part of the Sigstore project — supports software artifact signing, verification, and storage in an [OCI (Open Container Initiative)](/open-source/oci/what-is-the-oci/) registry, as well as the retrieval of said artifacts.
 - [In the Chainguard Console](#retrieve-a-container-image-attestation-in-the-chainguard-console)
 
@@ -36,13 +37,12 @@ You can retrieve a container image's attestation in two ways:
 
 To retrieve an attestation via Cosign, you'll need the following installed on your local machine:
 
-* **Cosign**: Follow [our guide on installing Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) to configure it.
-* **jq**: Follow instructions on the [jq downloads page](https://jqlang.github.io/jq/download/) to set it up.
-
+- **Cosign**: Follow [our guide on installing Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) to configure it.
+- **jq**: Follow instructions on the [jq downloads page](https://jqlang.github.io/jq/download/) to set it up.
 
 ### Retrieve a container image attestation using Cosign
 
-Cosign includes a `download attestation` command that allows you to retrieve a Chainguard Container's attestation over the command line. Different types of attestations are referenced by their **predicate type**. To authenticate these statements and verify the authenticity of the software producer, you can use [`cosign verify-attestation`](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/). 
+Cosign includes a `download attestation` command that allows you to retrieve a Chainguard Container's attestation over the command line. Different types of attestations are referenced by their **predicate type**. To authenticate these statements and verify the authenticity of the software producer, you can use [`cosign verify-attestation`](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).
 
 This example command downloads the SPDX attestation for Chainguard's [php image](https://images.chainguard.dev/directory/image/php/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-working-with-images-retrieve-image-sboms):
 
@@ -56,14 +56,14 @@ cosign download attestation \
 Cosign returns the attestation in a signed envelope, with the SBOM stored as a base64-encoded payload. The command pipes the output through jq to extract the payload, decodes it with base64, and then uses jq again to print the attestation’s predicate, which contains the SBOM.
 
 You can include the following flags when retrieving attestations:
-* The `--platform` flag, which selects the target platform for the image, such as `linux/amd64` or `linux/arm64`. 
-    * This flag requires Cosign version 2.2.1 or newer.
-* The `--predicate-type` flag, required to specify which type of attestation to retrieve. You can use the full URI or the shorthand version as the value of the flag. See the [Available attestation types](#available-attestation-types) section for a list of options.
 
+- The `--platform` flag, which selects the target platform for the image, such as `linux/amd64` or `linux/arm64`.
+    - This flag requires Cosign version 2.2.1 or newer.
+- The `--predicate-type` flag, required to specify which type of attestation to retrieve. You can use the full URI or the shorthand version as the value of the flag. See the [Available attestation types](#available-attestation-types) section for a list of options.
 
 ### Retrieve a container image attestation in the Chainguard Console
 
-You can also find container image SBOMs in the [Chainguard Console](https://console.chainguard.dev). After signing in to the Console and clicking either the **Public images** or, if available, **Organization images** you'll be presented with a list of images. Click on any of these to navigate that image's landing page. From there, navigate to the [**SBOM** tab](/platform/console/images-directory/#sbom-tab) to find and download the SBOM for the given image. 
+You can also find container image SBOMs in the [Chainguard Console](https://console.chainguard.dev). After signing in to the Console and clicking either the **Public images** or, if available, **Organization images** you'll be presented with a list of images. Click on any of these to navigate that image's landing page. From there, navigate to the [**SBOM** tab](/platform/console/images-directory/#sbom-tab) to find and download the SBOM for the given image.
 
 You can use the drop-down menus above the table to select which version and architecture of the image you want to view. You can also use the search box to find specific packages in the SBOM or use the button to the right of the search box to download the SBOM to your machine.
 
@@ -77,59 +77,59 @@ Check out our guide on [using the Chainguard Containers Directory](/platform/con
 
 Chainguard publishes several different types of attestations. Not every image will have every predicate type; availability depends on the image and its build process. Available predicate types include:
 
-* **SLSA**: `https://slsa.dev/provenance/v1` (`slsaprovenance1`)
-    * The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment.
-    * Available on all images.
-* **apko**: `https://apko.dev/image-configuration`
-    * Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.
-    * Available on all images.
-* **SPDX**: `https://spdx.dev/Document` (`spdx`,`spdxjson`)
-    * Contains the image SBOM in SPDX format.
-    * Available on all images.
-* **Chainguard EOL**: `https://chainguard.dev/end-of-life`
-    * End-of-life status.
-    * Only available on EOL images in grace period.
-* **CycloneDX**: `https://cyclonedx.org/bom` (`cyclonedx`)
-    * Contains the image SBOM in CycloneDX format.
-    * Only available to customers, on new builds or rebuilds after January 29, 2026.
-* **Chainguard Helm values**: `https://chainguard.dev/helm-values/v1`
-    * Contains Helm values for images with vetted upstream Helm charts.
-    * Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation.
-* **Chainguard Helm chart-lock**: `https://chainguard.dev/attestation/chart-lock/v1`
-    * Contains Helm chart-lock data for relevant images.
-    * Only present for images where Helm chart locking is relevant.
-* **Syft**: `https://chainguard.dev/attestation/syft/v1`
-    * Contains Syft-based SBOM attestation.
-    * Not available on all images; this predicate is less common.
+- **SLSA**: `https://slsa.dev/provenance/v1` (`slsaprovenance1`)
+    - The [SLSA 1.0](https://slsa.dev/spec/v1.0/provenance) provenance attestation contains information about the image build environment.
+    - Available on all images.
+- **apko**: `https://apko.dev/image-configuration`
+    - Contains the configuration used by that particular image build, including direct dependencies, user accounts, and entry point.
+    - Available on all images.
+- **SPDX**: `https://spdx.dev/Document` (`spdx`,`spdxjson`)
+    - Contains the image SBOM in SPDX format.
+    - Available on all images.
+- **Chainguard EOL**: `https://chainguard.dev/end-of-life`
+    - End-of-life status.
+    - Only available on EOL images in grace period.
+- **CycloneDX**: `https://cyclonedx.org/bom` (`cyclonedx`)
+    - Contains the image SBOM in CycloneDX format.
+    - Only available to customers, on new builds or rebuilds after January 29, 2026.
+- **Chainguard Helm values**: `https://chainguard.dev/helm-values/v1`
+    - Contains Helm values for images with vetted upstream Helm charts.
+    - Only images that are tested with Helm and have a corresponding upstream Helm chart have this attestation.
+- **Chainguard Helm chart-lock**: `https://chainguard.dev/attestation/chart-lock/v1`
+    - Contains Helm chart-lock data for relevant images.
+    - Only present for images where Helm chart locking is relevant.
+- **Syft**: `https://chainguard.dev/attestation/syft/v1`
+    - Contains Syft-based SBOM attestation.
+    - Not available on all images; this predicate is less common.
 
 ## License Information and Source Code references
 
 The SBOM downloaded using either Cosign or Console methods described previously contain identical information. It lists binary packages present in the image, their licensing information using [SPDX license](https://spdx.org/licenses/) and [exceptions lists](https://spdx.org/licenses/exceptions-index.html), and external source code references.
 
-These source code references are encoded in the [external references](https://spdx.github.io/spdx-spec/v2.3/package-information/#721-external-reference-field) field, using [external repository identifiers](https://spdx.github.io/spdx-spec/v2.3/external-repository-identifiers/#f35-purl) in the package URL (purl) format. The [purl specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst) allows for various different schemes and types. 
+These source code references are encoded in the [external references](https://spdx.github.io/spdx-spec/v2.3/package-information/#721-external-reference-field) field, using [external repository identifiers](https://spdx.github.io/spdx-spec/v2.3/external-repository-identifiers/#f35-purl) in the package URL (purl) format. The [purl specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst) allows for various different schemes and types.
 
 The following purls are used in Chainguard SPDX SBOM:
 
-* `pkg:apk` denotes binary package origin, name, full version number with epoch, and architecture:
+- `pkg:apk` denotes binary package origin, name, full version number with epoch, and architecture:
 
 ```
 pkg:apk/wolfi/ca-certificates-bundle@20240315-r4?arch=x86_64
 ```
 
-* `pkg:github` is used for upstream source code reference for packages built from GitHub repositories. These purls always include a fixed commit hash and, when available, also include a tag-version:
+- `pkg:github` is used for upstream source code reference for packages built from GitHub repositories. These purls always include a fixed commit hash and, when available, also include a tag-version:
 
 ```
 pkg:github/openssl/openssl.git@openssl-3.3.1
 pkg:github/openssl/openssl.git@db2ac4f6ebd8f3d7b2a60882992fbea1269114e2
 ```
 
-* Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash:
+- Note that `pkg:github` is also used to reference melange packaging files from Wolfi and Chainguard. These are provided with a subpath component and a fixed commit hash:
 
 ```
 pkg:github/wolfi-dev/os@f18ff825f94b9177cf603c6e3d72936683a504d2#glibc.yaml
 ```
 
-* `pkg:generic` is used to reference any other upstream download locations, most commonly tarballs:
+- `pkg:generic` is used to reference any other upstream download locations, most commonly tarballs:
 
 ```
 pkg:generic/gcc@13.2.0?
@@ -137,7 +137,7 @@ checksum=sha256%3A8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af3150
 download_url=https%3A%2F%2Fftp.gnu.org%2Fgnu%2Fgcc%2Fgcc-13.2.0%2Fgcc-13.2.0.tar.gz
 ```
 
-* Also note that `pkg:generic` is used to reference upstream git repositories, outside of GitHub:
+- Also note that `pkg:generic` is used to reference upstream git repositories, outside of GitHub:
 
 ```
 pkg:generic/ca-certificates@20240315?

--- a/content/chainguard/chainguard-images/network-requirements.md
+++ b/content/chainguard/chainguard-images/network-requirements.md
@@ -71,8 +71,8 @@ Containers and endpoints:
 
 - TLSv1.3 with the TLS_AES_256_GCM_SHA384 cipher suite
 - TLSv1.2 with
-  - ECDHE-ECDSA-AES256-GCM-SHA384 cipher string
-  - [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627) Extended Master Secret Extension support
+    - ECDHE-ECDSA-AES256-GCM-SHA384 cipher string
+    - [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627) Extended Master Secret Extension support
 - Signatures using P-256 with SHA-256
 - Signatures using RSA-PSS with 2048 bits and SHA-256
 - Support for encrypted HTTP/2 is required, including by any proxies in use

--- a/content/chainguard/chainguard-images/overview.md
+++ b/content/chainguard/chainguard-images/overview.md
@@ -23,7 +23,8 @@ Many Chainguard Containers implement a [distroless approach](/chainguard/chaingu
 
 Chainguard Containers are primarily available from [Chainguard's registry](/chainguard/chainguard-registry/overview/), but a selection of developer images is also available on [Docker Hub](https://hub.docker.com/u/chainguard). You can find the complete list of available Chainguard Containers in our public [Containers Directory](https://images.chainguard.dev/?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-overview) or within the [Chainguard Console](https://console.chainguard.dev/).
 
-### Built-in security and supply chain guarantees
+## Built-in security and supply chain guarantees
+
 All Chainguard Containers are built with a consistent set of security and supply-chain guarantees, without requiring additional configuration:
 
 - Minimal design, with no unnecessary software bloat
@@ -32,8 +33,7 @@ All Chainguard Containers are built with a consistent set of security and supply
 - [Verifiable signatures](/chainguard/chainguard-images/working-with-images/retrieve-image-sboms/) provided by [Sigstore](/open-source/sigstore/cosign/an-introduction-to-cosign/)
 - Reproducible builds with Cosign and apko ([read more about reproducibility](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds))
 
-
-### Chainguard Container customization and lifecycle features
+## Chainguard Container customization and lifecycle features
 
 Chainguard Containers include features that allow you to customize images, manage updates, and meet security and compliance requirements across the container lifecycle:
 
@@ -58,13 +58,15 @@ Chainguard originally took a single-layer approach to container images built [wi
 Chainguard's approach to layering is a "per-origin" strategy, where packages that derive from the same upstream source are grouped in the same layer because they tend to receive updates together.
 
 We observed that this approach achieved the following:
-* A ~70% reduction in the total size of unique layer data across our image catalog compared to the single-layer approach
-* A 70-85% reduction in the cumulative bytes transferred when simulating sequential pulls of updated images like PyTorch and NeMo
+
+- A ~70% reduction in the total size of unique layer data across our image catalog compared to the single-layer approach
+- A 70-85% reduction in the cumulative bytes transferred when simulating sequential pulls of updated images like PyTorch and NeMo
 
 To maximize the stability and re-usability of our layers, Chainguard identified, analyzed, and implemented three additional technical changes:
-* Added in an additional final layer that captures frequently updated OS-level metadata
-* Developed intelligent layer ordering to optimize compatibility
-* Ensured sufficient layer counts to optimize parallel downloads by container clients
+
+- Added in an additional final layer that captures frequently updated OS-level metadata
+- Developed intelligent layer ordering to optimize compatibility
+- Ensured sufficient layer counts to optimize parallel downloads by container clients
 
 The primary benefit of this layered approach is that when one package changes it impacts only its particular layer, requiring only that layer to be downloaded again. Because the other layers don't need to be downloaded again, Chainguard's multi-layer container images support greater efficiency and developer velocity.
 
@@ -78,7 +80,6 @@ You can access our container images directly from [Chainguard's registry](/chain
 
 For a complete list of Free Containers that are currently available, check our [Containers Directory](https://images.chainguard.dev/?category=developer). Registered users can also access all Free and Production container images in the [Chainguard Console](https://console.chainguard.dev/?utm=docs). After logging in you will be able to find all the current Free containers in the **Chainguard catalog** tab. If you've selected an appropriate Organization in the drop-down menu above the left hand navigation, you can find your organization's Production containers in the **Organization** tab.
 
-
 ## Comparing Container Images
 
 The following graph shows a comparison between the official Nginx image and Chainguard's [Nginx container image](https://images.chainguard.dev/directory/image/nginx/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-overview), based on the number of CVEs (common vulnerabilities and exposures) detected by [Grype](https://github.com/anchore/grype):
@@ -91,13 +92,12 @@ You can review more comparisons of Chainguard Containers and external images by 
 
 `chainctl`, Chainguard's command line interface tool, comes with a useful `diff` feature that also allows you to [compare two Chainguard Containers](/chainguard/chainguard-images/how-to-use/comparing-images/).
 
-
 ## Architecture
 
 By default, all Wolfi-based images are built for x86_64 (also known as AMD64) and AArch64 (also known as ARM64) architecture with the following CPU Instruction Set Architecture (ISA) baseline features:
 
-* x86_64: x86-64-v2 (Sapphire Rapids)
-* AArch64: Armv8-A with CRC and Cryptographic extensions (Neoverse V2)
+- x86_64: x86-64-v2 (Sapphire Rapids)
+- AArch64: Armv8-A with CRC and Cryptographic extensions (Neoverse V2)
 
 Being able to provide multi-platform Chainguard Containers enables the support of more than one runtime environment, like those available on all three major clouds, AWS, GCP, and Azure. The macOS M-series (M1, M2, etc.) chips are also based on ARM architecture. Chainguard Containers allow you to take advantage of ARM's power consumption and cost benefits.
 
@@ -124,27 +124,25 @@ This verifies that the Ruby Chainguard Container is built for both AMD64 and ARM
 
 You can read more about our support of ARM64 in our blog on [Building Wolfi from the ground up](https://www.chainguard.dev/unchained/building-wolfi-from-the-ground-up-and-announcing-arm64-support?utm=docs).
 
-
 ## Annotations
 
 All Chainguard Containers include metadata in the form of *annotations* (also commonly referred to as "*labels*"). These annotations provide important information about a container image's origin, contents, and characteristics. The annotations are visible in every container image's **Specifications** tab in both the [Chainguard Console](https://console.chainguard.dev) and [Directory](https://images.chainguard.dev/), and can also be inspected programmatically using container tools.
 
 Chainguard Containers follow the [Open Container Initiative (OCI) Image Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md) for annotations. Chainguard sets the following standard OCI annotations on its container images:
 
-* `org.opencontainers.image.authors`: Contact details for the Chainguard Container's author (typically `Chainguard Team https://www.chainguard.dev/`)
-* `org.opencontainers.image.base.digest`: The SHA256 digest of the base image used to build this container image
+- `org.opencontainers.image.authors`: Contact details for the Chainguard Container's author (typically `Chainguard Team https://www.chainguard.dev/`)
+- `org.opencontainers.image.base.digest`: The SHA256 digest of the base image used to build this container image
 
-* `org.opencontainers.image.created`: Timestamp indicating when the image was built; specifically, this annotation is calculated from the build time of the most recently built package within the container image
-* `org.opencontainers.image.source`: URL to the source code used to build the image in the Chainguard images repository
-* `org.opencontainers.image.title`: The original image name as listed in the catalogue (for example `chainguard-base`)
-* `org.opencontainers.image.url`: URL to the container image's Overview page in the Chainguard Directory (for example, `https://images.chainguard.dev/directory/image/nginx/overview`)
-* `org.opencontainers.image.vendor`: The distributing organization, always set to `Chainguard`
-
+- `org.opencontainers.image.created`: Timestamp indicating when the image was built; specifically, this annotation is calculated from the build time of the most recently built package within the container image
+- `org.opencontainers.image.source`: URL to the source code used to build the image in the Chainguard images repository
+- `org.opencontainers.image.title`: The original image name as listed in the catalogue (for example `chainguard-base`)
+- `org.opencontainers.image.url`: URL to the container image's Overview page in the Chainguard Directory (for example, `https://images.chainguard.dev/directory/image/nginx/overview`)
+- `org.opencontainers.image.vendor`: The distributing organization, always set to `Chainguard`
 
 In addition to the standard OCI annotations, Chainguard sets custom annotations (which begin with `dev.chainguard` instead of `org.opencontainers`) that provide additional context about the container image:
 
-* `dev.chainguard.package.main`: The name of the primary package in the image. This may change between different versions of an image. In some situations, it may also be empty or unset.
-* `dev.chainguard.image.title`: Duplicate of the original image name as listed in the catalogue, in case downstream build processes override the same value in the `org.opencontainers` namespace.
+- `dev.chainguard.package.main`: The name of the primary package in the image. This may change between different versions of an image. In some situations, it may also be empty or unset.
+- `dev.chainguard.image.title`: Duplicate of the original image name as listed in the catalogue, in case downstream build processes override the same value in the `org.opencontainers` namespace.
 
 ### Retrieving annotation information
 
@@ -178,6 +176,7 @@ crane config cgr.dev/chainguard/node:latest | jq '.config.Labels'
 ```
 
 The expected output is the same:
+
 ```json
 {
   "dev.chainguard.image.title": "node",
@@ -191,7 +190,7 @@ The expected output is the same:
 }
 ```
 
-This returns the same output as the previous `crane` command. 
+This returns the same output as the previous `crane` command.
 
 Lastly, you can use the `docker inspect` command to inspect a container image's labels:
 
@@ -201,6 +200,7 @@ docker inspect cgr.dev/chainguard/node:latest | jq '.[].Config.Labels'
 ```
 
 The expected output is the same:
+
 ```json
 {
   "dev.chainguard.image.title": "node",
@@ -243,6 +243,6 @@ a063d5e94934   39 hours ago   apko         151kB     node by Chainguard
 
 OCI labels are specific to a container image, not to an entire layer. This means that for base images, annotation information is often overridden later on with more accurate details after the image has been ingested. For example, the `image.author` annotation might be reset to reflect the customer consuming the container image.
 
-Some users relabel their container images after they've been ingested. As an example, you may wish to add an annotation like `com.mycompany.image.source=chainguard` to your Chainguard Containers; this would allow you to filter for all the container images provided by Chainguard at `mycompany`. 
+Some users relabel their container images after they've been ingested. As an example, you may wish to add an annotation like `com.mycompany.image.source=chainguard` to your Chainguard Containers; this would allow you to filter for all the container images provided by Chainguard at `mycompany`.
 
 Some package mirroring tools support this functionality, but we recommend using Chainguard's [Custom Assembly](/chainguard/chainguard-images/features/ca-docs/custom-assembly/) tool to add custom annotations to your Chainguard Containers. Refer to our guide on [managing Custom Assembly resources with `chainctl`](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#adding-custom-annotations-with-custom-assembly) for more information.

--- a/content/chainguard/chainguard-images/staying-secure/enforcement/opa-gatekeeper/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/enforcement/opa-gatekeeper/index.md
@@ -15,13 +15,12 @@ toc: true
 [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/) is an admission controller that enforces policies in Kubernetes clusters. This
 article describes how it can be leveraged to ensure resources follow best practices related to the use of Chainguard Containers.
 
-
 ## Prerequisites
 
 To follow the examples in this guide, you will need the following:
+
 - `kubectl` — the command line interface tool for Kubernetes — installed on your local machine.
 - Administrative access to a Kubernetes cluster where [OPA Gatekeeper is already installed](https://open-policy-agent.github.io/gatekeeper/website/docs/install).
-
 
 ## Ensure Images are Pulled From Allowed Repositories
 
@@ -70,12 +69,12 @@ spec:
       image: nginx
 EOF
 ```
+
 ```output
 Error from server (Forbidden): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: [repo-is-cgr-dev] container <nginx> has an invalid image <nginx>, allowed images are ["cgr.dev/*"]
 ```
 
 This example tries to create a pod using a container image downloaded from the Docker Hub registry, not Chainguard's registry. As this output indicates, attempting to create a non-compliant pod resulted in an error, and the request was denied.
-
 
 ## Ensure Images are Referenced By Digest
 
@@ -125,12 +124,12 @@ spec:
       image: cgr.dev/chainguard/nginx
 EOF
 ```
+
 ```output
 Error from server (Forbidden): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: [container-image-must-have-digest] container <nginx> uses an image without a digest <cgr.dev/chainguard/nginx>
 ```
 
 This example attempts to create a pod using the `nginx` Chainguard container image, but does not pull the image by its digest as required by the constraint. As the output indicates, the attempt resulted in an error and the request was denied.
-
 
 ## Warn First, Deny Later
 
@@ -147,6 +146,7 @@ You can also find non-compliant resources that exist in the cluster by reviewing
 ```shell
 kubectl get k8simagedigests container-image-must-have-digest -o json | jq -r '.status.violations[]'
 ```
+
 ```output
 {
   "enforcementAction": "warn",
@@ -160,7 +160,6 @@ kubectl get k8simagedigests container-image-must-have-digest -o json | jq -r '.s
 ```
 
 Once all the violations have been addressed, you can remove `enforcementAction: warn` and Gatekeeper will start to block the creation of resources that violate the constraint.
-
 
 ## Ensure Images Are Signed By Chainguard
 
@@ -184,7 +183,7 @@ helm install ratify \
 
 The [verifier](https://ratify.dev/docs/reference/custom%20resources/verifiers) will set up the cosign verification. This example uses the public Chainguard images.
 
-> **Note**: If you want to use a private registry, you can follow the identity patterns laid out [here](/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/#privatededicated-registry)
+> **Note**: If you want to use a private registry, you can follow the identity patterns laid out [for private and dedicated registries](/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/#privatededicated-registry)
 
 ```yaml
 apiVersion: config.ratify.deislabs.io/v1beta1
@@ -242,7 +241,6 @@ spec:
           certificateOIDCIssuer: "https://issuer.enforce.dev"
           certificateIdentityRegExp: "https://issuer.enforce.dev/(${CATALOG_SYNCER}|${APKO_BUILDER})"
 ```
-
 
 ### Create the Policy
 
@@ -322,28 +320,28 @@ spec:
 
               violation contains {"msg": msg} if {
                 some resp in responses
-              	resp.data.system_error != ""
-              	msg := sprintf("image %q verification system error: %v", [resp.image, resp.data.system_error])
+               resp.data.system_error != ""
+               msg := sprintf("image %q verification system error: %v", [resp.image, resp.data.system_error])
               }
 
               violation contains {"msg": msg} if {
                 some resp in responses
-              	count(resp.data.responses) == 0
-              	msg := sprintf("image %q returned no verification response", [resp.image])
+               count(resp.data.responses) == 0
+               msg := sprintf("image %q returned no verification response", [resp.image])
               }
 
               violation contains {"msg": msg} if {
                 some resp in responses
                 not resp.data.isSuccess
-              	reason := object.get(resp.data, "message", "verification failed")
-              	msg := sprintf("image %q is not signed by Chainguard: %v", [resp.image, reason])
+               reason := object.get(resp.data, "message", "verification failed")
+               msg := sprintf("image %q is not signed by Chainguard: %v", [resp.image, reason])
               }
 
               violation contains {"msg": msg} if {
                 some resp in responses
-              	err := resp.data.errors[_]
+               err := resp.data.errors[_]
                 err[0] == resp.image
-              	msg := sprintf("image %q verification error: %v", [resp.image, err[1]])
+               msg := sprintf("image %q verification error: %v", [resp.image, err[1]])
               }
 ```
 
@@ -370,7 +368,6 @@ spec:
 ```
 
 ### Try Deploying a Chainguard Image
-
 
 ```yaml
 apiVersion: apps/v1

--- a/content/chainguard/chainguard-images/staying-secure/fedramp-considerations/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/fedramp-considerations/index.md
@@ -23,13 +23,13 @@ There are a number of things one should keep in mind when analyzing revision tre
 
 * FedRAMP authorization has tended to only include external customer communication under scope. Now, though, the FedRAMP PMO is expecting both external and internal communications in scope.
 * Customers will be now be required to provide an authorization boundary diagram with an associated network diagram that shows all FIPS encrypted flows:
-  * Anything that isn’t encrypted needs to be explicitly highlighted.
-  * Auditors will ask that these diagrams and flows not just show this but, in some cases, to prove this during the audit with observed testing scenarios.
+    * Anything that isn’t encrypted needs to be explicitly highlighted.
+    * Auditors will ask that these diagrams and flows not just show this but, in some cases, to prove this during the audit with observed testing scenarios.
 * Notable Revision 5 Changes ([Rev 5 - appendix queue](https://web.archive.org/web/20250214120456/https://www.fedramp.gov/blog/2023-05-30-rev-5-baselines-have-been-approved-and-released/):
-  * Customers must list every client and server communication in the infrastructure and which FIPS module is being used.
-  * DoD Security Technical Implementation Guides (STIGs) can be required, although CIS Level 2 benchmarks are accepted if a STIG does not exist, marking a change from Revision 4 which only required CIS Level 1 benchmarks.
+    * Customers must list every client and server communication in the infrastructure and which FIPS module is being used.
+    * DoD Security Technical Implementation Guides (STIGs) can be required, although CIS Level 2 benchmarks are accepted if a STIG does not exist, marking a change from Revision 4 which only required CIS Level 1 benchmarks.
 * In order to get FIPS validated, libraries need to be assessed by one of thirteen authorized labs:
-  * National Institute of Standards and Technology ([NIST](https://www.nist.gov/)) labs are overwhelmed, as there is a large influx of 140-2 demand but limited supply for approval on certification.
+    * National Institute of Standards and Technology ([NIST](https://www.nist.gov/)) labs are overwhelmed, as there is a large influx of 140-2 demand but limited supply for approval on certification.
 
 While FIPS 140-3 is not immediately on the horizon for 2025, it will become the law of the land in 2026. As organizations begin analyzing their requirements and architecture constraints this year, it will be crucial to review and plan for the upcoming changes that are outlined in this section.
 

--- a/content/chainguard/chainguard-images/staying-secure/policies/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/policies/index.md
@@ -25,8 +25,8 @@ This is how policies uses the following terms.
 - **Policy** — A reusable rule that determines whether an image is allowed. Each policy has a name, a description, and the resource types it applies to. Policies apply to registry repositories.
 - **Binding** — A link between a policy and an organization. While a binding exists, the policy is active for image pulls under that organization. Without a binding, the policy has no effect.
 - **Mode** — A binding's mode controls what happens when the policy denies an image:
-  - `ENFORCE` — Block the pull.
-  - `DRY_RUN` — Allow the pull but record the violation.
+    - `ENFORCE` — Block the pull.
+    - `DRY_RUN` — Allow the pull but record the violation.
 
 The default mode for new bindings is `DRY_RUN`.
 


### PR DESCRIPTION
## Type of change

Markdown lint cleanup — batch 3 (`content/chainguard/chainguard-images`, incl. files deferred from batch 1).

### What should this PR do?

Make the remaining 26 `chainguard-images` docs fully markdownlint-clean.

- Autofixes: tabs→spaces, list indent (4-space per MD007), list style, blanks around lists/headings/fences, trailing whitespace, EOF
- Manual: fixed 5 broken anchor links (MD051), one heading-increment (MD001), and reworded 2 non-descriptive "here" links (MD059)

### Why are we making this change?

Continuing the markdown lint backlog cleanup per section. This clears the whole `chainguard-images` tree.

### What are the acceptance criteria?

- Every changed file is markdownlint-clean.
- Anchor links resolve to real headings.
- No rendering changes.

### How should this PR be tested?

- `markdownlint-cli2` reports zero errors on all changed files; `hugo` builds all pages.
- **Anchor fixes verified against built HTML**: the repo sets `autoHeadingIDType = "github"`, so markdownlint's slug algorithm matches Hugo's generated IDs. Each corrected `#anchor` was checked against the actual `id=` in the rendered pages (e.g. `images`→`containers` and `via`→`using` heading renames, and an appendix anchor that had stray `:`/`()` punctuation).
- No hard line breaks lost (literal `<br>` counts match `main`).

---

**Risk**: low. Mechanical autofix plus targeted anchor/heading/link-text corrections; rendering and anchors verified.

**Review focus**:
1. The `MD051` anchor corrections point at the right sections.
2. The two `MD059` link-text rewordings read naturally.