### PR TITLE
add note to solve DOCS-87

### DIFF
--- a/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
+++ b/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL Grace Period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2024-06-11T08:49:31+00:00
+lastmod: 2026-07-29T12:53:45+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -46,9 +46,16 @@ Be aware that the following are not covered by Chainguard's EOL grace period:
 
 * Updating an image’s EOL primary package.
 * Backporting or cherry-picking individual commits or patches to the EOL primary package.
+* Installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package (see note).
 * Any package labeled end-of-life for more than 6 months by its open-source creators or maintainers.
 
 Additionally, if a container image fails to build because underlying dependencies conflict with the primary package, it will no longer be supported. A failed build signals the end of support for that image.
+
+{{< note >}}
+**Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate.
+
+You can attempt to use `apk upgrade` at you own risk to try to update those packages.
+{{< /note >}}
 
 <center><img src="eol-gp-3.png" alt="Diagram representing the lifecycle of an example unsuccessful build under the EOL Grace Period. A Python image whose primary package has reached EOL goes through an automated remediation and rebuild process, resulting in an unsuccessful build because the updated dependencies break the primary package. Because the build was unsuccessful, the EOL grace period ends and the customer should migrate to a newer package version." style="width:1050px;"></center>
 <br />

--- a/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
+++ b/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL Grace Period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2026-07-29T13:03:37+00:00
+lastmod: 2026-07-29T13:18:16+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -52,9 +52,7 @@ Be aware that the following are not covered by Chainguard's EOL grace period:
 Additionally, if a container image fails to build because underlying dependencies conflict with the primary package, it will no longer be supported. A failed build signals the end of support for that image.
 
 {{< note >}}
-**Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate.
-
-You can attempt to use `apk upgrade` at your own risk to try to update those packages.
+**Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate. You can attempt to use `apk upgrade` at your own risk to try to update those packages.
 {{< /note >}}
 
 <center><img src="eol-gp-3.png" alt="Diagram representing the lifecycle of an example unsuccessful build under the EOL Grace Period. A Python image whose primary package has reached EOL goes through an automated remediation and rebuild process, resulting in an unsuccessful build because the updated dependencies break the primary package. Because the build was unsuccessful, the EOL grace period ends and the customer should migrate to a newer package version." style="width:1050px;"></center>

--- a/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
+++ b/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL Grace Period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2026-07-29T13:18:16+00:00
+lastmod: 2026-07-29T13:49:57+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -52,7 +52,7 @@ Be aware that the following are not covered by Chainguard's EOL grace period:
 Additionally, if a container image fails to build because underlying dependencies conflict with the primary package, it will no longer be supported. A failed build signals the end of support for that image.
 
 {{< note >}}
-**Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate. You can attempt to use `apk upgrade` at your own risk to try to update those packages.
+When an image's primary package reaches EOL, newer versions of some dependency packages may no longer support it. In these cases, Chainguard does not update those packages solely to remediate CVEs, because doing so could introduce compatibility issues or result in a broken image. Instead, the existing package versions are retained to preserve image functionality while providing additional time to migrate to a supported image. You can attempt to install newer package versions at your own risk, using `apk upgrade`.
 {{< /note >}}
 
 <center><img src="eol-gp-3.png" alt="Diagram representing the lifecycle of an example unsuccessful build under the EOL Grace Period. A Python image whose primary package has reached EOL goes through an automated remediation and rebuild process, resulting in an unsuccessful build because the updated dependencies break the primary package. Because the build was unsuccessful, the EOL grace period ends and the customer should migrate to a newer package version." style="width:1050px;"></center>

--- a/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
+++ b/content/chainguard/chainguard-images/features/eol-gp-overview/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL Grace Period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2026-07-29T12:53:45+00:00
+lastmod: 2026-07-29T13:03:37+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -54,7 +54,7 @@ Additionally, if a container image fails to build because underlying dependencie
 {{< note >}}
 **Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate.
 
-You can attempt to use `apk upgrade` at you own risk to try to update those packages.
+You can attempt to use `apk upgrade` at your own risk to try to update those packages.
 {{< /note >}}
 
 <center><img src="eol-gp-3.png" alt="Diagram representing the lifecycle of an example unsuccessful build under the EOL Grace Period. A Python image whose primary package has reached EOL goes through an automated remediation and rebuild process, resulting in an unsuccessful build because the updated dependencies break the primary package. Because the build was unsuccessful, the EOL grace period ends and the customer should migrate to a newer package version." style="width:1050px;"></center>


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Adds a new entry in the **Be aware that the following are not covered by Chainguard's EOL grace period:** list

> * Installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package (see note).

And a new note with further clarification

> **Installing updated versions of packages:** Chainguard won't remediate CVEs by installing updated versions of packages in instances where the new package version no longer supports the EOL version of the image's main package. If we did, this would cause test failures and a broken image forcing an end of support for that image, so we're sticking with the old version of the package to avoid that and give you a little longer to migrate.

You can attempt to use `apk upgrade` at you own risk to try to update those packages.

### What should this PR do?
Fixes https://linear.app/chainguard/issue/DOCS-87/clarification-on-eol-grace-period

### Why are we making this change?
Addresses customer confusion

### What are the acceptance criteria? 
Is the wording clear and does it follow the style guide (Docs Team) and is the new content accurate (Max)?

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
