### PR TITLE
JS and Python global config update-hashes clarification

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2025-10-22T20:44:26+00:00
+lastmod: 2026-07-29T14:16:16+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -81,8 +81,10 @@ Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/
 
 ### Authentication
 
-`update-hashes` fetches checksums from Chainguard Libraries (`libraries.cgr.dev`),
-which requires authentication. Choose whichever fits your environment:
+`update-hashes` fetches checksums from Chainguard Libraries,
+which requires authentication. Where it fetches from depends on your environment: some setups authenticate directly to `libraries.cgr.dev`, but if your build routes through a repository manager configured as a pull-through proxy for Chainguard Libraries, point `update-hashes` there instead with `--registry-url` so it validates against the same source your build used.
+
+Authenticating to `libraries.cgr.dev` directly:
 
 - **Logged in locally**: Run the command while authenticated; if you have no
   other credential it prompts for an organization and authenticates with a
@@ -103,11 +105,14 @@ which requires authentication. Choose whichever fits your environment:
   (or `$NETRC`); see [.netrc for authentication](/chainguard/libraries/access/#netrc).
   Pass `--ignore-netrc` to skip an unrelated entry.
 
-When you target a repository manager with `--registry-url` (for example
-Artifactory or JFrog), authenticate with **that** registry's credentials —
+Authenticating to a repository manager:
+
+When you target a repository manager with `--registry-url`, authenticate with **that** registry's credentials —
 `--username`/`--password`, the `CHAINCTL_REGISTRY_USERNAME` /
 `CHAINCTL_REGISTRY_PASSWORD` environment variables, or a matching `~/.netrc`
 entry. Chainguard-scoped tokens are never sent to third-party hosts.
+
+Learn more about using a repository manager in the [global configuration documentation](/chainguard/libraries/javascript/global-configuration/).
 
 <a id="npm"></a>
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2025-04-07T14:11:00+00:00
+lastmod: 2026-07-29T14:25:06+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -173,7 +173,12 @@ Or specify a lockfile path directly:
 chainctl libraries update-hashes path/to/requirements.txt
 ```
 
-When using a repo manager, pass the full repository URL with `--registry-url`.
+If you install through a repository manager rather than pulling from Chainguard directly, pass the full repository URL with `--registry-url` so the hashes are updated against the same source your project actually installs from. For example:
+
+```bash
+chainctl libraries update-hashes --registry-url https://your-org.jfrog.io/artifactory/api/pypi/chainguard-libraries/simple
+```
+
 Learn about using this command with repo managers in the [Global
 configuration](/chainguard/libraries/python/global-configuration/) page.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to build config JS and Python docs

### What should this PR do?
Clarify how `--registry-url` works with `update-hashes`

### Why are we making this change?
[Internal feedback](https://linear.app/chainguard/issue/EXP-399/not-clear-from-docs-how-the-registry-url-interacts-with-update-hashes)

### What are the acceptance criteria? 
Content should clearly explain how to handle auth and distinguish between direct access and repo manager auth

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
