### PR TITLE
fix(ci): read Go version from go.mod in check-links workflow

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.24'
+          go-version-file: tools/chainlink/go.mod
 
       - name: Run chainlink
         run: go run . -contentDir ../../content -hostname edu.chainguard.dev -method GET -checkAll


### PR DESCRIPTION
[ x ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Set `setup-go` to read the Go version from `tools/chainlink/go.mod` instead of a hardcoded `go-version: '1.24'`

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Fix the daily `check-links` workflow so its `Run chainlink` step builds again and can reopen/update the link-check issue.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
PR #3511 bumped `tools/chainlink/go.mod` to require `go 1.25.0`, but the workflow still pinned `go-version: '1.24'`. Go 1.24 can't build a module requiring 1.25.0, so the `Run chainlink` step has failed on every scheduled run since 2026-07-07, aborting the job before it opens or updates the `[chainlink] check links on edu.chainguard.dev` issue. Reading the version from `go.mod` keeps the two in sync and prevents the next dependency bump from reintroducing the mismatch.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The `check-links` workflow completes successfully on a scheduled or manually dispatched run
- The `Run chainlink` step builds with the Go version declared in `tools/chainlink/go.mod`
- The `[chainlink] check links on edu.chainguard.dev` issue is created or updated again

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. After merge, trigger the workflow manually with `gh workflow run check-links.yaml --repo chainguard-dev/edu` (it only runs on `chainguard-dev/edu`, guarded by `if: github.repository == 'chainguard-dev/edu'`)
2. Confirm the run succeeds and the `Run chainlink` step no longer fails on the Go version requirement
3. Confirm the `[chainlink] check links on edu.chainguard.dev` issue is created or updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)