### PR TITLE
ci: align pre-commit actionlint shellcheck settings; fix trap quoting

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Action lint
         uses: step-security/action-actionlint@c3aa382d371c6b05513ae5907d4f77713e21813c # v1.72.0
         env:
+          # Keep these shellcheck settings in sync with the actionlint
+          # pre-commit hook in .pre-commit-config.yaml (its
+          # -shellcheck=... arg), so local hooks and CI agree.
           SHELLCHECK_OPTS: "--exclude=SC2129 --severity=error"
         with:
           actionlint_flags: ${{ steps.get_yamls.outputs.files }}

--- a/.github/workflows/export-edu-docs-to-gcs.yaml
+++ b/.github/workflows/export-edu-docs-to-gcs.yaml
@@ -9,10 +9,10 @@ on:
       - '**.md'
       - 'scripts/generate_image_catalog.py'
       - '.github/workflows/export-edu-docs-to-gcs.yaml'
-  
+
   schedule:
     - cron: '30 1 * * 0'  # Weekly on Sundays at 1:30 AM (same as other repos)
-  
+
   workflow_dispatch:
 
 permissions: {}
@@ -48,13 +48,13 @@ jobs:
     - name: Prepare documentation export
       run: |
         set -euo pipefail  # Exit on error, undefined variable, or pipe failure
-        
+
         echo "Preparing edu documentation export..."
-        
+
         # Use mktemp for secure temp directory
         EXPORT_DIR=$(mktemp -d)
-        trap "rm -rf $EXPORT_DIR" EXIT  # Clean up on exit
-        
+        trap 'rm -rf "$EXPORT_DIR"' EXIT  # Clean up on exit
+
         # Copy content directory (main documentation)
         if [ -d "content" ]; then
           echo "Copying and cleaning content directory..."
@@ -62,25 +62,25 @@ jobs:
           find content -type d | while read -r dir; do
             mkdir -p "$EXPORT_DIR/$dir"
           done
-          
+
           # Process each markdown file to remove HTML comments
           find content -name "*.md" -type f | while read -r file; do
             # Remove HTML comments and clean up empty lines
             sed -E 's/<!--[^>]*-->//g' "$file" | \
               sed '/^[[:space:]]*$/N;/\n[[:space:]]*$/d' > "$EXPORT_DIR/$file"
           done
-          
+
           echo "✓ Processed $(find content -name "*.md" -type f | wc -l) markdown files in content/"
         else
           echo "Warning: content directory not found"
         fi
-        
+
         # Create a content index for reference
         echo "Creating content index..."
         find "$EXPORT_DIR" -name "*.md" -type f | \
           sed "s|$EXPORT_DIR/||" | \
           sort > "$EXPORT_DIR/content-index.txt"
-        
+
         # Create metadata file with proper JSON escaping
         cat > "$EXPORT_DIR/metadata.json" << EOF
         {
@@ -93,22 +93,22 @@ jobs:
           "total_size": "$(du -sh "$EXPORT_DIR" | cut -f1)"
         }
         EOF
-        
+
         # Validate JSON
         python3 -m json.tool "$EXPORT_DIR/metadata.json" > /dev/null
-        
+
         # Display summary
         echo ""
         echo "Export Summary:"
         echo "---------------"
         echo "Total markdown files: $(find "$EXPORT_DIR" -name "*.md" -type f | wc -l)"
         echo "Total size: $(du -sh "$EXPORT_DIR" | cut -f1)"
-        
+
         # Create tarball with restricted permissions
         cd "$(dirname "$EXPORT_DIR")"
         tar --owner=0 --group=0 --mode='u+rwX,go+rX,go-w' \
             -czf /tmp/docs-export.tar.gz "$(basename "$EXPORT_DIR")"
-        
+
         echo ""
         echo "Documentation bundle created:"
         ls -lh /tmp/docs-export.tar.gz
@@ -116,35 +116,35 @@ jobs:
     - name: Upload to GCS
       run: |
         set -euo pipefail
-        
+
         echo "Uploading edu documentation to GCS..."
-        
+
         # Upload with specific content type and cache control
         gcloud storage cp /tmp/docs-export.tar.gz \
           "gs://academy-all-docs/edu/docs-export.tar.gz" \
           --project=chainguard-academy \
           --content-type="application/gzip" \
           --cache-control="no-cache"
-        
+
         # Extract for metadata upload
         EXPORT_DIR=$(mktemp -d)
-        trap "rm -rf $EXPORT_DIR" EXIT
+        trap 'rm -rf "$EXPORT_DIR"' EXIT
         tar -xzf /tmp/docs-export.tar.gz -C "$EXPORT_DIR" --strip-components=1
-        
+
         # Upload metadata
         gcloud storage cp "$EXPORT_DIR/metadata.json" \
           "gs://academy-all-docs/edu/metadata.json" \
           --project=chainguard-academy \
           --content-type="application/json" \
           --cache-control="no-cache"
-        
+
         # Upload content index
         gcloud storage cp "$EXPORT_DIR/content-index.txt" \
           "gs://academy-all-docs/edu/content-index.txt" \
           --project=chainguard-academy \
           --content-type="text/plain" \
           --cache-control="no-cache"
-        
+
         echo "✓ Successfully uploaded edu documentation to GCS"
 
     - name: Trigger compilation workflow
@@ -168,5 +168,5 @@ jobs:
               source: 'edu'
             }
           });
-          
+
           console.log('Triggered AI docs compilation workflow');

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,10 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+        # Match the standalone actionlint.yaml workflow's shellcheck settings so
+        # the hook and the workflow agree: fail only on error-severity findings
+        # and skip SC2129 (sequential-redirect style).
+        args: ['-shellcheck=shellcheck --severity=error --exclude=SC2129']
 
   - repo: https://github.com/PyCQA/bandit
     rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08  # frozen: 1.9.4


### PR DESCRIPTION
## Type of change

CI / workflow cleanup — clears the remaining actionlint (shellcheck) findings.

### What should this PR do?

Bring the repo to zero actionlint findings across all workflows:
- **Align the pre-commit actionlint hook** with the shellcheck settings the standalone `actionlint.yaml` workflow already uses (`--severity=error --exclude=SC2129`), so the hook and the workflow agree and only error-severity findings gate.
- **Fix a real `SC2064`** in `export-edu-docs-to-gcs.yaml`: quote the cleanup trap (`trap 'rm -rf "$EXPORT_DIR"' EXIT`) so it expands at signal time and the variable is quoted, rather than expanding when the trap is set.

### Why are we making this change?

Running actionlint across all workflows surfaced 7 shellcheck findings in three workflows that predate the pre-commit hook. Most are info/style/warning that the standalone workflow already ignores; the hook was stricter, so they would gate a PR that touched those files. This makes the two consistent and fixes the one genuine issue.

### What are the acceptance criteria?

- `actionlint` reports zero findings across all workflows (with the aligned shellcheck settings).
- The trap still removes the same temp directory on exit.

### How should this PR be tested?

- The pre-commit actionlint hook passes on all workflow files with the aligned settings; zizmor remains clean.
- The remaining findings were info/style (literal Markdown backticks in a `printf`, sequential redirects, `ls` in diagnostic echoes) that the project's actionlint config already excludes by severity; the only warning-level one (`SC2064`) is fixed directly.

---

**Risk**: low. One hook-argument alignment and a shell-quoting fix; no workflow behavior changes.

**Review focus**:
1. Aligning the pre-commit actionlint hook to the workflow's existing shellcheck severity/exclude.
2. The trap-quoting change in `export-edu-docs-to-gcs.yaml`.