### PR TITLE
Standardize workflow installs on npm ci (DOCS-83)

### DIFF
--- a/.github/workflows/autodocs-platform.yaml
+++ b/.github/workflows/autodocs-platform.yaml
@@ -53,8 +53,8 @@ jobs:
     - name: Update themes
       run: git submodule update --init --recursive
 
-    - name: npm install
-      run: npm install
+    - name: npm ci
+      run: npm ci
 
     - name: Fetch latest package mappings
       run: |

--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -40,8 +40,8 @@ jobs:
     - name: Update themes
       run: git submodule update --init --recursive
 
-    - name: npm install
-      run: npm install
+    - name: npm ci
+      run: npm ci
 
     - name: Fetch latest package mappings
       run: |

--- a/.github/workflows/validate-nginx-config.yaml
+++ b/.github/workflows/validate-nginx-config.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build project
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Run Nginx validation


### PR DESCRIPTION
## What

Standardize the workflow install step on `npm ci`. Three workflows used `npm install`; this changes them to `npm ci`:

- `autodocs-platform.yaml`, `cloud-run.yaml`, `validate-nginx-config.yaml`

`pre-commit.yaml` already used `npm ci --ignore-scripts` and is unchanged, so all four workflows are now consistent.

## Why

`npm install` resolves against `package.json` ranges and may rewrite `package-lock.json` mid-run, so CI can install versions that are not exactly what is committed. `npm ci` installs the lockfile exactly, never writes to it, and fails fast if `package.json` and the lockfile disagree.

The practical guarantee: **dependency changes become intentional — landed deliberately or via Dependabot — never introduced accidentally by a PR whose lockfile drifted.** CI now reproduces the committed dependency tree deterministically, matching how production and Netlify should build.

## Consequence to be aware of

This is a stricter gate. A PR that edits `package.json` without regenerating `package-lock.json` will now **fail these jobs** until the author runs `npm install` locally and commits the updated lockfile. That is the intended behavior (it catches lockfile drift), but it is a change in failure semantics worth knowing.

## Caveat (flagged so a future failure is traceable to here)

`npm ci` requires the lockfile to be in sync and does not tolerate a workflow regenerating `package.json` at runtime. These three jobs do not appear to rely on `npm install`'s looser behavior, but if one of them (for example `autodocs-platform`, which integrates generated platform docs) ever modifies dependencies as part of its run, `npm ci` would reject it. If a build breaks after this merge, this change is the first place to look.

## Scope

Companion to the Node-pin PR (#3738) but deliberately separate: that PR changes the Node version, this one changes install determinism. Keeping them apart makes any post-merge failure attributable to the right change.

Linear: [DOCS-83](https://linear.app/chainguard/issue/DOCS-83/investigate-pinning-node-version-as-single-source-of-truth-for-edu)

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-07.
