### PR TITLE
Fix `boostrap-icons` import

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1,4 +1,6 @@
-@import "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css";
+$bootstrap-icons-font-dir: "/fonts";
+
+@import "bootstrap-icons/font/bootstrap-icons.scss";
 @import "resets";
 @import "fontfamilies";
 @import "breakpoints";

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -163,6 +163,9 @@ notAlternative = true
     target = "assets/css/vendor/scalar"
     includeFiles = ["/style.css"]
   [[module.mounts]]
+    source = "node_modules/bootstrap-icons/font/fonts"
+    target = "static/fonts"
+  [[module.mounts]]
     source = "assets"
     target = "assets"
   [[module.mounts]]


### PR DESCRIPTION
- `bootstrap-icons` is in `packages.json` and installed but was never fully installed
- Migrate off cdn version to the packaged version
- Restores a bunch of `bi` icon instances