### PR TITLE
fix(chainctl): repoint reference doc URLs to /platform/chainctl/

### DIFF
--- a/.github/actions/integrate-platform-docs/action.yaml
+++ b/.github/actions/integrate-platform-docs/action.yaml
@@ -87,6 +87,16 @@ runs:
         rsync -av --delete --exclude="_index.md" \
           "/tmp/chainctl-docs/" "content/platform/chainctl/"
 
+    - name: repoint chainctl doc URLs to the platform path
+      shell: bash
+      # The upstream generator still emits `url: /chainguard/chainctl/...` in
+      # each doc's frontmatter. An explicit `url:` overrides the file location,
+      # so without this the pages publish at the old path and every link 404s.
+      # Drop this once the generator emits `/platform/chainctl/`.
+      run: |
+        sed -i 's|^url: /chainguard/chainctl/|url: /platform/chainctl/|' \
+          content/platform/chainctl/chainctl-docs/*.md
+
     - name: add tags to chainctl docs by inserting line with sed
       shell: bash
       run: |

--- a/content/platform/chainctl/chainctl-docs/chainctl.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl"
 slug: chainctl
-url: /chainguard/chainctl/chainctl-docs/chainctl/
+url: /platform/chainctl/chainctl-docs/chainctl/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions"
 slug: chainctl_actions
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions/
+url: /platform/chainctl/chainctl-docs/chainctl_actions/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_catalog.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_catalog.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions catalog"
 slug: chainctl_actions_catalog
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_catalog/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_catalog/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_catalog_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_catalog_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions catalog list"
 slug: chainctl_actions_catalog_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_catalog_list/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_catalog_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_discover.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_discover.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions discover"
 slug: chainctl_actions_discover
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_discover/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_discover/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions entitlements"
 slug: chainctl_actions_entitlements
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_entitlements/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_entitlements/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions entitlements create"
 slug: chainctl_actions_entitlements_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_entitlements_create/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_entitlements_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions entitlements delete"
 slug: chainctl_actions_entitlements_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_entitlements_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_entitlements_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_entitlements_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions entitlements list"
 slug: chainctl_actions_entitlements_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_entitlements_list/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_entitlements_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_actions_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_actions_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl actions list"
 slug: chainctl_actions_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_actions_list/
+url: /platform/chainctl/chainctl-docs/chainctl_actions_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_agent.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_agent.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl agent"
 slug: chainctl_agent
-url: /chainguard/chainctl/chainctl-docs/chainctl_agent/
+url: /platform/chainctl/chainctl-docs/chainctl_agent/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_agent_accept-terms.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_agent_accept-terms.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl agent accept-terms"
 slug: chainctl_agent_accept-terms
-url: /chainguard/chainctl/chainctl-docs/chainctl_agent_accept-terms/
+url: /platform/chainctl/chainctl-docs/chainctl_agent_accept-terms/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth"
 slug: chainctl_auth
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth/
+url: /platform/chainctl/chainctl-docs/chainctl_auth/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_configure-docker.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_configure-docker.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth configure-docker"
 slug: chainctl_auth_configure-docker
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_configure-docker/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_configure-docker/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth configure-npm"
 slug: chainctl_auth_configure-npm
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_delete-account.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_delete-account.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth delete-account"
 slug: chainctl_auth_delete-account
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_delete-account/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_delete-account/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_login.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_login.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth login"
 slug: chainctl_auth_login
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_login/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_login/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_logout.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_logout.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth logout"
 slug: chainctl_auth_logout
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_logout/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_logout/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth pull-token"
 slug: chainctl_auth_pull-token
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_pull-token/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth pull-token create"
 slug: chainctl_auth_pull-token_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_create/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_pull-token_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth pull-token list"
 slug: chainctl_auth_pull-token_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token_list/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_pull-token_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_status.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_status.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth status"
 slug: chainctl_auth_status
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_status/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_status/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_token.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_token.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth token"
 slug: chainctl_auth_token
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_token/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_token/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_auth_token_capabilities.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_auth_token_capabilities.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl auth token capabilities"
 slug: chainctl_auth_token_capabilities
-url: /chainguard/chainctl/chainctl-docs/chainctl_auth_token_capabilities/
+url: /platform/chainctl/chainctl-docs/chainctl_auth_token_capabilities/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config"
 slug: chainctl_config
-url: /chainguard/chainctl/chainctl-docs/chainctl_config/
+url: /platform/chainctl/chainctl-docs/chainctl_config/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_edit.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_edit.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config edit"
 slug: chainctl_config_edit
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_edit/
+url: /platform/chainctl/chainctl-docs/chainctl_config_edit/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_reset.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_reset.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config reset"
 slug: chainctl_config_reset
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_reset/
+url: /platform/chainctl/chainctl-docs/chainctl_config_reset/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_save.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_save.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config save"
 slug: chainctl_config_save
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_save/
+url: /platform/chainctl/chainctl-docs/chainctl_config_save/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_set.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_set.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config set"
 slug: chainctl_config_set
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_set/
+url: /platform/chainctl/chainctl-docs/chainctl_config_set/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_unset.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_unset.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config unset"
 slug: chainctl_config_unset
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_unset/
+url: /platform/chainctl/chainctl-docs/chainctl_config_unset/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_validate.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_validate.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config validate"
 slug: chainctl_config_validate
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_validate/
+url: /platform/chainctl/chainctl-docs/chainctl_config_validate/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_config_view.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_config_view.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl config view"
 slug: chainctl_config_view
-url: /chainguard/chainctl/chainctl-docs/chainctl_config_view/
+url: /platform/chainctl/chainctl-docs/chainctl_config_view/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_events.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_events.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl events"
 slug: chainctl_events
-url: /chainguard/chainctl/chainctl-docs/chainctl_events/
+url: /platform/chainctl/chainctl-docs/chainctl_events/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl events subscriptions"
 slug: chainctl_events_subscriptions
-url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions/
+url: /platform/chainctl/chainctl-docs/chainctl_events_subscriptions/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl events subscriptions create"
 slug: chainctl_events_subscriptions_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_create/
+url: /platform/chainctl/chainctl-docs/chainctl_events_subscriptions_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl events subscriptions delete"
 slug: chainctl_events_subscriptions_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_events_subscriptions_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_events_subscriptions_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl events subscriptions list"
 slug: chainctl_events_subscriptions_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_events_subscriptions_list/
+url: /platform/chainctl/chainctl-docs/chainctl_events_subscriptions_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_guardener.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_guardener.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl guardener"
 slug: chainctl_guardener
-url: /chainguard/chainctl/chainctl-docs/chainctl_guardener/
+url: /platform/chainctl/chainctl-docs/chainctl_guardener/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_guardener_github.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_guardener_github.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl guardener github"
 slug: chainctl_guardener_github
-url: /chainguard/chainctl/chainctl-docs/chainctl_guardener_github/
+url: /platform/chainctl/chainctl-docs/chainctl_guardener_github/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_guardener_github_link.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_guardener_github_link.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl guardener github link"
 slug: chainctl_guardener_github_link
-url: /chainguard/chainctl/chainctl-docs/chainctl_guardener_github_link/
+url: /platform/chainctl/chainctl-docs/chainctl_guardener_github_link/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_guardener_github_unlink.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_guardener_github_unlink.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl guardener github unlink"
 slug: chainctl_guardener_github_unlink
-url: /chainguard/chainctl/chainctl-docs/chainctl_guardener_github_unlink/
+url: /platform/chainctl/chainctl-docs/chainctl_guardener_github_unlink/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam"
 slug: chainctl_iam
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam/
+url: /platform/chainctl/chainctl-docs/chainctl_iam/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations"
 slug: chainctl_iam_account-associations
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations check"
 slug: chainctl_iam_account-associations_check
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations check aws"
 slug: chainctl_iam_account-associations_check_aws
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_aws/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations check azure"
 slug: chainctl_iam_account-associations_check_azure
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_azure/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations check gcp"
 slug: chainctl_iam_account-associations_check_gcp
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_check_gcp/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations describe"
 slug: chainctl_iam_account-associations_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations set"
 slug: chainctl_iam_account-associations_set
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations set aws"
 slug: chainctl_iam_account-associations_set_aws
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_aws/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations set azure"
 slug: chainctl_iam_account-associations_set_azure
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_azure/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations set gcp"
 slug: chainctl_iam_account-associations_set_gcp
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_set_gcp/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations unset"
 slug: chainctl_iam_account-associations_unset
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations unset aws"
 slug: chainctl_iam_account-associations_unset_aws
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_aws/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations unset azure"
 slug: chainctl_iam_account-associations_unset_azure
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_azure/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam account-associations unset gcp"
 slug: chainctl_iam_account-associations_unset_gcp
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_account-associations_unset_gcp/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam external-group-role-mappings"
 slug: chainctl_iam_external-group-role-mappings
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam external-group-role-mappings create"
 slug: chainctl_iam_external-group-role-mappings_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam external-group-role-mappings delete"
 slug: chainctl_iam_external-group-role-mappings_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam external-group-role-mappings list"
 slug: chainctl_iam_external-group-role-mappings_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_external-group-role-mappings_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_folders.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_folders.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam folders"
 slug: chainctl_iam_folders
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_folders/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam folders delete"
 slug: chainctl_iam_folders_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_folders_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam folders describe"
 slug: chainctl_iam_folders_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_folders_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam folders list"
 slug: chainctl_iam_folders_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_folders_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_folders_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam folders update"
 slug: chainctl_iam_folders_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_folders_update/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_folders_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities"
 slug: chainctl_iam_identities
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create"
 slug: chainctl_iam_identities_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create aws"
 slug: chainctl_iam_identities_create_aws
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create aws role"
 slug: chainctl_iam_identities_create_aws_role
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_role/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create aws user"
 slug: chainctl_iam_identities_create_aws_user
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create_aws_user/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_github.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_github.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create github"
 slug: chainctl_iam_identities_create_github
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_github/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create_github/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities create gitlab"
 slug: chainctl_iam_identities_create_gitlab
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_create_gitlab/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities delete"
 slug: chainctl_iam_identities_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities describe"
 slug: chainctl_iam_identities_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities list"
 slug: chainctl_iam_identities_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identities_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identities update"
 slug: chainctl_iam_identities_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identities_update/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identities_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identity-providers"
 slug: chainctl_iam_identity-providers
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identity-providers/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identity-providers create"
 slug: chainctl_iam_identity-providers_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identity-providers delete"
 slug: chainctl_iam_identity-providers_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identity-providers list"
 slug: chainctl_iam_identity-providers_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam identity-providers update"
 slug: chainctl_iam_identity-providers_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers_update/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_invites.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_invites.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam invites"
 slug: chainctl_iam_invites
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_invites/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam invites create"
 slug: chainctl_iam_invites_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_invites_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam invites delete"
 slug: chainctl_iam_invites_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_invites_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_invites_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam invites list"
 slug: chainctl_iam_invites_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_invites_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_invites_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam organizations"
 slug: chainctl_iam_organizations
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_organizations/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam organizations delete"
 slug: chainctl_iam_organizations_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_organizations_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam organizations describe"
 slug: chainctl_iam_organizations_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_organizations_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_organizations_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam organizations list"
 slug: chainctl_iam_organizations_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_organizations_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_organizations_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam role-bindings"
 slug: chainctl_iam_role-bindings
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_role-bindings/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam role-bindings create"
 slug: chainctl_iam_role-bindings_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam role-bindings delete"
 slug: chainctl_iam_role-bindings_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam role-bindings list"
 slug: chainctl_iam_role-bindings_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam role-bindings update"
 slug: chainctl_iam_role-bindings_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_role-bindings_update/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_role-bindings_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles"
 slug: chainctl_iam_roles
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles capabilities"
 slug: chainctl_iam_roles_capabilities
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles capabilities list"
 slug: chainctl_iam_roles_capabilities_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_capabilities_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles create"
 slug: chainctl_iam_roles_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_create/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles delete"
 slug: chainctl_iam_roles_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles list"
 slug: chainctl_iam_roles_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_list/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_iam_roles_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl iam roles update"
 slug: chainctl_iam_roles_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_iam_roles_update/
+url: /platform/chainctl/chainctl-docs/chainctl_iam_roles_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images"
 slug: chainctl_images
-url: /chainguard/chainctl/chainctl-docs/chainctl_images/
+url: /platform/chainctl/chainctl-docs/chainctl_images/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_advisories.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_advisories.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images advisories"
 slug: chainctl_images_advisories
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_advisories/
+url: /platform/chainctl/chainctl-docs/chainctl_images_advisories/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_advisories_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_advisories_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images advisories list"
 slug: chainctl_images_advisories_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_advisories_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_advisories_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_changelog.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_changelog.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images changelog"
 slug: chainctl_images_changelog
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_changelog/
+url: /platform/chainctl/chainctl-docs/chainctl_images_changelog/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_diff.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_diff.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images diff"
 slug: chainctl_images_diff
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_diff/
+url: /platform/chainctl/chainctl-docs/chainctl_images_diff/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_entitlements.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_entitlements.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images entitlements"
 slug: chainctl_images_entitlements
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_entitlements/
+url: /platform/chainctl/chainctl-docs/chainctl_images_entitlements/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_entitlements_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_entitlements_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images entitlements list"
 slug: chainctl_images_entitlements_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_entitlements_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_entitlements_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_helm.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_helm.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images helm"
 slug: chainctl_images_helm
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_helm/
+url: /platform/chainctl/chainctl-docs/chainctl_images_helm/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_helm_refs.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_helm_refs.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images helm refs"
 slug: chainctl_images_helm_refs
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_helm_refs/
+url: /platform/chainctl/chainctl-docs/chainctl_images_helm_refs/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_helm_values.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_helm_values.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images helm values"
 slug: chainctl_images_helm_values
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_helm_values/
+url: /platform/chainctl/chainctl-docs/chainctl_images_helm_values/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_history.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_history.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images history"
 slug: chainctl_images_history
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_history/
+url: /platform/chainctl/chainctl-docs/chainctl_images_history/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images list"
 slug: chainctl_images_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos"
 slug: chainctl_images_repos
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos build"
 slug: chainctl_images_repos_build
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_build/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_apply.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_apply.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos build apply"
 slug: chainctl_images_repos_build_apply
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_build_apply/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_edit.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_edit.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos build edit"
 slug: chainctl_images_repos_build_edit
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_edit/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_build_edit/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos build list"
 slug: chainctl_images_repos_build_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_build_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_logs.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_build_logs.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos build logs"
 slug: chainctl_images_repos_build_logs
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_logs/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_build_logs/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos create"
 slug: chainctl_images_repos_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_create/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos delete"
 slug: chainctl_images_repos_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos list"
 slug: chainctl_images_repos_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_repos_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_repos_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images repos update"
 slug: chainctl_images_repos_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_repos_update/
+url: /platform/chainctl/chainctl-docs/chainctl_images_repos_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_tags.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_tags.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images tags"
 slug: chainctl_images_tags
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags/
+url: /platform/chainctl/chainctl-docs/chainctl_images_tags/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_tags_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_tags_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images tags list"
 slug: chainctl_images_tags_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags_list/
+url: /platform/chainctl/chainctl-docs/chainctl_images_tags_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_images_tags_resolve.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_images_tags_resolve.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl images tags resolve"
 slug: chainctl_images_tags_resolve
-url: /chainguard/chainctl/chainctl-docs/chainctl_images_tags_resolve/
+url: /platform/chainctl/chainctl-docs/chainctl_images_tags_resolve/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries"
 slug: chainctl_libraries
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries entitlements"
 slug: chainctl_libraries_entitlements
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_entitlements/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries entitlements create"
 slug: chainctl_libraries_entitlements_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries entitlements delete"
 slug: chainctl_libraries_entitlements_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries entitlements list"
 slug: chainctl_libraries_entitlements_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_list/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries packages"
 slug: chainctl_libraries_packages
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_packages/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_packages/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_blocked.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_blocked.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries packages blocked"
 slug: chainctl_libraries_packages_blocked
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_packages_blocked/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_packages_blocked/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_count.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_count.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries packages count"
 slug: chainctl_libraries_packages_count
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_packages_count/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_packages_count/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries packages list"
 slug: chainctl_libraries_packages_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_packages_list/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_packages_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_versions.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_packages_versions.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries packages versions"
 slug: chainctl_libraries_packages_versions
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_packages_versions/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_packages_versions/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy"
 slug: chainctl_libraries_policy
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy binding"
 slug: chainctl_libraries_policy_binding
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_binding/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy binding create"
 slug: chainctl_libraries_policy_binding_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_binding_create/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy binding delete"
 slug: chainctl_libraries_policy_binding_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_binding_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy binding list"
 slug: chainctl_libraries_policy_binding_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_binding_list/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy binding update"
 slug: chainctl_libraries_policy_binding_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_binding_update/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_binding_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy create"
 slug: chainctl_libraries_policy_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_create/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy delete"
 slug: chainctl_libraries_policy_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy describe"
 slug: chainctl_libraries_policy_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_disable.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_disable.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy disable"
 slug: chainctl_libraries_policy_disable
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_disable/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_disable/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_enable.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_enable.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy enable"
 slug: chainctl_libraries_policy_enable
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_enable/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_enable/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy list"
 slug: chainctl_libraries_policy_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_list/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries policy update"
 slug: chainctl_libraries_policy_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_policy_update/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_policy_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries update-hashes"
 slug: chainctl_libraries_update-hashes
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_verify.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_verify.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl libraries verify"
 slug: chainctl_libraries_verify
-url: /chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/
+url: /platform/chainctl/chainctl-docs/chainctl_libraries_verify/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_packages.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_packages.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl packages"
 slug: chainctl_packages
-url: /chainguard/chainctl/chainctl-docs/chainctl_packages/
+url: /platform/chainctl/chainctl-docs/chainctl_packages/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_packages_versions.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_packages_versions.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl packages versions"
 slug: chainctl_packages_versions
-url: /chainguard/chainctl/chainctl-docs/chainctl_packages_versions/
+url: /platform/chainctl/chainctl-docs/chainctl_packages_versions/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_packages_versions_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_packages_versions_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl packages versions list"
 slug: chainctl_packages_versions_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list/
+url: /platform/chainctl/chainctl-docs/chainctl_packages_versions_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies"
 slug: chainctl_policies
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies/
+url: /platform/chainctl/chainctl-docs/chainctl_policies/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_binding.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_binding.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies binding"
 slug: chainctl_policies_binding
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_binding/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_binding/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies binding create"
 slug: chainctl_policies_binding_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_binding_create/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_binding_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies binding delete"
 slug: chainctl_policies_binding_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_binding_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_binding_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_binding_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies binding list"
 slug: chainctl_policies_binding_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_binding_list/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_binding_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_check.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_check.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies check"
 slug: chainctl_policies_check
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_check/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_check/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_decision.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_decision.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies decision"
 slug: chainctl_policies_decision
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_decision/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_decision/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_decision_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_decision_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies decision list"
 slug: chainctl_policies_decision_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_decision_list/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_decision_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies describe"
 slug: chainctl_policies_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_disable.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_disable.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies disable"
 slug: chainctl_policies_disable
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_disable/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_disable/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_enable.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_enable.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies enable"
 slug: chainctl_policies_enable
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_enable/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_enable/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_policies_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_policies_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl policies list"
 slug: chainctl_policies_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_policies_list/
+url: /platform/chainctl/chainctl-docs/chainctl_policies_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills"
 slug: chainctl_skills
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills/
+url: /platform/chainctl/chainctl-docs/chainctl_skills/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_accept-terms.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_accept-terms.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills accept-terms"
 slug: chainctl_skills_accept-terms
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_accept-terms/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_accept-terms/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills delete"
 slug: chainctl_skills_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_describe.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_describe.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills describe"
 slug: chainctl_skills_describe
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_describe/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_describe/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills entitlements"
 slug: chainctl_skills_entitlements
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_entitlements/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_entitlements/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_create.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills entitlements create"
 slug: chainctl_skills_entitlements_create
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_entitlements_create/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_entitlements_create/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_delete.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_delete.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills entitlements delete"
 slug: chainctl_skills_entitlements_delete
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_entitlements_delete/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_entitlements_delete/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_entitlements_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills entitlements list"
 slug: chainctl_skills_entitlements_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_entitlements_list/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_entitlements_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_install.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_install.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills install"
 slug: chainctl_skills_install
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_install/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_install/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_list.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_list.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills list"
 slug: chainctl_skills_list
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_list/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_list/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_pull.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_pull.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills pull"
 slug: chainctl_skills_pull
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_pull/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_pull/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_push.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_push.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills push"
 slug: chainctl_skills_push
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_push/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_push/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_uninstall.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_uninstall.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills uninstall"
 slug: chainctl_skills_uninstall
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_uninstall/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_uninstall/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_validate.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_validate.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills validate"
 slug: chainctl_skills_validate
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_validate/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_validate/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_skills_versions.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_skills_versions.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl skills versions"
 slug: chainctl_skills_versions
-url: /chainguard/chainctl/chainctl-docs/chainctl_skills_versions/
+url: /platform/chainctl/chainctl-docs/chainctl_skills_versions/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_starter.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_starter.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl starter"
 slug: chainctl_starter
-url: /chainguard/chainctl/chainctl-docs/chainctl_starter/
+url: /platform/chainctl/chainctl-docs/chainctl_starter/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_starter_add-images.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_starter_add-images.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl starter add-images"
 slug: chainctl_starter_add-images
-url: /chainguard/chainctl/chainctl-docs/chainctl_starter_add-images/
+url: /platform/chainctl/chainctl-docs/chainctl_starter_add-images/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_starter_init.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_starter_init.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl starter init"
 slug: chainctl_starter_init
-url: /chainguard/chainctl/chainctl-docs/chainctl_starter_init/
+url: /platform/chainctl/chainctl-docs/chainctl_starter_init/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_starter_request-access.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_starter_request-access.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl starter request-access"
 slug: chainctl_starter_request-access
-url: /chainguard/chainctl/chainctl-docs/chainctl_starter_request-access/
+url: /platform/chainctl/chainctl-docs/chainctl_starter_request-access/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_starter_status.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_starter_status.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl starter status"
 slug: chainctl_starter_status
-url: /chainguard/chainctl/chainctl-docs/chainctl_starter_status/
+url: /platform/chainctl/chainctl-docs/chainctl_starter_status/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_update.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl update"
 slug: chainctl_update
-url: /chainguard/chainctl/chainctl-docs/chainctl_update/
+url: /platform/chainctl/chainctl-docs/chainctl_update/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []

--- a/content/platform/chainctl/chainctl-docs/chainctl_version.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_version.md
@@ -2,7 +2,7 @@
 date: 2026-07-01T03:32:22Z
 title: "chainctl version"
 slug: chainctl_version
-url: /chainguard/chainctl/chainctl-docs/chainctl_version/
+url: /platform/chainctl/chainctl-docs/chainctl_version/
 draft: false
 tags: ["chainctl", "Reference", "Product"]
 images: []


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Repoint the `url:` frontmatter in all 188 generated `chainctl` reference docs from `/chainguard/chainctl/` to `/platform/chainctl/`
- Add a self-correcting `sed` step to the `integrate-platform-docs` action so every AutoDocs sync re-applies the rewrite

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Fix the 404s on every `chainctl` reference page by publishing the docs at the `/platform/chainctl/` path where the navigation and redirects point.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
#3562 moved the docs under `content/platform/chainctl/`, but each generated file still carried an explicit `url: /chainguard/chainctl/...` in its frontmatter. Hugo honors an explicit `url:` over the file's location, so the pages kept publishing at the old path while the left nav and the `nginx.conf` redirect target both pointed at `/platform/chainctl/` — 404ing every link. The upstream generator still emits the old URL and the AutoDocs sync rsyncs it verbatim (#3574 re-broke it after the move), so the fix must survive re-syncs.

### What are the acceptance criteria?
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- Pages render at `/platform/chainctl/chainctl-docs/…` (e.g. `/platform/chainctl/chainctl-docs/chainctl/`) with no 404
- No pages are published under the old `/chainguard/chainctl/chainctl-docs/…` path
- Old `/chainguard/chainctl/…` URLs still 301 to the new paths and resolve to a live page
- A future AutoDocs sync re-applies the `url:` rewrite rather than reintroducing the old path

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. In the left nav under Platform & Tools, open **chainctl Reference** and click through several command pages — confirm they load instead of 404ing
3. Visit an old `/chainguard/chainctl/chainctl-docs/chainctl/` URL and confirm it redirects to the working `/platform/chainctl/…` page
