### PR TITLE
Remove broken SCSS stylelint pre-commit hook (temporary, unblocks CI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,21 +142,11 @@ repos:
         # any local fix would lose on the next sync, so it is not linted here.
         exclude: ^content/platform/chainctl/chainctl-docs/
 
-  # Lint SCSS against .stylelintrc.json. Unlike the eslint/markdown hooks above,
-  # this is a repo-local node hook rather than an external mirror: no maintained
-  # stylelint mirror exists, so pinning the toolchain in-repo via
-  # additional_dependencies avoids a third-party wrapper. pre-commit installs
-  # these into an isolated node environment, so contributors need no local
-  # `npm install` and CI needs only Python. --allow-empty-input keeps the hook
-  # green when a commit touches only files excluded by .stylelintignore.
-  - repo: local
-    hooks:
-      - id: stylelint
-        name: stylelint (SCSS)
-        entry: stylelint
-        language: node
-        args: ['--allow-empty-input']
-        files: ^assets/scss/.*\.(css|scss|sass)$
-        additional_dependencies:
-          - stylelint@^17.14.1
-          - stylelint-config-standard-scss@^17.0.0
+  # SCSS/stylelint linting is temporarily not wired here. The previous repo-local
+  # node hook could not resolve the shared `extends`
+  # (stylelint-config-standard-scss) in CI: stylelint resolves `extends` from the
+  # config file's directory (repo root), not from the hook's isolated node
+  # environment, and the pre-commit CI has no repo-root node_modules. That made
+  # every PR touching assets/scss fail the required check. It will be re-added to
+  # run against the project's own toolchain, with a Node/npm step in the
+  # pre-commit CI job. Tracking: DOCS-81.


### PR DESCRIPTION
## Why

The SCSS/stylelint pre-commit hook added in #3630 **fails in CI on every PR that touches `assets/scss/`** — a repo-wide regression. It surfaced on #3631 (the first SCSS change since #3630 merged):

```
stylelint (SCSS)........Failed
ConfigurationError: Could not find "stylelint-config-standard-scss".
```

As a repo-local `language: node` hook, it installs stylelint and its config into pre-commit's isolated environment, but stylelint resolves the `extends` in `.stylelintrc.json` relative to the **config file's directory** (repo root). The Python-only pre-commit CI does no `npm install`, so there's no repo-root `node_modules` for it to resolve from. #3630's own CI passed only because it changed no `.scss` files, so the hook never ran.

## What this does

Removes the hook so the required `pre-commit` check stops failing repo-wide. This is the fast unblock; SCSS linting returns in the proper fix.

## Follow-up

**DOCS-81** re-adds SCSS linting against the project's own toolchain (the package-locked `stylelint`), with a cached Node/`npm ci` step in the `pre-commit` CI job so the shared config resolves. That PR should land before #3631 merges, since #3631's docs describe stylelint as an active check.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-23.