### PR TITLE
Exclude synced static/api*.json from whitespace pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,17 +9,28 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
-      # content/platform/chainctl/chainctl-docs/ is generated upstream and synced
-      # in verbatim (see .github/actions/integrate-platform-docs). Its cobra-
-      # generated code fences carry trailing whitespace that reappears on every
-      # sync, so exclude it from the whitespace formatters (also unlinted below).
+      # Two sets of generated files are synced in verbatim (see
+      # .github/actions/integrate-platform-docs) and excluded from the whitespace
+      # formatters, because any fix the hooks apply is clobbered on the next sync:
+      #   - content/platform/chainctl/chainctl-docs/: cobra-generated docs whose
+      #     code fences carry trailing whitespace (also unlinted below).
+      #   - static/api*.json: OpenAPI specs pulled from cloud storage that lack a
+      #     trailing newline.
       - id: trailing-whitespace
-        exclude: ^content/platform/chainctl/chainctl-docs/
+        exclude: |
+          (?x)^(
+            content/platform/chainctl/chainctl-docs/|
+            static/api[^/]*\.json$
+          )
         # Preserve two-space hard line breaks in Markdown; strip other trailing
         # whitespace as usual.
         args: ['--markdown-linebreak-ext=md']
       - id: end-of-file-fixer
-        exclude: ^content/platform/chainctl/chainctl-docs/
+        exclude: |
+          (?x)^(
+            content/platform/chainctl/chainctl-docs/|
+            static/api[^/]*\.json$
+          )
       - id: check-yaml
       - id: check-added-large-files
         args: ['--maxkb=1000']


### PR DESCRIPTION
## Problem

The AutoDocs PR [#3626](https://github.com/chainguard-dev/edu/pull/3626) failed the required `pre-commit` check — a job that has always passed. The failing hook is `end-of-file-fixer`, on four files:

```
static/api.json
static/api-v1.json
static/api-v2alpha1.json
static/api-v2beta1.json
```

These are OpenAPI specs that `.github/actions/integrate-platform-docs` syncs verbatim from cloud storage (`gsutil ... enforce-openapi/api*.json static/`), and the generator emits them **without a trailing newline**. They've always lacked one; prior AutoDocs runs simply didn't change them, so they stayed out of the pre-commit diff. This run updated the spec, pulling them into the changed-file set, and `end-of-file-fixer` rewrote them — failing the check on content the docs team can't hand-fix (the next sync clobbers any newline we add).

## Fix

Exclude `static/api*.json` from `trailing-whitespace` and `end-of-file-fixer`, mirroring the existing `chainctl-docs` exclusion — same rationale: generated, synced verbatim, fixes don't survive the next sync. Each `exclude` becomes a verbose (`(?x)`) regex covering both paths.

## Verification

- Regex tested against the four files plus near-misses (`static/apidocs/x.json`, `static/api.json.bak`) — matches only the intended specs, no over-match.
- `pre-commit run end-of-file-fixer --files static/api*.json README.md` now passes (the specs are skipped; normal files still checked).
- Config-only change; `check-yaml` and the full local hook suite pass.

Once this merges, the next AutoDocs run (or a rebase of #3626 onto updated `main`) will pass the check.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-23.