### PR TITLE
Fix dev-scoped yaml and node-fetch audit findings (DOCS-103)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@scalar/api-reference/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -8882,10 +8882,11 @@
       }
     },
     "node_modules/netlify-plugin-submit-sitemap/node_modules/node-fetch": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
-      "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -8924,10 +8925,11 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11582,10 +11584,11 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
@@ -13939,9 +13942,9 @@
           "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="
         },
         "yaml": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-          "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+          "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="
         }
       }
     },
@@ -17695,9 +17698,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
-          "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
           "dev": true,
           "requires": {
             "data-uri-to-buffer": "^4.0.0",
@@ -17719,9 +17722,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -19433,9 +19436,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true
     },
     "yargs": {


### PR DESCRIPTION
## What

Clear two development-scoped `npm audit` advisories with a **lockfile-only** change:

| Severity | Package | Advisory | Change | Pulled by |
|---|---|---|---|---|
| Moderate | yaml | GHSA-48c2-rrv3-qjmp (stack overflow) | 1.10.2 → 1.10.3 | postcss-load-config |
| Moderate | node-fetch | GHSA-vp56-6g26-6827 (ReDoS) | 3.2.4 → 3.3.2 | netlify-plugin-submit-sitemap |

The non-vulnerable 2.x copies of each also move up within their existing caret ranges (incidental, benign). `package.json` is unchanged.

## Context

Both advisories are **development-scoped**, so GitHub already auto-dismissed them on the security tab. This PR therefore cleans up `npm audit` output rather than closing security-tab alerts — worthwhile for keeping audit signal clean going forward.

The third audit finding, `hugo-installer`/`semver` (high), is **intentionally left out**: its only fix is a major `hugo-installer` bump (runs in `postinstall` to fetch Hugo), which is potentially breaking and warrants its own testing. That decision is being tracked separately.

Part of the same effort as the js-yaml fix ([#3734](https://github.com/chainguard-dev/edu/pull/3734)); scoped separately so each change stays small and independently reviewable.

## Testing

- `npm audit` no longer reports `yaml` or `node-fetch` (confirmed).
- Change is `package-lock.json` only; diff verified to touch nothing belonging to #3734 (js-yaml/markdownlint-cli2) or the deferred hugo-installer.
- Relying on this PR's Netlify deploy preview + `validate` checks for build confirmation.

Linear: [DOCS-103](https://linear.app/chainguard/issue/DOCS-103/deal-with-vulns-in-edu-repo)

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-07.
