### PR TITLE
Document GitHub immutable subject claims for assumable identities

### DIFF
--- a/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/chainguard-images/chainguard-registry/authenticating/index.md
@@ -111,12 +111,12 @@ First create an identity using `chainctl`, which can be limited to only allow OI
 
 ```sh
 chainctl iam identity create github [GITHUB-IDENTITY] \
-  --github-repo=${GITHUB_ORG}/${GITHUB_REPO} \
+  --github-repo=${GITHUB_ORG}@${GITHUB_OWNER_ID}/${GITHUB_REPO}@${GITHUB_REPO_ID} \
   --github-ref=refs/heads/main \
   --role=registry.pull
 ```
 
-**Note**: The value passed to `--github-repo` should be equal to the repository name you expect to be returned in the `subject` field of the token from GitHub. If you need to further scope or change the subject you can find a number of useful examples in the ["Example subject claims"](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims) section of GitHub's OIDC documentation and then you may update the identity with [`chainctl iam identities update`](/platform/chainctl/chainctl-docs/chainctl_iam_identities_update/).
+**Note**: The value passed to `--github-repo` must equal the repository portion of the `subject` field in the token GitHub issues. GitHub now embeds immutable numeric owner and repository IDs in that subject (for example, `my-org@123456/repo-name@654321`), so `--github-repo` must include them. Populate `GITHUB_OWNER_ID` and `GITHUB_REPO_ID` with your repository's numeric IDs; for how to retrieve them and when the format applies, see [Finding your repository's numeric identifiers](/platform/administration/assumable-ids/identity-examples/github-identity/#finding-your-repositorys-numeric-identifiers). If you need to further scope or change the subject, see the ["Example subject claims"](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims) section of GitHub's OIDC documentation, then update the identity with [`chainctl iam identities update`](/platform/chainctl/chainctl-docs/chainctl_iam_identities_update/).
 
 This creates a Chainguard identity that can be assumed by a GitHub Actions workflow only for the specified GitHub repository, triggered on pushes to the specified branch (such as `refs/heads/main`), with permissions only to pull from Chainguard's registry.
 

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-gitops.md
@@ -109,6 +109,10 @@ chainctl iam identities create github-actions-identity \
 
 This creates an identity that GitHub Actions workflows in `your-org/your-repo` can assume when triggered by push events.
 
+{{< note >}}
+This example matches on the `repository` and `event_name` claims rather than the `sub` claim, so it is unaffected by GitHub's [immutable subject claims](/platform/administration/assumable-ids/identity-examples/github-identity/#finding-your-repositorys-numeric-identifiers), which change only the `sub` claim. The `repository` claim carries the repository name, and names can be reassigned. For stronger protection against namespace reuse, pin the identity to the repository's numeric ID by adding `--claim=repository_id=<repo-id>`.
+{{< /note >}}
+
 ## Step 2: Grant permissions
 
 The identity needs permission to build Custom Assembly images. You can create a [least-privilege custom role](/chainguard/chainguard-images/features/ca-docs/custom-assembly/#custom-assembly-permissions-requirements/) that contains the `repo.update` and `repo.create` permissions, then grant the necessary permission using `chainctl`:

--- a/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
@@ -204,11 +204,11 @@ This is an example of a minimal configuration:
 
 Push this file to the `main` branch of your repository.
 
-Next, create an assumable identity for your GitHub repository:
+Next, create an assumable identity for your GitHub repository. The `--github-repo` value embeds GitHub's immutable numeric owner and repository IDs; see [Finding your repository's numeric identifiers](/platform/administration/assumable-ids/identity-examples/github-identity/#finding-your-repositorys-numeric-identifiers) for how to retrieve them and when the format applies.
 
 ```shell
 chainctl iam identities create github <identity-name> \
-  --github-repo=<github-org>/<github-repo-name> \
+  --github-repo=<github-org>@<owner-id>/<github-repo-name>@<repo-id> \
   --github-ref=refs/heads/main \
   --role=registry.pull
 ```

--- a/content/open-source/octo-sts/faq.md
+++ b/content/open-source/octo-sts/faq.md
@@ -109,17 +109,21 @@ Prefer exact subject matching when possible:
 
 ```yaml
 # Better: Exact match
-subject: repo:org/repo:ref:refs/heads/main
+subject: repo:org@<owner-id>/repo@<repo-id>:ref:refs/heads/main
 ```
 
 Use pattern matching only when you need flexibility:
 
 ```yaml
 # When necessary: Pattern match
-subject_pattern: "repo:org/repo:ref:refs/heads/.*"
+subject_pattern: "repo:org@<owner-id>/repo@<repo-id>:ref:refs/heads/.*"
 ```
 
 Exact matching is more secure because it's harder to accidentally grant broader access than intended.
+
+{{< note >}}
+These subjects use GitHub's immutable format, which embeds the numeric owner ID and repository ID in the `sub` claim (for example, `repo:org@123456/repo@654321:ref:refs/heads/main`). This format is the default for repositories created after July 15, 2026, and an opt-in for older repositories. Match the exact subject your repository's token carries. For how to find the IDs, see [Finding your repository's numeric identifiers](/platform/administration/assumable-ids/identity-examples/github-identity/#finding-your-repositorys-numeric-identifiers).
+{{< /note >}}
 
 ## Integration
 
@@ -159,7 +163,7 @@ Yes, use organization trust policies with a `repositories` field:
 
 ```yaml
 issuer: https://token.actions.githubusercontent.com
-subject: repo:org/automation-repo:ref:refs/heads/main
+subject: repo:org@<owner-id>/automation-repo@<repo-id>:ref:refs/heads/main
 
 permissions:
   contents: read

--- a/content/platform/administration/assumable-ids/identity-examples/github-identity/index.md
+++ b/content/platform/administration/assumable-ids/identity-examples/github-identity/index.md
@@ -37,14 +37,22 @@ To complete this guide, you will need the following.
 ## Creating an Identity
 
 {{< note >}}
-GitHub now issues OIDC tokens whose `sub` claim embeds immutable numeric IDs for the repository owner and the repository. For example, the subject `repo:my-org@123456/repo-name@654321:ref:refs/heads/main` replaces the older name-only form `repo:my-org/repo-name:ref:refs/heads/main`. This format is the default for repositories created after July 15, 2026, and is available as an opt-in for older repositories through GitHub's OIDC settings.
+GitHub issues OIDC tokens whose `sub` claim embeds immutable numeric IDs for the repository owner and the repository. For example, the subject `repo:my-org@123456/repo-name@654321:ref:refs/heads/main` replaces the older name-only form `repo:my-org/repo-name:ref:refs/heads/main`. This format is the default for repositories created after July 15, 2026, and is available as an opt-in for older repositories through GitHub's OIDC settings.
 
 An identity that matches the older name-only subject will not match a token that carries the immutable subject, so the workflow fails to authenticate. The examples that follow use the immutable format. If your repository still sends the name-only subject, leave out the `@<owner-id>` and `@<repo-id>` portions.
 {{< /note >}}
 
 ### Finding your repository's numeric identifiers
 
-The immutable subject claim uses the numeric ID of the repository owner and the numeric ID of the repository. Retrieve both with the [GitHub CLI](https://cli.github.com/):
+The immutable subject claim uses the numeric ID of the repository owner and the numeric ID of the repository.
+
+To retrieve the subject claim in the GitHub UI, modify and browse to this URL:
+
+```http
+https://github.com/<org-name>/<repo-name>/settings/actions/oidc-configuration
+```
+
+To retrieve the subject claim with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
 gh api repos/OWNER/REPO --jq '{owner_id: .owner.id, repo_id: .id}'

--- a/content/platform/administration/assumable-ids/identity-examples/github-identity/index.md
+++ b/content/platform/administration/assumable-ids/identity-examples/github-identity/index.md
@@ -10,7 +10,7 @@ lead: ""
 description: "Tutorial outlining how to create a Chainguard identity that can be assumed by a GitHub Actions workflow."
 type: "article"
 date: 2023-05-04T08:48:45+00:00
-lastmod: 2025-11-28T06:00:00+00:00
+lastmod: 2026-07-21T06:00:00+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -36,15 +36,31 @@ To complete this guide, you will need the following.
 
 ## Creating an Identity
 
+{{< note >}}
+GitHub now issues OIDC tokens whose `sub` claim embeds immutable numeric IDs for the repository owner and the repository. For example, the subject `repo:my-org@123456/repo-name@654321:ref:refs/heads/main` replaces the older name-only form `repo:my-org/repo-name:ref:refs/heads/main`. This format is the default for repositories created after July 15, 2026, and is available as an opt-in for older repositories through GitHub's OIDC settings.
+
+An identity that matches the older name-only subject will not match a token that carries the immutable subject, so the workflow fails to authenticate. The examples that follow use the immutable format. If your repository still sends the name-only subject, leave out the `@<owner-id>` and `@<repo-id>` portions.
+{{< /note >}}
+
+### Finding your repository's numeric identifiers
+
+The immutable subject claim uses the numeric ID of the repository owner and the numeric ID of the repository. Retrieve both with the [GitHub CLI](https://cli.github.com/):
+
+```sh
+gh api repos/OWNER/REPO --jq '{owner_id: .owner.id, repo_id: .id}'
+```
+
+You can also preview the exact subject your repository sends from its OIDC settings in the GitHub web interface. To confirm the subject a running workflow presents, inspect the `sub` claim of the OIDC token in the workflow logs. For background on the format, see GitHub's changelog announcing [immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/).
+
 ### Chainctl
 
 This command creates an identity that can be assumed by workflows in the
-`my-org/repo-name` repository. The identity is bound to the `registry.pull`
-role.
+`my-org/repo-name` repository. Substitute the owner and repository IDs you
+retrieved earlier. The identity is bound to the `registry.pull` role.
 
 ```sh
 chainctl iam identities create github my-identity-name \
-    --github-repo=my-org/repo-name \
+    --github-repo=my-org@<owner-id>/repo-name@<repo-id> \
     --role registry.pull
 ```
 
@@ -53,17 +69,17 @@ run from a specific branch. For instance, the `main` branch.
 
 ```sh
 chainctl iam identities create github my-identity-name \
-    --github-repo=my-org/repo-name \
+    --github-repo=my-org@<owner-id>/repo-name@<repo-id> \
     --github-ref=refs/heads/main \
     --role registry.pull
 ```
 
-Regex is also available. For example creating an identity that can be assumed by multiple repositories and multiple branches.
+Regex is also available. For example, you can create an identity that can be assumed by multiple repositories and multiple branches. Because every repository in an organization shares the same owner ID, a single pattern can match all of them.
 
 ```sh
-chainctl iam identitie create github my-identity-name \
-    --github-repo='my-org/.*' \
-    --github-refs='refs/heads/main|master'
+chainctl iam identities create github my-identity-name \
+    --github-repo='my-org@<owner-id>/.*' \
+    --github-ref='refs/heads/main|master' \
     --role registry.pull
 ```
 
@@ -83,8 +99,11 @@ chainctl iam identities list --name=my-identity-name
 Alternatively, you could create the identity with the [Chainguard Terraform
 provider](https://registry.terraform.io/providers/chainguard-dev/chainguard/latest).
 
-Substitute your Chainguard organization name, GitHub organization and GitHub
-repository for `<org-name>`, `<github-org>` and `<github-repo>`, respectively.
+Substitute your Chainguard organization name, GitHub organization, and GitHub
+repository for `<org-name>`, `<github-org>`, and `<github-repo>`, respectively.
+Substitute the numeric owner and repository IDs for `<owner-id>` and
+`<repo-id>`, following the steps in
+[Finding your repository's numeric identifiers](#finding-your-repositorys-numeric-identifiers).
 
 ```hcl
 data "chainguard_group" "org" {
@@ -97,7 +116,7 @@ resource "chainguard_identity" "my_identity_name" {
 
   claim_match {
     issuer  = "https://token.actions.githubusercontent.com"
-    subject = "repo:<github-org>/<github-repo>:ref:refs/heads/main"
+    subject = "repo:<github-org>@<owner-id>/<github-repo>@<repo-id>:ref:refs/heads/main"
   }
 }
 


### PR DESCRIPTION
## Summary

GitHub now embeds immutable numeric owner and repository IDs in the OIDC token subject claim — `repo:org@<owner-id>/repo@<repo-id>:...` instead of `repo:org/repo:...`. This format is the default for repositories created after July 15, 2026, and an opt-in for older ones. An identity that matches the old name-only subject will not match a token that carries the immutable subject, so the workflow fails to authenticate.

Reported by a solution architect in [DOCS-73](https://linear.app/chainguard/issue/DOCS-73/docs-request-assumable-identities-document-immutable-subject-claims) after a customer (Aleph Alpha) hit it. See GitHub's [changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/).

## Changes

- **GitHub Actions identity guide** (source of truth): explains the format, adds a "Finding your repository's numeric identifiers" section (the `gh api` lookup and token-log verification), and updates the `chainctl` and Terraform examples.
- **Octo STS FAQ**: updates the exact-match, pattern-match, and org-policy subject examples.
- **Registry authentication guide**: updates the `--github-repo` command and its subject note.
- **Renovate guide**: updates the `--github-repo` command.
- **Custom Assembly GitOps guide**: this matches on the `repository` claim, which is *unaffected* by the change. Added a note explaining that, plus optional `repository_id` hardening guidance.

The auto-generated `chainctl` CLI reference still shows the old format. It regenerates from the CLI source, so it needs a separate fix in the CLI repo rather than a manual edit here.

## Before merge — verify against a live org

These use `chainctl` in ways I could not test from the docs repo:

- [x] `chainctl iam identities create github … --github-repo=my-org@<owner-id>/repo-name@<repo-id>` is accepted and produces the immutable subject.
- [x] `--github-ref` (not `--github-refs`) is the correct flag for the multi-branch regex example.
- [x] `--claim=repository_id=<repo-id>` is a valid claim key (the optional hardening in the Custom Assembly guide).

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-21.
