### PR TITLE
Cleanup: WCAG theme fixes

### DIFF
--- a/assets/js/snippets.js
+++ b/assets/js/snippets.js
@@ -111,6 +111,7 @@ const customizeUI = (pre) => {
 
   const copyButton = document.createElement("button");
   copyButton.classList.add("tooltip-container");
+  copyButton.setAttribute("aria-label", "Copy code to clipboard");
   const copyIcon = document.createElement("i");
   copyIcon.classList.add("bi", "bi-files");
   const copyText = document.createElement("span");

--- a/assets/scss/common/_theming.scss
+++ b/assets/scss/common/_theming.scss
@@ -119,7 +119,7 @@
     --tag-background: #f1ecfe; // light blurple
     --tag-color: var(--primary-1);
     --terminal-background: #fff;
-    --terminal-border: var(--primary-2)!;
+    --terminal-border: var(--primary-2);
     --terminal-color: var(--primary-3);
     --terminal-handle: #dcdcdc;
     --terminal-title-color: var(--primary-3);

--- a/assets/scss/components/_typography-improvements.scss
+++ b/assets/scss/components/_typography-improvements.scss
@@ -186,7 +186,7 @@ a {
 
 // Better focus styles for accessibility
 :focus-visible {
-  outline: 2px solid var(--primary);
+  outline: 2px solid var(--primary-1);
   outline-offset: 2px;
   border-radius: 2px;
 }

--- a/layouts/article/single-semantic.html
+++ b/layouts/article/single-semantic.html
@@ -68,7 +68,7 @@
             {{ if .Params.tags -}}
             <nav class="tag-container" aria-label="Article tags">
               {{ range $index, $tag := .Params.tags -}}
-                <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" role="button" rel="tag" itemprop="keywords">{{ . }}</a>
+                <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" rel="tag" itemprop="keywords">{{ . }}</a>
               {{end}}
             </nav>
             {{end}}
@@ -87,7 +87,7 @@
         {{ partial "notice.html" . }}
         {{ partial "rumble-comparison.html" . }}
         {{ partial "rumble-vuln.html" . }}
-        
+
         <div class="article-content mb-5" itemprop="articleBody">
           {{ .Content }}
         </div>
@@ -141,7 +141,7 @@
     {{- $feedbackWidget := resources.Get "js/feedback-widget.js" -}}
     {{ $feedbackWidget := $feedbackWidget | minify }}
     <script src="{{ $feedbackWidget.Permalink }}" integrity="{{ $feedbackWidget.Data.Integrity }}"></script>
-    
+
     {{ if ne .Params.toc false -}}
     <aside class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }}" role="navigation" aria-label="Table of contents">
       {{ partial "sidebar/docs-toc.html" . }}

--- a/layouts/partials/footer/footer-new.html
+++ b/layouts/partials/footer/footer-new.html
@@ -2,20 +2,20 @@
   <div class="container footer">
     <!-- Main footer content with two-part layout -->
     <div class="footer-main-content">
-      
+
       <!-- Left side: Brand section -->
       <div class="footer-brand-section">
         <!-- Logo -->
         <a href="/" class="footer-logo">
           <img src="/Chainguard_Wordmark_White.svg" alt="Chainguard" />
         </a>
-        
+
         <!-- Contact Us button -->
-        <a href="https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement" 
+        <a href="https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement"
            class="footer-contact-btn" target="_blank">
           Contact us
         </a>
-        
+
         <!-- Social icons in brand section -->
         <div class="footer-brand-socials">
           {{ range .Site.Menus.social }}
@@ -25,7 +25,7 @@
           {{ end }}
         </div>
       </div>
-      
+
       <!-- Right side: Navigation columns -->
       <div class="footer-nav-section">
         {{ range .Site.Menus.footer }}
@@ -45,9 +45,9 @@
         </div>
         {{ end }}
       </div>
-      
+
     </div>
-    
+
     <!-- Bottom section: Copyright and legal -->
     <div class="footer-bottom-section">
       <div class="footer-legal">
@@ -57,7 +57,7 @@
         <span class="separator">|</span>
         <a href="https://www.chainguard.dev/legal/terms-of-use?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement">Terms of Use</a>
       </div>
-      
+
       <!-- Optional: Social icons repeated at bottom (remove if not needed) -->
       <div class="footer-bottom-socials">
         {{ range .Site.Menus.social }}
@@ -67,11 +67,11 @@
         {{ end }}
       </div>
     </div>
-    
+
   </div>
 </footer>
 
-<div id="notification">
+<div id="notification" aria-live="polite">
   <i class="bi bi-files-opposite"></i>
   <div id="notification-text"></div>
 </div>

--- a/layouts/partials/footer/footer-original.html
+++ b/layouts/partials/footer/footer-original.html
@@ -47,7 +47,7 @@
         <span>
           <a target="_blank" href="{{ .URL }}">
             <img src="/iconography/socials/{{ .Params.icon }}" alt="Follow Chainguard on {{ .Name}}">
-          </a>              
+          </a>
         </span>
         {{ end }}
     </span>
@@ -57,7 +57,7 @@
       <span class="footer-separator">|</span>
       <a class="footer-item" href="https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement">Contact Us</a>
     </div>
-    
+
     <div class="footer-copyright-legal">
       <span>
         <a class="footer-item" href="https://www.chainguard.dev">©{{ time.Now.Year }} Chainguard. All Rights Reserved.</a>
@@ -70,7 +70,7 @@
   </div>
 </footer>
 
-<div id="notification">
+<div id="notification" aria-live="polite">
   <i class="bi bi-files-opposite"></i>
   <div id="notification-text"></div>
 </div>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -75,7 +75,7 @@
   </div>
 </footer>
 
-<div id="notification">
+<div id="notification" aria-live="polite">
   <i class="bi bi-files-opposite"></i>
   <div id="notification-text"></div>
 </div>

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -20,7 +20,7 @@
 />
 <meta
   name="viewport"
-  content="width=device-width, initial-scale=1.0, user-scalable=no"
+  content="width=device-width, initial-scale=1.0"
 />
 <script
   async
@@ -28,7 +28,7 @@
   data-website-id="8f790868-51e3-414c-a546-e613a4ebbd51"
   data-project-name="Chainguard"
   data-project-color="#000000"
-  data-project-logo="https://raw.githubusercontent.com/chainguard-dev/edu/refs/heads/main/static/logos/linky-white-on-blurple.png" 
+  data-project-logo="https://raw.githubusercontent.com/chainguard-dev/edu/refs/heads/main/static/logos/linky-white-on-blurple.png"
   data-user-analytics-fingerprint-enabled="true"
   data-button-position-top="20px"
   data-button-position-right="20px"

--- a/layouts/partials/rumble-comparison.html
+++ b/layouts/partials/rumble-comparison.html
@@ -34,7 +34,7 @@
     <form class="search">
       <ul>
         <li>
-          <input class="form-control is-search" id="filterInput" placeholder="Search packages and CVEs"
+          <input class="form-control" id="filterInput" placeholder="Search packages and CVEs"
             size="25" />
         </li>
         <li id="severity-picker">

--- a/layouts/partials/rumble-vuln.html
+++ b/layouts/partials/rumble-vuln.html
@@ -16,7 +16,7 @@
     <form class="search">
       <ul>
         <li>
-          <input class="form-control is-search" type="search" id="filterInput" placeholder="Search images" size="25" />
+          <input class="form-control" type="search" id="filterInput" placeholder="Search images" size="25" />
         </li>
       </ul>
     </form>

--- a/layouts/partials/single-body.html
+++ b/layouts/partials/single-body.html
@@ -70,7 +70,7 @@
         {{ if .Params.tags -}}
         <div class="tag-container">
           {{ range $index, $tag := .Params.tags -}}
-            <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" role="button">{{ . }}</a>
+            <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/">{{ . }}</a>
           {{end}}
         </div>
         {{end}}

--- a/layouts/wide/single.html
+++ b/layouts/wide/single.html
@@ -64,7 +64,7 @@
       {{ if .Params.tags -}}
       <div class="tag-container">
         {{ range $index, $tag := .Params.tags -}}
-          <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/" role="button">{{ . }}</a>
+          <a class="tag" href="{{ "/tags/" | absURL }}{{ . | urlize }}/">{{ . }}</a>
         {{end}}
         </div>
       {{end}}


### PR DESCRIPTION
- Restore focus outlines and pinch-zoom. Fixed the global `:focus-visible` rule referencing undefined `--primary` (focus rings were silently suppressed site-wide), removed `user-scalable=no` from the viewport meta, and fixed a stray `!` breaking `--terminal-border`
- Screen reader support for copy-code. Added `aria-label` to the injected copy button and `aria-live="polite"` to the toast so the confirmation is announced. Removed misleading `role="button"` from tag links
- Stop DocSearch hijacking the rumble filters