### PR TITLE
Link to malware list chainctl command

### DIFF
--- a/content/chainguard/chainguard-repository/library-policies.md
+++ b/content/chainguard/chainguard-repository/library-policies.md
@@ -4,7 +4,7 @@ linktitle: "Library Policies"
 description: "Configure and enforce policies that control which Chainguard Libraries package versions your organization can pull"
 type: "article"
 date: 2026-07-31T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T14:52:37+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -177,7 +177,7 @@ chainctl libraries policy enable team-policy --ecosystem=PYTHON --mode=ENFORCE
 
 ### Check blocked packages
 
-Use `chainctl libraries packages blocked` to review what a policy has blocked. By default, this shows pull events that were blocked under any enforced policies. For example:
+Use `chainctl libraries packages blocked` to review what has been blocked by your organization's policy. By default, this shows pull events that were blocked under any enforced policies. For example:
 
 ```bash
 chainctl libraries packages blocked --ecosystem=JAVASCRIPT
@@ -191,6 +191,8 @@ chainctl libraries packages blocked --mode=PREVIEW --ecosystem=JAVASCRIPT
 ```
 
 Replace `example-policy` with the name of the policy you want to preview.
+
+To check packages that have been blocked by [Chainguard's global malware/greyware blocklist](/chainguard/libraries/overview/#malware-and-greyware-detection), use [`chainctl libraries packages malware list`](/platform/chainctl/chainctl-docs/chainctl_libraries_packages_malware_list/).
 
 ## Override policies
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-07-30T14:25:45+00:00
+lastmod: 2026-08-05T14:52:37+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -194,7 +194,9 @@ Chainguard's scanning evaluates multiple signal types, including:
 * **Typosquatting and impersonation**: The package is named or brand-engineered to deceive users into downloading the wrong package.
 * **Compromised or untrusted releases**: The package exhibits signs that a release cannot be trusted.
 
-You can view blocked packages [in the Chainguard Console](/chainguard/libraries/browse/#view-malware-information) or [using `chainctl` commands](/chainguard/libraries/access/#check-blocked-packages).
+#### View blocked packages
+
+You can view blocked packages [in the Chainguard Console](/chainguard/libraries/browse/#view-malware-information), [using `chainctl` commands](/platform/chainctl/chainctl-docs/chainctl_libraries_packages_malware_list/), or [via the API](#malware-api).
 
 #### Malware API
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T14:56:25+00:00
+lastmod: 2026-08-05T15:44:08+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -200,7 +200,7 @@ You can view blocked packages [in the Chainguard Console](/chainguard/libraries/
 
 #### Malware API
 
-Chainguard's [malware API endpoint](/chainguard/api/spec-api-v1/#tag/malware/) provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard.
+Chainguard's malware API endpoint provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard. Learn more about it in the [API documentation](/platform/api/spec-api-v1/#tag/malware/).
 
 Expand the following section to see examples:
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T15:44:08+00:00
+lastmod: 2026-08-05T15:47:45+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -200,7 +200,7 @@ You can view blocked packages [in the Chainguard Console](/chainguard/libraries/
 
 #### Malware API
 
-Chainguard's malware API endpoint provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard. Learn more about it in the [API documentation](/platform/api/spec-api-v1/#tag/malware/).
+Chainguard's malware API endpoint provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard. Learn more about it in the [API documentation](/platform/api/spec-api-v1/).
 
 Expand the following section to see examples:
 

--- a/content/chainguard/libraries/overview.md
+++ b/content/chainguard/libraries/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T14:52:37+00:00
+lastmod: 2026-08-05T14:56:25+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -200,7 +200,7 @@ You can view blocked packages [in the Chainguard Console](/chainguard/libraries/
 
 #### Malware API
 
-Chainguard's [malware API endpoint](/chainguard/api/spec-api-v1/#tag/malware) provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard.
+Chainguard's [malware API endpoint](/chainguard/api/spec-api-v1/#tag/malware/) provides access to Chainguard's malware blocklist. You can use it to retrieve a list of packages that have been identified as malicious and blocked by Chainguard.
 
 Expand the following section to see examples:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update Libraries overview and CGRepo library policies

### What should this PR do?
Link to and mention the chainctl command to list malware/greyware blocked by Chainguard

### Why are we making this change?
Clarity / another option for getting this information

### What are the acceptance criteria? 
Content should be clear and accurate, links should work

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
