### PR TITLE
Override semver to patched 7.x under hugo-installer (DOCS-107)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4732,21 +4732,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/hugo-installer/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/hugo-installer/node_modules/strip-dirs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-3.0.0.tgz",
@@ -5395,18 +5380,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/magic-string": {
@@ -7731,6 +7704,19 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -8980,12 +8966,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -12308,7 +12288,7 @@
         "got": "12.4.x",
         "hpagent": "1.0.x",
         "object-path": "0.11.x",
-        "semver": "7.3.x",
+        "semver": "^7.5.2",
         "yargs": "17.5.x"
       },
       "dependencies": {
@@ -12324,15 +12304,6 @@
             "@xhmikosr/decompress-unzip": "^8.1.1",
             "graceful-fs": "^4.2.11",
             "strip-dirs": "^3.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         },
         "strip-dirs": {
@@ -12774,15 +12745,6 @@
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
         "highlight.js": "~11.11.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
       }
     },
     "magic-string": {
@@ -14237,6 +14199,12 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true
     },
+    "semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -15031,12 +14999,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,11 @@
     "@scalar/api-reference": "^1.64.0",
     "bootstrap-icons": "^1.13.1"
   },
+  "//overrides": "semver: hugo-installer@4.0.1 hard-pins semver 7.3.x (vulnerable to ReDoS GHSA-c2qf-rxjj-qqgw, >=7.0.0 <7.5.2) with no upstream fix, so we force its transitive semver to a patched 7.x. Scoped to hugo-installer so execa's non-vulnerable semver 5.x is left alone. See DOCS-107.",
   "overrides": {
-    "decompress": "npm:@xhmikosr/decompress@^11.1.3"
+    "decompress": "npm:@xhmikosr/decompress@^11.1.3",
+    "hugo-installer": {
+      "semver": "^7.5.2"
+    }
   }
 }


### PR DESCRIPTION
## What

Adds a scoped npm `overrides` entry that forces `semver` to a patched 7.x (`^7.5.2`) **within `hugo-installer` only**, clearing the last dev-scope Dependabot finding tracked in DOCS-107 ([GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw), high-severity semver ReDoS).

## Why the ticket's original plan didn't apply

DOCS-107 was written assuming `hugo-installer` needed a breaking bump to 2.0.0. It doesn't — DOCS-103 already moved us to `hugo-installer@^4.0` (currently `4.0.1`, the latest published release). But that bump **did not clear the vuln**: `hugo-installer@4.0.1` still hard-pins `semver: "7.3.x"`, resolving to `semver@7.3.7`, which sits inside the vulnerable range (`>=7.0.0 <7.5.2`). There is no upstream `hugo-installer` fix, so a version bump can't resolve it — an override is the only path.

## Why scoped, not global

A second `semver` exists in the tree — `execa/node_modules/semver@5.7.2` — which is **not** vulnerable (5.x is outside the affected range). A global `semver` override would needlessly drag execa from 5.x to 7.x and risk an API break for zero security benefit. The scoped override patches exactly the vulnerable node and leaves execa alone.

A `//overrides` comment key in `package.json` documents this for future maintainers.

## Verification

| Check | Result |
|---|---|
| `postinstall` Hugo download | Hugo 0.152.1 extended, unchanged |
| hugo-installer's semver | now `7.8.5` (patched) |
| execa's semver (untouched) | still `5.7.2`, non-vulnerable |
| `npm audit` | **0 vulnerabilities** (was 2 high) |
| `npm run build` | 1681 pages, builds clean |

`hugo-installer`'s own version and postinstall behavior are unchanged, so regression risk is low. The Netlify deploy preview on this PR is the final build-environment confirmation.

Resolves DOCS-107.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-12.
