### PR TITLE
Update settings for Artifactory javascript-chainguard

### DIFF
--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -228,8 +228,6 @@ To prevent this:
 
 1. Apply the following settings to your Artifactory `javascript-chainguard`
    remote repository, within in the **Advanced** tab:
-    * **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD
-      requests that may not be handled correctly by redirect-based registries.
     * **Disable Lenient Host Authentication** — disabling this setting ensures
       credentials are not forwarded across the redirect.
     * **Enable Cookie Management** - this setting is optional, but recommended


### PR DESCRIPTION
Removed recommendation to enable Bypass HEAD Requests for Artifactory.

I am still working on testing this in production before we merge this
