### PR TITLE
docs(actions): document Chainguard Actions telemetry and privacy

### DIFF
--- a/content/chainguard/actions/overview.md
+++ b/content/chainguard/actions/overview.md
@@ -233,5 +233,6 @@ If an action isn't working as expected, [open an issue](https://github.com/chain
 
 ## Learn more
 
+- [Chainguard Actions telemetry and privacy](/chainguard/actions/telemetry/)
 - [Chainguard Actions product page](https://www.chainguard.dev/actions)
 - For other questions, [contact Chainguard](https://www.chainguard.dev/contact?utm=docs).

--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -14,33 +14,22 @@ weight: 002
 toc: true
 ---
 
-Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that records a usage and entitlement event to `https://actions.enforce.dev/actions/v1/record`. This page documents what the hook sends, what Chainguard stores, and how you can control it.
-
-The hook is fire-and-forget. It has a 2 second timeout and fails open, so it can never block or break your workflow.
+Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that records a usage event to `https://actions.enforce.dev/actions/v1/record`. The hook is fire-and-forget, with a 2 second timeout that fails open, so it cannot break your build.
 
 ## What we collect
 
-What Chainguard receives depends on whether your workflow grants the `id-token: write` permission to the job running the action.
+What we collect depends on whether your workflow grants `id-token: write`:
 
-- **Without `id-token: write`:** we record only your repository name, a timestamp, and an "unverified" flag. Nothing else.
-- **With `id-token: write`:** the hook mints a GitHub OIDC token scoped to the `actions.chainguard.dev` audience and includes it so we can verify the record. From that verified token we store usage and entitlement metadata: repository, actor, ref, sha, workflow path, repository visibility, and run identifiers.
+- **Without `id-token: write`:** we record your repository name, a timestamp, and an "unverified" flag.
+- **With `id-token: write`:** the hook mints a GitHub OIDC token scoped to the `actions.chainguard.dev` audience and sends it so we can verify the record. From that token we store metadata: repository, actor, ref, sha, workflow path, repository visibility, and run identifiers.
 
-The hook never grants itself the `id-token: write` permission. It only uses the permission if your workflow already grants it. If you would rather Chainguard receive only your repository name, do not grant `id-token: write` to the job that runs the action.
+The hook never grants itself `id-token: write`. It only uses the permission if your workflow already grants it. If you would rather we receive only your repository name, do not grant `id-token: write` to that job.
 
-## About the OIDC token
+## About the token
 
-When it is sent, the token is a short-lived, audience-locked GitHub OIDC token. Because it is locked to the `actions.chainguard.dev` audience, it cannot be replayed against GitHub, a cloud provider, or any other service. The underlying `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner; it is used locally only to mint the audience-scoped token.
-
-## Why we collect it
-
-The telemetry lets Chainguard verify that an organization is entitled to the hardened actions it uses and understand how the actions are used so we can improve them. It is usage and entitlement metadata, not the contents of your build.
-
-## Data retention
-
-Operational logs that include telemetry events are retained for a limited period (approximately 30 days). A durable analytics copy of usage and entitlement metadata is retained in accordance with our [Privacy Notice](https://www.chainguard.dev/legal/privacy-notice).
+It is a short-lived, audience-locked GitHub OIDC token. Because it is locked to the `actions.chainguard.dev` audience, it cannot be used against GitHub, a cloud provider, or any other service. The underlying `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner; it is used locally only to mint the audience-scoped token.
 
 ## Learn more
 
 - [Chainguard Actions overview](/chainguard/actions/overview/)
-- [Chainguard Privacy Notice](https://www.chainguard.dev/legal/privacy-notice)
 - For other questions, [contact Chainguard](https://www.chainguard.dev/contact?utm=docs).

--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -20,14 +20,14 @@ Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that r
 
 What we collect depends on whether your workflow grants `id-token: write`:
 
-- **Without `id-token: write`:** we record your repository name, a timestamp, and an "unverified" flag.
-- **With `id-token: write`:** the hook mints a GitHub OIDC token scoped to the `actions.chainguard.dev` audience and sends it so we can verify the record. From that token we store metadata: repository, actor, ref, sha, workflow path, repository visibility, and run identifiers.
+- **Without `id-token: write`**: we record your repository name, a timestamp, and an "unverified" flag.
+- **With `id-token: write`**: the hook mints a GitHub OIDC token scoped to the `actions.chainguard.dev` audience and sends it so we can verify the record. From that token we store metadata: repository, actor, ref, sha, workflow path, repository visibility, and run identifiers.
 
 The hook never grants itself `id-token: write`. It only uses the permission if your workflow already grants it. If you would rather we receive only your repository name, do not grant `id-token: write` to that job.
 
 ## About the token
 
-It is a short-lived, audience-locked GitHub OIDC token. Because it is locked to the `actions.chainguard.dev` audience, it cannot be used against GitHub, a cloud provider, or any other service. The underlying `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner; it is used locally only to mint the audience-scoped token.
+The token is a short-lived, audience-locked GitHub OIDC token. Because it is locked to the `actions.chainguard.dev` audience, it cannot be used against GitHub, a cloud provider, or any other service. The underlying `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner; it is used locally only to mint the audience-scoped token.
 
 ## Learn more
 

--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -1,0 +1,46 @@
+---
+title: "Chainguard Actions telemetry and privacy"
+linktitle: "Telemetry and privacy"
+description: "Learn what usage telemetry Chainguard hardened actions send, what data is collected, and how to control it."
+type: "article"
+date: 2026-07-16T00:00:00+00:00
+lastmod: 2026-07-16T00:00:00+00:00
+draft: false
+tags: ["Chainguard Actions", "Telemetry", "Privacy"]
+menu:
+  docs:
+    parent: "actions"
+weight: 002
+toc: true
+---
+
+Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that records a usage and entitlement event to `https://actions.enforce.dev/actions/v1/record`. This page documents what the hook sends, what Chainguard stores, and how you can control it.
+
+The hook is fire-and-forget. It has a 2 second timeout and fails open, so it can never block or break your workflow.
+
+## What we collect
+
+What Chainguard receives depends on whether your workflow grants the `id-token: write` permission to the job running the action.
+
+- **Without `id-token: write`:** we record only your repository name, a timestamp, and an "unverified" flag. Nothing else.
+- **With `id-token: write`:** the hook mints a GitHub OIDC token scoped to the `actions.chainguard.dev` audience and includes it so we can verify the record. From that verified token we store usage and entitlement metadata: repository, actor, ref, sha, workflow path, repository visibility, and run identifiers.
+
+The hook never grants itself the `id-token: write` permission. It only uses the permission if your workflow already grants it. If you would rather Chainguard receive only your repository name, do not grant `id-token: write` to the job that runs the action.
+
+## About the OIDC token
+
+When it is sent, the token is a short-lived, audience-locked GitHub OIDC token. Because it is locked to the `actions.chainguard.dev` audience, it cannot be replayed against GitHub, a cloud provider, or any other service. The underlying `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner; it is used locally only to mint the audience-scoped token.
+
+## Why we collect it
+
+The telemetry lets Chainguard verify that an organization is entitled to the hardened actions it uses and understand how the actions are used so we can improve them. It is usage and entitlement metadata, not the contents of your build.
+
+## Data retention
+
+Operational logs that include telemetry events are retained for a limited period (approximately 30 days). A durable analytics copy of usage and entitlement metadata is retained in accordance with our [Privacy Notice](https://www.chainguard.dev/legal/privacy-notice).
+
+## Learn more
+
+- [Chainguard Actions overview](/chainguard/actions/overview/)
+- [Chainguard Privacy Notice](https://www.chainguard.dev/legal/privacy-notice)
+- For other questions, [contact Chainguard](https://www.chainguard.dev/contact?utm=docs).


### PR DESCRIPTION
Adds a dedicated **Telemetry and privacy** page for Chainguard Actions and links it from the overview.

## Why

A beta customer (Baseten) flagged that the hardened-action phone-home telemetry was only discoverable by reading the code, and asked for public docs on the endpoint and payload. This page answers that.

## What the page covers

- The phone-home endpoint (`actions.enforce.dev/actions/v1/record`) and that the hook is fire-and-forget / fails open.
- **What we collect, split by permission:**
  - Without `id-token: write`: repository name, timestamp, and an unverified flag.
  - With `id-token: write`: verified OIDC claims (repository, actor, ref, sha, workflow path, repository visibility, run identifiers).
- The token is audience-locked to `actions.chainguard.dev` and cannot be used elsewhere; `ACTIONS_ID_TOKEN_REQUEST_TOKEN` never leaves the runner.
- How to limit what is sent (withhold `id-token: write`).

Content mirrors the internal telemetry statement. Suggested reviewers: Actions product + PMM/enablement (Tyler Paxton, Nevin Coco, Elsie Phillips) and legal (Sara Haneef / Sean Pan) for the data-collection language.

Opened as a **draft** pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
