### PR TITLE
agent-skills: correct public catalog location to skills.cgr.dev/public

### DIFF
--- a/content/chainguard/agent-skills/overview.md
+++ b/content/chainguard/agent-skills/overview.md
@@ -47,7 +47,7 @@ The security work happens upstream, before you or your agent ever touches the sk
 
 Chainguard Agent Skills involves two registries, both served from `skills.cgr.dev`:
 
-- **The public catalog**, maintained by Chainguard at `skills.cgr.dev/chainguard/<skill>`. This is the hardened catalog described above. Anyone can pull from it, and the skills in it are reviewed and re-hardened on an ongoing basis.
+- **The public catalog**, maintained by Chainguard at `skills.cgr.dev/public`. This is the hardened catalog described above. Anyone can pull from it, and the skills in it are reviewed and re-hardened on an ongoing basis. Public skills are namespaced by their upstream source (`public/<host>/<owner>/<repo>/<name>`).
 - **Your organization's private registry**, available to customers with access, at `skills.cgr.dev/<your-org>/<skill>`. You can use it to publish, manage, and distribute your own skills scoped to your organization, and you control who can push and install them.
 
 To interact with either of these registries, use the [`chainctl skills` commands](/platform/chainctl/chainctl-docs/chainctl_skills/).


### PR DESCRIPTION
## What

Corrects the **Agent Skills overview** page, which still listed the public catalog at `skills.cgr.dev/chainguard/<skill>`.

Public skills have migrated to the dedicated **`public`** org. The catalog is served from **`skills.cgr.dev/public`**, namespaced by upstream source (`public/<host>/<owner>/<repo>/<name>`) — matching what the [Public Registry guide](https://edu.chainguard.dev/chainguard/agent-skills/public-registry/) already documents (`chainctl skills list --group public`, `skills.cgr.dev/public/...`).

## Change

Single line in `content/chainguard/agent-skills/overview.md`:

- **Before:** `skills.cgr.dev/chainguard/<skill>`
- **After:** `skills.cgr.dev/public` + a note on the `public/<host>/<owner>/<repo>/<name>` namespacing

Only `overview.md` referenced the stale path (verified via code search); the Public Registry and Skills Registry pages were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
