### PR TITLE
chore(source-policy): accept both OIDC connectors for keyless commit signing

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -5,6 +5,19 @@ spec:
   authorities:
     - keyless:
         url: https://fulcio.sigstore.dev
+        # Accept keyless gitsign signatures from a chainguard.dev identity via
+        # either the GitHub or the Google OIDC connector. Without these explicit
+        # identities, commits signed through the Google connector are rejected
+        # ("certificate does not satisfy any policy authority").
+        identities:
+          - issuer: https://github.com/login/oauth
+            subjectRegExp: .+@chainguard.dev$
+          - issuer: https://accounts.google.com
+            subjectRegExp: .+@chainguard.dev$
+          # TODO(IT/security): add the CI/bot workflow identities that sign
+          # commits in this repo (issuer https://token.actions.githubusercontent.com,
+          # subject https://github.com/chainguard-dev/edu/.github/workflows/<file>.yaml@refs/heads/main)
+          # so automated commits keep passing. Confirm the full set before merge.
       ctlog:
         url: https://rekor.sigstore.dev
     - key:


### PR DESCRIPTION
## Summary
edu's `.chainguard/source.yaml` keyless authority lists no explicit signer identities. On **2026-07-30** Guardener changed how it evaluates commit-signing policy (aligns with chainguard-dev/mono#43583), and it no longer accepts an under-specified keyless authority. As a result, **every gitsign commit to edu checked after that cutover fails** the "Enforce - Commit Signing" check with "certificate does not satisfy any policy authority" — regardless of OIDC connector, author, or machine.

This PR adds explicit identities so keyless commits are accepted again, matching sibling repos (infra, stereo, stigs) that already use this form and continue to pass.

## Evidence
- edu commits split cleanly by check time: gitsign commits checked **before ~2026-07-30 14:26 UTC** pass; commits checked **after ~2026-07-30 19:13 UTC** fail. Two commits from the same author with identical certificate identity (`matthew.helmke@chainguard.dev`, issuer `https://github.com/login/oauth`) land on opposite sides of that cutover — one passes (checked 07-29), one fails (checked 07-31).
- Sibling repos with explicit `identities` pass post-cutover: `chainguard-dev/infra` (success @ 2026-07-30 21:44) and `chainguard-dev/stereo` (success @ 2026-07-31 13:2x).
- The failing check's own certificate dump confirms a valid public-Fulcio, Rekor-logged signature; only the "Allowed by policy" claim fails.

## Why this PR's own check is red
Guardener evaluates each commit against the policy on the repo's default branch (`main`), which still has the under-specified authority. This PR's commit is therefore judged against the old policy and fails, exactly like every other current gitsign commit. Once this change is on `main`, edu commits will pass as infra/stereo/stigs do.

## Open questions for IT / security — please confirm before merge
1. **CI/bot identities.** Automated commits (digestabot, AutoDocs, octo-sts) appear to land as GitHub-committed (web-flow) and would pass via the `web-flow` / `github: verified` authorities. Confirm none rely on the keyless authority; if any do, add their `token.actions.githubusercontent.com` identities so this change doesn't break them.
2. **External contributors.** Scoping keyless to `subjectRegExp: .+@chainguard.dev$` would reject community PR commits signed with a non-chainguard gitsign identity. They still pass via the GitHub-verified / squash-merge paths. Confirm whether to keep the subject scope (starting tighter) or accept any subject from these issuers (as stigs does).
3. **Semantics confirmation.** Confirm this matches the intended post-2026-07-30 Guardener behavior, so edu's policy stays aligned with the platform going forward.

## Impact in the meantime
Nothing is blocked: the only required status check on `main` is `pre-commit`. The failing "Enforce - Commit Signing" check is advisory. Contributors do **not** need to change their local gitsign configuration.

## References
- Guardener commit-verification docs (canonical policy form): https://edu.chainguard.dev/chainguard/guardener/github/commit-verification/ — same `keyless → identities → subjectRegExp + issuer` shape as this change (docs use `.+@example.com$` as a placeholder domain).
- Precedent: `chainguard-dev/infra`, `chainguard-dev/stereo`, and `chainguard-dev/stigs` each list explicit `identities` and continue to pass post-2026-07-30.

## Status
Draft — a proposal for IT/security review. Not ready to merge until the questions above are resolved.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-07-31.

