### PR TITLE
fix(deps): bump nanoid to 5.1.16 (CVE-2026-67214) [DOCS-109]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/@scalar/api-reference/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -8938,15 +8938,16 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14021,9 +14022,9 @@
       },
       "dependencies": {
         "nanoid": {
-          "version": "5.1.9",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-          "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="
+          "version": "5.1.16",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+          "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="
         }
       }
     },
@@ -17815,9 +17816,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="
     },
     "natural-compare": {
       "version": "1.4.0",


### PR DESCRIPTION
## What

Resolves [Dependabot alert #138](https://github.com/chainguard-dev/edu/security/dependabot/138) — **`nanoid` CVE-2026-67214** (GHSA-28wg-ghj8-5hjv), high severity. In the non-secure module, `nanoid`/`customAlphabet` loop indefinitely when given a negative `size`, hanging the calling thread — a denial-of-service condition. Fixed version is `nanoid >= 5.1.16`.

Linear: DOCS-109

## Root cause

The only vulnerable copy was a **nested `nanoid@5.1.9`** pinned in `package-lock.json` under `@scalar/api-reference`. That package declares `nanoid: ^5.1.6`, which the patched `5.1.16` already satisfies — the lock simply had never been re-resolved. No `package.json` change was required.

## Change

`npm update nanoid` — touches **only `package-lock.json`**:

- `nanoid` `5.1.9` → `5.1.16` (the vulnerable copy; updated in both lock sections)
- `postcss`'s `nanoid` `3.3.17` → `3.3.18` (incidental, stays on the already-patched 3.x line — `>= 3.3.16`)

## Testing

- **`npm ci`** from the updated lock succeeds — the lockfile is internally consistent and installs deterministically (matches this repo's `npm ci` convention).
- **`npm audit`** reports no `nanoid` advisories.
- **`npm ls nanoid`** confirms every resolved `nanoid` is now `5.1.16` (5.x line) or `3.3.18` (3.x line); zero references to `5.1.9` remain in the tree.

```
$ npm ls nanoid
├─┬ @scalar/api-reference@1.64.0
│ ├── nanoid@5.1.16
│ ...
│ └── nanoid@5.1.16
└─┬ postcss@8.5.26
  └── nanoid@3.3.18
```

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-10.
