### PR TITLE
Document PKCE for OAuth token exchange with custom IdPs

### DIFF
--- a/content/platform/administration/custom-idps/_index.md
+++ b/content/platform/administration/custom-idps/_index.md
@@ -9,6 +9,7 @@ lastmod: 2023-04-13T08:49:15+00:00
 draft: false
 images: []
 weight: 045
+landingpage: "/platform/administration/custom-idps/custom-idps/"
 ---
 
 Example tutorials on integrating various Identity Providers (IdPs) with Chainguard.

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard Custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2025-01-07T15:22:20+01:00
+lastmod: 2026-07-29T15:22:20+01:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -115,6 +115,22 @@ Typically, identity providers enable you to set up SSO by creating a specific re
 
 To set up SSO for your identity provider, you must configure one of these resources to use OIDC so that the Chainguard platform can interact with the provider. Following that, you have to configure the Chainguard platform to use that application.
 
+### Confidential and public applications
+
+OAuth classifies client applications as either confidential or public, and most identity providers use this terminology when you register an application. The classification determines whether your application authenticates with a client secret.
+
+- **Confidential applications** can store credentials securely, so they authenticate with a client secret. A web application backed by a server is the typical example, and identity providers usually label these as "Web" applications.
+- **Public applications** can't store credentials securely, because their code runs where the user can reach it. Native, mobile, desktop, and single-page applications fall here, and identity providers usually label these as "Native" or "SPA" applications.
+
+A public application has no secret to prove its identity, so it uses PKCE (Proof Key for Code Exchange) instead. PKCE binds the authorization code to the client that requested it, so an intercepted code is useless to anyone else.
+
+Chainguard supports both models:
+
+- **Confidential**: a client ID and client secret. The integration guides describe this setup, and you can also [add PKCE on top of the client secret](/platform/administration/custom-idps/enabling-pkce/).
+- **Public**: a client ID and PKCE, with no client secret. OAuth 2.1 requires this model for public clients going forward.
+
+Identity providers usually tie this classification to the application *type* you select at registration rather than to a separate setting, and some don't let you change the type afterward. If you want a public application, choose the matching type when you first register it. For the underlying definitions, refer to [section 2.1 of RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1); your identity provider's documentation names the application types it offers.
+
 ### Integration Guides for supported identity providers
 
 We have [published guides for multiple platforms](/chainguard/administration/custom-idps/), including Okta and Ping Identity. If you aren’t using one of these identity providers, you can complete the following Generic Integration Guide to configure your provider to work with Chainguard. However, be aware that Chainguard does not actively support identity providers other than the ones listed previously. If you are using an alternate identity provider, we encourage you to contact us to learn more.
@@ -135,7 +151,7 @@ Next, configure your OIDC application as follows:
 - Restrict grant types to **authorization code** only. It is critical that your application does not support "client credentials", "device code", "implicit" or other grant types (sometimes called “flows”)
 - Restrict response types to only authorization codes (sometimes called just “code”)
 - Enable “openid”, “email” and “profile” scopes for application
-- Disable or set PKCE to **optional**
+- Set PKCE to **optional**. Chainguard supports PKCE for the OAuth token exchange, so you can also set it to **required** if you [enable PKCE on the Chainguard side](/platform/administration/custom-idps/enabling-pkce/). Don't disable PKCE if you plan to enable it for Chainguard.
 
 Finally, configure a set of client credentials and make note of the following details to configure Chainguard:
 

--- a/content/platform/administration/custom-idps/disabling-social-logins/index.md
+++ b/content/platform/administration/custom-idps/disabling-social-logins/index.md
@@ -9,7 +9,7 @@ lastmod: 2026-07-02T08:48:45+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
-weight: 7
+weight: 015
 ---
 
 By default, users can authenticate to the Chainguard platform with a built-in social login provider: GitHub, GitLab, or Google. After you [configure a custom identity provider](/chainguard/administration/custom-idps/custom-idps/#setup-and-administration) for single sign-on (SSO), you may want to require that everyone in your organization authenticate through that provider instead.

--- a/content/platform/administration/custom-idps/enabling-pkce/index.md
+++ b/content/platform/administration/custom-idps/enabling-pkce/index.md
@@ -93,7 +93,7 @@ Next, test a login from end to end:
 chainctl auth login --identity-provider=$IDENTITY_PROVIDER
 ```
 
-If your organization is verified, you can log in with your organization name instead:
+You can also log in with your organization name:
 
 ```sh
 chainctl auth login --org-name=example.com

--- a/content/platform/administration/custom-idps/enabling-pkce/index.md
+++ b/content/platform/administration/custom-idps/enabling-pkce/index.md
@@ -1,0 +1,102 @@
+---
+title: "Enable PKCE for OAuth Token Exchange"
+linktitle: "Enable PKCE"
+lead: ""
+description: "How to add PKCE to your custom identity provider's OAuth token exchange with Chainguard, either alongside a client secret or as a secret-free public client."
+type: "article"
+date: 2026-07-29T08:48:45+00:00
+lastmod: 2026-07-29T08:48:45+00:00
+draft: false
+tags: ["Chainguard Containers", "Procedural"]
+images: []
+weight: 020
+---
+
+You can add PKCE (Proof Key for Code Exchange, commonly referred to as "pixy") to the OAuth token exchange between Chainguard and your custom identity provider (IdP). PKCE is a security extension to OAuth that adds an extra layer of protection against authorization code interception during login, and it is required by the OAuth 2.1 standard.
+
+Chainguard supports two configurations, depending on your needs:
+
+- **Client ID + client secret + PKCE** — In this configuration, PKCE is layered on top of your existing confidential client setup. This is additive: you keep your client ID and client secret.
+- **Client ID + PKCE only, no client secret** — This is the newer "public client" model where PKCE replaces the client secret entirely, and is the approach OAuth 2.1 requires going forward.
+
+Enabling PKCE is optional. If you leave PKCE disabled or optional on your IdP, your login behavior remains unchanged and you don't need to take any action.
+
+## Prerequisites
+
+To follow this guide, you need:
+
+- A custom identity provider (such as [Okta](/platform/administration/custom-idps/idp-providers/okta/), [Microsoft Entra ID](/platform/administration/custom-idps/idp-providers/ms-entra-id/), or [Ping Identity](/platform/administration/custom-idps/idp-providers/ping-id/)) already configured for login to Chainguard. If you haven't set one up yet, refer to our guide [Using Custom Identity Providers to Authenticate to Chainguard](/platform/administration/custom-idps/custom-idps/).
+- An IAM role that can manage identity providers in your Chainguard organization, such as the `owner` role.
+- [`chainctl` installed](/chainguard/chainctl-usage/how-to-install-chainctl/) on your local machine. You must also authenticate with `chainctl auth login`.
+
+The rest of this guide refers to your identity provider by its UIDP, stored in the `IDENTITY_PROVIDER` environment variable. Retrieve and set it with the following command:
+
+```sh
+export IDENTITY_PROVIDER=$(chainctl iam identity-providers list -o json | jq -r '.items[0].id')
+```
+
+This command selects the first identity provider the list returns. If your account can access more than one identity provider, replace `.items[0]` with a filter that matches the one you want, or set the variable to the UIDP manually.
+
+## Option 1: Client ID + client secret + PKCE
+
+This option adds PKCE on top of an existing confidential client setup. You keep using your client ID and client secret, and PKCE is layered on as an additional protection.
+
+To enable it, complete the following steps:
+
+1. In your identity provider, locate the application registration used for your Chainguard integration.
+2. Enable PKCE for that application. This is typically a toggle or checkbox labeled "Require PKCE" or similar.
+3. Update your identity provider configuration on the Chainguard platform to turn on PKCE:
+
+    ```sh
+    chainctl iam identity-providers update $IDENTITY_PROVIDER --oidc-pkce-enabled
+    ```
+
+    You can also set this at creation time by including the `--oidc-pkce-enabled` flag with [`chainctl iam identity-providers create`](/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers_create/).
+
+> **Note**: Complete steps 1 and 2 before you run the command in step 3. When you enable PKCE on the Chainguard side, we check your IdP's configuration and reject it if your IdP explicitly advertises that it doesn't support PKCE. Not all IdPs advertise this either way, so a successful command doesn't guarantee that your IdP is configured correctly.
+
+## Option 2: Client ID + PKCE only, no client secret
+
+Unlike Option 1, this usually isn't a setting you can toggle on or off. Most IdPs tie "public client" (no secret) behavior to the *type* of application you've registered, not just a PKCE setting. To go secret-free, the application must be a type your IdP treats as a public client.
+
+Whether you can change an existing application's type depends on your identity provider. Some providers, including Okta, don't allow it: a "Web" app in Okta is confidential and always expects a secret, even with PKCE enabled. If your provider won't let you convert an existing application, you can instead register a new application as a public client type from the start, then create a matching identity provider configuration in Chainguard that includes the `--oidc-pkce-enabled` flag and omits the `--oidc-client-secret` flag.
+
+To switch an existing application, complete the following steps:
+
+1. In your identity provider, locate the application registration used for your Chainguard integration and change its type to a public client type, such as **Native** or **SPA** in Okta, or the equivalent for your IdP.
+2. Confirm that PKCE is required for that application.
+3. Update your identity provider configuration on the Chainguard platform to remove the client secret and turn on PKCE:
+
+    ```sh
+    chainctl iam identity-providers update $IDENTITY_PROVIDER --oidc-client-secret="" --oidc-pkce-enabled
+    ```
+
+    You must explicitly set the `--oidc-client-secret` field to `""` to clear it. The configured IdP must always have either a client secret or PKCE enabled.
+
+> **Note**: Complete steps 1 and 2 before you run the command in step 3. When you enable PKCE on the Chainguard side, we check your IdP's configuration and reject it if your IdP explicitly advertises that it doesn't support PKCE. Not all IdPs advertise this either way, so a successful command doesn't guarantee that your IdP is configured correctly.
+
+## Verify that PKCE is enabled
+
+After completing either option, confirm that Chainguard has PKCE enabled for your identity provider:
+
+```sh
+chainctl iam identity-providers list -o json | jq '.items[] | {name, pkce: .oidc.pkce_enabled}'
+```
+
+If PKCE is enabled, your provider reports `"pkce": true`. You can also run `chainctl iam identity-providers list -o table` and look for `PKCE Enabled` in the `CONFIGURATION` column.
+
+This checks the Chainguard side of the configuration only. Chainguard never returns client secrets in command output, so these commands can't confirm that a secret has been removed.
+
+Next, test a login from end to end:
+
+```sh
+chainctl auth login --identity-provider=$IDENTITY_PROVIDER
+```
+
+If your organization is verified, you can log in with your organization name instead:
+
+```sh
+chainctl auth login --org-name=example.com
+```
+
+A successful login completes the browser redirect and returns an authenticated session. If you have any questions or issues, contact your Customer Success Team or Support, and we'll help confirm your configuration is working correctly.

--- a/content/platform/administration/custom-idps/enabling-pkce/index.md
+++ b/content/platform/administration/custom-idps/enabling-pkce/index.md
@@ -4,8 +4,8 @@ linktitle: "Enable PKCE"
 lead: ""
 description: "How to add PKCE to your custom identity provider's OAuth token exchange with Chainguard, either alongside a client secret or as a secret-free public client."
 type: "article"
-date: 2026-07-29T08:48:45+00:00
-lastmod: 2026-07-29T08:48:45+00:00
+date: 2026-07-30T08:48:45+00:00
+lastmod: 2026-07-30T08:48:45+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []

--- a/content/platform/administration/custom-idps/grant-roles-from-groups/index.md
+++ b/content/platform/administration/custom-idps/grant-roles-from-groups/index.md
@@ -9,7 +9,7 @@ lastmod: 2026-07-01T08:48:45+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
-weight: 007
+weight: 010
 ---
 
 Chainguard can grant roles based on a user's groups in your identity provider (IdP). You map an IdP group to a Chainguard role once, and from then on any user who logs in with that group in their token receives the role for that session. Access follows group membership, so you manage who gets what in your IdP instead of assigning roles to each user in Chainguard.

--- a/content/platform/administration/custom-idps/idp-providers/_index.md
+++ b/content/platform/administration/custom-idps/idp-providers/_index.md
@@ -8,5 +8,5 @@ date: 2025-01-16T08:49:15+00:00
 lastmod: 2025-01-16T08:49:15+00:00
 draft: false
 images: []
-weight: 010
+weight: 025
 ---

--- a/content/platform/administration/custom-idps/idp-providers/okta/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/okta/index.md
@@ -33,6 +33,8 @@ To integrate your Okta identity provider with the Chainguard platform, [log in t
 
 Select **OIDC - OpenID Connect** as the sign-in method and **Web Application** as the application type.
 
+> **Note**: A Web Application is a confidential client and always expects a client secret. You can [add PKCE to the token exchange](/platform/administration/custom-idps/enabling-pkce/) on top of that secret. To use a secret-free public client instead, select **Native** or **SPA** here, since Okta doesn't let you change an application's type after you create it.
+
 Next, in the **General Settings** window, configure the application as follows:
 
 * **App integration name**: Enter a descriptive name (like "Chainguard") here.

--- a/content/platform/administration/custom-idps/idp-providers/ping-id/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/ping-id/index.md
@@ -60,7 +60,7 @@ Next, configure the OIDC application. Navigate to the **Configuration** tab and 
 To configure the application, add the following settings.
 
 * **Response Type**: Select the **Code** checkbox.
-* **Grant Type**: Select the **Authorization Code** checkbox, and set PKCE Enforcement to "Optional."
+* **Grant Type**: Select the **Authorization Code** checkbox, and set PKCE Enforcement to "Optional." You can instead set this to "Required" if you [enable PKCE for the token exchange](/platform/administration/custom-idps/enabling-pkce/) on the Chainguard side.
 
 > Warning: Setting a grant type other than **Authorization Code** may compromise your security posture.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**New Content / Documentation Update**
- Adds a new guide, Enable PKCE for OAuth Token Exchange, covering PKCE alongside a client secret and PKCE as a secret-free public client
- Adds a Confidential and public applications section to the custom IdP overview
- Replaces guidance telling customers to disable PKCE in the generic and Ping Identity setup steps
- Reorders the custom IdP section weights and sets a landing page for the section index

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-51/docs-pkce-for-oauth-signin

Documents how to enable PKCE on a custom identity provider's OAuth token exchange with Chainguard, either layered on an existing client secret or replacing it entirely.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Chainguard's OAuth client previously didn't support PKCE, so our setup guides told customers to disable it or set it to optional. Now that PKCE is supported, that guidance is misleading and would break login for anyone who enables PKCE on the Chainguard side. Customers whose internal security policies flag OAuth without PKCE also need a documented path to both the confidential and public client models.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The new Enable PKCE guide renders and appears in the custom IdP section navigation in the correct position
- No page still instructs readers to disable PKCE
- `chainctl` commands in the new guide run as written, including clearing a client secret with `--oidc-client-secret=""`
- The confidential vs. public application terminology matches what Okta, Entra ID, and Ping Identity use in their consoles

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Visit **Enable PKCE** under Custom IdPs and confirm both options and the verification steps read correctly
3. Confirm the **Confidential and public applications** section renders on the custom IdP overview, before the integration guides
4. Confirm the Okta and Ping Identity guides link to the new PKCE guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
