### PR TITLE
chore: resolve lint one-offs (private-key FPs, unnecessary cat, menu dup)

### DIFF
--- a/.github/workflows/compile-docs.yml
+++ b/.github/workflows/compile-docs.yml
@@ -274,7 +274,7 @@ jobs:
         # Check results - parse JSON to see if there are actual findings
         if [ -f gitleaks-report.json ]; then
           # Check if JSON array is not empty (more than just "[]")
-          findings_count=$(cat gitleaks-report.json | grep -o '"Description":' | wc -l)
+          findings_count=$(grep -o '"Description":' gitleaks-report.json | wc -l)
 
           if [ "$findings_count" -gt 0 ]; then
             echo "Potential secrets detected in compiled documentation!"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,10 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=1000']
       - id: detect-private-key
-        # This workflow embeds a gitleaks allowlist whose regexes include an
-        # example PEM private-key header string as a redaction pattern, not a
-        # real key. Exclude it to avoid a false positive.
-        exclude: ^\.github/workflows/compile-docs\.yml$
+        # These files contain an example PEM private-key header string as
+        # documentation (a redaction example / allowlist pattern), not a real
+        # key. Exclude them to avoid a false positive.
+        exclude: ^(\.github/workflows/compile-docs\.yml|content/ai-docs-security\.md)$
       - id: check-merge-conflict
       - id: mixed-line-ending
 

--- a/content/ai-docs-security.md
+++ b/content/ai-docs-security.md
@@ -79,6 +79,7 @@ During compilation, we automatically remove:
 - Authentication tokens
 
 Example patterns we redact:
+
 - `api_key=...`
 - `password=...`
 - `-----BEGIN PRIVATE KEY-----`
@@ -132,6 +133,7 @@ python3 scripts/compile_docs.py
 ### How do I verify the build logs?
 
 Build logs are public on GitHub Actions:
+
 - [View Build Logs](https://github.com/chainguard-dev/edu/actions/workflows/compile-docs.yml)
 
 ### What if verification fails?

--- a/content/chainguard/agent-skills/overview.md
+++ b/content/chainguard/agent-skills/overview.md
@@ -11,6 +11,7 @@ images: []
 menu:
   docs:
     parent: "agent-skills"
+    identifier: "Agent Skills Overview"
 toc: true
 weight: 001
 ---

--- a/content/software-security/videos/github-typosquatting.md
+++ b/content/software-security/videos/github-typosquatting.md
@@ -19,19 +19,19 @@ toc: true
 <br>
 Hi, I’m Dan Lorenc, CEO & Co-founder of Chainguard and I’ve been working in the open source software supply chain security space for a long time.
 
-Today, we’re going to recap the massive typo squatting attack that was carried out against a bunch of open source projects on GitHub on August 3, 2022. 
+Today, we’re going to recap the massive typo squatting attack that was carried out against a bunch of open source projects on GitHub on August 3, 2022.
 
-Typosquatting is a type of attack where an attacker changes the name of a real project subtly to make it look like that project but it's not actually the same repository or package and it is really hard to detect because there are a lot of subtle ways to do it. You can change underscores to hyphens, mess around with Unicode characters, plurals, just to name a few. 
+Typosquatting is a type of attack where an attacker changes the name of a real project subtly to make it look like that project but it's not actually the same repository or package and it is really hard to detect because there are a lot of subtle ways to do it. You can change underscores to hyphens, mess around with Unicode characters, plurals, just to name a few.
 
-On August 3, a tweet went viral about over 35,000 fake repositories created cloning after real projects, things like Kubernetes, cryptography, libraries, and programming languages, all designed with very similar names. This got a little bit over sensationalized because of the scale of the attack until everyone found out what really happened. 
+On August 3, a tweet went viral about over 35,000 fake repositories created cloning after real projects, things like Kubernetes, cryptography, libraries, and programming languages, all designed with very similar names. This got a little bit over sensationalized because of the scale of the attack until everyone found out what really happened.
 
-Fortunately, this was caught early, so no malicious commits are actually found in real projects. That's where a lot of the confusion came from. Only malicious code slipped into these imposter repositories. Typically, there's a second phase of these attacks where developers may unknowingly use the malicious fake repository’s code, thinking it was the real one, thus compromising their project. Thankfully, though, this one was caught in the middle, so nothing bad actually happened. 
+Fortunately, this was caught early, so no malicious commits are actually found in real projects. That's where a lot of the confusion came from. Only malicious code slipped into these imposter repositories. Typically, there's a second phase of these attacks where developers may unknowingly use the malicious fake repository’s code, thinking it was the real one, thus compromising their project. Thankfully, though, this one was caught in the middle, so nothing bad actually happened.
 
-But we don't know how bad this one really could have been if it hadn't been noticed and played out for longer. This attack was the largest and most advanced I've seen so far. The scale of over 35,000 repositories showed some clear automation. The malicious commands were slipped in and hidden inside of real ones and they were all semantically correct, too. So it'd be tough to catch, if you were just casually looking around. 
+But we don't know how bad this one really could have been if it hadn't been noticed and played out for longer. This attack was the largest and most advanced I've seen so far. The scale of over 35,000 repositories showed some clear automation. The malicious commands were slipped in and hidden inside of real ones and they were all semantically correct, too. So it'd be tough to catch, if you were just casually looking around.
 
 So what can you do to protect yourself against stuff like this?  
 There's a couple of different ways:
 
-As an end user, pay very close attention to your dependencies, it's going to be hard to notice typosquatting attacks like this, but these are all very recently created repositories with very few stars and little activity as a maintainer. 
+As an end user, pay very close attention to your dependencies, it's going to be hard to notice typosquatting attacks like this, but these are all very recently created repositories with very few stars and little activity as a maintainer.
 
 To prevent someone from creating an imposter repository, the only protection really available today is to sign your commits. There's a bunch of different tooling to do this, including a new one called Gitsign, it's part of the Sigstore project. None of these are perfect and solve it completely. But if you pay enough attention, and if enough people start signing their commits, it will be easier for us to detect these across the open source ecosystem at scale.


### PR DESCRIPTION
## Type of change

Cleanup — resolves several small, unrelated lint/build one-offs together.

### What should this PR do?

- **detect-private-key false positive:** exclude `content/ai-docs-security.md` (it documents an example `BEGIN PRIVATE KEY` header in a redaction list, not a real key) and lint-clean the file.
- **Markdown:** lint-clean `content/software-security/videos/github-typosquatting.md`.
- **actionlint SC2002:** replace a "useless cat" (`cat file | grep`) with `grep ... file` in `compile-docs.yml`.
- **Hugo duplicate menu warning:** add a unique `identifier` to `agent-skills/overview.md`'s menu entry so it no longer collides with another "Overview" in the `docs` menu.

### Why are we making this change?

These are the leftover items from the lint cleanup that didn't fit a section batch.

### What are the acceptance criteria?

- `compile-docs.yml` passes actionlint/zizmor.
- The two docs are markdownlint-clean.
- `detect-private-key` no longer flags `ai-docs-security.md`.
- The build no longer emits the duplicate `Overview` menu warning.

### How should this PR be tested?

- `actionlint` and `zizmor` pass on `compile-docs.yml` (the `SC2002` warning is gone).
- `hugo` builds with the previous `duplicate menu entry with identifier "Overview"` warning no longer emitted.
- No hard line breaks lost (the `<br>` in `github-typosquatting.md` is preserved).

### Notes

The `agent-skills/overview.md` identifier follows the same pattern as peer overview pages (for example, `chainguard-images/overview.md` already sets a unique menu `identifier`).

---

**Risk**: low. One hook exclusion, one shell tweak, one frontmatter identifier, and markdown autofixes; build verified.

**Review focus**:
1. The `detect-private-key` exclusion for `ai-docs-security.md` is warranted (example header, not a real key).
2. The `agent-skills/overview.md` menu `identifier` reads sensibly.