### PR TITLE
fix(mcp): keep HTTP redirects on https behind Cloud Run (DOCS-99 root cause)

### DIFF
--- a/scripts/serve-mcp-http.sh
+++ b/scripts/serve-mcp-http.sh
@@ -11,5 +11,11 @@ echo "Clients can connect using the Streamable HTTP transport at:" >&2
 echo "  http://<host>:${MCP_PORT:-8080}/mcp" >&2
 echo >&2
 
+# Trust the Cloud Run front end's forwarded headers so uvicorn honors
+# X-Forwarded-Proto and keeps redirects (for example, the /mcp/ -> /mcp
+# trailing-slash redirect) on https instead of downgrading to http. Safe here:
+# the container is only reachable through Cloud Run's front end. See DOCS-99.
+export FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-*}"
+
 # Run the MCP server in HTTP mode
 exec python3 /usr/local/bin/mcp-server.py --transport http


### PR DESCRIPTION
## What this does

Sets `FORWARDED_ALLOW_IPS="*"` in the HTTP entrypoint `scripts/serve-mcp-http.sh` so uvicorn honors the Cloud Run front end's `X-Forwarded-Proto: https`. This is the **root-cause fix** for [DOCS-99](https://linear.app/chainguard/issue/DOCS-99); the docs mitigation is #3703.

## The bug

The hosted endpoint's trailing-slash URL `https://mcp.edu.chainguard.dev/mcp/` returned a `307` whose `Location` was `http://…/mcp` — it dropped the slash *and* downgraded HTTPS→HTTP. Clients that won't follow a cross-scheme redirect to plain HTTP failed to connect. Confirmed in Claude Code: `/mcp/` failed, `/mcp` connected.

## Root cause (app-level, not ingress)

Reproduced against a local run of the server with nothing in front of it:

| Request | Result |
| --- | --- |
| `POST /mcp/`, no forwarded headers | `307` → `Location: http://…/mcp` |
| `POST /mcp/` with `X-Forwarded-Proto: https` | `307` → `Location: https://…/mcp` |
| `POST /mcp` (no slash) | `200` |

Two mechanisms:

1. The `307` is Starlette's default trailing-slash redirect (`redirect_slashes=True`); the MCP app mounts at `/mcp`.
2. The HTTPS→HTTP downgrade is uvicorn ignoring `X-Forwarded-Proto`. The mcp SDK launches uvicorn without `forwarded_allow_ips`, so it uses the default `"127.0.0.1"`. Cloud Run's front end isn't loopback, so its `X-Forwarded-Proto: https` is ignored and the redirect is built from the raw `http` scheme.

`FORWARDED_ALLOW_IPS` is read by uvicorn from the environment when unset in code (`uvicorn.Config`: `os.environ.get("FORWARDED_ALLOW_IPS", "127.0.0.1")`), so setting it in the entrypoint fixes this with no SDK change.

## Why `*` is safe here

The container is only reachable through Cloud Run's front end — it isn't directly addressable — so trusting forwarded headers from any peer is appropriate. The value is left overridable (`${FORWARDED_ALLOW_IPS:-*}`).

## Verification

Local, with the entrypoint's env set:

- `POST /mcp` → `200`.
- `POST /mcp/` with `X-Forwarded-Proto: https` → `307` → `Location: https://…/mcp` (scheme preserved).

This change touches `scripts/`, so the `mcp-image-smoke-test` workflow runs the container-boot check on this PR.

After deploy, confirm against production:

```bash
curl -sS -D - -o /dev/null -X POST https://mcp.edu.chainguard.dev/mcp/ \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'
# Location should now be https://…/mcp

claude mcp add --transport http chainguard-docs https://mcp.edu.chainguard.dev/mcp/ && claude mcp list
# Should connect on the trailing-slash URL
```

Relates to DOCS-99 (root cause), DOCS-92 (surfaced during post-merge validation), DOCS-90 (2.0 port). Pairs with #3703 (docs mitigation).

---
Created in collaboration with Claude Code running claude-opus-4-8 on 2026-08-04.
