### PR TITLE
Fix broken Renovate jsonata link and add libraries-policies alias

### DIFF
--- a/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/chainguard-images/staying-secure/updating-images/renovate/index.md
@@ -190,7 +190,7 @@ The benefit of this approach is that it allows you to define your update strateg
 
 Renovate supports updating [Helmfile](https://helmfile.readthedocs.io/) releases with its [built-in `helmfile` manager](https://docs.renovatebot.com/modules/manager/helmfile/). However, it doesn't presently support updating [digest references](/chainguard/chainguard-images/how-to-use/container-image-digests/) for OCI chart URLs, which is a [recommended practice when deploying Chainguard Helm charts](/chainguard/chainguard-images/how-to-use/use-chainguard-helm-charts/#pin-to-digest). See [renovatebot/renovate#45054](https://github.com/renovatebot/renovate/discussions/45054) for more details.
 
-To pin Chainguard Helm charts to digests and update them with Renovate, you can use a [custom `jsonata` manager](https://docs.renovatebot.com/modules/manager/custom.jsonata/) as a workaround.
+To pin Chainguard Helm charts to digests and update them with Renovate, you can use a [custom `jsonata` manager](https://docs.renovatebot.com/modules/manager/jsonata/) as a workaround.
 
 Given a `helmfile.yaml` such as:
 

--- a/content/chainguard/chainguard-repository/library-policies.md
+++ b/content/chainguard/chainguard-repository/library-policies.md
@@ -1,6 +1,8 @@
 ---
 title: "Chainguard Libraries policies"
 linktitle: "Library Policies"
+aliases:
+  - /chainguard/chainguard-repository/libraries-policies/
 description: "Configure and enforce policies that control which Chainguard Libraries package versions your organization can pull"
 type: "article"
 date: 2026-07-31T00:00:00+00:00


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Point the Renovate custom manager link at `modules/manager/jsonata/` instead of the 404ing `modules/manager/custom.jsonata/`
- Add a `/chainguard/chainguard-repository/libraries-policies/` alias to the Chainguard Libraries policies page

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://github.com/chainguard-dev/edu/issues/3688

Fixes two broken links reported by the link checker.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Renovate moved its custom jsonata manager docs, so the link in the Renovate guide returned a 404. Separately, three pages link to `/chainguard/chainguard-repository/libraries-policies/`, but the page lives at `library-policies`. Adding an alias fixes all three links without touching the pages that reference them.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The custom `jsonata` manager link in the Renovate guide resolves to the Renovate docs
- `/chainguard/chainguard-repository/libraries-policies/` redirects to the Chainguard Libraries policies page
- Links from `libraries/access`, `libraries/java/migration`, and `libraries/javascript/migration` reach the policies page

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. On the Renovate guide, follow the "custom `jsonata` manager" link in the Helmfile section
3. Visit `/chainguard/chainguard-repository/libraries-policies/` and confirm it redirects to the policies page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
