### PR TITLE
Clarify how Helm chart updates track image updates

### DIFF
--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -38,12 +38,13 @@ You can use these Helm charts with Chainguard FIPS container images, but you wil
 
 ## How chart updates deliver image updates
 
-Chainguard rebuilds container images regularly to pick up the latest package versions and CVE fixes. When an image updates, the associated chart updates too so that it pins the new image digests. How you receive those image updates depends on whether you reference the chart by tag or by digest:
+Chainguard rebuilds container images regularly to pick up the latest package versions and CVE fixes. When an image updates, the associated chart updates too so that it pins the new image digests.
 
-- **If you reference the chart by tag** (for example, `--version 10.5.13`), the tag continues to point to the latest image digests as those images update. You stay on the same chart version and pull in the latest image versions each time you install or upgrade.
-- **If you pin the chart by digest**, your deployment stays fixed to the exact images that the chart referenced when you recorded that digest. To pick up newer images, update your pinned digest to the current one.
+A chart tag always refers to the chart version, not to a fixed set of images. Chainguard rolls the underlying image digests forward within a tag, so even a specific tag like `10.5.13-r1` keeps pointing at the latest images for that chart version. As with image tags, you can pick a tag fidelity that matches your upgrade appetite — `latest`, a version stream, or a specific `x.y` version — but every chart tag rolls its dependent image digests forward.
 
-In short, referencing a chart by tag keeps you current with the latest images automatically, while pinning by digest gives you a fixed, reproducible set of images that you update on your own schedule. The [Pin to digest](#pin-to-digest) section covers how to choose between these approaches.
+Helm does not apply these updates on its own. A release picks up newer images only when something triggers a redeploy: a `helm upgrade`, or a controller such as Argo CD or Flux reconciling the release. A chart referenced by tag then pulls the current chart digest along with its newer image digests.
+
+To pin both the chart and its images to a fixed, reproducible set, reference the chart by digest instead of by tag. Your deployment then stays fixed to the exact images the chart referenced when you recorded that digest. To pick up newer images, update your pinned digest to the current one. The [Pin to digest](#pin-to-digest) section covers how to do this.
 
 ## Authentication
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -38,11 +38,11 @@ You can use these Helm charts with Chainguard FIPS container images, but you wil
 
 ## How chart updates deliver image updates
 
-Chainguard rebuilds container images regularly to pick up the latest package versions and CVE fixes. When an image updates, the associated chart updates too so that it pins the new image digests.
+Chainguard rebuilds container images regularly to pick up the latest package versions and CVE fixes. Just like images, charts are also rebuilt regularly to pick up the latest chart updates and the chart's new dependent image digests.
 
-A chart tag always refers to the chart version, not to a fixed set of images. Chainguard rolls the underlying image digests forward within a tag, so even a specific tag like `10.5.13-r1` keeps pointing at the latest images for that chart version. As with image tags, you can pick a tag fidelity that matches your upgrade appetite — `latest`, a version stream, or a specific `x.y` version — but every chart tag rolls its dependent image digests forward.
+A chart tag always refers to the chart version, not to a fixed set of images. Chainguard rolls the underlying image digests forward within a tag, so even a specific tag like `10.5.13-r1` keeps pointing at the latest images for that chart version. As with image tags, you can pick a tag fidelity that matches your upgrade appetite — `latest`, a version stream, or a specific `x.y.y-r#` version — but every chart tag rolls its dependent image digests forward.
 
-Helm does not apply these updates on its own. A release picks up newer images only when something triggers a redeploy: a `helm upgrade`, or a controller such as Argo CD or Flux reconciling the release. A chart referenced by tag then pulls the current chart digest along with its newer image digests.
+Helm will not apply these updates on its own. A release picks up newer images only when something triggers a redeploy: a `helm upgrade`, or a controller such as Argo CD or Flux reconciling the release. A chart referenced by tag then pulls the current chart digest along with its newer image digests. Running a `helm upgrade` on the same tag will resolve to its newest digest the tag pins to.
 
 To pin both the chart and its images to a fixed, reproducible set, reference the chart by digest instead of by tag. Your deployment then stays fixed to the exact images the chart referenced when you recorded that digest. To pick up newer images, update your pinned digest to the current one. The [Pin to digest](#pin-to-digest) section covers how to do this.
 

--- a/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/index.md
@@ -36,6 +36,15 @@ The following is an instructional guide for Chainguard users that are looking fo
 
 You can use these Helm charts with Chainguard FIPS container images, but you will need to adjust the charts as they use the non-FIPS images by default. We build a single chart per application and validate that both FIPS and non-FIPS Chainguard Images work with it.
 
+## How chart updates deliver image updates
+
+Chainguard rebuilds container images regularly to pick up the latest package versions and CVE fixes. When an image updates, the associated chart updates too so that it pins the new image digests. How you receive those image updates depends on whether you reference the chart by tag or by digest:
+
+- **If you reference the chart by tag** (for example, `--version 10.5.13`), the tag continues to point to the latest image digests as those images update. You stay on the same chart version and pull in the latest image versions each time you install or upgrade.
+- **If you pin the chart by digest**, your deployment stays fixed to the exact images that the chart referenced when you recorded that digest. To pick up newer images, update your pinned digest to the current one.
+
+In short, referencing a chart by tag keeps you current with the latest images automatically, while pinning by digest gives you a fixed, reproducible set of images that you update on your own schedule. The [Pin to digest](#pin-to-digest) section covers how to choose between these approaches.
+
 ## Authentication
 
 You will need to authenticate to pull charts. These instructions explain how to use charts and images with the `cgr.dev` repository. If you have mirrored or copied the charts and images to an organization-specific registry, you will need to adapt these instructions to authenticate to your registry, as appropriate.


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Add a "How chart updates deliver image updates" section to the Helm charts guide, explaining tag-versus-digest update behavior

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-72/clarify-how-helm-chart-updates-track-image-updates

Clarifies how image updates propagate to customers depending on whether they reference a Chainguard Helm chart by tag or by digest.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Customers were unclear on what happens to the underlying images when Chainguard updates them. Referencing a chart by tag keeps deployments current with the latest image digests automatically, while pinning by digest requires updating the pin to receive newer images — a distinction the guide did not spell out.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The guide explains that tag references continue to point to the latest image digests as images update
- The guide explains that digest pins stay fixed until the reader updates the pin
- The new section links to the existing "Pin to digest" section for guidance on choosing an approach

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [\`edu\` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Navigate to the Helm charts guide and confirm the new "How chart updates deliver image updates" section reads clearly and the "Pin to digest" anchor link resolves