### PR TITLE
Add link from Chainguard Actions to Chainguard Guardener page enablin…

### DIFF
--- a/content/chainguard/actions/overview.md
+++ b/content/chainguard/actions/overview.md
@@ -4,7 +4,7 @@ linktitle: "Overview"
 description: "Learn how Chainguard Actions provides hardened drop-in replacements for popular GitHub Actions to protect your CI/CD pipelines from supply chain attacks."
 type: "article"
 date: 2026-06-18T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-12T12:24:08+00:00
 draft: false
 tags: ["Chainguard Actions", "Overview"]
 menu:
@@ -27,7 +27,7 @@ Each hardened action:
 
 Chainguard Actions protect against common threats including tag hijacking, dependency confusion, `pull_request_target` abuse, and secret exfiltration.
 
-This page provides enough to get you started. Refer to the [Chainguard Actions README](https://github.com/chainguard-actions) in GitHub for deeper technical details and some example migrations.
+This page provides enough to get you started. Refer to the [Chainguard Actions README](https://github.com/chainguard-actions) in GitHub for deeper technical details and some example migrations. You can also [use Chainguard Guardener to enable Chainguard Actions](/chainguard/guardener/github/actions-security/).
 
 ## Prerequisites
 


### PR DESCRIPTION
…g actions

[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Add a link between related pages.

### What should this PR do?
Fixes https://linear.app/chainguard/issue/DOCS-118/update-actions-page-with-info-and-link

### Why are we making this change?
To help customers know that they can use Chainguard Guardener to enable Chainguard Actions.

### What are the acceptance criteria? 
Does the link work as intended?

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).


