### PR TITLE
docs: update links to canonical apko and false-results paths

### DIFF
--- a/content/chainguard/chainguard-images/faq.md
+++ b/content/chainguard/chainguard-images/faq.md
@@ -4,7 +4,7 @@ linktitle: "FAQ"
 type: "article"
 description: "Chainguard container FAQs: why they have zero CVEs, how they compare to DockerHub, what makes them more secure, pricing, and enterprise deployment best practices"
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2024-12-18T08:49:31+00:00
+lastmod: 2026-07-27T16:03:25+00:00
 draft: false
 tags: ["Chainguard Containers", "FAQ"]
 images: []
@@ -24,7 +24,7 @@ Chainguard Containers are based on [Wolfi](/open-source/wolfi/), a Linux _undist
 
 ## How do Chainguard Containers relate to the Google Distroless Container Images?
 
-The [Google distroless](https://github.com/GoogleContainerTools/distroless) images follow a similar philosophy to many of our images: they are minimal images that don't include package managers or shells. The main difference is in the implementation. The Google distroless images are built with [Bazel](https://bazel.build) and based on the Debian distribution, whereas Chainguard Containers are built with [apko](/open-source/apko/) and based on [Wolfi](/open-source/wolfi/). We believe our approach is more maintainable and extensible.
+The [Google distroless](https://github.com/GoogleContainerTools/distroless) images follow a similar philosophy to many of our images: they are minimal images that don't include package managers or shells. The main difference is in the implementation. The Google distroless images are built with [Bazel](https://bazel.build) and based on the Debian distribution, whereas Chainguard Containers are built with [apko](/open-source/build-tools/apko/) and based on [Wolfi](/open-source/wolfi/). We believe our approach is more maintainable and extensible.
 
 ## Which images are available?
 

--- a/content/chainguard/chainguard-images/staying-secure/security-advisories/how-chainguard-issues/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/security-advisories/how-chainguard-issues/index.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "The life cycle of Chainguard-Issued Security Advisories"
 date: 2024-07-26T18:09:12+00:00
-lastmod: 2025-04-11T12:26:23+00:00
+lastmod: 2026-07-27T16:03:25+00:00
 draft: false
 tags: ["Chainguard Containers", "CVE"]
 images: []
@@ -68,7 +68,7 @@ The newly detected CVE is then moved into the next phase where it waits for a te
 
 ### Stage 4: Advisory is Updated
 
-With an advisory issued for the package, further investigation is often needed to determine the impact of the CVE. In some cases, it will be determined that the CVE is not truly present in the package, therefore making it a [false positive](/chainguard/chainguard-images/recommended-practices/false-results/). The associated security advisory would have its status updated to "Not Affected", and further updates to the advisory would not occur.
+With an advisory issued for the package, further investigation is often needed to determine the impact of the CVE. In some cases, it will be determined that the CVE is not truly present in the package, therefore making it a [false positive](/chainguard/chainguard-images/staying-secure/working-with-scanners/false-results/). The associated security advisory would have its status updated to "Not Affected", and further updates to the advisory would not occur.
 
 If the vulnerability is a true positive finding, then it is present in the package and further action must be taken. When an  upstream fix is available, such as a newer package version which remediates the CVE, then this update will be made and the advisory modified to state the vulnerability is now "Fixed".
 

--- a/content/chainguard/chainguard-images/staying-secure/security-advisories/managing-advisories/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/security-advisories/managing-advisories/index.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "Guide on how to use the wolfictl tool to create, update, and manage security advisories"
 date: 2024-08-05T20:23:51+00:00
-lastmod: 2024-08-09T14:55:03+00:00
+lastmod: 2026-07-27T16:03:25+00:00
 draft: false
 tags: ["Chainguard Containers", "CVE"]
 images: []
@@ -177,7 +177,7 @@ Type:
 Fixed Version: 2.39-r7
 ```
 
-The same process can be followed for other status updates, whether you wish to mark a vulnerability as “Not affected” in the case of a [false positive finding](/chainguard/chainguard-images/recommended-practices/false-results/), “Fix not planned”, or another applicable status.
+The same process can be followed for other status updates, whether you wish to mark a vulnerability as “Not affected” in the case of a [false positive finding](/chainguard/chainguard-images/staying-secure/working-with-scanners/false-results/), “Fix not planned”, or another applicable status.
 
 ## Further Reading
 

--- a/content/open-source/oci/what-is-the-oci.md
+++ b/content/open-source/oci/what-is-the-oci.md
@@ -4,7 +4,7 @@ linktitle: "What is the OCI?"
 type: "article"
 description: "The Open Container Initiative (OCI) is a Linux Foundation project dedicated to managing specifications and projects related to the storage, distribution, and execution of container images."
 date: 2022-06-09T15:22:20+01:00
-lastmod: 2022-06-09T15:22:20+01:00
+lastmod: 2026-07-27T16:03:25+00:00
 draft: false
 tags: ["OCI", "Conceptual"]
 images: []
@@ -101,7 +101,7 @@ Otherwise, the mediatype string will likely include “docker” as follows:
 "mediaType": "application/vnd.docker.distribution.manifest.v2+json"
 ```
 
-There are a few interesting nuances about OCI images that are worth pointing out. First, because Docker donated its image specifications to OCI, Docker and OCI image specifications are the same in substance. In fact, most images on Docker are _Docker_ images and not OCI images, which you can confirm by inspecting the image manifests. This is largely due to the fact that Docker’s tools for publishing and building images create _Docker_ images — not _OCI_ images — by default, a convention set by historical practice. If you want to build and publish OCI images, you must use tools that support OCI, such as [apko](/open-source/apko/overview/), an open source OCI image builder.  
+There are a few interesting nuances about OCI images that are worth pointing out. First, because Docker donated its image specifications to OCI, Docker and OCI image specifications are the same in substance. In fact, most images on Docker are _Docker_ images and not OCI images, which you can confirm by inspecting the image manifests. This is largely due to the fact that Docker’s tools for publishing and building images create _Docker_ images — not _OCI_ images — by default, a convention set by historical practice. If you want to build and publish OCI images, you must use tools that support OCI, such as [apko](/open-source/build-tools/apko/overview/), an open source OCI image builder.  
 
 Relatedly, a final nuance to point out is that OCI-compliant registries are only required to _support_  OCI images, but may distribute other image types as well. Thus, you should not expect all images distributed on an OCI-compliant registry to be OCI compliant themselves, such as evidenced by Docker Hub in the example above.  
 

--- a/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign.md
@@ -7,7 +7,7 @@ type: "article"
 description: "Use Cosign to verify non-container software artifacts"
 lead: "Cosign can verify software artifacts beyond containers"
 date: 2022-12-21T15:22:20+01:00
-lastmod: 2025-12-26T15:16:50+01:00
+lastmod: 2026-07-27T16:03:25+00:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -18,7 +18,7 @@ weight: 006
 toc: true
 ---
 
-Cosign can be used to verify binary artifacts ("blobs") using provided signatures as long as they are published to an OCI registry. In this tutorial, we’ll verify a binary artifact — in this case, a release of [`apko`](/open-source/apko/overview/), a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file Cosign has signed with a keyless signature.
+Cosign can be used to verify binary artifacts ("blobs") using provided signatures as long as they are published to an OCI registry. In this tutorial, we’ll verify a binary artifact — in this case, a release of [`apko`](/open-source/build-tools/apko/overview/), a command-line tool for building container images using a declarative language based on YAML. The methods in this tutorial apply to any blob file Cosign has signed with a keyless signature.
 
 This tutorial assumes you [have Cosign installed](/open-source/sigstore/cosign/how-to-install-cosign/).
 

--- a/content/open-source/wolfi/apk-package-manager.md
+++ b/content/open-source/wolfi/apk-package-manager.md
@@ -4,7 +4,7 @@ type: "article"
 lead: "How apk-tools is different from other package managers"
 description: "How apk-tools is different from other package managers"
 date: 2022-07-06T08:49:31+00:00
-lastmod: 2022-07-06T08:49:31+00:00
+lastmod: 2026-07-27T16:03:25+00:00
 contributors: ["Ariadne Conill"]
 draft: false
 tags: ["apko", "Conceptual",]
@@ -16,7 +16,7 @@ weight: 400
 toc: true
 ---
 
-[apko](/open-source/apko/getting-started-with-apko/) uses the [apk](https://wiki.alpinelinux.org/wiki/Package_management) package manager to compose container images based on declarative pipelines.
+[apko](/open-source/build-tools/apko/getting-started-with-apko/) uses the [apk](https://wiki.alpinelinux.org/wiki/Package_management) package manager to compose container images based on declarative pipelines.
 The apk format was introduced by [Alpine Linux](https://www.alpinelinux.org/) to address specific design requirements that could not be met by existing package managers such as `apt` and `dnf`. But what makes it different, and why does that matter in the context of apko?
 
 ## Manipulating the Desired State

--- a/content/software-security/what-are-containers/index.md
+++ b/content/software-security/what-are-containers/index.md
@@ -5,7 +5,7 @@ description: "An overview of the structure, contents, and applications of contai
 lead: "An overview of the structure, contents, and applications of container technology"
 type: "article"
 date: 2023-10-17T20:02:23+00:00
-lastmod: 2026-06-04T00:00:00+00:00
+lastmod: 2026-07-27T16:03:25+00:00
 contributors: ["Michelle McAveety"]
 draft: false
 tags: ["Conceptual", "Overview"]
@@ -31,7 +31,7 @@ To build a container for your application, start with a *container image*. A con
 
 To create a container image, select a *base image*. A base image is a foundational image that you extend by adding image *layers*. Typically, base images include a Linux distribution, though minimal or distroless images omit the full userland to reduce size and attack surface. Each distribution differs in its size, dependencies, and functionality, making certain distributions better suited for certain images than others.
 
-After selecting a base image, you add layers containing your application-specific code and dependencies. Tools such as [Docker](https://www.docker.com/) and [Podman](https://podman.io/) ingest a [*Dockerfile*](https://docs.docker.com/reference/dockerfile/), a configuration file that specifies the instructions to assemble a multi-layer image. You can also use tools such as [apko](/open-source/apko/overview/) and [ko](https://github.com/ko-build/ko), which produce images using a single-layer construction method.
+After selecting a base image, you add layers containing your application-specific code and dependencies. Tools such as [Docker](https://www.docker.com/) and [Podman](https://podman.io/) ingest a [*Dockerfile*](https://docs.docker.com/reference/dockerfile/), a configuration file that specifies the instructions to assemble a multi-layer image. You can also use tools such as [apko](/open-source/build-tools/apko/overview/) and [ko](https://github.com/ko-build/ko), which produce images using a single-layer construction method.
 
 For example, say you want to build a container to run your Python application. You can start with a Python base image, such as a [Wolfi-based image](/open-source/wolfi/wolfi-with-dockerfiles/), then add your application and its dependencies through Dockerfile layers. The resulting image is ready to deploy with your application bundled inside.
 


### PR DESCRIPTION
[ X ] Check if this is a typo or other quick fix and ignore the rest :)

## Summary

Fixes internal links that pointed at old URL paths left over from the information-architecture reorg. Each link still resolved through a redirect alias, so nothing was broken for readers — this is hygiene to point them at the current canonical paths and avoid an extra redirect hop.

Changes across seven pages:

- `/open-source/apko/*` → `/open-source/build-tools/apko/*` (overview, getting-started, and the section index)
- `/chainguard/chainguard-images/recommended-practices/false-results/` → `/chainguard/chainguard-images/staying-secure/working-with-scanners/false-results/`

Only link targets changed; no prose was altered.

## Context

These were found while working on the SBOM documentation (DOCS-12 and DOCS-13, PR #3656). The two SBOM pages that share the same issue are fixed in that PR and are intentionally excluded here to avoid overlap.

## Testing

- Confirmed each canonical target page exists and carries the old path as an alias (so the redirect works today).
- `hugo --gc --minify` builds cleanly with no new warnings.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
