### PR TITLE
docs(agent-skills): simplify beta notice and rename Inspect to Describe

### DIFF
--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -19,7 +19,7 @@ Chainguard publishes a curated set of hardened agent skills in a public catalog 
 
 This guide walks through the full workflow: listing the available skills, inspecting one, pulling it to audit how Chainguard hardened it, installing it, and running it with an agent.
 
-{{< beta feature="Chainguard Agent Skills" access="Chainguard Containers customers who sign up for the beta program. You can sign up by visiting the [Chainguard Agent Skills product page](https://www.chainguard.dev/agent-skills) and clicking **Join the beta**" >}}
+{{< beta feature="Chainguard Agent Skills" >}}
 
 ## Prerequisites
 
@@ -64,7 +64,7 @@ chainctl skills list --group chainguard/anthropics
  skill | frontend-design | latest     | 1 hour ago
 ```
 
-## Inspect a skill
+## Describe a skill
 
 To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand. The output records the upstream source and the exact commit Chainguard hardened from:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Trim the beta notice shortcode on the Agent Skills public catalog page to just the feature name
- Rename the "Inspect a skill" section to "Describe a skill" to match the `describe` subcommand it documents

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Cleans up the Chainguard Agent Skills public catalog guide so the beta notice is concise and section headings match the commands they cover.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The beta shortcode carried beta-program signup details that don't apply to the public catalog, and the "Inspect a skill" heading didn't match the `describe` subcommand documented in that section, which could confuse readers.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The beta notice renders with only the feature name
- The section is titled "Describe a skill" and matches the Command reference table entry
- markdownlint passes on the changed file

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Navigate to the Agent Skills → Public Catalog page and confirm the beta notice and the "Describe a skill" heading render correctly
