### PR TITLE
Document Guardener on-demand Actions migration

### DIFF
--- a/content/chainguard/guardener/_index.md
+++ b/content/chainguard/guardener/_index.md
@@ -17,7 +17,7 @@ Chainguard Guardener is a tool for managing and hardening your source code. Rath
 The Guardener's capabilities fall into two groups:
 
 - **[GitHub App](/chainguard/guardener/github/)** — Capabilities that run through the Guardener GitHub App and are enabled per repository with `.chainguard/` configuration files:
-    - **[Hardened Actions](/chainguard/guardener/github/actions-security/)** — Recommends and migrates your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents, either through non-blocking pull request review comments or automated migration pull requests.
+    - **[Hardened Actions](/chainguard/guardener/github/actions-security/)** — Recommends and migrates your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents, through non-blocking pull request review comments or migration pull requests that run on a schedule or [on demand](/chainguard/guardener/github/actions-security/#run-an-on-demand-migration).
     - **[Commit Verification](/chainguard/guardener/github/commit-verification/)** — Enforces cryptographically signed commits against a policy you control, supporting both keyless (Sigstore) signatures and static keys such as GPG.
 - **[Dockerfile migration](/chainguard/guardener/dockerfile-migration/)** — Uses AI to iteratively convert your Dockerfiles to Chainguard Containers. This capability runs locally through `chainctl agent dockerfile` commands.
 

--- a/content/chainguard/guardener/github/_index.md
+++ b/content/chainguard/guardener/github/_index.md
@@ -4,7 +4,7 @@ linktitle: "GitHub App"
 description: "The Chainguard Guardener GitHub App secures and maintains your repositories through capabilities you enable per repository with .chainguard/ configuration files."
 type: "article"
 date: 2026-07-13T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-10T00:00:00+00:00
 draft: false
 tags: ["GitHub"]
 images: []
@@ -27,7 +27,7 @@ The Chainguard Guardener GitHub App is a single, hardened bot that runs against 
 
 ## Capabilities
 
-- **[Hardened Actions](/chainguard/guardener/github/actions-security/)** — Recommends and migrates your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents, either through non-blocking pull request review comments or automated migration pull requests.
+- **[Hardened Actions](/chainguard/guardener/github/actions-security/)** — Recommends and migrates your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents, through non-blocking pull request review comments or automated migration pull requests. Migration pull requests run on a schedule and can also be [triggered on demand](/chainguard/guardener/github/actions-security/#run-an-on-demand-migration) with `chainctl`.
 - **[Commit Verification](/chainguard/guardener/github/commit-verification/)** — Enforces cryptographically signed commits against a policy you control, supporting both keyless (Sigstore) signatures and static keys such as GPG.
 
 Each capability is configured with its own file in the `.chainguard/` directory.

--- a/content/chainguard/guardener/github/actions-security.md
+++ b/content/chainguard/guardener/github/actions-security.md
@@ -4,7 +4,7 @@ linktitle: "Hardened Actions"
 description: "Configure Chainguard Guardener to recommend and migrate your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents."
 type: "article"
 date: 2026-07-08T00:00:00+00:00
-lastmod: 2026-07-08T00:00:00+00:00
+lastmod: 2026-08-10T00:00:00+00:00
 draft: false
 tags: ["GitHub", "Automation"]
 images: []
@@ -20,7 +20,7 @@ The Hardened Actions feature recommends and migrates your GitHub Actions to Chai
 Hardened Actions operates in two independent modes:
 
 - **Pull request recommendations** — non-blocking review comments that suggest hardened action alternatives, with one-click suggestion blocks.
-- **Automated migration pull requests** — a periodically maintained pull request that updates workflows across your repository.
+- **Automated migration pull requests** — a periodically maintained pull request that updates workflows across your repository. You can also [trigger this migration on demand](#run-an-on-demand-migration) with `chainctl` instead of waiting for the next scheduled run.
 
 You can enable either mode on its own or both together.
 
@@ -46,6 +46,55 @@ migrate:
 ```
 
 The Guardener opens (and keeps updated) a single migration pull request on the cadence you set with `period`.
+
+## Run an on-demand migration
+
+Instead of waiting for the next scheduled run — for example, right after enabling migration, or after Chainguard publishes a hardened equivalent for an action you use — you can trigger the migration immediately with `chainctl`.
+
+An on-demand run performs exactly the same migration as the scheduled flow: it opens (or updates) the repository's single migration pull request and honors the same `.chainguard/actions.yaml` configuration, including `migrate.ignore`. Because it shares the opt-in gate, the repository (or its organization, through the [org-level `.github` configuration](/chainguard/guardener/github/configuration/)) must have `migrate.enabled: true`; if migration is not enabled, the run completes as a no-op without opening a pull request. Triggering an on-demand run does not change the periodic schedule.
+
+Before you start, make sure that:
+
+- The Guardener GitHub App is installed and your Chainguard organization is linked to your GitHub organization, as described in [Getting started](/chainguard/guardener/github/getting-started/). The migration must be requested through the Chainguard organization that owns the GitHub App installation.
+- You hold the `guardener.actions.migrate` capability on that Chainguard organization. Organization owners have it, and it is included in the built-in `guardener.user` and `guardener.admin` roles. Refer to the [Built-in roles and capabilities reference](/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for more information on roles.
+
+Run `chainctl guardener github migrate create` with the repository to migrate:
+
+```shell
+chainctl guardener github migrate create <owner>/<repo> \
+  --parent <group-name>
+```
+
+The repository can be given as `owner/repo` shorthand or as a full URL (`https://github.com/owner/repo`); only github.com repositories are supported today. `--parent` is the Chainguard organization that owns the GitHub App installation — if you omit it, `chainctl` prompts you to select one.
+
+By default the command waits for the migration to finish (up to 10 minutes, adjustable with `--timeout`) and prints the result:
+
+```
+Repository: https://github.com/<owner>/<repo>
+Triggered by: you@example.com (user)
+Status: completed
+Pull request: https://github.com/<owner>/<repo>/pull/42
+```
+
+When there is nothing to migrate — every action is already on a Chainguard equivalent, the ignore rules exclude everything, or the repository has not enabled migration — the run reports `Status: completed (no changes needed)` instead of a pull request.
+
+If the migration fails because the GitHub App installation does not cover the repository (for example, the app was installed on **selected repositories** and this one isn't included), the error says so; grant the app access to the repository in your GitHub organization settings and trigger the migration again.
+
+## Check a migration operation
+
+Pass `--wait=false` to return immediately instead of waiting. The command prints an operation name of the form `operations/migrate/<group>/<id>`, which you can check later with `chainctl guardener github migrate get`:
+
+```shell
+chainctl guardener github migrate get operations/migrate/<group>/<id>
+```
+
+The owning organization is derived from the operation name, so no `--parent` is needed. Add `--wait` to poll until the operation completes (bounded by `--timeout`, 10 minutes by default). Interrupting a waiting `migrate create` is also safe — the migration keeps running server-side, and the command prints the operation name so you can check it later.
+
+For the complete set of flags and options, refer to the `chainctl` reference:
+
+- [`chainctl guardener github migrate`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate/)
+- [`chainctl guardener github migrate create`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate_create/)
+- [`chainctl guardener github migrate get`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate_get/)
 
 ## Exclude files and actions
 


### PR DESCRIPTION
## Type of change
Documentation — new section on an existing product page.

### What should this PR do?
Document the on-demand GitHub Actions migration flow (`chainctl guardener github migrate create` / `migrate get`) under the Guardener product docs:

- Adds a **Run an on-demand migration** section to the Hardened Actions page covering when to use it, prerequisites (a linked GitHub org whose App installation is owned by the Chainguard group, plus the `guardener.actions.migrate` capability — held by org owners and the built-in `guardener.user`/`guardener.admin` roles), the `migrate create` command, and example output.
- Adds a **Check a migration operation** section covering `--wait=false`, the `operations/migrate/<group>/<id>` operation name, `migrate get --wait/--timeout`, and that interrupting a waiting `migrate create` is safe. Links the three new `chainctl` reference pages.
- Updates the Guardener and GitHub App index pages' Hardened Actions bullets to mention on-demand triggering, with deep links to the new section.

### Why are we making this change?
The `chainctl guardener github migrate` commands shipped with auto-generated reference pages only ([#3584](https://github.com/chainguard-dev/edu/pull/3584)-era work added the surrounding product docs); there was no product documentation explaining the on-demand flow, its prerequisites, or its interaction with the scheduled migration.

### What are the acceptance criteria?
Behavior claims were verified against the implementation (migrateservice server and migrate reconciler in mono), notably the two most surprising behaviors:

- An on-demand run shares the scheduled flow's opt-in gate: `migrate.enabled: true` (repo- or org-level) is still required, and a run against a repo that hasn't opted in completes as a **no-op**, not an error. It also honors `migrate.ignore`.
- It opens/updates the **same single migration PR** the scheduled flow maintains, and doesn't affect the periodic cadence.

Also documents the "installation doesn't cover this repository" failure mode and its remediation.

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

`npm run build` passes; rendered anchors (`#run-an-on-demand-migration`, `#check-a-migration-operation`) verified in the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)