### PR TITLE
Fix: Mobile search and Ask AI overlay

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,13 +1,36 @@
+(() => {
+  const hideKapaButtonOnMobile = () => {
+    const host = document.getElementById("kapa-widget-container");
+    if (!host || !host.shadowRoot) return false;
+    const style = document.createElement("style");
+    style.textContent =
+      "@media (max-width: 672px) { #kapa-button { display: none !important; } }";
+    host.shadowRoot.appendChild(style);
+    return true;
+  };
+  if (hideKapaButtonOnMobile()) return;
+  const observer = new MutationObserver(() => {
+    if (hideKapaButtonOnMobile()) observer.disconnect();
+  });
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+})();
+
 const menuPositioner = () => {
-  const nav = document.querySelectorAll("#sidebar-default")[1]
-  const itemActive = document.querySelectorAll(".sidebar-item-active")
-  const itemActiveMobile = document.querySelectorAll(".offcanvas-body .sidebar-item-active")
-  const navMobile = document.querySelector(".offcanvas-body")
+  const nav = document.querySelectorAll("#sidebar-default")[1];
+  const itemActive = document.querySelectorAll(".sidebar-item-active");
+  const itemActiveMobile = document.querySelectorAll(
+    ".offcanvas-body .sidebar-item-active",
+  );
+  const navMobile = document.querySelector(".offcanvas-body");
 
   if (itemActive.length) {
-    nav.scrollTop = itemActive[itemActive.length - 1].offsetTop - 300
-    navMobile.scrollTop = itemActiveMobile[itemActiveMobile.length - 1].offsetTop - 200
+    nav.scrollTop = itemActive[itemActive.length - 1].offsetTop - 300;
+    navMobile.scrollTop =
+      itemActiveMobile[itemActiveMobile.length - 1].offsetTop - 200;
   }
-}
+};
 
-menuPositioner()
+menuPositioner();

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -38,6 +38,9 @@
 @import "layouts/posts";
 @import "layouts/sidebar";
 
+/** Import DocSearch */
+@import "@docsearch/css/dist/style.scss";
+
 /** Import custom styles */
 @import "common/custom";
 @import "common/mobile";
@@ -50,6 +53,3 @@
 @import "components/footer-border-fix";
 @import "components/header-logo";
 @import "components/changelog";
-
-/** Import DocSearch */
-@import "@docsearch/css/dist/style.scss";

--- a/assets/scss/common/_mobile.scss
+++ b/assets/scss/common/_mobile.scss
@@ -8,7 +8,7 @@
   nav {
     padding: 0;
     display: flex;
-    gap: 24px;
+    gap: 12px;
 
     .btn-menu {
       color: inherit;
@@ -135,6 +135,11 @@
     .search.is-search {
       padding-left: 40px !important;
       padding-right: 40px !important;
+
+      @media (max-width: 575.98px) {
+        padding-left: 16px !important;
+        padding-right: 16px !important;
+      }
 
       // Fix placeholder color to be gray, not pink
       &::placeholder {

--- a/assets/scss/common/_theming.scss
+++ b/assets/scss/common/_theming.scss
@@ -84,7 +84,7 @@
     --pre-container-border: #dcdcdc;
     --righthand-title-color: var(--primary-3);
     --search-background: #F5F5FB;
-    --search-box-background: inherit;
+    --search-box-background: var(--search-background);
     --search-slash-border: #dcdcdc;
     --segmented-button-background: #F5F5FB;
     --segmented-button-checked: var(--primary-1);

--- a/assets/scss/components/_header-enhanced.scss
+++ b/assets/scss/components/_header-enhanced.scss
@@ -8,7 +8,7 @@
     -webkit-backdrop-filter: blur(10px);
     border-bottom: 1px solid rgba(20, 0, 61, 0.08);
     transition: all 0.3s ease;
-    
+
     // Add subtle shadow on scroll
     &.scrolled {
         box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
@@ -19,21 +19,21 @@
 .navbar {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
-    
+
     .navbar-brand {
         font-weight: 600;
         transition: opacity 0.2s ease;
-        
+
         &:hover {
             opacity: 0.8;
         }
-        
+
         img {
             height: 32px;
             width: auto;
         }
     }
-    
+
     .navbar-nav {
         .nav-link {
             color: var(--body-color);
@@ -42,12 +42,12 @@
             border-radius: 4px;
             transition: all 0.2s ease;
             position: relative;
-            
+
             &:hover {
                 background-color: rgba(117, 69, 251, 0.08);
                 color: var(--primary-1);
             }
-            
+
             &.active {
                 color: var(--primary-1);
                 background-color: rgba(117, 69, 251, 0.1);
@@ -64,19 +64,19 @@
         border-radius: 4px;
         padding: 0.5rem 1rem;
         transition: all 0.2s ease;
-        
+
         &:focus {
             border-color: var(--primary-1);
             box-shadow: 0 0 0 3px rgba(117, 69, 251, 0.1);
             background: var(--body-background);
         }
-        
+
         &::placeholder {
             color: var(--placeholder-color);
             opacity: 0.7;
         }
     }
-    
+
     .search-icon {
         color: var(--primary-1);
     }
@@ -87,31 +87,31 @@
     .offcanvas-header {
         border-bottom: 1px solid rgba(20, 0, 61, 0.08);
         padding: 1rem 1.5rem;
-        
+
         .btn-close {
             opacity: 0.5;
             transition: opacity 0.2s ease;
-            
+
             &:hover {
                 opacity: 1;
             }
         }
     }
-    
+
     .offcanvas-body {
         padding: 1.5rem;
-        
+
         .nav-link {
             padding: 0.75rem 1rem;
             margin-bottom: 0.25rem;
             border-radius: 4px;
             transition: all 0.2s ease;
-            
+
             &:hover {
                 background-color: rgba(117, 69, 251, 0.08);
                 transform: translateX(4px);
             }
-            
+
             &.active {
                 background-color: rgba(117, 69, 251, 0.1);
                 color: var(--primary-1);
@@ -131,11 +131,11 @@
         font-size: 0.9rem;
         transition: all 0.2s ease;
         cursor: pointer;
-        
+
         &:hover {
             border-color: var(--primary-1);
         }
-        
+
         &:focus {
             border-color: var(--primary-1);
             box-shadow: 0 0 0 3px rgba(117, 69, 251, 0.1);
@@ -152,15 +152,15 @@
     padding: 4px 12px;
     cursor: pointer;
     transition: all 0.2s ease;
-    
+
     &:hover {
         background: var(--primary-1);
-        
+
         .toggle-icon {
             color: white;
         }
     }
-    
+
     .toggle-icon {
         font-size: 1rem;
         transition: color 0.2s ease;
@@ -172,25 +172,25 @@
     background: transparent;
     padding: 0.5rem 0;
     margin-bottom: 1rem;
-    
+
     .breadcrumb-item {
         font-size: 0.875rem;
-        
+
         + .breadcrumb-item::before {
             color: var(--body-color);
             opacity: 0.5;
         }
-        
+
         a {
             color: var(--body-color);
             text-decoration: none;
             transition: color 0.2s ease;
-            
+
             &:hover {
                 color: var(--primary-1);
             }
         }
-        
+
         &.active {
             color: var(--primary-1);
             font-weight: 500;
@@ -214,12 +214,12 @@
 :root[data-dark-mode] {
     .header-background {
         border-bottom-color: rgba(255, 255, 255, 0.1);
-        
+
         &.scrolled {
             box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
         }
     }
-    
+
     .navbar {
         .navbar-nav {
             .nav-link {
@@ -227,7 +227,7 @@
                     background-color: rgba(122, 240, 254, 0.08);
                     color: var(--primary-2);
                 }
-                
+
                 &.active {
                     color: var(--primary-2);
                     background-color: rgba(122, 240, 254, 0.1);
@@ -235,7 +235,7 @@
             }
         }
     }
-    
+
     .search-container {
         .form-control {
             &:focus {
@@ -244,27 +244,66 @@
             }
         }
     }
-    
+
     .language-selector {
         select {
             border-color: rgba(255, 255, 255, 0.1);
-            
+
             &:hover {
                 border-color: var(--primary-2);
             }
-            
+
             &:focus {
                 border-color: var(--primary-2);
                 box-shadow: 0 0 0 3px rgba(122, 240, 254, 0.1);
             }
         }
     }
-    
+
     .dark-mode-toggle {
         border-color: var(--primary-2);
-        
+
         &:hover {
             background: var(--primary-2);
         }
+    }
+}
+
+.ask-ai-header {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 44px;
+    padding: 0 14px;
+    font-size: 14px;
+    white-space: nowrap;
+    color: var(--body-color);
+    background: var(--search-background);
+    border: 1px solid transparent;
+    border-radius: 4px;
+    touch-action: manipulation;
+
+    .bi {
+        font-size: 18px;
+    }
+
+    &:hover {
+        color: var(--primary-1);
+        background: var(--watch-btn-hover-background);
+        border-color: var(--primary-1);
+    }
+
+    :root[data-dark-mode] &:hover {
+        color: var(--primary-2);
+        border-color: var(--primary-2);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--primary-2);
+        outline-offset: 2px;
+    }
+
+    @media (max-width: 575.98px) {
+        padding: 0 10px;
     }
 }

--- a/assets/scss/components/_sidebar-search-fix.scss
+++ b/assets/scss/components/_sidebar-search-fix.scss
@@ -82,12 +82,10 @@
     background: var(--search-background);
     border-radius: 4px;
 
-    svg {
+    .bi {
         margin-right: 4px;
-
-        path {
-            fill: #3443f4;
-        }
+        font-size: 18px;
+        color: #3443f4;
     }
 
     &:hover {
@@ -104,10 +102,8 @@
             color: var(--primary-2);
         }
 
-        svg {
-            path {
-                fill: #fff;
-            }
+        .bi {
+            color: #fff;
         }
     }
 }
@@ -215,4 +211,13 @@
     ul li {
         margin-bottom: unset;
     }
+}
+
+.DocSearch-Container {
+    z-index: 1500;
+}
+
+#kapa-widget-container {
+    position: relative;
+    z-index: 1500;
 }

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -35,7 +35,7 @@
   data-search-mode-default="false"
   data-search-result-primary-text-color="#14003D"
   data-search-result-secondary-text-color="#3200AF"
-  data-modal-override-open-selector="#ask-ai"
+  data-modal-override-open-selector=".ask-ai-trigger"
   data-button-hide="false"
   data-search-mode-enabled="false"
   data-modal-title="Chainguard AI Assistant"

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -59,6 +59,11 @@
   </button>
 </div>
 
+<button type="button" class="btn ask-ai-header ask-ai-trigger order-1 d-lg-none">
+  <i class="bi bi-stars" aria-hidden="true"></i>
+  Ask AI
+</button>
+
     {{ if $showFlexSearch -}}
     <div class="search-container">
       <form class="doks-search position-relative">

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -22,8 +22,8 @@
       <button class="search form-control is-search text-left" aria-label="Search">Search</button>
     </div>
 
-    <button id="ask-ai" class="btn mt-2 w-100 text-left">
-        <svg width="18" height="18" aria-hidden="true" viewBox="0 0 24 24"><path d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm0 6-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25zm-7.5-5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zm-1.51 3.49L9 15.17l-.99-2.18L5.83 12l2.18-.99L9 8.83l.99 2.18 2.18.99z"/></svg> Ask AI
+    <button id="ask-ai" class="btn mt-2 w-100 text-left ask-ai-trigger">
+        <i class="bi bi-stars" aria-hidden="true"></i> Ask AI
     </button>
   </div>
 


### PR DESCRIPTION
- Add an **Ask AI button to the mobile header** and move the kapa widget to a shared class-based trigger (`.ask-ai-trigger`) used by both the header chip and the sidebar button, with the sidebar's inline SVG replaced by the `bi-stars` font icon.
- **Fix mobile search layout and stacking**: tighter header spacing and search-input padding (with a further reduction below 576px), gray placeholder and correct search-box background variable, and DocSearch/kapa modals raised above the sticky header and offcanvas
- Hide kapa's floating button on mobile