### PR TITLE
Note required entitlement and pull permission for libraries commands

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -536,12 +536,12 @@ dependency added in the example project can be found at:
 
 To verify the artifact was built by Chainguard, use `chainctl`:
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
-
 ```bash
 chainctl libraries verify \
   ~/.m2/repository/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar
 ```
+
+> **Note**: Running `chainctl libraries verify` requires the `libraries.java.pull` permission or the Owner role.
 
 A successfully verified artifact produces output similar to the following:
 
@@ -781,11 +781,11 @@ find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava -name "*.jar" |
 
 Then copy the exact path to the jar and verify it with `chainctl`:
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
-
 ```bash
 chainctl libraries verify --parent your-org /full/path/to/guava-<version>.jar
 ```
+
+> **Note**: Running `chainctl libraries verify` requires the `libraries.java.pull` permission or the Owner role.
 
 A successfully verified artifact produces output similar to the following:
 

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -536,6 +536,8 @@ dependency added in the example project can be found at:
 
 To verify the artifact was built by Chainguard, use `chainctl`:
 
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
+
 ```bash
 chainctl libraries verify \
   ~/.m2/repository/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar
@@ -778,6 +780,8 @@ find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava -name "*.jar" |
 ```
 
 Then copy the exact path to the jar and verify it with `chainctl`:
+
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
 
 ```bash
 chainctl libraries verify --parent your-org /full/path/to/guava-<version>.jar

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -505,8 +505,6 @@ If all artifacts download from Central, your credentials may be invalid or expir
 
 To check whether a specific artifact was built by Chainguard, use `chainctl libraries verify /full/path/to/artifact.jar`. Verify artifacts immediately after a clean build, before any repackaging.
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
-
 When upstream fallback is enabled, [packages that aren't built by Chainguard] are subject to Chainguard's security controls.
 
 {{< tabs >}}
@@ -587,6 +585,8 @@ chainctl libraries verify ~/Library/Caches/bazel/_bazel_example/c22a55500...f423
 {{% /tab %}}
 
 {{< /tabs >}}
+
+> **Note**: Running `chainctl libraries verify` requires the `libraries.java.pull` permission or the Owner role.
 
 A successful result shows what percentage of your project's dependencies were built by Chainguard:
 

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -504,6 +504,8 @@ If all artifacts download from Central, your credentials may be invalid or expir
 ## Step 6: Verify artifacts
 
 To check whether a specific artifact was built by Chainguard, use `chainctl libraries verify /full/path/to/artifact.jar`. Verify artifacts immediately after a clean build, before any repackaging.
+
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Java and the `libraries.java.pull` permission.
 
 When upstream fallback is enabled, [packages that aren't built by Chainguard] are subject to Chainguard's security controls.
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -84,7 +84,7 @@ Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/
 `update-hashes` fetches checksums from Chainguard Libraries,
 which requires authentication. Where it fetches from depends on your environment: some setups authenticate directly to `libraries.cgr.dev`, but if your build routes through a repository manager configured as a pull-through proxy for Chainguard Libraries, point `update-hashes` there instead with `--registry-url` so it validates against the same source your build used.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.javascript.pull` permission or the Owner role.
 
 Authenticating to `libraries.cgr.dev` directly:
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -83,6 +83,8 @@ Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/
 
 `update-hashes` fetches checksums from Chainguard Libraries,
 which requires authentication. Where it fetches from depends on your environment: some setups authenticate directly to `libraries.cgr.dev`, but if your build routes through a repository manager configured as a pull-through proxy for Chainguard Libraries, point `update-hashes` there instead with `--registry-url` so it validates against the same source your build used.
+
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
 
 Authenticating to `libraries.cgr.dev` directly:
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-07-29T13:35:56+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -71,6 +71,8 @@ this page follow this pattern.
 
 If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
 for all supported JavaScript lockfile formats.
+
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -72,8 +72,6 @@ this page follow this pattern.
 If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
 for all supported JavaScript lockfile formats.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
-
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 
 ```bash
@@ -81,6 +79,8 @@ chainctl libraries update-hashes \
   --registry-url https://repo.example.com:8443/repository/javascript-all/ \
   --token "$REPO_TOKEN"
 ```
+
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.javascript.pull` permission or the Owner role.
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-06T13:19:30+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -181,18 +181,19 @@ chainctl auth configure-npm
 Because [this command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) uses a session-backed bearer token, you will need to re-run it when the token expires. If the command returns an error, ensure you are
 using the [latest version of chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
-For pnpm and Yarn, [configure the .npmrc manually](#manual-registry-configuration).
-`chainctl auth configure-npm` generates path-scoped credentials (`//libraries.cgr.dev/javascript/:_auth`)
-that do not cover pnpm's upstream-fallback path, causing HTTP 401 errors on packages
+For pnpm and Yarn, [configure the .npmrc
+manually](#manual-registry-configuration). `chainctl auth configure-npm`
+generates path-scoped credentials (`//libraries.cgr.dev/javascript/:_auth`) that
+do not cover pnpm's upstream-fallback path, causing HTTP 401 errors on packages
 Chainguard has not yet rebuilt.
 
 #### CI/CD and automated environments
 
-For CI/CD environments, [assumable identities](/chainguard/administration/assumable-ids/assumable-ids/)
-are the recommended approach. Rather than managing a static token, an assumable
-identity lets your CI/CD workload authenticate directly with Chainguard using
-its own platform identity; no long-lived credentials to rotate or accidentally
-expose.
+For CI/CD environments, [assumable
+identities](/chainguard/administration/assumable-ids/assumable-ids/) are the
+recommended approach. Rather than managing a static token, an assumable identity
+lets your CI/CD workload authenticate directly with Chainguard using its own
+platform identity; no long-lived credentials to rotate or accidentally expose.
 
 Once configured, authenticate and write the registry configuration in your
 pipeline. For example, in a GitHub Actions workflow using npm:

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -402,6 +402,8 @@ Chainguard's artifacts, without regenerating the lockfile from scratch. This
 preserves your pinned dependency versions. Supported formats include `package-lock.json` (npm v2/v3), `yarn.lock` (Yarn
 Classic and Berry), `pnpm-lock.yaml`, and `bun.lock`.
 
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
+
 Run the command in the directory containing the lockfile:
 
 ```shell
@@ -631,6 +633,8 @@ directory. `chainctl libraries verify` auto-detects npm and pnpm caches by
 their directory structure.
 
 When upstream fallback is enabled, [packages that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
+
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
 
 {{< tabs >}}
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -402,13 +402,13 @@ Chainguard's artifacts, without regenerating the lockfile from scratch. This
 preserves your pinned dependency versions. Supported formats include `package-lock.json` (npm v2/v3), `yarn.lock` (Yarn
 Classic and Berry), `pnpm-lock.yaml`, and `bun.lock`.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
-
 Run the command in the directory containing the lockfile:
 
 ```shell
 chainctl libraries update-hashes
 ```
+
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.javascript.pull` permission or the Owner role.
 
 If your build tool appends the Chainguard hashes to your lock file, include the flag `--replace` to ensure the hashes are replaced with Chainguard hashes. When using a repo manager, pass the full repository URL with `--registry-url`.
 
@@ -634,8 +634,6 @@ their directory structure.
 
 When upstream fallback is enabled, [packages that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for JavaScript and the `libraries.javascript.pull` permission.
-
 {{< tabs >}}
 
 {{% tab title="npm" %}}
@@ -688,6 +686,8 @@ chainctl libraries verify ./node_modules
 {{% /tab %}}
 
 {{< /tabs >}}
+
+> **Note**: Running `chainctl libraries verify` requires the `libraries.javascript.pull` permission or the Owner role.
 
 A successful result shows what percentage of your project's dependencies were built by Chainguard. For example:
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -165,13 +165,13 @@ The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-d
 
 Supported formats include `requirements.txt` (pip-tools `--hash` style), `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
-
 Run the command in your project directory to auto-detect the lockfile:
 
 ```bash
 chainctl libraries update-hashes
 ```
+
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.python.pull` permission or the Owner role.
 
 Or specify a lockfile path directly:
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -164,6 +164,8 @@ If you are migrating an existing Python project to Chainguard Libraries, your lo
 The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates for all supported Python lockfile formats. Rather than manually regenerating lock files with each tool, you can run the command directly against your existing lockfile to update hashes to Chainguard checksums while preserving your locked dependency versions, without re-resolving your dependency graph.
 
 Supported formats include `requirements.txt` (pip-tools `--hash` style), `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
+
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
 
 Run the command in your project directory to auto-detect the lockfile:
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -69,7 +69,9 @@ However, if you intentionally want to manage fallback ordering yourself, you can
 ### Updating lockfile hashes
 
 If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
-for all supported JavaScript lockfile formats.
+for all supported Python lockfile formats.
+
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -71,8 +71,6 @@ However, if you intentionally want to manage fallback ordering yourself, you can
 If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
 for all supported Python lockfile formats.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
-
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
 
 ```bash
@@ -80,6 +78,8 @@ chainctl libraries update-hashes \
   --registry-url https://repo.example.com:8443/repository/python-all/ \
   --token "$REPO_TOKEN"
 ```
+
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.python.pull` permission or the Owner role.
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-07-31T18:47:05+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -312,6 +312,8 @@ Your existing lockfile or hash-pinned `requirements.txt` contains checksums gene
 
 Use `chainctl libraries update-hashes` to rewrite only the integrity hashes in your existing lockfile or requirements file to match Chainguard's artifacts, without re-resolving your dependency graph. Supported formats include `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 
+> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
+
 Run the following command to auto-detect and update the lockfile in the current project:
 
 ```bash
@@ -444,6 +446,8 @@ poetry install
 ## Step 5: Verify your libraries
 
 After reinstalling, you can use `chainctl` to verify which dependencies are built by Chainguard. When upstream fallback is enabled, [libraries that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
+
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
 
 {{< tabs >}}
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -312,13 +312,13 @@ Your existing lockfile or hash-pinned `requirements.txt` contains checksums gene
 
 Use `chainctl libraries update-hashes` to rewrite only the integrity hashes in your existing lockfile or requirements file to match Chainguard's artifacts, without re-resolving your dependency graph. Supported formats include `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 
-> **Note**: Running `chainctl libraries update-hashes` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
-
 Run the following command to auto-detect and update the lockfile in the current project:
 
 ```bash
 chainctl libraries update-hashes
 ```
+
+> **Note**: Running `chainctl libraries update-hashes` requires the `libraries.python.pull` permission or the Owner role.
 
 Or specify the lockfile when running the command. For example:
 
@@ -447,8 +447,6 @@ poetry install
 
 After reinstalling, you can use `chainctl` to verify which dependencies are built by Chainguard. When upstream fallback is enabled, [libraries that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for Python and the `libraries.python.pull` permission.
-
 {{< tabs >}}
 
 {{% tab title="pip and uv" %}}
@@ -476,6 +474,8 @@ chainctl libraries verify --detailed $(poetry env info --path)
 {{% /tab %}}
 
 {{< /tabs >}}
+
+> **Note**: Running `chainctl libraries verify` requires the `libraries.python.pull` permission or the Owner role.
 
 A successful result shows what percentage of your project's dependencies were built by Chainguard.
 

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quick Start"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -254,6 +254,8 @@ Check out minimal example projects for
 ## Step 4: Verify your libraries
 
 After setup, you can verify which dependencies were built from source by Chainguard:
+
+> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for the ecosystem you're verifying and the matching pull permission (`libraries.java.pull`, `libraries.javascript.pull`, or `libraries.python.pull`).
 
 ```bash
 chainctl libraries verify /path/to/artifact

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quick Start"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -255,11 +255,11 @@ Check out minimal example projects for
 
 After setup, you can verify which dependencies were built from source by Chainguard:
 
-> **Note**: Running `chainctl libraries verify` requires an [entitlement to Chainguard Libraries](/chainguard/libraries/access/#entitlement) for the ecosystem you're verifying and the matching pull permission (`libraries.java.pull`, `libraries.javascript.pull`, or `libraries.python.pull`).
-
 ```bash
 chainctl libraries verify /path/to/artifact
 ```
+
+> **Note**: Running `chainctl libraries verify` requires one of the `libraries.java.pull`, `libraries.javascript.pull`, or `libraries.python.pull` permissions, or the Owner role.
 
 Learn more in [Chainguard Libraries verification](/chainguard/libraries/verification/).
 

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-05T18:42:36+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -51,7 +51,10 @@ You also need:
 - A Linux, macOS, or Windows system (x86_64 or arm64)
 - Sufficient [network access](/chainguard/libraries/network-requirements/)
 - Your organization [must include entitlement for access to Chainguard
-  Libraries](/chainguard/libraries/access/#entitlement)
+  Libraries](/chainguard/libraries/access/#entitlement) for the ecosystem you're
+  verifying, and your identity must have the matching pull permission
+  (`libraries.java.pull`, `libraries.javascript.pull`, or
+  `libraries.python.pull`)
 
 Confirm that `chainctl` and `cosign` are installed and available on the `PATH`
 with the following commands:

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-08-05T18:42:36+00:00
+lastmod: 2026-08-05T19:13:35+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -51,10 +51,7 @@ You also need:
 - A Linux, macOS, or Windows system (x86_64 or arm64)
 - Sufficient [network access](/chainguard/libraries/network-requirements/)
 - Your organization [must include entitlement for access to Chainguard
-  Libraries](/chainguard/libraries/access/#entitlement) for the ecosystem you're
-  verifying, and your identity must have the matching pull permission
-  (`libraries.java.pull`, `libraries.javascript.pull`, or
-  `libraries.python.pull`)
+  Libraries](/chainguard/libraries/access/#entitlement)
 
 Confirm that `chainctl` and `cosign` are installed and available on the `PATH`
 with the following commands:
@@ -120,6 +117,8 @@ Analyze a Python wheel file in the current directory:
 ```sh
 chainctl libraries verify flask-3.0.1-py3-none-any.whl
 ```
+
+> **Note**: Running `chainctl libraries verify` requires one of the `libraries.java.pull`, `libraries.javascript.pull`, or `libraries.python.pull` permissions, or the Owner role.
 
 The analysis of wheel files is fast because the provenance information is
 available within the archive. Python development tools often unpack the wheel


### PR DESCRIPTION
## What this changes

`chainctl libraries update-hashes` and `chainctl libraries verify` both require an entitlement to the relevant ecosystem plus the matching pull permission (`libraries.java.pull`, `libraries.javascript.pull`, or `libraries.python.pull`). That requirement wasn't stated where the docs tell readers to run these commands.

This adds a short note at each procedure step across the Python, JavaScript, and Java libraries guides, and to the verification page's Requirements list. Ecosystem-specific pages name only that ecosystem's permission; the ecosystem-agnostic pages (quickstart, verification) list all three.

Auto-generated `chainctl` reference pages (`content/platform/chainctl/chainctl-docs/`) and the docs bundle are intentionally excluded.

Also fixes a copy-paste error on the Python global-configuration page that read "all supported **JavaScript** lockfile formats."

### Files touched
- `quickstart.md` — Step 4 (verify)
- `verification.md` — Requirements list
- `python/migration.md` — Steps 2 (update-hashes) and 5 (verify)
- `python/build-configuration.md`, `python/global-configuration.md` — update-hashes
- `javascript/migration.md` — Steps 3 (update-hashes) and 6 (verify)
- `javascript/build-configuration.md`, `javascript/global-configuration.md` — update-hashes
- `java/migration.md` — Step 6 (verify)
- `java/build-configuration.md` — Maven and Gradle cache verify steps

## Open item for reviewers

The permission enforced by these commands is documented here as `libraries.<ecosystem>.pull`, consistent with `access.md`. If anyone has confirmed hands-on whether `update-hashes`/`verify` enforce `.pull` specifically (versus only requiring a valid pull token created via `.pull_token_creator`), please confirm on this PR.

## Testing plan

1. Check out this branch and run the site locally (`hugo server`).
2. Open each page and confirm the note renders as a blockquote at the command's instruction point:
   - `/chainguard/libraries/quickstart/#step-4-verify-your-libraries`
   - `/chainguard/libraries/verification/#requirements`
   - `/chainguard/libraries/python/migration/` (Steps 2 and 5)
   - `/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes`
   - `/chainguard/libraries/python/global-configuration/#updating-lockfile-hashes`
   - `/chainguard/libraries/javascript/migration/` (Steps 3 and 6)
   - `/chainguard/libraries/javascript/build-configuration/#authentication`
   - `/chainguard/libraries/javascript/global-configuration/#updating-lockfile-hashes`
   - `/chainguard/libraries/java/migration/#step-6-verify-artifacts`
   - `/chainguard/libraries/java/build-configuration/` (Maven and Gradle verify sections)
3. On each note, click the **entitlement to Chainguard Libraries** link and confirm it lands on `/chainguard/libraries/access/#entitlement`.
4. Confirm ecosystem-specific pages name only that ecosystem's permission, and quickstart/verification list all three.
5. Confirm the Python global-configuration page now reads "all supported Python lockfile formats."
6. Confirm no `content/platform/chainctl/chainctl-docs/` page or the docs bundle was modified (`git diff --stat main` shows only the 10 files above).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Created in collaboration with Claude Code running Opus 4.8 (1M context) on 2026-08-05.