### PR TITLE
fix(links): replace dead community Slack invite

### DIFF
--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -234,5 +234,5 @@ The bundle is rebuilt weekly. The compilation date appears at the top of the dow
 If you have questions or need assistance:
 
 - Visit [Chainguard Support](https://support.chainguard.dev?utm=docs)
-- Join our [community Slack](https://go.chainguard.dev/slack?utm=docs)
+- Join our [community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw)
 - Browse the [documentation site](https://edu.chainguard.dev)

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -407,5 +407,5 @@ docker pull ghcr.io/chainguard-dev/ai-docs:latest
 ## Need help?
 
 - [Chainguard Support](https://support.chainguard.dev?utm=docs)
-- [Community Slack](https://go.chainguard.dev/slack?utm=docs)
+- [Community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw)
 - [GitHub Issues](https://github.com/chainguard-dev/edu/issues)


### PR DESCRIPTION
The go.chainguard.dev/slack short link redirected to a CommunityInviter page that returns 404, so readers had no working way to join the community Slack. Point both references at the shared_invite URL already used by the site sidebar.

resolves https://github.com/chainguard-dev/edu/issues/3651

[ x ] Check if this is a typo or other quick fix and ignore the rest :)
