### PR TITLE
Link Java, JavaScript, and Python migration guides

### DIFF
--- a/content/chainguard/libraries/_index.md
+++ b/content/chainguard/libraries/_index.md
@@ -4,7 +4,7 @@ linktitle: "Chainguard Libraries"
 description: "Chainguard Libraries provide enhanced security for Java and Python dependencies with automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-03T14:51:58+00:00
+lastmod: 2026-08-03T15:05:54+00:00
 draft: false
 images: []
 weight: 030
@@ -33,12 +33,7 @@ tutorials: [
     description: "Secure npm packages for your JavaScript projects",
     url: "/chainguard/libraries/javascript/"
   },
-  {
-    title: "Quick Start",
-    description: "Configure your build to pull from Chainguard Libraries",
-    url: "/chainguard/libraries/quickstart/"
-  },
-  {
+    {
     title: "Migrate a Java project",
     description: "Switch an existing Maven or Gradle project to Chainguard Libraries",
     url: "/chainguard/libraries/java/migration/"
@@ -52,6 +47,11 @@ tutorials: [
     title: "Migrate a Python project",
     description: "Switch an existing pip, uv, or Poetry project to Chainguard Libraries",
     url: "/chainguard/libraries/python/migration/"
+  },
+  {
+    title: "Quick Start",
+    description: "Configure your build to pull from Chainguard Libraries",
+    url: "/chainguard/libraries/quickstart/"
   },
   {
     title: "Access",

--- a/content/chainguard/libraries/_index.md
+++ b/content/chainguard/libraries/_index.md
@@ -4,7 +4,7 @@ linktitle: "Chainguard Libraries"
 description: "Chainguard Libraries provide enhanced security for Java and Python dependencies with automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 images: []
 weight: 030
@@ -37,6 +37,21 @@ tutorials: [
     title: "Quick Start",
     description: "Configure your build to pull from Chainguard Libraries",
     url: "/chainguard/libraries/quickstart/"
+  },
+  {
+    title: "Migrate a Java project",
+    description: "Switch an existing Maven or Gradle project to Chainguard Libraries",
+    url: "/chainguard/libraries/java/migration/"
+  },
+  {
+    title: "Migrate a JavaScript project",
+    description: "Switch an existing npm project to Chainguard Libraries",
+    url: "/chainguard/libraries/javascript/migration/"
+  },
+  {
+    title: "Migrate a Python project",
+    description: "Switch an existing pip, uv, or Poetry project to Chainguard Libraries",
+    url: "/chainguard/libraries/python/migration/"
   },
   {
     title: "Access",

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-07-31T15:01:57+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -36,6 +36,10 @@ on any build server such as Jenkins, TeamCity, GitHub or other infrastructure
 that builds the applications or otherwise downloads and uses relevant libraries.
 
 The `https://libraries.cgr.dev/java/` endpoint is also the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint for Java. By default, it serves only Chainguard-built artifacts. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is enabled for your organization, the same endpoint can also serve requested versions from Maven Central under Chainguard security controls.
+
+If you are migrating an existing project to Chainguard Libraries, follow the
+[Java migration guide](/chainguard/libraries/java/migration/) for a step-by-step
+walkthrough.
 
 ## Library access approaches
 

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -113,7 +113,7 @@ discussed in [Build
 configuration](/chainguard/libraries/java/build-configuration/).
 
 For a step-by-step walkthrough of moving an existing Maven or Gradle project to
-Chainguard Libraries, see the [Java migration
+Chainguard Libraries, check out the [Java migration
 guide](/chainguard/libraries/java/migration/).
 
 ## CVE remediation

--- a/content/chainguard/libraries/java/overview.md
+++ b/content/chainguard/libraries/java/overview.md
@@ -4,7 +4,7 @@ linktitle: "Java overview"
 description: "Learn about Chainguard Libraries for Java, providing enhanced security for Maven dependencies through automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java", "Overview"]
 menu:
@@ -111,6 +111,10 @@ is strongly recommended.
 Alternatively, you can use the token for direct access from a build tool as
 discussed in [Build
 configuration](/chainguard/libraries/java/build-configuration/).
+
+For a step-by-step walkthrough of moving an existing Maven or Gradle project to
+Chainguard Libraries, see the [Java migration
+guide](/chainguard/libraries/java/migration/).
 
 ## CVE remediation
 

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -6,7 +6,7 @@ aliases:
 description: "JavaScript libraries for your application development"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2025-06-05T09:00:00+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript", "Overview"]
 menu:
@@ -94,6 +94,8 @@ Configure this endpoint [globally through a repository manager](/chainguard/libr
 ## Updating lockfile hashes
 
 Existing JavaScript lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/).
+
+For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, see the [JavaScript migration guide](/chainguard/libraries/javascript/migration/).
 
 If you install through a repository manager, see [Global configuration](/chainguard/libraries/javascript/global-configuration/#updating-lockfile-hashes/).
 

--- a/content/chainguard/libraries/javascript/overview.md
+++ b/content/chainguard/libraries/javascript/overview.md
@@ -95,7 +95,7 @@ Configure this endpoint [globally through a repository manager](/chainguard/libr
 
 Existing JavaScript lockfiles usually contain upstream integrity hashes. Because Chainguard rebuilds packages from verified source, those hashes must be updated before reinstalling. Use `chainctl libraries update-hashes` to update them in place. Learn more in [Build configuration](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/).
 
-For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, see the [JavaScript migration guide](/chainguard/libraries/javascript/migration/).
+For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, check out the [JavaScript migration guide](/chainguard/libraries/javascript/migration/).
 
 If you install through a repository manager, see [Global configuration](/chainguard/libraries/javascript/global-configuration/#updating-lockfile-hashes/).
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-07-31T15:01:57+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -98,6 +98,11 @@ Chainguard Libraries is available for the following library ecosystems:
   [Chainguard Libraries for JavaScript](/chainguard/libraries/javascript/overview/)
 * Python and the larger ecosystem with
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/)
+
+To move an existing project over, follow the migration guide for
+[Java](/chainguard/libraries/java/migration/),
+[JavaScript](/chainguard/libraries/javascript/migration/), or
+[Python](/chainguard/libraries/python/migration/).
 
 ## Chainguard criteria for building a library
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-07-29T14:25:06+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -34,6 +34,10 @@ default, it serves only Chainguard-built artifacts. When [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled for your organization, the same endpoint can also serve requested
 versions from PyPI under Chainguard security controls.
+
+If you are migrating an existing project to Chainguard Libraries, follow the
+[Python migration guide](/chainguard/libraries/python/migration/) for a
+step-by-step walkthrough.
 
 See the [minimal example projects](#minimal-example-projects) on this page for demonstrations using `uv` and `pip`.
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -4,7 +4,7 @@ linktitle: "Python overview"
 description: "Learn about Chainguard Libraries for Python, providing enhanced security for PyPI packages through automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-04-09T04:00:00+00:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python", "Overview"]
 menu:
@@ -314,6 +314,8 @@ curl -L --user "$CHAINGUARD_PYTHON_IDENTITY_ID:$CHAINGUARD_PYTHON_TOKEN" \
 The option `-L` is required to follow redirects for the actual file locations.
 
 ## Hash verification when migrating to Chainguard Libraries
+
+For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, see the [Python migration guide](/chainguard/libraries/python/migration/). This section covers hash verification, one part of that process.
 
 Because Chainguard rebuilds Python packages from source rather than mirroring upstream PyPI artifacts, it is expected that checksums for Chainguard-built packages differ from their PyPI counterparts, even for identical package versions. This affects any tool that pins or verifies hashes:
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -315,7 +315,7 @@ The option `-L` is required to follow redirects for the actual file locations.
 
 ## Hash verification when migrating to Chainguard Libraries
 
-For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, see the [Python migration guide](/chainguard/libraries/python/migration/). This section covers hash verification, one part of that process.
+For a step-by-step walkthrough of moving an existing project to Chainguard Libraries, check out the [Python migration guide](/chainguard/libraries/python/migration/). This section covers hash verification, one part of that process.
 
 Because Chainguard rebuilds Python packages from source rather than mirroring upstream PyPI artifacts, it is expected that checksums for Chainguard-built packages differ from their PyPI counterparts, even for identical package versions. This affects any tool that pins or verifies hashes:
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quick Start"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-07-29T19:28:59+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -37,6 +37,7 @@ pages:
 
 * [Java migration guide](/chainguard/libraries/java/migration/)
 * [JavaScript migration guide](/chainguard/libraries/javascript/migration/)
+* [Python migration guide](/chainguard/libraries/python/migration/)
 
 ## Prerequisites
 

--- a/content/get-started/libraries-examples/_index.md
+++ b/content/get-started/libraries-examples/_index.md
@@ -2,18 +2,22 @@
 title: "Libraries Examples"
 linktitle: "Libraries Examples"
 lead: ""
-description: "Swap in your first secure dependency with Chainguard Libraries: a quickstart and a JavaScript migration walkthrough. Available for Java, Python, and JavaScript."
+description: "Swap in your first secure dependency with Chainguard Libraries: a quickstart and migration walkthroughs for Java, JavaScript, and Python."
 type: "article"
 date: 2026-06-26T00:00:00+00:00
-lastmod: 2026-06-26T00:00:00+00:00
+lastmod: 2026-08-03T14:51:58+00:00
 draft: false
 images: []
 weight: 025
 crosslinks:
 - title: "Quickstart: swap in a library"
   url: "/chainguard/libraries/quickstart/"
+- title: "Migrate a Java project"
+  url: "/chainguard/libraries/java/migration/"
 - title: "Migrate a JavaScript project"
   url: "/chainguard/libraries/javascript/migration/"
+- title: "Migrate a Python project"
+  url: "/chainguard/libraries/python/migration/"
 ---
 
 Point your package manager at Chainguard, reinstall, and ship — no breaking changes. Chainguard Libraries are rebuilt from verified source as drop-in replacements for the packages you already use.
@@ -23,4 +27,6 @@ These on-ramp guides link to the published Chainguard Libraries documentation. L
 ## On-ramp guides
 
 - **[Quickstart: swap in a library](/chainguard/libraries/quickstart/)** — point your package manager at Chainguard, reinstall, and ship.
+- **[Migrate a Java project](/chainguard/libraries/java/migration/)** — switch an existing Maven or Gradle project over to Chainguard Libraries.
 - **[Migrate a JavaScript project](/chainguard/libraries/javascript/migration/)** — switch an existing npm project over to Chainguard Libraries.
+- **[Migrate a Python project](/chainguard/libraries/python/migration/)** — switch an existing pip, uv, or Poetry project over to Chainguard Libraries.


### PR DESCRIPTION
## What this changes

Links the Java, JavaScript, and Python library migration guides wherever migration is relevant, and adds all three to the **Libraries Examples** menu under **Get Started**.

Before this change, the Python migration guide was not linked from anywhere on the site, and both the Libraries Examples menu and the Quick Start guide listed only a subset of the three ecosystems. After this change, each migration guide is reachable from six pages, with parity across ecosystems.

## Files changed

- `content/get-started/libraries-examples/_index.md` — add Java and Python to the `crosslinks` sidebar menu and the on-ramp guides list; correct the page description, which previously promised only a JavaScript walkthrough.
- `content/chainguard/libraries/quickstart.md` — add the Python migration guide to the ecosystem-specific guides list.
- `content/chainguard/libraries/python/overview.md` — add a pointer at the top of the "Hash verification when migrating" section.
- `content/chainguard/libraries/javascript/overview.md` — add a pointer in "Updating lockfile hashes."
- `content/chainguard/libraries/java/overview.md` — add a pointer after the access-configuration paragraph.
- `content/chainguard/libraries/java/build-configuration.md` and `content/chainguard/libraries/python/build-configuration.md` — add a migration pointer, matching the existing JavaScript build-configuration page.
- `content/chainguard/libraries/overview.md` — add a migration pointer after the ecosystem list.
- `content/chainguard/libraries/_index.md` — add three migration cards to the ecosystem card grid.

## Testing plan

1. Install dependencies once, then start the local preview server:

   ```bash
   npm install
   npm run start
   ```

   Open `http://localhost:1313`.

2. **Libraries Examples menu (the main requirement).** Go to `/get-started/libraries-examples/`. In the left sidebar under **Libraries Examples**, confirm the menu lists **Quickstart**, **Migrate a Java project**, **Migrate a JavaScript project**, and **Migrate a Python project**. Click each and confirm it lands on the correct migration guide:
   - `/chainguard/libraries/java/migration/`
   - `/chainguard/libraries/javascript/migration/`
   - `/chainguard/libraries/python/migration/`

   Confirm the on-ramp guides list in the page body shows the same four entries.

3. **Quick Start.** Go to `/chainguard/libraries/quickstart/`. Confirm the ecosystem-specific guides list now includes the Java, JavaScript, **and Python** migration guides, and that each link resolves.

4. **Ecosystem overviews.** On each of the following, confirm the new migration-guide link is present and resolves:
   - `/chainguard/libraries/python/overview/` — pointer under "Hash verification when migrating to Chainguard Libraries."
   - `/chainguard/libraries/javascript/overview/` — pointer under "Updating lockfile hashes."
   - `/chainguard/libraries/java/overview/` — pointer under "Technical details," after the direct-access paragraph.

5. **Build configuration.** On `/chainguard/libraries/java/build-configuration/` and `/chainguard/libraries/python/build-configuration/`, confirm the intro now points to the matching migration guide, consistent with `/chainguard/libraries/javascript/build-configuration/`.

6. **Libraries landing pages.** On `/chainguard/libraries/overview/`, confirm the migration pointer after the ecosystem list. On `/chainguard/libraries/` (the card grid), confirm the three new "Migrate a … project" cards render and link correctly.

7. **Build check.** Confirm a clean production build with no errors:

   ```bash
   npm run build
   ```

## Notes for reviewers

- New multi-ecosystem lists are ordered Java → JavaScript → Python. Pre-existing lists elsewhere were left as-is, so ordering is still mixed site-wide.
- The three cards added to `content/chainguard/libraries/_index.md` are the most redundant change — each ecosystem already reaches its migration guide through the sidebar. Easy to drop if the card grid feels crowded.
- No changes were made to the migration guides' own outbound links; this PR only adds inbound links to them.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
