### PR TITLE
fix(mcp): pin mcp SDK below 2.0 to fix Cloud Run startup crash

### DIFF
--- a/scripts/mcp-requirements.txt
+++ b/scripts/mcp-requirements.txt
@@ -1,3 +1,6 @@
 # MCP Server dependencies for Chainguard AI Docs
-mcp>=1.28.1
+# Cap mcp below 2.0: the 2.0 SDK (released 2026-07-28) is a major rework that
+# removes the low-level Server.list_tools()/call_tool() decorators this server
+# uses, so 2.x crashes the container at startup. Upgrade tracked in DOCS-85.
+mcp>=1.28.1,<2
 httpx>=0.28.1


### PR DESCRIPTION
## What

Pin the MCP Python SDK below 2.0 in `scripts/mcp-requirements.txt`:

```
mcp>=1.28.1,<2
```

## Why

The `mcp` 2.0 SDK was released on 2026-07-28. It is a major rework that removes the low-level `Server.list_tools()` / `call_tool()` decorators that `scripts/mcp-server.py` registers **at import time**. Because our requirement was unpinned (`mcp>=1.28.1`), the next container build resolved to 2.0.0, and the server raised `AttributeError: 'Server' object has no attribute 'list_tools'` before binding port 8080.

That is the root cause of the Cloud Run failures that began this morning:

```
The user-provided container failed to start and listen on the port
defined provided by the PORT=8080 environment variable ...
```

Every **Deploy to Cloud Run** and **Compile AI Documentation Bundle from GCS** run failed on the `mcp-server` service. Reverting the docs image digest (#3664) did not help, because that image is unrelated to the `mcp-server` container.

## Verification

Probed the exact API surface `mcp-server.py` uses against 1.28.1, 1.29.0, and 2.0.0. Only 2.0.0 drops the decorators. With the pin (`<2` resolves to 1.29.0), the real server was booted in HTTP mode and confirmed to bind `0.0.0.0:8080` and respond on `/mcp`.

## Follow-up

This is the intentional short-term fix. Migrating to the 2.0 SDK and the 2026-07-28 MCP spec (new `MCPServer` API, built-in ASGI runner) is tracked in **DOCS-85**, informed by the research spike in **DOCS-86**. That work will also add a CI smoke test that boots both transports so a bad SDK bump fails the build loudly instead of silently at deploy.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-07-29.
