### PR TITLE
Add npm scanning to Dependabot (DOCS-103)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10
+    assignees:
+      - "matthewhelmke"
     groups:
       gomod:
         update-types:
@@ -19,8 +21,8 @@ updates:
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10
-    reviewers:
-      - "security-team"
+    assignees:
+      - "matthewhelmke"
     labels:
       - "dependencies"
       - "github-actions"
@@ -30,7 +32,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-          
+
   # Python dependencies for documentation compilation
   - package-ecosystem: "pip"
     directory: "/scripts"
@@ -38,9 +40,28 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
-    reviewers:
-      - "security-team"
+    assignees:
+      - "matthewhelmke"
     labels:
       - "dependencies"
       - "security"
       - "documentation"
+
+  # npm dependencies for the site theme and tooling (root package.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    assignees:
+      - "matthewhelmke"
+    labels:
+      - "dependencies"
+      - "security"
+    groups:
+      npm:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Enable Dependabot scanning for the **npm** ecosystem and tidy up the existing config.

- **Add npm ecosystem** covering the root `package.json` / `package-lock.json`, which Dependabot was not scanning. Weekly, with minor/patch grouped into a single PR.
- **Remove the dead `reviewers:` keys** (github-actions, pip). GitHub [removed `reviewers` from Dependabot on 2025-05-20](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) in favor of CODEOWNERS, so those lines were silently ignored. Review requests already flow to the Docs Team through the `*` rule in `CODEOWNERS`.
- **Add `matthewhelmke` as assignee** on all four ecosystems, so security dependency PRs land on a named owner (mirrors how `[AutoDocs]` PRs are assigned).

## Why

The root npm dependencies were unscanned, so vulnerabilities in them accrued without PRs being opened. There are currently three open Dependabot alerts, all in the transitive `js-yaml` dependency, that npm scanning should help surface and fix:

| Severity | Advisory | Installed | Fixed in |
|---|---|---|---|
| High | GHSA-5p4m-2wfm-xmqj | js-yaml 4.3.0 | 4.3.1 |
| High | GHSA-pm4m-ph32-ghv5 | js-yaml 5.2.0 (under markdownlint-cli2) | 5.2.2 |
| Medium | GHSA-724g-mxrg-4qvm | js-yaml 5.2.0 (under markdownlint-cli2) | 5.2.1 |

After this merges, a manual "Check for updates" run on the [Dependabot updates page](https://github.com/chainguard-dev/edu/network/updates) will pick up npm and open fix PRs. Any alerts not auto-resolved will be handled as follow-up.

## Testing

- `dependabot.yml` validated as well-formed YAML (parses to four ecosystems: gomod, github-actions, pip, npm).
- Pre-commit hooks (including `check yaml`) pass.

Linear: [DOCS-103](https://linear.app/chainguard/issue/DOCS-103/deal-with-vulns-in-edu-repo)

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-07.
