### PR TITLE
docs(agent-skills): point the public catalog at the public org

### DIFF
--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -37,10 +37,11 @@ chainctl skills list --group public --recursive
 ```
 
 ```output
-                        NAME                        | LATEST TAG |  UPDATED
-----------------------------------------------------|------------|------------
- github.com/anthropics/skills/brand-guidelines      | latest     | 5 days ago
- github.com/anthropics/skills/internal-comms        | latest     | 5 days ago
+                          NAME                           | LATEST TAG |  UPDATED
+---------------------------------------------------------|------------|------------
+ github.com/github/awesome-copilot/agent-supply-chain    | latest     | 5 days ago
+ github.com/github/awesome-copilot/game-engine           | latest     | 5 days ago
+ github.com/github/awesome-copilot/mcp-security-audit    | latest     | 5 days ago
 
  . . .
 ```
@@ -50,14 +51,22 @@ The public catalog is large, so a full `--recursive` listing can take a while to
 To list the skills under a single upstream repository, name its path in the `--group` value. Public skills are namespaced by their source, so an owner's repo lives at `public/<host>/<owner>/<repo>`:
 
 ```shell
-chainctl skills list --group public/github.com/anthropics/skills
+chainctl skills list --group public/github.com/github/awesome-copilot
 ```
 
 ```output
- TYPE  |       NAME       | LATEST TAG |  UPDATED
--------|------------------|------------|------------
- skill | brand-guidelines | latest     | 5 days ago
- skill | internal-comms   | latest     | 5 days ago
+ TYPE  |          NAME           | LATEST TAG |  UPDATED
+-------|-------------------------|------------|------------
+ skill | acreadiness-policy      | latest     | 5 days ago
+ skill | agent-supply-chain      | latest     | 5 days ago
+ skill | chrome-devtools         | latest     | 5 days ago
+ skill | codeql                  | latest     | 5 days ago
+ skill | game-engine             | latest     | 5 days ago
+ skill | mcp-security-audit      | latest     | 5 days ago
+ skill | multi-stage-dockerfile  | latest     | 5 days ago
+ skill | postgresql-optimization | latest     | 5 days ago
+
+ . . .
 ```
 
 ## Describe a skill
@@ -65,23 +74,23 @@ chainctl skills list --group public/github.com/anthropics/skills
 To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand. The output records the upstream source and the exact commit Chainguard hardened from:
 
 ```shell
-chainctl skills describe skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
+chainctl skills describe skills.cgr.dev/public/github.com/github/awesome-copilot/game-engine:latest
 ```
 
 ```output
-      FIELD      |                                                                     VALUE
------------------|-----------------------------------------------------------------------------------------------------------------------------------------------
- Display Name    | brand-guidelines
- Reference       | public/github.com/anthropics/skills/brand-guidelines
- Install Name    | public-github.com-anthropics-skills-brand-guidelines
- OCI URL         | skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
- Description     | Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel.
- License         | Apache-2.0
- Upstream        | github.com/anthropics/skills/skills/brand-guidelines
- Upstream Commit | ef740771ac901e03fbca3ce4e1c453a96010f30a
- License Source  | skills/brand-guidelines/LICENSE.txt
- Tag             | ef740771ac901e03fbca3ce4e1c453a96010f30a
- Digest          | sha256:78b0910c0d349f4d0ca14b4f8545e52d7aceaaf1a567b8cccd1f49e11cf329c8
+      FIELD      |                                              VALUE
+-----------------|--------------------------------------------------------------------------------------------------
+ Display Name    | game-engine
+ Reference       | public/github.com/github/awesome-copilot/game-engine
+ Install Name    | public-github.com-github-awesome-copilot-game-engine
+ OCI URL         | skills.cgr.dev/public/github.com/github/awesome-copilot/game-engine:latest
+ Description     | Expert skill for building web-based game engines and games using HTML5, Canvas, WebGL, and ...
+ License         | MIT
+ Upstream        | github.com/github/awesome-copilot/skills/game-engine
+ Upstream Commit | cf4347e88c2e40a9aabe5801748ec6bf924c09be
+ License Source  | LICENSE
+ Tag             | cf4347e88c2e40a9aabe5801748ec6bf924c09be
+ Digest          | sha256:c8a079466ef2eb8de03847f0a96efe0b5131c628d9164bf7edb887bdd5ed668d
  Size            | 1.2 KB
  Published       | 6 days ago
 ```
@@ -91,47 +100,47 @@ chainctl skills describe skills.cgr.dev/public/github.com/anthropics/skills/bran
 Where `install` drops a skill straight into your agent's skills directory, `pull` writes the skill's files to a directory you choose so you can inspect them first:
 
 ```shell
-chainctl skills pull skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest ./brand-guidelines
+chainctl skills pull skills.cgr.dev/public/github.com/github/awesome-copilot/game-engine:latest ./game-engine
 ```
 
 ```output
-Skill written to: /home/linky/brand-guidelines
+Skill written to: /home/linky/game-engine
 ```
 
 Every hardened skill ships with a `HARDENING.md` that records the upstream source, the exact commit Chainguard hardened from, and the outcome of each hardening run:
 
 ```shell
-cat brand-guidelines/HARDENING.md
+cat game-engine/HARDENING.md
 ```
 
 ```output
 # Hardening report
 
-- skill: brand-guidelines
-- sha: ef740771ac901e03fbca3ce4e1c453a96010f30a
+- skill: `github.com/github/awesome-copilot/skills/game-engine`
+- sha: `cf4347e88c2e40a9aabe5801748ec6bf924c09be`
 - harden run: 1 (outcome: completed)
+- SKILL.md modified: true
 
-The per-model transcripts and any findings for this run are recorded under
-`notes/harden/run_1/`.
+Hardened by the multi-model harden pipeline. The per-model fix plans, cross-model critiques, and the reconciled synthesis are recorded under `notes/harden/run_1/`. The corrected SKILL.md is this version's hardened overlay.
 ```
 
-The report pins the exact upstream `sha` Chainguard hardened from and the outcome of the run. The full per-model hardening transcripts and any findings are written alongside the skill under `notes/harden/run_1/`, so you can audit exactly what the hardening engine inspected and changed.
+The report pins the exact upstream `sha` Chainguard hardened from, the outcome of the run, and whether the hardened overlay changed the skill's `SKILL.md`. Skills are hardened by a multi-model pipeline whose per-model fix plans and reconciled synthesis are recorded for the run, so you can trace exactly what was inspected and changed.
 
 ## Install a skill
 
 Download and install the skill to make it available to agents on your machine with the `install` subcommand:
 
 ```shell
-chainctl skills install skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
+chainctl skills install skills.cgr.dev/public/github.com/github/awesome-copilot/game-engine:latest
 ```
 
 This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
 
 ```output
-Installing github.com/anthropics/skills/brand-guidelines
+Installing github.com/github/awesome-copilot/game-engine
     AGENT    |                              LOCATION                              |                                        MODE
 -------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------
- Claude Code | .claude/skills/public-github.com-anthropics-skills-brand-guidelines | symlink → ../../.agents/skills/public-github.com-anthropics-skills-brand-guidelines
+ Claude Code | .claude/skills/public-github.com-github-awesome-copilot-game-engine | symlink → ../../.agents/skills/public-github.com-github-awesome-copilot-game-engine
 ```
 
 ## Run the skill from an agent
@@ -139,26 +148,26 @@ Installing github.com/anthropics/skills/brand-guidelines
 Load the skill into Claude Code or any MCP-compatible agent. In Claude Code, invoke it by name:
 
 ```Agent
-/brand-guidelines
+/game-engine
 ```
 
 The agent loads the skill and runs it, confirming it installed and loaded correctly end to end.
 
 ## Uninstall the skill
 
-To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `public-github.com-anthropics-skills-brand-guidelines`:
+To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `public-github.com-github-awesome-copilot-game-engine`:
 
 ```shell
-chainctl skills uninstall public-github.com-anthropics-skills-brand-guidelines
+chainctl skills uninstall public-github.com-github-awesome-copilot-game-engine
 ```
 
 The command prompts for confirmation before removing any files:
 
 ```output
-This will remove skill "public-github.com-anthropics-skills-brand-guidelines" from local agent directories.
+This will remove skill "public-github.com-github-awesome-copilot-game-engine" from local agent directories.
 Proceed?
 Do you want to continue? [y,N]:
-Uninstalled skill "public-github.com-anthropics-skills-brand-guidelines".
+Uninstalled skill "public-github.com-github-awesome-copilot-game-engine".
 ```
 
 By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -15,7 +15,7 @@ toc: true
 weight: 003
 ---
 
-Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/chainguard`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The Chainguard Agent Skills public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
+Chainguard publishes a curated set of hardened agent skills in a public catalog at `skills.cgr.dev/public`. Anyone with `chainctl` can browse and install them — no entitlement and no legal terms required. The Chainguard Agent Skills public catalog is pull-only: you can install skills from the catalog, but you can't push your own skills to it.
 
 This guide walks through the full workflow: listing the available skills, inspecting one, pulling it to audit how Chainguard hardened it, installing it, and running it with an agent.
 
@@ -33,7 +33,7 @@ Sign in, then browse the skills published in the public Chainguard catalog with 
 
 ```shell
 chainctl auth login
-chainctl skills list --group chainguard --recursive
+chainctl skills list --group public --recursive
 ```
 
 ```output
@@ -54,7 +54,7 @@ chainctl skills list --group chainguard --recursive
 To list the skills from a single upstream owner, name it in the `--group` value:
 
 ```shell
-chainctl skills list --group chainguard/anthropics
+chainctl skills list --group public/anthropics
 ```
 
 ```output
@@ -69,16 +69,16 @@ chainctl skills list --group chainguard/anthropics
 To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand. The output records the upstream source and the exact commit Chainguard hardened from:
 
 ```shell
-chainctl skills describe skills.cgr.dev/chainguard/github/add-educational-comments:latest
+chainctl skills describe skills.cgr.dev/public/github/add-educational-comments:latest
 ```
 
 ```output
       FIELD      |                                                    VALUE
 -----------------|--------------------------------------------------------------------------------------------------------------
  Display Name    | add-educational-comments
- Reference       | chainguard/github/add-educational-comments
- Install Name    | chainguard-github-add-educational-comments
- OCI URL         | skills.cgr.dev/chainguard/github/add-educational-comments:latest
+ Reference       | public/github/add-educational-comments
+ Install Name    | public-github-add-educational-comments
+ OCI URL         | skills.cgr.dev/public/github/add-educational-comments:latest
  Description     | Add educational comments to the file specified, or prompt asking for file to comment if one is not provided.
  License         | MIT
  Upstream        | github.com/github/awesome-copilot/skills/add-educational-comments
@@ -95,7 +95,7 @@ chainctl skills describe skills.cgr.dev/chainguard/github/add-educational-commen
 Where `install` drops a skill straight into your agent's skills directory, `pull` writes the skill's files to a directory you choose so you can inspect them first:
 
 ```shell
-chainctl skills pull skills.cgr.dev/chainguard/github/add-educational-comments:latest ./add-educational-comments
+chainctl skills pull skills.cgr.dev/public/github/add-educational-comments:latest ./add-educational-comments
 ```
 
 ```output
@@ -144,7 +144,7 @@ Here, the engine flagged `minimal-permissions`: the skill only needs to read and
 Download and install the skill to make it available to agents on your machine with the `install` subcommand:
 
 ```shell
-chainctl skills install skills.cgr.dev/chainguard/github/add-educational-comments:latest
+chainctl skills install skills.cgr.dev/public/github/add-educational-comments:latest
 ```
 
 This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
@@ -153,7 +153,7 @@ This command automatically detects any agents on your machine and places the ski
 Installing github/add-educational-comments
     AGENT    |                         LOCATION                          |                                   MODE
 -------------|-----------------------------------------------------------|---------------------------------------------------------------------------
- Claude Code | .claude/skills/chainguard-github-add-educational-comments | symlink → ../../.agents/skills/chainguard-github-add-educational-comments
+ Claude Code | .claude/skills/public-github-add-educational-comments | symlink → ../../.agents/skills/public-github-add-educational-comments
 ```
 
 ## Run the skill from an agent
@@ -168,19 +168,19 @@ The agent loads the skill and runs it, confirming it installed and loaded correc
 
 ## Uninstall the skill
 
-To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `chainguard-github-add-educational-comments`:
+To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `public-github-add-educational-comments`:
 
 ```shell
-chainctl skills uninstall chainguard-github-add-educational-comments
+chainctl skills uninstall public-github-add-educational-comments
 ```
 
 The command prompts for confirmation before removing any files:
 
 ```output
-This will remove skill "chainguard-github-add-educational-comments" from local agent directories.
+This will remove skill "public-github-add-educational-comments" from local agent directories.
 Proceed?
 Do you want to continue? [y,N]:
-Uninstalled skill "chainguard-github-add-educational-comments".
+Uninstalled skill "public-github-add-educational-comments".
 ```
 
 By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.
@@ -189,10 +189,10 @@ By default, `uninstall` removes the skill from every agent directory where it's 
 
 | Action | Command |
 | ----- | ----- |
-| List skills | `chainctl skills list --group chainguard --recursive` |
-| Describe a skill | `chainctl skills describe skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
-| Pull a skill | `chainctl skills pull skills.cgr.dev/chainguard/<owner>/<name>:<tag> <dir>` |
-| Install a skill | `chainctl skills install skills.cgr.dev/chainguard/<owner>/<name>:<tag>` |
+| List skills | `chainctl skills list --group public --recursive` |
+| Describe a skill | `chainctl skills describe skills.cgr.dev/public/<owner>/<name>:<tag>` |
+| Pull a skill | `chainctl skills pull skills.cgr.dev/public/<owner>/<name>:<tag> <dir>` |
+| Install a skill | `chainctl skills install skills.cgr.dev/public/<owner>/<name>:<tag>` |
 | Uninstall a skill | `chainctl skills uninstall <install-name>` |
 
 ## Next steps

--- a/content/chainguard/agent-skills/public-catalog.md
+++ b/content/chainguard/agent-skills/public-catalog.md
@@ -29,7 +29,7 @@ Unlike a [private Chainguard Skills Registry](/chainguard/agent-skills/skills-re
 
 ## List available skills
 
-Sign in, then browse the skills published in the public Chainguard catalog with the `list` subcommand. The `--recursive` flag lists skills across every owner in the catalog:
+Sign in, then browse the skills published in the public Chainguard catalog with the `list` subcommand. The `--recursive` flag lists skills across every source in the catalog. Public skills are namespaced by their upstream source (`public/<host>/<owner>/<repo>/<name>`), so the recursive listing shows each skill's full path:
 
 ```shell
 chainctl auth login
@@ -37,31 +37,27 @@ chainctl skills list --group public --recursive
 ```
 
 ```output
-              NAME              | LATEST TAG |   UPDATED
---------------------------------|------------|--------------
- agentspace-so/agentspace       | latest     | 21 hours ago
- antfu/antfu                    | latest     | 21 hours ago
- antfu/nuxt                     | latest     | 21 hours ago
- antfu/vitest                   | latest     | 21 hours ago
- antfu/vue                      | latest     | 21 hours ago
- anthropics/doc-coauthoring     | latest     | 21 hours ago
- anthropics/frontend-design     | latest     | 21 hours ago
- apollographql/apollo-client    | latest     | 21 hours ago
+                        NAME                        | LATEST TAG |  UPDATED
+----------------------------------------------------|------------|------------
+ github.com/anthropics/skills/brand-guidelines      | latest     | 5 days ago
+ github.com/anthropics/skills/internal-comms        | latest     | 5 days ago
 
  . . .
 ```
 
-To list the skills from a single upstream owner, name it in the `--group` value:
+The public catalog is large, so a full `--recursive` listing can take a while to return. To browse a single source, scope the `--group` to its path instead (shown next).
+
+To list the skills under a single upstream repository, name its path in the `--group` value. Public skills are namespaced by their source, so an owner's repo lives at `public/<host>/<owner>/<repo>`:
 
 ```shell
-chainctl skills list --group public/anthropics
+chainctl skills list --group public/github.com/anthropics/skills
 ```
 
 ```output
- TYPE  |      NAME       | LATEST TAG | UPDATED
--------|-----------------|------------|------------
- skill | doc-coauthoring | latest     | 1 hour ago
- skill | frontend-design | latest     | 1 hour ago
+ TYPE  |       NAME       | LATEST TAG |  UPDATED
+-------|------------------|------------|------------
+ skill | brand-guidelines | latest     | 5 days ago
+ skill | internal-comms   | latest     | 5 days ago
 ```
 
 ## Describe a skill
@@ -69,25 +65,25 @@ chainctl skills list --group public/anthropics
 To retrieve a skill's reference, digest, tags, and metadata, use the `describe` subcommand. The output records the upstream source and the exact commit Chainguard hardened from:
 
 ```shell
-chainctl skills describe skills.cgr.dev/public/github/add-educational-comments:latest
+chainctl skills describe skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
 ```
 
 ```output
-      FIELD      |                                                    VALUE
------------------|--------------------------------------------------------------------------------------------------------------
- Display Name    | add-educational-comments
- Reference       | public/github/add-educational-comments
- Install Name    | public-github-add-educational-comments
- OCI URL         | skills.cgr.dev/public/github/add-educational-comments:latest
- Description     | Add educational comments to the file specified, or prompt asking for file to comment if one is not provided.
- License         | MIT
- Upstream        | github.com/github/awesome-copilot/skills/add-educational-comments
- Upstream Commit | cf4347e88c2e40a9aabe5801748ec6bf924c09be
- License Source  | LICENSE
- Tag             | cf4347e88c2e40a9aabe5801748ec6bf924c09be
- Digest          | sha256:59b781f87f82aba08ccf622b60a31ee5b8fbb27fa447ed5910850d4320505735
- Size            | 1.1 KB
- Published       | 1 day ago
+      FIELD      |                                                                     VALUE
+-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------
+ Display Name    | brand-guidelines
+ Reference       | public/github.com/anthropics/skills/brand-guidelines
+ Install Name    | public-github.com-anthropics-skills-brand-guidelines
+ OCI URL         | skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
+ Description     | Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel.
+ License         | Apache-2.0
+ Upstream        | github.com/anthropics/skills/skills/brand-guidelines
+ Upstream Commit | ef740771ac901e03fbca3ce4e1c453a96010f30a
+ License Source  | skills/brand-guidelines/LICENSE.txt
+ Tag             | ef740771ac901e03fbca3ce4e1c453a96010f30a
+ Digest          | sha256:78b0910c0d349f4d0ca14b4f8545e52d7aceaaf1a567b8cccd1f49e11cf329c8
+ Size            | 1.2 KB
+ Published       | 6 days ago
 ```
 
 ## Pull a skill to inspect it
@@ -95,65 +91,47 @@ chainctl skills describe skills.cgr.dev/public/github/add-educational-comments:l
 Where `install` drops a skill straight into your agent's skills directory, `pull` writes the skill's files to a directory you choose so you can inspect them first:
 
 ```shell
-chainctl skills pull skills.cgr.dev/public/github/add-educational-comments:latest ./add-educational-comments
+chainctl skills pull skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest ./brand-guidelines
 ```
 
 ```output
-Skill written to: /home/linky/add-educational-comments
+Skill written to: /home/linky/brand-guidelines
 ```
 
-Every hardened skill ships with a `HARDENING.md` that records the upstream source, the exact commit Chainguard hardened from, and every change the hardening engine made:
+Every hardened skill ships with a `HARDENING.md` that records the upstream source, the exact commit Chainguard hardened from, and the outcome of each hardening run:
 
 ```shell
-cat add-educational-comments/HARDENING.md
+cat brand-guidelines/HARDENING.md
 ```
 
 ```output
-# Hardening Report: github.com/github/awesome-copilot/skills/add-educational-comments
+# Hardening report
 
-| Field | Value |
-|---|---|
-| Upstream SHA | `cf4347e88c2e40a9aabe5801748ec6bf924c09be` |
-| Hardened at | 2026-06-09T23:14:22Z |
-| Files processed | 2 |
-| .md files (clean after harden) | 1 |
-| .md files (attempts exhausted) | 0 |
-| Non-.md files (copied verbatim) | 1 |
+- skill: brand-guidelines
+- sha: ef740771ac901e03fbca3ce4e1c453a96010f30a
+- harden run: 1 (outcome: completed)
 
-## Markdown files
-
-### `SKILL.md`
-
-- Status: **clean**
-- Attempts used: 2
-- Findings + fixes applied:
-
-  | Attempt | Rule | Severity | Finding |
-  |---|---|---|---|
-  | 1 | `minimal-permissions` | high | The skill's purpose is to statically analyze and add comments to code files. It does not require the ability to execute the code to fulfill its objectives. The prompt's rules about not 'breaking execution' are constraints on the output, not a requirement to test the code by running it in a live environment. |
-
-## Verbatim files
-
-- `LICENSE`
+The per-model transcripts and any findings for this run are recorded under
+`notes/harden/run_1/`.
 ```
 
-Here, the engine flagged `minimal-permissions`: the skill only needs to read and comment on files, so the hardened version drops the implied permission to execute them.
+The report pins the exact upstream `sha` Chainguard hardened from and the outcome of the run. The full per-model hardening transcripts and any findings are written alongside the skill under `notes/harden/run_1/`, so you can audit exactly what the hardening engine inspected and changed.
 
 ## Install a skill
 
 Download and install the skill to make it available to agents on your machine with the `install` subcommand:
 
 ```shell
-chainctl skills install skills.cgr.dev/public/github/add-educational-comments:latest
+chainctl skills install skills.cgr.dev/public/github.com/anthropics/skills/brand-guidelines:latest
 ```
 
 This command automatically detects any agents on your machine and places the skill into their relevant directories. The following example output shows the results on a machine where Claude Code is present:
 
 ```output
-Installing github/add-educational-comments
-    AGENT    |                         LOCATION                          |                                   MODE
--------------|-----------------------------------------------------------|---------------------------------------------------------------------------
- Claude Code | .claude/skills/public-github-add-educational-comments | symlink → ../../.agents/skills/public-github-add-educational-comments
+Installing github.com/anthropics/skills/brand-guidelines
+    AGENT    |                              LOCATION                              |                                        MODE
+-------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------
+ Claude Code | .claude/skills/public-github.com-anthropics-skills-brand-guidelines | symlink → ../../.agents/skills/public-github.com-anthropics-skills-brand-guidelines
 ```
 
 ## Run the skill from an agent
@@ -161,26 +139,26 @@ Installing github/add-educational-comments
 Load the skill into Claude Code or any MCP-compatible agent. In Claude Code, invoke it by name:
 
 ```Agent
-/add-educational-comments
+/brand-guidelines
 ```
 
 The agent loads the skill and runs it, confirming it installed and loaded correctly end to end.
 
 ## Uninstall the skill
 
-To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `public-github-add-educational-comments`:
+To remove a skill from your machine, pass its name to the `uninstall` subcommand. Use the skill's install name, which `describe` reports as the `Install Name` field — for this skill, `public-github.com-anthropics-skills-brand-guidelines`:
 
 ```shell
-chainctl skills uninstall public-github-add-educational-comments
+chainctl skills uninstall public-github.com-anthropics-skills-brand-guidelines
 ```
 
 The command prompts for confirmation before removing any files:
 
 ```output
-This will remove skill "public-github-add-educational-comments" from local agent directories.
+This will remove skill "public-github.com-anthropics-skills-brand-guidelines" from local agent directories.
 Proceed?
 Do you want to continue? [y,N]:
-Uninstalled skill "public-github-add-educational-comments".
+Uninstalled skill "public-github.com-anthropics-skills-brand-guidelines".
 ```
 
 By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.
@@ -190,9 +168,9 @@ By default, `uninstall` removes the skill from every agent directory where it's 
 | Action | Command |
 | ----- | ----- |
 | List skills | `chainctl skills list --group public --recursive` |
-| Describe a skill | `chainctl skills describe skills.cgr.dev/public/<owner>/<name>:<tag>` |
-| Pull a skill | `chainctl skills pull skills.cgr.dev/public/<owner>/<name>:<tag> <dir>` |
-| Install a skill | `chainctl skills install skills.cgr.dev/public/<owner>/<name>:<tag>` |
+| Describe a skill | `chainctl skills describe skills.cgr.dev/public/<host>/<owner>/<repo>/<name>:<tag>` |
+| Pull a skill | `chainctl skills pull skills.cgr.dev/public/<host>/<owner>/<repo>/<name>:<tag> <dir>` |
+| Install a skill | `chainctl skills install skills.cgr.dev/public/<host>/<owner>/<repo>/<name>:<tag>` |
 | Uninstall a skill | `chainctl skills uninstall <install-name>` |
 
 ## Next steps

--- a/content/chainguard/agent-skills/public-registry.md
+++ b/content/chainguard/agent-skills/public-registry.md
@@ -48,9 +48,7 @@ chainctl skills list --group public --recursive
  . . .
 ```
 
-The public registry is large, so a full `--recursive` listing can take a while to return. To browse a single source, scope the `--group` to its path instead (shown next).
-
-To list the skills under a single upstream repository, name its path in the `--group` value. Public skills are namespaced by their source, so an owner's repo lives at `public/<host>/<owner>/<repo>`:
+The public registry is large, so a full `--recursive` listing can take a while to return. To browse a single source, scope the `--group` to its path instead:
 
 ```shell
 chainctl skills list --group public/github.com/github/awesome-copilot

--- a/content/chainguard/agent-skills/public-registry.md
+++ b/content/chainguard/agent-skills/public-registry.md
@@ -29,6 +29,8 @@ To follow this guide, you need `chainctl` **v0.2.282** or later, installed. Refe
 
 Unlike a [private Chainguard skills registry](/chainguard/agent-skills/skills-registry/), the public registry requires no entitlement, terms acceptance, or organization membership. You do need a Chainguard account to list and pull skills, but you don't need to be a customer.
 
+The public registry is served from Chainguard's production environment, which is where `chainctl` points by default. If you've configured `chainctl` for a different environment, sign back in to production before continuing — otherwise `list` and `pull` report `public org "public" not found`. You can confirm the configured environment with `chainctl config view` (the `api` should be `https://console-api.enforce.dev`).
+
 ## List available skills
 
 Sign in, then browse the skills published in Chainguard's public registry with the `list` subcommand. The `--recursive` flag lists skills across every source in the registry. Public skills are namespaced by their upstream source (`public/<host>/<owner>/<repo>/<name>`), so the recursive listing shows each skill's full path:

--- a/content/chainguard/agent-skills/public-registry.md
+++ b/content/chainguard/agent-skills/public-registry.md
@@ -29,8 +29,6 @@ To follow this guide, you need `chainctl` **v0.2.282** or later, installed. Refe
 
 Unlike a [private Chainguard skills registry](/chainguard/agent-skills/skills-registry/), the public registry requires no entitlement, terms acceptance, or organization membership. You do need a Chainguard account to list and pull skills, but you don't need to be a customer.
 
-The public registry is served from Chainguard's production environment, which is where `chainctl` points by default. If you've configured `chainctl` for a different environment, sign back in to production before continuing — otherwise `list` and `pull` report `public org "public" not found`. You can confirm the configured environment with `chainctl config view` (the `api` should be `https://console-api.enforce.dev`).
-
 ## List available skills
 
 Sign in, then browse the skills published in Chainguard's public registry with the `list` subcommand. The `--recursive` flag lists skills across every source in the registry. Public skills are namespaced by their upstream source (`public/<host>/<owner>/<repo>/<name>`), so the recursive listing shows each skill's full path:


### PR DESCRIPTION
## What

Repoints the **public catalog** getting-started guide (`content/chainguard/agent-skills/public-catalog.md`) from the `chainguard` org to the **`public`** org — the public hardened-skills catalog and the skills MCP now serve from `skills.cgr.dev/public` (the auto-ingested public org), not `skills.cgr.dev/chainguard` — and rewrites every example with data verified against the live catalog via `chainctl`.

## Changes

- **Org/namespace**: all references now use `skills.cgr.dev/public`; intro, list, describe, pull, install, uninstall, and the command-reference table.
- **Real deep-nested layout**: public skills are namespaced by upstream source as `public/<host>/<owner>/<repo>/<name>`. Examples and placeholders use this shape instead of the old flat `owner/name`.
- **Verified running example**: the walkthrough uses `public/github.com/github/awesome-copilot/game-engine`, with real reference, install name (`public-github.com-github-awesome-copilot-game-engine`), OCI URL, digest, license, upstream, and commit pulled from the live catalog.
- **Current HARDENING.md format**: shown verbatim in the multi-model pipeline format (report + `sha` + run outcome + `SKILL.md modified` flag + `notes/harden/run_1/` reference), replacing the obsolete findings-table format.
- **List output**: scoped `--group public/github.com/github/awesome-copilot` sample with empty folders (sources with no published `latest` tag) omitted and the long list truncated with an ellipsis. Added a note that a full `--recursive` listing over the large catalog can be slow, pointing readers to scoped `--group` paths.

## Scope note

`skills-registry.md` was **not** touched — that page documents a customer's *own* private org (`$ORG` / `example.dev`) and has no `chainguard`-org references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)