### PR TITLE
ci(mcp): smoke-test the MCP server image before deploy, pin base digest

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -262,6 +262,15 @@ jobs:
         # Sign container image by immutable digest
         cosign sign --yes "ghcr.io/$REPO_OWNER/ai-docs@$DIGEST"
 
+    - name: Smoke-test MCP server image
+      if: github.ref == 'refs/heads/main'
+      env:
+        REPO_OWNER: ${{ github.repository_owner }}
+      run: |
+        # Gate the deploy: confirm the freshly built image actually boots and
+        # serves the MCP HTTP transport before it reaches Cloud Run (DOCS-91).
+        scripts/smoke-test-mcp.sh "ghcr.io/$REPO_OWNER/ai-docs:latest"
+
     - name: Push container image to Artifact Registry
       if: github.ref == 'refs/heads/main'
       env:

--- a/scripts/Dockerfile.ai-docs
+++ b/scripts/Dockerfile.ai-docs
@@ -1,8 +1,9 @@
 # Chainguard AI Documentation Container
 # Provides secure distribution of compiled documentation with MCP server support
 
-# Use wolfi-base which includes a shell but is still minimal and secure
-FROM cgr.dev/chainguard/wolfi-base:latest AS final
+# Use wolfi-base which includes a shell but is still minimal and secure.
+# Pinned by digest for reproducible builds; digestabot keeps it current.
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e AS final
 
 # Add metadata labels
 LABEL org.opencontainers.image.source="https://github.com/chainguard-dev/edu"

--- a/scripts/smoke-test-mcp.sh
+++ b/scripts/smoke-test-mcp.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Smoke-test the AI-docs MCP server image before it is allowed to deploy.
+#
+# Boots the freshly built container the same way Cloud Run does
+# (serve-mcp-http) and confirms the MCP server starts and serves HTTP on its
+# port. This catches the failure that took the server down on 2026-07-29: an
+# incompatible mcp SDK crashed the process at startup, so it never bound the
+# port and every deploy failed Cloud Run's health check (DOCS-91).
+#
+# Usage: scripts/smoke-test-mcp.sh <image-ref>
+
+set -eu
+
+IMAGE="${1:?usage: smoke-test-mcp.sh <image-ref>}"
+HOST_PORT="${HOST_PORT:-18080}"   # host side; the container always listens on 8080
+CONTAINER_PORT=8080
+TIMEOUT="${TIMEOUT:-30}"          # seconds to wait for the server to respond
+
+# --- Check 1: the module imports and registers its tools --------------------
+# `--help` forces mcp-server.py to import, which runs the tool-registration
+# decorators at module load. A breaking SDK change fails here immediately,
+# before any networking is involved.
+echo "Check 1: module import + tool registration"
+docker run --rm --entrypoint python3 "$IMAGE" /usr/local/bin/mcp-server.py --help >/dev/null
+echo "  OK"
+
+# --- Check 2: the HTTP transport starts and binds the port ------------------
+echo "Check 2: HTTP transport boots and serves on :$CONTAINER_PORT"
+CID=$(docker run -d -p "127.0.0.1:$HOST_PORT:$CONTAINER_PORT" "$IMAGE" /usr/local/bin/serve-mcp-http)
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+fail() {
+    echo "  FAIL: $1" >&2
+    echo "  --- container logs ---" >&2
+    docker logs "$CID" 2>&1 | sed 's/^/    /' >&2 || true
+    exit 1
+}
+
+# Poll until the server answers on /mcp, or give up after TIMEOUT seconds.
+i=0
+while [ "$i" -lt "$TIMEOUT" ]; do
+    # curl exits 0 as soon as it gets any HTTP response (a redirect counts);
+    # a non-zero exit means the port is not accepting connections yet.
+    if curl -s -o /dev/null "http://127.0.0.1:$HOST_PORT/mcp"; then
+        [ "$(docker inspect -f '{{.State.Running}}' "$CID")" = "true" ] \
+            || fail "server responded but the container is no longer running"
+        echo "  OK: server responded on /mcp"
+        exit 0
+    fi
+    i=$((i + 1))
+    sleep 1
+done
+
+fail "server did not serve on :$CONTAINER_PORT within ${TIMEOUT}s"


### PR DESCRIPTION
## What

Two changes to the AI-docs / MCP-server pipeline:

1. **Startup smoke test that gates the deploy.** New `scripts/smoke-test-mcp.sh` boots the freshly built container the same way Cloud Run does (`serve-mcp-http`) and fails the job unless the MCP server (a) imports cleanly — which runs the tool-registration decorators at module load — and (b) serves HTTP on port 8080. The **Compile AI Documentation Bundle from GCS** workflow runs it between "Build and push container image" and the Artifact Registry push / Cloud Run deploy, so a broken image can never reach production.
2. **Pin the base image.** `scripts/Dockerfile.ai-docs` now pins `cgr.dev/chainguard/wolfi-base` by digest, matching the repo's other Dockerfiles. digestabot already covers subdirectory Dockerfiles, so the pin stays current automatically.

## Why

On 2026-07-29 the `mcp-server` Cloud Run service failed every deploy with:

```
The user-provided container failed to start and listen on the port
defined provided by the PORT=8080 environment variable ...
```

Root cause (short-term fix shipped in #3667): the unpinned `mcp` SDK resolved to the breaking 2.0 release, which removed the low-level `Server.list_tools()` decorators `mcp-server.py` uses at import time. The image **built** fine, so nothing in CI caught it — the failure only surfaced at deploy, against production Cloud Run.

This PR closes the two gaps that let that happen: no startup test before deploy, and a floating base image.

## Verification

Built the image locally and ran the smoke test both ways:

- **Pinned image (`mcp<2`)** → exits `0`; both checks pass.
- **`mcp>=2` image** → exits `1`, caught at the import check with the exact `AttributeError: 'Server' object has no attribute 'list_tools'` — i.e. it reproduces the production failure and blocks it.

## Scope / follow-ups

This gates the **deploy** in the Compile workflow. A complementary PR-level check (build + smoke-test on `scripts/` changes, so a bad Dependabot SDK bump fails on the PR itself) is a deliberate fast-follow. The full migration to the 2.0 SDK and the 2026-07-28 MCP spec is tracked in DOCS-85.

Part of **DOCS-91**.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-07-29.
