### PR TITLE
[DO NOT MERGE until #3629] Add stylelint pre-commit hook for SCSS (DOCS-79)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,3 +141,22 @@ repos:
         # generator-inherent violations (hard tabs, unlabeled code fences) that
         # any local fix would lose on the next sync, so it is not linted here.
         exclude: ^content/platform/chainctl/chainctl-docs/
+
+  # Lint SCSS against .stylelintrc.json. Unlike the eslint/markdown hooks above,
+  # this is a repo-local node hook rather than an external mirror: no maintained
+  # stylelint mirror exists, so pinning the toolchain in-repo via
+  # additional_dependencies avoids a third-party wrapper. pre-commit installs
+  # these into an isolated node environment, so contributors need no local
+  # `npm install` and CI needs only Python. --allow-empty-input keeps the hook
+  # green when a commit touches only files excluded by .stylelintignore.
+  - repo: local
+    hooks:
+      - id: stylelint
+        name: stylelint (SCSS)
+        entry: stylelint
+        language: node
+        args: ['--allow-empty-input']
+        files: ^assets/scss/.*\.(css|scss|sass)$
+        additional_dependencies:
+          - stylelint@^17.14.1
+          - stylelint-config-standard-scss@^17.0.0

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,1 @@
-assets/scss/components/_syntax.scss
-assets/scss/vendor
 node_modules


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until #3629 is merged.** Opened as a **draft** to enforce this.
> Until the remaining manual SCSS fixes (#3629) land, `main`'s SCSS tree still has findings, so merging this hook first would make the next PR that touches any of those files fail on pre-existing errors. Merge order: **#3629 → then mark this ready → merge.**

Final step of DOCS-2 / DOCS-79: wire stylelint into pre-commit so the SCSS tree stays clean via the same changed-files ratchet already used for eslint and markdownlint.

## What this adds

A `stylelint` hook in `.pre-commit-config.yaml`, scoped to `^assets/scss/.*\.(css|scss|sass)$`.

**Why a repo-local node hook instead of an external mirror:** the eslint and markdownlint hooks use maintained upstream mirrors, but there is no comparably maintained stylelint mirror (the common one was last updated in 2023). Rather than take a stale third-party wrapper into the toolchain, this pins stylelint in-repo via `additional_dependencies` (`stylelint@^17`, `stylelint-config-standard-scss@^17`). pre-commit still installs it into an isolated node environment, so contributors need no local `npm install` and CI needs only Python — same contributor experience as the other hooks.

`--allow-empty-input` keeps the hook green when a commit touches only files excluded by `.stylelintignore` (otherwise stylelint 17 exits non-zero when all inputs are ignored).

## Also: .stylelintignore cleanup

Removed two stale entries — `assets/scss/components/_syntax.scss` and `assets/scss/vendor` — neither of which exists in the repo. Kept `node_modules`.

## Verification

- `pre-commit run stylelint` against a file with a finding **fails** (exit 2); against a clean file **passes**; against an ignored file it's skipped without error.
- `.stylelintignore` is honored for explicitly-passed files; confirmed the all-ignored case passes with `--allow-empty-input`.
- YAML validates; full local hook suite passes on the committed change.

Depends on #3629.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-23.