### PR TITLE
Revert "Update images digests"

### DIFF
--- a/tools/chaindocs/Dockerfile
+++ b/tools/chaindocs/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/php:latest-dev@sha256:aa87e4d66017b9f3c24da1ca726325caa0cd973523819f48dc94440d6f2be208
+FROM cgr.dev/chainguard/php:latest-dev@sha256:f30adc06d58488f44ae84e91262355e8c02c3abdfa814f81264b8771771b86ef
 
 COPY . /app
 RUN cd /app && \


### PR DESCRIPTION
Reverts chainguard-dev/edu#3662 as I believe it is causing Deploy to Cloud run failures