### PR TITLE
Update wording around verifying libraries

### DIFF
--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-07-02T00:00:00+00:00
+lastmod: 2026-07-30T19:56:46+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -505,6 +505,8 @@ If all artifacts download from Central, your credentials may be invalid or expir
 
 To check whether a specific artifact was built by Chainguard, use `chainctl libraries verify /full/path/to/artifact.jar`. Verify artifacts immediately after a clean build, before any repackaging.
 
+When upstream fallback is enabled, [packages that aren't built by Chainguard] are subject to Chainguard's security controls.
+
 {{< tabs >}}
 
 {{% tab title="Maven" %}}
@@ -584,9 +586,23 @@ chainctl libraries verify ~/Library/Caches/bazel/_bazel_example/c22a55500...f423
 
 {{< /tabs >}}
 
-A successfully verified artifact produces output similar to:
+A successful result shows what percentage of your project's dependencies were built by Chainguard:
 
 ```bash
 Artifact: /path/to/artifact.jar
 Verification Coverage: 100.00%
 ```
+
+## Packages not available in Chainguard Libraries
+
+Chainguard Libraries covers a large and growing collection of Java packages, but not every package or version is available. If a package is missing, your install will fail with a 404 unless you have configured [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls).
+
+With upstream fallback enabled, packages not yet available from Chainguard are proxied from Maven Central, subject to Chainguard's security controls. Confirm your current policy with:
+
+```shell
+chainctl libraries entitlements list
+```
+
+For repository manager setups, Chainguard recommends using the configurable fallback rather than configuring a separate public registry fallback in your repository manager, to preserve Chainguard’s security controls.
+
+Learn more about upstream fallback configurations in the [Libraries Overview](/chainguard/libraries/overview/#upstream-fallback-and-controls).

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-06-01T00:00:00+00:00
+lastmod: 2026-07-30T19:49:39+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -625,10 +625,12 @@ Then check the `packages` section in `bun.lock` to verify that package source UR
 
 ## Step 6: Verify your libraries
 
-After reinstalling, verify that your JavaScript dependencies are sourced from
+After reinstalling, you can verify which of your JavaScript dependencies are built by
 Chainguard by scanning your local package manager cache or `node_modules`
 directory. `chainctl libraries verify` auto-detects npm and pnpm caches by
 their directory structure.
+
+When upstream fallback is enabled, [packages that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
 
 {{< tabs >}}
 
@@ -683,7 +685,7 @@ chainctl libraries verify ./node_modules
 
 {{< /tabs >}}
 
-A successful result shows verification coverage for the scanned packages. For example:
+A successful result shows what percentage of your project's dependencies were built by Chainguard. For example:
 
 ```
 Artifact: ./node_modules

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-01-06T15:09:59+00:00
+lastmod: 2026-07-30T19:49:39+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -16,17 +16,15 @@ weight: 004
 toc: true
 ---
 
-## Overview
-
 Chainguard's `chainctl` tool with the command [`libraries
 verify`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/) verifies
-that your language ecosystem dependencies come from Chainguard Libraries,
+which of your language ecosystem dependencies were built by Chainguard,
 providing critical visibility into your software supply chain security. By
-verifying binary artifacts across your projects and repositories, you can ensure
-dependencies are sourced from Chainguard's hardened build environment rather
-than potentially compromised public repositories, identify opportunities to
+verifying binary artifacts across your projects and repositories, you can confirm which dependencies came from Chainguard's hardened build environment, identify opportunities to
 improve security posture, and maintain compliance with supply chain security
 policies.
+
+For packages that aren't built by Chainguard, you can enable [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to apply additional configurable security controls.
 
 Command characteristics:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update JS migration guide and Libraries Verification pages

### What should this PR do?
Clarify wording around the `chainctl libraries verify` command

### Why are we making this change?
Previous wording didn't include the context of having upstream fallback enabled

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
