### PR TITLE
ci(mcp): add shift-left PR smoke test for the MCP server image

### DIFF
--- a/.github/workflows/mcp-image-smoke-test.yaml
+++ b/.github/workflows/mcp-image-smoke-test.yaml
@@ -1,0 +1,53 @@
+name: MCP image smoke test
+
+# Shift-left gate for the AI-docs MCP server (DOCS-93). The deploy-time gate in
+# compile-ai-docs-from-gcs.yaml only runs on main, so a breaking dependency or
+# base-image bump (which arrives as a PR) would otherwise merge green and fail
+# later at deploy. Build the image and smoke-test it here so it fails on the PR.
+
+on:
+  pull_request:
+    paths:
+      - scripts/**
+      - .github/workflows/mcp-image-smoke-test.yaml
+
+permissions: {}
+
+jobs:
+  smoke-test:
+    if: github.repository == 'chainguard-dev/edu'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          apk.cgr.dev:443
+          cgr.dev:443
+          files.pythonhosted.org:443
+          github.com:443
+          objects.githubusercontent.com:443
+          pypi.org:443
+          release-assets.githubusercontent.com:443
+
+    - name: Checkout edu repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Build and smoke-test the MCP server image
+      run: |
+        # The Dockerfile COPYs docs artifacts that only exist after the full
+        # GCS pipeline runs. This check validates the MCP server layer, not the
+        # docs content, so stub those artifacts to let the image build.
+        cd scripts
+        echo "# placeholder for PR smoke test" > chainguard-ai-docs.md
+        echo '{}' > image-catalog.json
+        echo "placeholder" > checksums.txt
+        cd ..
+        docker build -f scripts/Dockerfile.ai-docs -t ai-docs:pr-smoke scripts/
+        scripts/smoke-test-mcp.sh ai-docs:pr-smoke

--- a/.github/workflows/mcp-image-smoke-test.yaml
+++ b/.github/workflows/mcp-image-smoke-test.yaml
@@ -33,6 +33,7 @@ jobs:
           objects.githubusercontent.com:443
           pypi.org:443
           release-assets.githubusercontent.com:443
+          *.r2.cloudflarestorage.com:443
 
     - name: Checkout edu repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## What

A new `pull_request` workflow, **MCP image smoke test**, that builds `scripts/Dockerfile.ai-docs` and runs `scripts/smoke-test-mcp.sh` whenever a PR touches `scripts/**` (or the workflow itself).

## Why

DOCS-91 (#3669) added a startup smoke test, but it runs in the **Compile AI Documentation Bundle** workflow, which is **main-only**. MCP SDK bumps arrive as **Dependabot PRs** that don't build the container, so a breaking bump — exactly like the `mcp` 2.0 release that caused the 2026-07-29 outage — would still merge green and only fail later at deploy.

This gate runs the same check on the PR itself, so a bad dependency or base-image bump fails **before merge**.

## How

- Triggers only on `scripts/**` changes (plus this workflow file), so it doesn't run on unrelated docs PRs.
- The Dockerfile COPYs docs artifacts generated only by the full GCS pipeline, so the job stubs `chainguard-ai-docs.md` / `image-catalog.json` / `checksums.txt`. This validates the **MCP server layer**, not docs content — the server boots fine without real content.
- **No push, no registry, no GCP, no secrets** (`permissions: contents: read`), so it's safe for fork and Dependabot PRs. Follows repo conventions: `harden-runner` egress-block with a minimal allowlist, SHA-pinned actions, `persist-credentials: false`.

## Verification

Ran the workflow's exact build + smoke-test sequence locally: the pinned image passes (exit 0). The negative case is already proven in DOCS-91 — an `mcp>=2` image fails at the import check with `AttributeError: 'Server' object has no attribute 'list_tools'`; the smoke-test script is unchanged here, so that behavior carries over.

Closes **DOCS-93**. Follows #3669.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-07-29.
