### PR TITLE
Add Dockerfile migration reference under Guardener product section

### DIFF
--- a/content/chainguard/guardener/_index.md
+++ b/content/chainguard/guardener/_index.md
@@ -18,7 +18,7 @@ The Guardener's capabilities include:
 
 - **[Actions Security](/chainguard/guardener/actions-security/)** — Recommends and migrates your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents, either through non-blocking pull request review comments or automated migration pull requests.
 - **[Commit Verification](/chainguard/guardener/commit-verification/)** — Enforces cryptographically signed commits against a policy you control, supporting both keyless (Sigstore) signatures and static keys such as GPG.
-- **[Dockerfile migration](/chainguard/migration/the-guardener/)** — Uses AI to iteratively convert your Dockerfiles to Chainguard Containers. This capability runs locally through `chainctl agent dockerfile` commands rather than the GitHub App. See the [Dockerfile migration guide](/chainguard/migration/the-guardener/) for details.
+- **[Dockerfile migration](/chainguard/guardener/dockerfile-migration/)** — Uses AI to iteratively convert your Dockerfiles to Chainguard Containers. This capability runs locally through `chainctl agent dockerfile` commands rather than the GitHub App.
 
 Additional capabilities will be added over time, each with its own opt-in configuration.
 
@@ -28,6 +28,7 @@ Additional capabilities will be added over time, each with its own opt-in config
 - **[Configuration](/chainguard/guardener/configuration/)** — Understand the `.chainguard/` configuration model and how features are enabled per repository.
 - **[Actions Security](/chainguard/guardener/actions-security/)** — Configure hardened-action recommendations and automated migration pull requests.
 - **[Commit Verification](/chainguard/guardener/commit-verification/)** — Configure a signing policy for commits in pull requests.
+- **[Dockerfile migration](/chainguard/guardener/dockerfile-migration/)** — Migrate your Dockerfiles to Chainguard Containers using the `chainctl agent dockerfile` commands.
 
 ## How it works
 

--- a/content/chainguard/guardener/dockerfile-migration.md
+++ b/content/chainguard/guardener/dockerfile-migration.md
@@ -105,11 +105,11 @@ The Dockerfile migration agent runs server-side, but its access to your environm
 
 - **Workspace analysis.** The agent scans your workspace to understand your Dockerfile and [build context](https://docs.docker.com/build/concepts/context/).
 - **Analysis tools.** During a migration, the agent has access to tools for:
-  - Searching `APKINDEX`.
-  - Finding which package provides a given binary or library.
-  - Comparing installed packages and filesystem layers between the original and migrated images.
-  - Running commands in built images.
-  - Reading build context files such as `requirements.txt`, `package.json`, and similar.
+    - Searching `APKINDEX`.
+    - Finding which package provides a given binary or library.
+    - Comparing installed packages and filesystem layers between the original and migrated images.
+    - Running commands in built images.
+    - Reading build context files such as `requirements.txt`, `package.json`, and similar.
 - **Interactive guidance.** If the agent cannot resolve an issue automatically, it prompts you for guidance with suggested alternatives. In `--non-interactive` mode it skips these prompts and automatically selects the first suggestion.
 
 ## Next steps

--- a/content/chainguard/guardener/dockerfile-migration.md
+++ b/content/chainguard/guardener/dockerfile-migration.md
@@ -1,0 +1,119 @@
+---
+title: "Chainguard Guardener Dockerfile Migration"
+linktitle: "Dockerfile Migration"
+description: "Use Chainguard Guardener to migrate, optimize, upgrade, and validate your Dockerfiles against Chainguard Containers with AI-driven, iterative conversion."
+type: "article"
+date: 2026-07-13T00:00:00+00:00
+lastmod: 2026-07-13T00:00:00+00:00
+draft: false
+tags: ["GitHub", "AI", "Chainguard Containers"]
+images: []
+menu:
+  docs:
+    parent: "guardener"
+weight: 050
+toc: true
+---
+
+The Dockerfile migration feature converts your Dockerfiles to use Chainguard Containers. It uses AI to iteratively translate instructions, build images, compare results, and fix issues until the migrated Dockerfile works as expected.
+
+Unlike the Guardener's [Actions Security](/chainguard/guardener/actions-security/) and [Commit Verification](/chainguard/guardener/commit-verification/) features, Dockerfile migration does not run through the GitHub App or the `.chainguard/` configuration directory. Instead, you drive it locally through `chainctl agent dockerfile` commands. The AI runs server-side and scans your workspace to perform its analysis, while Docker builds and file access remain local to your machine.
+
+{{< beta feature="The Guardener" >}}
+
+This page is a reference for the `chainctl agent dockerfile` commands. For a full walkthrough — including prerequisites, a step-by-step migration, available optimizers, a before-and-after example, and FAQ — see the [Dockerfile migration guide](/chainguard/migration/the-guardener/).
+
+## How it works
+
+The migration agent runs on Chainguard's servers, but it never touches your machine directly. Every file read, Docker build, and command is *requested* by the agent and mediated by `chainctl` on your machine. The local client evaluates each request, and only performs and returns the ones it deems acceptable — so you stay in control of what the agent can do and what data is sent back.
+
+```text
+   Your machine (client)                       Chainguard (server)
+ ┌───────────────────────────┐               ┌──────────────────────┐
+ │ chainctl                  │◀── request ───│   Migration agent    │
+ │                           │  read a file, │        (AI)          │
+ │  Dockerfile               │  run a build, │                      │
+ │  build context            │  run a command│                      │
+ │  Docker                   │               │                      │
+ │        ▼                  │               │                      │
+ │  evaluate request:        │               │                      │
+ │  allowed?                 │               │                      │
+ │        ▼                  │─── result ───▶│  analyzes result,    │
+ │  perform locally,         │  (only for    │  plans next step     │
+ │  return result            │   approved    │                      │
+ │                           │   requests)   │                      │
+ └───────────────────────────┘               └──────────────────────┘
+```
+
+Because every action is mediated by the local client, the agent can't read a file, run a build, or execute a command unless `chainctl` approves the request first.
+
+## IAM access
+
+Access to Dockerfile migration is governed by Chainguard IAM roles:
+
+| Action                                                                                                   | Minimum role                 |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Accepting the Guardener legal terms for your organization (required once before anyone can run sessions) | `guardener.admin` or `owner` |
+| Running Dockerfile migration sessions                                                                    | `guardener.user`             |
+
+See the [Built-in Roles and Capabilities Reference](/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for details.
+
+## Commands
+
+`chainctl agent dockerfile` includes the following subcommands:
+
+| Command    | What it does                                          |
+| ---------- | ----------------------------------------------------- |
+| `build`    | Migrate a Dockerfile to a Chainguard equivalent image |
+| `optimize` | Optimize an already-migrated Dockerfile               |
+| `upgrade`  | Upgrade package versions in a Dockerfile              |
+| `validate` | Validate a migrated Dockerfile                        |
+
+To run a basic migration, provide the path to your Dockerfile and a target image tag:
+
+```shell
+chainctl agent dockerfile build -f Dockerfile \
+  -t myapp:chainguard
+```
+
+For CI environments or automated workflows, use the `--non-interactive` flag to skip prompts and automatically select the first suggestion:
+
+```shell
+chainctl agent dockerfile build -f Dockerfile \
+  --non-interactive
+```
+
+To optimize an already-migrated Dockerfile, run the `optimize` subcommand. Pass a comma-separated list to `--optimizers` to run only specific optimizers:
+
+```shell
+chainctl agent dockerfile optimize -f Dockerfile \
+  --optimizers=cache,security
+```
+
+To upgrade outdated packages in a Dockerfile without modifying any files, combine `upgrade` with `--dry-run`:
+
+```shell
+chainctl agent dockerfile upgrade -f Dockerfile \
+  --dry-run
+```
+
+For the complete set of usage examples, see [Usage examples](/chainguard/migration/the-guardener/#usage-examples) in the migration guide.
+
+## Agent access
+
+The Dockerfile migration agent runs server-side, but its access to your environment is scoped to what it needs to analyze and migrate a single Dockerfile:
+
+- **Workspace analysis.** The agent scans your workspace to understand your Dockerfile and [build context](https://docs.docker.com/build/concepts/context/).
+- **Analysis tools.** During a migration, the agent has access to tools for:
+  - Searching `APKINDEX`.
+  - Finding which package provides a given binary or library.
+  - Comparing installed packages and filesystem layers between the original and migrated images.
+  - Running commands in built images.
+  - Reading build context files such as `requirements.txt`, `package.json`, and similar.
+- **Interactive guidance.** If the agent cannot resolve an issue automatically, it prompts you for guidance with suggested alternatives. In `--non-interactive` mode it skips these prompts and automatically selects the first suggestion.
+
+## Next steps
+
+- **[Dockerfile migration guide](/chainguard/migration/the-guardener/)** — Full walkthrough, prerequisites, optimizers, and FAQ.
+- **[Actions Security](/chainguard/guardener/actions-security/)** — Recommend and migrate GitHub Actions to hardened, SHA-pinned equivalents.
+- **[Commit Verification](/chainguard/guardener/commit-verification/)** — Require cryptographically signed commits in pull requests.

--- a/content/get-started/migration/the-guardener.md
+++ b/content/get-started/migration/the-guardener.md
@@ -44,30 +44,6 @@ chainctl iam organizations list -o table
 chainctl iam role-bindings create --parent <group-id> --identity <identity> --role <role-with-repo.create>
 ```
 
-### Retrieving your organization's group ID
-
-The Guardener needs to know which Chainguard organization to reference when migrating Dockerfiles. For this reason, you must include your organization's group ID value (also known as the organization UID) in the `chainctl` commands you use to interact with the tool.
-
-Note that the group ID is **not** the name of your organization; it is a 40-character string used to identify your organization.
-
-To retrieve your organization's group ID value, run the following command:
-
-```shell
-chainctl iam organizations list -o table
-```
-
-```output
-                    ID                    |      NAME      |          DESCRIPTION
-------------------------------------------|----------------|-------------------------------------
- EXAMPLE05850c357EXAMPLE6e10d007c9EXAMPLE | example.com    | This is an example organization.
-```
-
-Your organization's group ID is the value that appears in the `ID` column of this command's output.
-
-You can also retrieve the ID in the Chainguard Console. After logging into the Console, [navigate to **Settings**](https://console.chainguard.dev/org/$ORGANIZATION$/settings/general) where you'll find the ID under **Organization UID**.
-
-Once you have your organization's group ID, you'll use it in the following `chainctl` commands by passing it to the `--group-id` flag.
-
 ## Usage examples
 
 `chainctl agent dockerfile` includes the following subcommands which you can use to interact with The Guardener:
@@ -85,8 +61,7 @@ To run a basic migration, provide the path to your Dockerfile and a target image
 
 ```shell
 chainctl agent dockerfile build -f Dockerfile \
-  -t myapp:chainguard \
-  --group <group-id>
+  -t myapp:chainguard
 ```
 
 If your image requires build arguments, pass them with `--build-arg`:
@@ -94,61 +69,53 @@ If your image requires build arguments, pass them with `--build-arg`:
 ```shell
 chainctl agent dockerfile build -f Dockerfile \
   -t myapp:chainguard \
-  --build-arg VERSION=1.0 \
-  --group <group-id>
+  --build-arg VERSION=1.0
 ```
 
 For CI environments or automated workflows, you can use the `--non-interactive` flag to skip prompts and automatically select the first suggestion:
 
 ```shell
 chainctl agent dockerfile build -f Dockerfile \
-  --non-interactive \
-  --group <group-id>
+  --non-interactive
 ```
 
 To resume a migration from a previously saved local state, use `--resume`:
 
 ```shell
 chainctl agent dockerfile build -f Dockerfile \
-  --resume \
-  --group <group-id>
+  --resume
 ```
 
 To optimize an already-migrated Dockerfile:
 
 ```shell
-chainctl agent dockerfile optimize -f Dockerfile \
-  --group <group-id>
+chainctl agent dockerfile optimize -f Dockerfile
 ```
 
 To run only specific optimizers, pass a comma-separated list with `--optimizers`:
 
 ```shell
 chainctl agent dockerfile optimize -f Dockerfile \
-  --optimizers=cache,security \
-  --group <group-id>
+  --optimizers=cache,security
 ```
 
 To upgrade outdated packages in a Dockerfile:
 
 ```shell
-chainctl agent dockerfile upgrade -f Dockerfile \
-  --group <group-id>
+chainctl agent dockerfile upgrade -f Dockerfile
 ```
 
 To preview what an upgrade would change without modifying any files, use the `--dry-run` flag:
 
 ```shell
 chainctl agent dockerfile upgrade -f Dockerfile \
-  --dry-run \
-  --group <group-id>
+  --dry-run
 ```
 
 To validate a migrated Dockerfile:
 
 ```shell
-chainctl agent dockerfile validate -f Dockerfile \
-  --group <group-id>
+chainctl agent dockerfile validate -f Dockerfile
 ```
 
 ## What happens during a migration


### PR DESCRIPTION
## What

Adds a **Dockerfile Migration** reference page to the Chainguard Guardener product section. Previously, Dockerfile migration was only documented under the migration section (`the-guardener.md`); this gives it a home alongside the other Guardener capabilities.

The new page (`content/chainguard/guardener/dockerfile-migration.md`) covers:
- The `chainctl agent dockerfile` subcommands (`build`/`optimize`/`upgrade`/`validate`) with examples
- A **How it works** section with an ASCII diagram showing how `chainctl` gates the server-side agent's file/build/command requests
- **Agent access** — what the agent can request during a migration
- **IAM access** — the roles required, as a table

It's linked from the Guardener landing page (`_index.md`) both in the capabilities list and "Where to start".

## Also

Updates the existing migration guide (`the-guardener.md`):
- Removes the "Retrieving your organization's group ID" section
- Drops the `--group` flag from all command examples

...since the group can now be resolved by name rather than requiring a group ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)