### PR TITLE
Add documentation for Helm chart self-serve (DOCS-100)

### DIFF
--- a/content/chainguard/containers/about/catalog-starter.md
+++ b/content/chainguard/containers/about/catalog-starter.md
@@ -4,7 +4,7 @@ linktitle: "Catalog Starter"
 type: "article"
 description: "Learn about Chainguard Catalog Starter, an offering allowing teams to try out five Chainguard container images for free."
 date: 2026-03-09T07:52:00+02:00
-lastmod: 2026-07-13T00:00:00+00:00
+lastmod: 2026-08-18T15:48:57+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -57,6 +57,59 @@ After trying out Chainguard Containers with Catalog Starter, you can reach out t
 * Per-image pricing — a scoped set of images licensed individually, often used for tightly defined image deployments.
 
 Moving to a paid plan means moving off Catalog Starter; the free five-image entitlement is not stacked on top of a paid subscription.
+
+## Manage Catalog Starter with `chainctl`
+
+As an alternative to the Console, you can sign up for and manage Catalog Starter from the command line with `chainctl`.
+
+### Sign up with `chainctl`
+
+To sign up for a new account, run the interactive [`chainctl starter init`](/platform/chainctl/chainctl-docs/chainctl_starter_init/) command:
+
+```shell
+chainctl starter init
+```
+
+This requires selection of a valid authentication option:
+
+```shell
+    Choose an identity provider to login to Chainguard
+
+  > Email and password
+    Google
+```
+
+Use the arrow keys and press **Enter** to select an option, which launches a browser window to the Chainguard Console to complete sign-up.
+
+### Request access with `chainctl`
+
+If your organization already has a Catalog Starter plan, request access to it with [`chainctl starter request-access`](/platform/chainctl/chainctl-docs/chainctl_starter_request-access/):
+
+```shell
+chainctl starter request-access
+```
+
+### Add images with `chainctl`
+
+You can see which images are available [using the Chainguard Directory](/chainguard/chainguard-images/how-to-use/chainguard-directory/). To add one or more images, run [`chainctl starter add-images`](/platform/chainctl/chainctl-docs/chainctl_starter_add-images/), substituting the desired image names for the variables:
+
+```shell
+chainctl starter add-images $IMAGE1 [$IMAGE2] ... [$IMAGE4]
+```
+
+After the Chainguard system has processed your request, the images become accessible. This can take up to a few hours. When available, you can pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name:
+
+```shell
+docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest
+```
+
+### Check status with `chainctl`
+
+To show the status of your Catalog Starter organization, including the registry path, account provisioning status, image quota usage, and per-image readiness, run [`chainctl starter status`](/platform/chainctl/chainctl-docs/chainctl_starter_status/):
+
+```shell
+chainctl starter status
+```
 
 ## Plan limitations and terms
 

--- a/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-18T15:48:57+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "Product"]
 images: []
@@ -33,6 +33,8 @@ The community charts have been tested by Chainguard to confirm they produce expe
 Chainguard makes the provenance of these charts clear. Helm charts are packaged as [OCI artifacts](/open-source/oci/what-are-oci-artifacts/) using the upstream version adding an appended revision suffix for updates that include material changes to the chart; otherwise, tags will float based as their dependent images update. The OCI artifacts are signed and generate provenance attestations that link to the exact image digests used to ensure that all artifacts are cryptographically verifiable end-to-end for integrity and origin.
 
 You can find Helm charts in the [Chainguard Console](/platform/console/images-directory/#find-helm-charts-in-the-chainguard-console) and in the [Chainguard Directory](/chainguard/containers/how-to-use/chainguard-directory/#find-helm-charts-in-the-chainguard-directory).
+
+Before you can use a chart, it must be added to your organization. Catalog customers can add charts and their required images from the Chainguard Console. For instructions, see [Self-serve Helm charts](/get-started/self-serve/helm-charts/).
 
 The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images.
 

--- a/content/get-started/self-serve/helm-charts.md
+++ b/content/get-started/self-serve/helm-charts.md
@@ -1,0 +1,65 @@
+---
+title: "Self-serve Helm charts"
+linktitle: "Self-serve Helm charts"
+description: "Provision Chainguard Helm charts and their required images from the Chainguard Console as a Catalog customer"
+type: "article"
+date: 2026-08-06T00:00:01+00:00
+lastmod: 2026-08-06T18:00:35+00:00
+draft: false
+weight: 020
+toc: true
+---
+
+Catalog customers can provision Chainguard Helm charts, along with the container images each chart depends on, directly from the Chainguard Console. This replaces the previous manual request process, which required coordination with Chainguard sales, customer success, and support and could take 1 to 4 days.
+
+{{< note >}}
+This capability is available to Catalog customers whose plan includes the APPLICATION tier. It does not apply to the free [Catalog Starter](/chainguard/chainguard-images/about/catalog-starter/) plan. Customers on per-image pricing can request charts through a support workflow, described in [Per-image pricing customers](#per-image-pricing-customers).
+{{< /note >}}
+
+## Add a chart in the Chainguard Console
+
+To add Helm charts to your organization from the Console, complete the following steps:
+
+1. In the Chainguard Console, go to the **Helm charts** section in the sidebar.
+1. Review the available charts. Charts already enabled for your organization are marked.
+1. Select one or more charts to add. The Console checks whether your organization already has the container images each chart requires, then lists any missing images by name.
+1. Optional: If your organization is entitled to FIPS images, select the FIPS option to add FIPS variants where they are available.
+1. Confirm your selection to add the charts and their required images to your organization.
+
+Provisioning runs in the background. The Console shows in-progress and completion states while it adds the charts and images, which can take some time to finish.
+
+## Add a chart with `chainctl`
+
+You can perform the same action from the command line with `chainctl`. For a Catalog customer, the following command resolves the chart's image dependencies and creates any missing chart and image repositories in your organization, matching the Console flow:
+
+```shell
+chainctl images helm add-chart $CHART
+```
+
+Replace `$CHART` with the chart you want to add. The command will output a small chart showing the name of every image in the Helm chart and the image status, such as whether it already exists in your org or is being added.
+
+{{< note >}}
+This command is available starting in a specific `chainctl` release. If it isn't available in your installation, update `chainctl` to the latest version.
+{{< /note >}}
+
+You can use the command to add `iamguarded` charts, too:
+
+```shell
+chainctl images helm add-chart iamguarded-charts/$CHART
+```
+
+If you want to test the process before actually adding the chart, use:
+
+```shell
+chainctl images helm add-chart $CHART --dry-run
+```
+
+To learn more, use `chainctl images helm add-chart --help` or refer to the [`chainctl` Reference documentation](/platform/chainctl/).
+
+## Per-image pricing customers
+
+If your organization uses per-image pricing, or a chart requires images outside your active tiers, the Console doesn't provision the chart instantly. Instead, it generates a single support request that lists the chart and any missing images, prefilled with your organization's details. Chainguard support then provisions the chart and images, typically within 1 to 2 days.
+
+## Use your charts
+
+After provisioning completes, authenticate and deploy your charts by following [How to Use Chainguard Helm Charts](/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/).

--- a/content/get-started/self-serve/overview.md
+++ b/content/get-started/self-serve/overview.md
@@ -3,110 +3,19 @@ aliases:
 - /chainguard/self-serve/overview/
 title : "Self-serve overview"
 lead: ""
-description: "Signing yourself up for the Catalog Starter plan and other Chainguard products"
+description: "Overview of the self-serve options for provisioning Chainguard products, including Catalog Starter and self-serve Helm charts"
 type: "article"
 date: 2026-05-12T01:00:01+00:00
-lastmod: 2026-07-01T01:00:01+00:00
+lastmod: 2026-08-18T15:48:57+00:00
 draft: false
 weight: 010
 ---
 
-**Self-Serve** is a general term to capture all forms of users
-being able to Chainguard products (images etc.) on their own
-without any direct help or involvement of Chainguard employees.
+**Self-serve** refers to the ways you can provision Chainguard products,
+such as container images and Helm charts, on your own, without direct
+involvement from Chainguard employees.
 
-**Catalog Starter** refers to a specific plan that enables users
-to self-serve up to 5 images for free.
+This section covers the self-serve options available today:
 
-The Catalog Starter plan has the following restrictions:
-
-You must be authenticated with a business email address using one of the following:
-
-- Email and password
-- Google (only if your business uses a Google Workspace account)
-
-Other limitations include:
-
-- Only a maximum of 5 Chainguard Images can be used
-- Only images from the following tiers are available:
-    - AI
-    - APPLICATION
-    - BASE
-- No access to nested UIDP image repos, such as Helm charts
-
-## Manage Catalog Starter plans in the Chainguard Console
-
-Sign up and manage a Catalog Starter plan using the Chainguard Console. If you prefer, you can instead [use `chainctl`](#manage-catalog-starter-plans-using-chainctl).
-
-### Sign up with the Chainguard Console
-
-To sign up, use [this console link](https://console.chainguard.dev/signup) or click **Get Started** on the main login screen.
-
-### Manage image selections in the Chainguard Console
-
-To add images in the console:
-
-1. Browse to **Settings > Plan and Subscription**, which shows your current account status and currently selected images.
-1. Click **Select images**.
-1. Use the checkboxes to select or deselect images.
-1. Click **Review and confirm**.
-
-> **Note:** Changes made to image selections can take up to a few hours to process before the images become accessible to you.
-
-## Manage Catalog Starter plans using `chainctl`
-
-Sign up and manage a Catalog Starter plan using `chainctl`. If you prefer, you can instead [use the Chainguard Console](#manage-catalog-starter-plans-in-the-chainguard-console).
-
-### Sign up with `chainctl`
-
-The current method for signing up is with `chainctl`.
-
-To begin, sign up with a brand new account (identity)
-using the following interactive command:
-
-```shell
-chainctl starter init
-```
-
-This will require selection of a valid authentication option:
-
-```shell
-    Choose an identity provider to login to Chainguard
-
-  > Email and password
-    Google
-```
-
-Use the arrow keys and click 'Enter' to select either, which will launch a browser window to the Chainguard console to complete sign-up.
-
-### Add images with `chainctl`
-
-You can see which images are available [using the Chainguard Directory](/chainguard/containers/how-to-use/chainguard-directory/), but remember the images available are limited to the tiers mentioned above.
-
-To add one or more images with chainctl, run the following command, substituting the desired image names for the variables:
-
-```shell
-chainctl starter add-images $IMAGE1 [$IMAGE2]
-```
-
-After the Chainguard system has processed your request, the image(s) will be accessible. This can take up to a few hours. When available, you will be able to pull the images like this, replacing `$ORGANIZATION` with your organization's name and `$IMAGE` with the desired image's name.
-
-```shell
-docker pull cgr.dev/$ORGANIZATION/$IMAGE:latest
-```
-
-### Find status with `chainctl`
-
-To show the status of your catalog starter organization, including the registry path, account provisioning status, image quota usage, and per-image readiness, use:
-
-```shell
-chainctl starter status
-```
-
-## Add additional users to your Catalog Starter plan
-
-To request access for additional users for your organization, use:
-
-```shell
-chainctl starter request-access
-```
+- **[Catalog Starter](/chainguard/chainguard-images/about/catalog-starter/)** is a free plan that lets you try up to five Chainguard container images. Any Helm charts that depend on those images are included.
+- **[Self-serve Helm charts](/get-started/self-serve/helm-charts/)** lets Catalog customers provision Chainguard Helm charts, along with the container images they depend on, directly from the Chainguard Console.


### PR DESCRIPTION
Adds documentation for self-serve Helm chart provisioning (Catalog customers) and reorganizes the self-serve section into a hub with focused sub-pages. Resolves [DOCS-100](https://linear.app/chainguard/issue/DOCS-100/add-documentation-for-helm-chart-self-serve).

## Changes

- **New page** `get-started/self-serve/helm-charts.md`: the Console flow, the `chainctl` path, the FIPS opt-in, and the per-image support-ticket path.
- `get-started/self-serve/overview.md` is now a hub that links to the Catalog Starter page and the new Helm charts page. Removed Starter content that duplicated the canonical Catalog Starter page, including a stale "no Helm access" line that contradicted it.
- Moved the `chainctl starter` CLI steps onto the canonical Catalog Starter page so they aren't lost.
- Cross-linked the Helm charts usage guide to the new provisioning page.

## Testing

I tested this in both the console and using chainctl using test plans and releases behind feature flags. Everything included in this doc was proven to work in a dev environment as written.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
