### PR TITLE
Add the week of 2026-08-03 to the changelog

### DIFF
--- a/content/chainguard/changelog.md
+++ b/content/chainguard/changelog.md
@@ -15,6 +15,69 @@ tocEndLevel: 2
 
 This page logs Chainguard product updates week by week, newest first: product announcements, breaking changes, container images that reached end-of-life or are no longer available, and images newly added to the catalog. Each event is listed once, in the week it first appeared.
 
+## Week of 2026-08-03
+
+{{< changelog-label "Breaking Changes" >}}
+
+### ingress-nginx-controller entrypoint, command, and default user changes
+
+_Effective July 15, 2026._
+
+Chainguard aligned the entrypoint and command behavior of all supported `ingress-nginx-controller` images with the upstream image, correcting a startup configuration defect present since the image was first published in 2024. Non-`iamguarded` variants also changed their default runtime user from `root` (UID 0) to `www-data` (UID 101).
+
+- **Affected:** all supported `ingress-nginx-controller` images, including FIPS and `-iamguarded` variants.
+- **Action:** review any configuration that overrides `command`, `args`, `entrypoint`, or `runAsUser`, or that depends on admission policies or file ownership assumptions. Deployments using the upstream Helm chart defaults need no changes.
+
+{{< changelog-label "EOL" >}}
+
+Chainguard offers [a grace period](/chainguard/chainguard-images/features/eol-gp-overview/) for eligible end-of-life images: up to six months of continued rebuilds and security updates while you complete your upgrade.
+
+### Images that are no longer available
+
+The following container images reached the end of their grace period and are no longer available:
+
+| Image | End-of-life | Grace period ended |
+| --- | --- | --- |
+| `cilium:1.16` | 2026-02-03 | 2026-08-03 |
+| `neo4j:2025.12` | 2026-02-03 | 2026-08-03 |
+
+### Images that have reached end-of-life
+
+The following container images reached end-of-life and entered their grace period:
+
+| Image | End-of-life | Grace period ends |
+| --- | --- | --- |
+| `eks-distro:1.33` | 2026-07-29 | 2027-07-29 |
+| `mongo:8.2` | 2026-07-31 | 2027-01-31 |
+| `prometheus:3.5` | 2026-07-31 | 2027-01-31 |
+| `cockroach:26.1` | 2026-08-02 | 2027-02-02 |
+| `cockroach-openssl:26.1` | 2026-08-02 | 2027-02-02 |
+
+{{< changelog-label "New Images" >}}
+
+Chainguard built 22 new container images this week, including both standard and FIPS variants.
+
+<table class="cl-images">
+<thead><tr><th>Image</th><th>Tier</th><th>Added</th></tr></thead>
+<tbody>
+<tr><td><a href="https://images.chainguard.dev/directory/image/glab/versions"><code>glab</code></a></td><td>application +fips</td><td>2026-07-27</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/metabase/versions"><code>metabase</code></a></td><td>application</td><td>2026-07-27</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/atlas/versions"><code>atlas</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/azure-metrics-exporter/versions"><code>azure-metrics-exporter</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-solutions/versions"><code>crossplane-azure-solutions</code></a></td><td>application</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-streamanalytics/versions"><code>crossplane-azure-streamanalytics</code></a></td><td>application</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-web/versions"><code>crossplane-azure-web</code></a></td><td>application</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/dns-controller-manager/versions"><code>dns-controller-manager</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/instrumentisto-haraka/versions"><code>instrumentisto-haraka</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/openstack-kolla-toolbox/versions"><code>openstack-kolla-toolbox</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/sftpgo/versions"><code>sftpgo</code></a></td><td>application</td><td>2026-07-29</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/flink-kubernetes-operator-fips/versions"><code>flink-kubernetes-operator-fips</code></a></td><td>fips</td><td>2026-07-30</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/traccar/versions"><code>traccar</code></a></td><td>application +fips</td><td>2026-07-30</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/metacontroller-fips/versions"><code>metacontroller-fips</code></a></td><td>fips</td><td>2026-07-31</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/chainguard-desktop-workstation-rpi/versions"><code>chainguard-desktop-workstation-rpi</code></a></td><td>base</td><td>2026-08-01</td></tr>
+</tbody>
+</table>
+
 ## Week of 2026-07-28
 
 {{< changelog-label "Product Announcements" >}}


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Appends the week of 2026-08-03 to the Chainguard Products Changelog
- Adds the ingress-nginx-controller breaking change for that week

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Append this week's changelog entry: two images that left their grace period, five that reached end-of-life, 22 newly added images, and one breaking change.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The changelog is now published weekly on a team rotation. This is the first appended week following the seed week of 2026-07-28, and it establishes the cadence.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The new `## Week of 2026-08-03` section appears at the top of the page, above the week of 2026-07-28
- The week of 2026-07-28, the front matter, and the page preamble are unchanged
- The Breaking Changes, EOL, and New Images labels render in that order, each with its pill color
- Image names in the new-images table link to their Chainguard directory pages

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Navigate to `/chainguard/changelog/` and confirm the week of 2026-08-03 renders at the top with all three sections
3. Spot-check a few new-image links to confirm they resolve in the Images directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
