### PR TITLE
Validate vulnerability id before use in the DOM (DOCS-106)

### DIFF
--- a/assets/js/rumble/vulnerability.js
+++ b/assets/js/rumble/vulnerability.js
@@ -10,14 +10,21 @@ updateTitleAndURLs();
 showVuln();
 
 function getVulnID() {
-  let id = "";
+  let id;
   let host = document.location.host;
   if (host.match(".+netlify.app:443") || host == "localhost:1313") {
     id = new URLSearchParams(document.location.search).get("id");
   } else {
     id = document.location.pathname.replace(/\/$/, "").split("/").pop();
   }
-  return id;
+  // Only accept well-formed vulnerability identifiers such as CVE-2024-1234
+  // or GHSA-xxxx-xxxx-xxxx. Rejecting anything else keeps untrusted URL input
+  // out of the DOM sinks below (canonical href, innerHTML, and meta content).
+  // See DOCS-106.
+  if (id && /^[A-Za-z0-9._-]{1,64}$/.test(id)) {
+    return id;
+  }
+  return "";
 }
 
 async function getData(url) {


### PR DESCRIPTION
## What

Validate the vulnerability `id` at its source before it reaches the DOM, resolving the open CodeQL alert [#97](https://github.com/chainguard-dev/edu/security/code-scanning/97) (`js/client-side-unvalidated-url-redirection`, CWE-601 / CWE-79 / CWE-116) in `assets/js/rumble/vulnerability.js`.

`getVulnID()` is the single choke point: the `id` it returns (from the `?id=` query param on preview/localhost, or the URL path segment in prod) flows into every DOM sink on the page — `link.href` (the flagged line), plus `innerHTML` and meta `content`. Guarding it once neutralizes all of them:

```js
if (id && /^[A-Za-z0-9._-]{1,64}$/.test(id)) {
  return id;
}
return "";
```

Legitimate identifiers (`CVE-2024-1234`, `GHSA-xxxx-xxxx-xxxx`) pass unchanged; anything containing HTML/URL metacharacters is rejected. Also dropped a dead `let id = ""` initializer (both branches reassign it) that eslint's `no-useless-assignment` flagged.

## Why validate at the source

The flagged sink (`link.href += id` on the canonical `<link>`) is low real-world risk on its own, but the same untrusted `id` is written unescaped to `innerHTML` a few lines up — a genuine DOM-XSS vector. Validating the shared source is cleaner and more robust than escaping each sink individually, and matches CodeQL's own "validate against an allowlist" recommendation.

## Testing

- **Validation battery (Node):** all legitimate IDs pass through unchanged; every attack vector returns `""` — `<img src=x onerror=…>`, `"><script>`, `//evil.com`, `https://evil.com`, `javascript:…`, `../../etc/passwd`, query-string injection, an over-length string, and `null`/empty.
- **eslint** clean on the changed file.
- **`npm run build`** succeeds (JS bundles via Hugo/esbuild).
- CodeQL should mark alert #97 resolved once this runs on the PR / after merge.

Linear: [DOCS-106](https://linear.app/chainguard/issue/DOCS-106/fix-codeql-client-side-url-redirect-dom-xss-in-rumble-vulnerabilityjs)

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-07.
