### PR TITLE
Document Custom Assembly custom runtime keys

### DIFF
--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl.md
@@ -264,6 +264,49 @@ Custom runtime repository URLs are validated when the configuration is applied. 
 * `localhost` isn't allowed.
 * Hostnames that resolve to any of the blocked IP ranges listed earlier aren't allowed either.
 
+### Custom runtime keys
+
+Custom Assembly images trust only Chainguard's APK signing key by default. If your mirror re-signs packages with its own key — as Artifactory virtual repositories and Sonatype Nexus Alpine repositories do — runtime `apk add` commands reject packages from that mirror. Custom runtime keys let you embed your mirror's public signing key in the image's `/etc/apk/keys` directory so that `apk` can verify re-signed packages.
+
+To add a runtime key, pass the public key file to the `--with-runtime-keyring` option:
+
+```shell
+chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER --with-runtime-keyring=key-ee8fa0a3.rsa.pub
+```
+
+Each file becomes a key in `/etc/apk/keys` named after the file's basename. The name must match the filename referenced by your repository's APKINDEX signature (`.SIGN.RSA256.<name>`), because `apk` looks up the key by that name during verification. `chainctl` uses filenames verbatim and returns an error if two files share the same basename.
+
+You can also define runtime keys in the editor or in a YAML manifest by adding a `runtime_keyring` field under `contents`. Each entry has a `name` and the key's PEM `content`:
+
+```yaml
+contents:
+  packages:
+    - curl
+    - jq
+  runtime_repositories:
+    - https://apk-mirror.example.com/chainguard
+  runtime_keyring:
+    - name: key-ee8fa0a3.rsa.pub
+      content: |
+        -----BEGIN PUBLIC KEY-----
+        ...
+        -----END PUBLIC KEY-----
+```
+
+Apply the manifest with the `apply` subcommand as with other customizations. In the confirmation diff, each key appears as the SHA-256 digest of its content rather than the raw PEM text. To confirm that a digest matches a local key file, run `sha256sum <keyfile>`.
+
+When you run the `edit` subcommand, the editor buffer includes any existing runtime keys. Keep the `runtime_keyring` section to preserve the keys, edit an entry to replace a key, or delete the field to remove all custom keys from the image.
+
+#### Key validation rules
+
+Runtime keys are validated when the configuration is applied. The following rules apply:
+
+* Each entry must contain exactly one PEM-encoded RSA public key: a single `PUBLIC KEY` block with no other content before or after it. Certificates, OpenSSH keys, and EC keys aren't accepted.
+* Key names must be unique.
+* Key names can't be empty, begin with a dot, or contain path separators.
+* Key names can't begin with `chainguard` or `wolfi`; these prefixes are reserved.
+* The combined size of all keys can't exceed 512 KB.
+
 ## Retrieving Information about Custom Assembly Containers
 
 You can also use the `list` subcommand to retrieve every one of a customized image's builds from the past 24 hours:

--- a/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
+++ b/content/chainguard/chainguard-images/features/ca-docs/custom-assembly.md
@@ -40,6 +40,7 @@ With Custom Assembly, you can add the following to your container images:
 * [Environment variables and annotations](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#adding-custom-annotations-and-environment-variables) — Set custom runtime environment variables and custom metadata annotations.
 * [Custom user accounts and groups](/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/) — Use `chainctl images repos build apply` or `chainctl images repos build edit` to define custom users with specific UIDs/GIDs, home directories, group memberships, and specify which user the image runs as.
 * [Custom runtime repositories](#custom-runtime-repositories) — Replace the default APK repository URLs in the assembled image with your own internal mirror URLs, so that runtime `apk add` commands resolve against your infrastructure instead of Chainguard's default endpoints.
+* [Custom runtime keys](#custom-runtime-keys) — Embed your mirror's APK signing public keys in the assembled image, so that runtime `apk add` commands can verify packages from mirrors that re-sign them.
 
 Note: You cannot remove base packages that come with the source image — you can only add to them.
 
@@ -188,20 +189,20 @@ This setting doesn't affect build-time package resolution. Packages are always f
 
 To learn how to configure custom runtime repositories using `chainctl`, refer to the [Custom runtime repositories section](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#custom-runtime-repositories) of the `chainctl` Custom Assembly guide.
 
+### Custom runtime keys
+
+By default, Custom Assembly images trust only the Chainguard signing key, which is embedded in the image at build time. If your mirror re-signs packages with its own key, `apk` inside the container rejects those packages because it can't verify the new signature.
+
+Custom runtime keys let you embed your mirror's public signing key in the image's `/etc/apk/keys` directory alongside the Chainguard key. With the key in place, runtime `apk add` commands can verify packages from mirrors that re-sign them.
+
+To learn how to configure custom runtime keys using `chainctl`, refer to the [Custom runtime keys section](/chainguard/chainguard-images/features/ca-docs/custom-assembly-chainctl/#custom-runtime-keys) of the `chainctl` Custom Assembly guide.
+
 ### Limitations and compatibility
 
-Custom runtime repositories work with APK mirrors that serve packages with the original Chainguard signatures. The Chainguard signing key is embedded in the image at build time, so `apk` verifies packages from your mirror using this existing key.
+Whether a mirror requires a custom runtime key depends on how it signs packages:
 
-This means custom runtime repositories are compatible with:
-
-* **Artifactory remote repositories** — Remote repositories in [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/) act as pull-through caches and serve packages with their original signatures intact. These work with custom runtime repositories without additional configuration.
-
-Custom runtime repositories are **not compatible** with repositories that use their own signing key, including:
-
-* **Artifactory virtual repositories** — Virtual repositories in Artifactory add an additional signing key to packages. Because the Custom Assembly image contains only the Chainguard signing key, `apk` won't trust packages signed with a different key. Users who need virtual repositories can work around this by using the `--allow-untrusted` flag with `apk`, or by injecting the additional signing key into the image via a Dockerfile.
-* **Sonatype Nexus Alpine repositories** — Nexus requires its own signing key for Alpine repositories. As with Artifactory virtual repositories, this is incompatible with the Chainguard signing key embedded in Custom Assembly images.
-
-Support for custom keyrings may be added in a future release, which would allow repositories with their own signing keys to be used with Custom Assembly. Contact your account team if this is a requirement for your organization.
+* **Mirrors that preserve Chainguard signatures work without additional configuration.** For example, remote repositories in [JFrog Artifactory](/chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-packages-pull-through/) act as pull-through caches and serve packages with their original signatures intact, so the embedded Chainguard signing key verifies them.
+* **Mirrors that re-sign packages with their own key require a custom runtime key.** Artifactory virtual repositories add their own signing key to packages, and Sonatype Nexus requires its own signing key for Alpine repositories. To use these mirrors, embed the mirror's public signing key in the image as a custom runtime key.
 
 > **Note**: Custom runtime repository URLs must use HTTPS. Chainguard does not validate the reachability of custom repository URLs at configuration time. A misconfigured URL will not cause build failures, but will cause runtime `apk add` failures inside the container.
 


### PR DESCRIPTION
## Summary

Follow-up to #3434 (custom runtime repositories). Documents the custom runtime keyring feature shipped in chainguard-dev/mono#43731, chainguard-dev/mono#43749, chainguard-dev/mono#46359, and chainguard-dev/mono#45294: customers can embed APK signing public keys into `/etc/apk/keys` so `apk` trusts packages from mirrors that re-sign them.

### `custom-assembly-chainctl.md`
- New **Custom runtime keys** section under Custom runtime repositories: the `--with-runtime-keyring` flag, the `contents.runtime_keyring` YAML field (`name` + PEM `content`), key naming against the APKINDEX signature filename (`.SIGN.RSA256.<name>`), SHA-256 digests in confirmation diffs, editor keep/replace/delete semantics, and removal.
- **Key validation rules** list: single PEM RSA public key per entry, unique non-empty names, no leading dots or path separators, reserved `chainguard`/`wolfi` prefixes, 512 KB total cap.

### `custom-assembly.md`
- Adds a **Custom runtime keys** feature bullet and concept section linking to the chainctl guide.
- Rewrites **Limitations and compatibility**: re-signing mirrors (Artifactory virtual repositories, Sonatype Nexus Alpine repositories) were previously documented as not compatible with a future-release caveat; they now work by adding the mirror's public signing key. Drops the `--allow-untrusted`/Dockerfile workarounds.

The new content sits under the existing beta-flagged Custom runtime repositories section, matching the shared feature gate on the platform side.

Refs: CON-1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)