### PR TITLE
feat(landing): make banner images clickable

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -41,9 +41,9 @@
           <h1 class="landing-title text-capitalize">{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
           <p>{{ .Description }}</p>
           <div class="install-container">
-            <div class="card-background install-card col-lg">
+            <a href="{{ .Params.banner.link }}" class="card-background install-card col-lg">
               <img src="{{ .Params.banner.image }}" alt="Video Icon">
-            </div>
+            </a>
             <div class="install-text-container d-flex flex-column col-lg">
               <h3 class="banner-title">{{ .Params.banner.title }}</h3>
               <p>{{ .Params.banner.subtitle }}</p>


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Make landing-page banner images clickable, linking to the same doc as the "Read more" CTA

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Wraps the banner image on landing pages in a link so clicking the banner icon navigates to the same destination as the "Read more" button.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The banner image looked interactive but wasn't. Making it clickable matches user expectations and gives the prominent banner icon a useful navigation target, reinforcing the "Read more" call to action.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- Clicking the banner image on a landing page navigates to the same URL as its "Read more" link
- The change applies to all landing pages using the `_default/list.html` layout (e.g. Chainguard Libraries, Chainguard Containers, Administration)
- Banner layout and appearance are unchanged in both light and dark mode

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Visit a landing page such as `/chainguard/libraries/` and click the banner icon — confirm it navigates to the same page as "Read more" (`/chainguard/libraries/quickstart/`)
3. Spot-check another landing page (e.g. `/chainguard/chainguard-images/`) to confirm the link resolves to that page's own CTA target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
