### PR TITLE
Add the week of 2026-08-10 to the changelog

### DIFF
--- a/content/chainguard/changelog.md
+++ b/content/chainguard/changelog.md
@@ -4,7 +4,7 @@ linktitle: "Changelog"
 type: "article"
 description: "Weekly changelog of Chainguard product updates — product announcements, breaking changes, container images reaching end-of-life or leaving the catalog, and images newly added to it."
 date: 2026-07-28T00:00:00+00:00
-lastmod: 2026-07-28T00:00:00+00:00
+lastmod: 2026-08-10T00:00:00+00:00
 draft: false
 tags: ["Chainguard Containers", "Changelog"]
 images: []
@@ -14,6 +14,80 @@ tocEndLevel: 2
 ---
 
 This page logs Chainguard product updates week by week, newest first: product announcements, breaking changes, container images that reached end-of-life or are no longer available, and images newly added to the catalog. Each event is listed once, in the week it first appeared.
+
+## Week of 2026-08-10
+
+{{< changelog-label "Product Announcements" >}}
+
+### Chainguard Libraries available through AWS Security Hub Extended
+
+_Launched August 4, 2026._
+
+AWS added a Supply Chain category to Security Hub Extended and named Chainguard one of its inaugural partners. You can now subscribe to Chainguard Libraries from the Security Hub console and pay through your existing AWS account. Libraries findings arrive normalized to the Open Cybersecurity Schema Framework (OCSF), so they appear alongside your AWS and other partner findings, and AWS Enterprise Support customers receive Level 1 support from AWS.
+
+For more information about the catalog, refer to the [Chainguard Libraries overview](/chainguard/libraries/overview/).
+
+### Malware avoidance in the Console (beta)
+
+_Launched August 4, 2026._
+
+The Console now shows which malicious and suspicious packages Chainguard Libraries blocked before they reached your environment. A weekly chart tracks the malware and greyware stopped across the Python and JavaScript ecosystems, and a search tool reports why any given package was flagged unsafe. Find it under the **Malware** tab in the Libraries section of the Console sidebar; it is enabled by default for every organization entitled to Libraries.
+
+For more information, refer to [View malware information](/chainguard/libraries/browse/#view-malware-information).
+
+### PKCE support for custom identity providers
+
+_Launched August 3, 2026._
+
+Chainguard now supports Proof Key for Code Exchange (PKCE) on the OAuth token exchange with custom OIDC identity providers, in line with OAuth 2.1. Administrators can enable it with `chainctl` or the Chainguard API, either alongside an existing client secret or as a secret-free public client.
+
+For more information, including setup steps, refer to [Enable PKCE for OAuth Token Exchange](/platform/administration/custom-idps/enabling-pkce/).
+
+{{< changelog-label "EOL" >}}
+
+Chainguard offers [a grace period](/chainguard/chainguard-images/features/eol-gp-overview/) for eligible end-of-life images: up to six months of continued rebuilds and security updates while you complete your upgrade.
+
+### Images that have reached end-of-life
+
+The following container images reached end-of-life and entered their grace period:
+
+| Image | End-of-life | Grace period ends |
+| --- | --- | --- |
+| `net-kourier:1.21` | 2026-08-04 | 2027-02-04 |
+| `tekton-pipelines:1.3` | 2026-08-04 | 2027-02-04 |
+| `ruby3.2-rails:7.2` | 2026-08-09 | 2027-02-09 |
+| `ruby3.3-rails:7.2` | 2026-08-09 | 2027-02-09 |
+| `ruby3.4-rails:7.2` | 2026-08-09 | 2027-02-09 |
+| `ruby4.0-rails:7.2` | 2026-08-09 | 2027-02-09 |
+
+{{< changelog-label "New Images" >}}
+
+Chainguard built 25 new container images this week, including both standard and FIPS variants.
+
+<table class="cl-images">
+<thead><tr><th>Image</th><th>Tier</th><th>Added</th></tr></thead>
+<tbody>
+<tr><td><a href="https://images.chainguard.dev/directory/image/prometheus-stackdriver-exporter/versions"><code>prometheus-stackdriver-exporter</code></a></td><td>application +fips</td><td>2026-08-03</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-keyvault/versions"><code>crossplane-azure-keyvault</code></a></td><td>application</td><td>2026-08-04</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-kusto/versions"><code>crossplane-azure-kusto</code></a></td><td>application</td><td>2026-08-04</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/influxdb-fips/versions"><code>influxdb-fips</code></a></td><td>fips</td><td>2026-08-04</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/moodle-iamguarded/versions"><code>moodle-iamguarded</code></a></td><td>application</td><td>2026-08-04</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/pypiserver-fips/versions"><code>pypiserver-fips</code></a></td><td>fips</td><td>2026-08-04</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/kubevirt-cdi-cloner/versions"><code>kubevirt-cdi-cloner</code></a></td><td>application +fips</td><td>2026-08-05</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/yopass/versions"><code>yopass</code></a></td><td>application</td><td>2026-08-05</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/acm-controller/versions"><code>acm-controller</code></a></td><td>application +fips</td><td>2026-08-06</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/gremlin-server/versions"><code>gremlin-server</code></a></td><td>application</td><td>2026-08-06</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/rollouts-plugin-trafficrouter-gatewayapi/versions"><code>rollouts-plugin-trafficrouter-gatewayapi</code></a></td><td>application +fips</td><td>2026-08-06</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/chainguard-desktop-workstation-qemu/versions"><code>chainguard-desktop-workstation-qemu</code></a></td><td>base</td><td>2026-08-07</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/claude/versions"><code>claude</code></a></td><td>application</td><td>2026-08-07</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/codex/versions"><code>codex</code></a></td><td>application</td><td>2026-08-07</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/cruise-control/versions"><code>cruise-control</code></a></td><td>application +fips</td><td>2026-08-07</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/dotstatsuite-supercore/versions"><code>dotstatsuite-supercore</code></a></td><td>application</td><td>2026-08-07</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/chainguard-server-workstation-gcp/versions"><code>chainguard-server-workstation-gcp</code></a></td><td>base</td><td>2026-08-08</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/opencode/versions"><code>opencode</code></a></td><td>application</td><td>2026-08-08</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/zalando-pgbouncer/versions"><code>zalando-pgbouncer</code></a></td><td>application +fips</td><td>2026-08-10</td></tr>
+</tbody>
+</table>
 
 ## Week of 2026-08-03
 
@@ -55,13 +129,11 @@ The following container images reached end-of-life and entered their grace perio
 
 {{< changelog-label "New Images" >}}
 
-Chainguard built 22 new container images this week, including both standard and FIPS variants.
+Chainguard built 18 new container images this week, including both standard and FIPS variants.
 
 <table class="cl-images">
 <thead><tr><th>Image</th><th>Tier</th><th>Added</th></tr></thead>
 <tbody>
-<tr><td><a href="https://images.chainguard.dev/directory/image/glab/versions"><code>glab</code></a></td><td>application +fips</td><td>2026-07-27</td></tr>
-<tr><td><a href="https://images.chainguard.dev/directory/image/metabase/versions"><code>metabase</code></a></td><td>application</td><td>2026-07-27</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/atlas/versions"><code>atlas</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/azure-metrics-exporter/versions"><code>azure-metrics-exporter</code></a></td><td>application +fips</td><td>2026-07-29</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-solutions/versions"><code>crossplane-azure-solutions</code></a></td><td>application</td><td>2026-07-29</td></tr>
@@ -74,7 +146,6 @@ Chainguard built 22 new container images this week, including both standard and 
 <tr><td><a href="https://images.chainguard.dev/directory/image/flink-kubernetes-operator-fips/versions"><code>flink-kubernetes-operator-fips</code></a></td><td>fips</td><td>2026-07-30</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/traccar/versions"><code>traccar</code></a></td><td>application +fips</td><td>2026-07-30</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/metacontroller-fips/versions"><code>metacontroller-fips</code></a></td><td>fips</td><td>2026-07-31</td></tr>
-<tr><td><a href="https://images.chainguard.dev/directory/image/chainguard-desktop-workstation-rpi/versions"><code>chainguard-desktop-workstation-rpi</code></a></td><td>base</td><td>2026-08-01</td></tr>
 </tbody>
 </table>
 
@@ -123,7 +194,7 @@ The following container images reached end-of-life and entered their grace perio
 
 {{< changelog-label "New Images" >}}
 
-Chainguard built 16 new container images this week, including both standard and FIPS variants.
+Chainguard built 15 new container images this week, including both standard and FIPS variants.
 
 <table class="cl-images">
 <thead><tr><th>Image</th><th>Tier</th><th>Added</th></tr></thead>
@@ -135,7 +206,6 @@ Chainguard built 16 new container images this week, including both standard and 
 <tr><td><a href="https://images.chainguard.dev/directory/image/nuclio-controller/versions"><code>nuclio-controller</code></a></td><td>application +fips</td><td>2026-07-23</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/phpmyadmin/versions"><code>phpmyadmin</code></a></td><td>application +fips</td><td>2026-07-23</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/apache-exporter-iamguarded/versions"><code>apache-exporter-iamguarded</code></a></td><td>application</td><td>2026-07-24</td></tr>
-<tr><td><a href="https://images.chainguard.dev/directory/image/rpi-server-bootc/versions"><code>rpi-server-bootc</code></a></td><td>base</td><td>2026-07-25</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/glab/versions"><code>glab</code></a></td><td>application +fips</td><td>2026-07-27</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/metabase/versions"><code>metabase</code></a></td><td>application</td><td>2026-07-27</td></tr>
 <tr><td><a href="https://images.chainguard.dev/directory/image/crossplane-azure-relay/versions"><code>crossplane-azure-relay</code></a></td><td>application</td><td>2026-07-28</td></tr>


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Adds the week of 2026-08-10 to the Chainguard Products Changelog
- Removes duplicate `glab` and `metabase` rows from the week of 2026-08-03
- Removes two rows whose Images directory links do not resolve, and adjusts the affected image counts
- Bumps `lastmod` so the page's last-updated date reflects this week

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Publish this week's changelog entry and correct two errors in earlier weeks.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The changelog is published weekly on rotation. Alongside this week's entry, this PR fixes two problems in already-published weeks. First, `glab` and `metabase` were listed in both the week of 2026-07-28 and the week of 2026-08-03, contradicting the page's statement that each event appears once, in the week it first appeared. Second, two rows linked to Images directory pages that do not exist, because those images belong to other product lines.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The week of 2026-08-10 lists three product announcements, six images that entered their grace period, and 25 new images
- No image appears in more than one week
- The page's last-updated date reads 2026-08-10
- Earlier weeks are otherwise unchanged

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Visit `/chainguard/changelog/` and confirm the week of 2026-08-10 renders its product announcement, EOL, and new image sections in that order
3. Follow the three announcement links — Libraries overview, malware information, and PKCE setup — and confirm each resolves

Note on new-image links: the Images directory indexes a few days behind, so links for images added within roughly the last five days can 404 until the directory catches up. Eight of this week's links are in that state as of publication and resolve on their own; earlier weeks show the same pattern and are now fully resolved.
