### PR TITLE
docs: Remove --blocked-license flags from Libraries policy reference

### DIFF
--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_create.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_create.md
@@ -20,15 +20,8 @@ Create a CUSTOM Libraries policy for an organization.
 A policy configures the gates applied when your organization pulls upstream
 packages. Use --cooldown-days to quarantine newly published versions for N
 days (0 disables the cooldown, 1-30 sets an explicit window, omit to inherit
-the system default), --block to always deny a package, --allow to let a
-package override the cooldown and/or malware gates, and --blocked-license to
-deny versions by their declared SPDX license.
-
-License matching is case-insensitive and per exact identifier: a version is
-withheld when any identifier in its declared license (expressions like
-"MIT OR GPL-3.0" are split) equals a blocked entry. Blocking GPL-3.0 does not
-block GPL-3.0-only or GPL-3.0-or-later; list each identifier. The license
-gate cannot be bypassed by --allow entries.
+the system default), --block to always deny a package, and --allow to let a
+package override the cooldown and/or malware gates.
 
 Packages are identified by their package URL (purl). The purl namespace
 selects the ecosystem, so the same --block and --allow flags work for Java, JavaScript, and Python:
@@ -49,7 +42,7 @@ A newly created policy is inactive: activate it for an ecosystem with
 "chainctl libraries policy enable".
 
 ```
-chainctl libraries policy create --name NAME [--parent ORGANIZATION_NAME | ORGANIZATION_ID] [--cooldown-days N] [--block ...] [--allow ...] [--blocked-license ...] [flags]
+chainctl libraries policy create --name NAME [--parent ORGANIZATION_NAME | ORGANIZATION_ID] [--cooldown-days N] [--block ...] [--allow ...] [flags]
 ```
 
 ### Examples
@@ -76,24 +69,17 @@ chainctl libraries policy create --name NAME [--parent ORGANIZATION_NAME | ORGAN
   # Allow a Java package to skip the cooldown window
   chainctl libraries policy create --name=trusted --parent=example.com \
   --allow=purl=pkg:maven/org.apache.commons/commons-lang3,override-cooldown=true
-  
-  # Deny copyleft-licensed versions (repeat --blocked-license per identifier)
-  chainctl libraries policy create --name=no-copyleft --parent=example.com \
-  --blocked-license=GPL-3.0 \
-  --blocked-license=GPL-3.0-only \
-  --blocked-license=AGPL-3.0
 ```
 
 ### Options
 
 ```
-      --allow stringArray             A package permitted to override gates, as comma-separated key=value pairs: purl=<package-url>[,override-cooldown=true][,override-malware=true][,justification="..."]. justification is required with override-malware. Repeatable.
-      --block stringArray             A package to always deny, as purl=<package-url>. The purl namespace selects the ecosystem (pkg:maven/<group>/<artifact>, pkg:npm/<name>, pkg:pypi/<name>); append @<version> to block a single version. Repeatable.
-      --blocked-license stringArray   An SPDX license identifier to deny (e.g. GPL-3.0). Package versions whose declared license contains a matching identifier are withheld. Matching is case-insensitive and per exact identifier: blocking GPL-3.0 does not block GPL-3.0-only. Repeatable.
-      --cooldown-days int32           The cooldown window in days (0 disables, 1-30 explicit, omit to inherit the default). (default -1)
-      --description string            The description of the policy.
-      --name string                   The name of the policy.
-      --parent string                 The name or id of the organization to scope the policy to.
+      --allow stringArray     A package permitted to override gates, as comma-separated key=value pairs: purl=<package-url>[,override-cooldown=true][,override-malware=true][,justification="..."]. justification is required with override-malware. Repeatable.
+      --block stringArray     A package to always deny, as purl=<package-url>. The purl namespace selects the ecosystem (pkg:maven/<group>/<artifact>, pkg:npm/<name>, pkg:pypi/<name>); append @<version> to block a single version. Repeatable.
+      --cooldown-days int32   The cooldown window in days (0 disables, 1-30 explicit, omit to inherit the default). (default -1)
+      --description string    The description of the policy.
+      --name string           The name of the policy.
+      --parent string         The name or id of the organization to scope the policy to.
 ```
 
 ### Options inherited from parent commands

--- a/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_update.md
+++ b/content/platform/chainctl/chainctl-docs/chainctl_libraries_policy_update.md
@@ -17,20 +17,18 @@ Update a custom Libraries policy.
 
 Update a CUSTOM Libraries policy for an organization.
 
-By default --block, --allow, and --blocked-license ADD to the policy's
-existing lists: a new --block purl or --blocked-license identifier is appended
-(duplicates are ignored) and a new --allow purl replaces any existing allow
-entry for the same purl. Use --remove-block, --remove-allow, and
---remove-blocked-license to drop entries, or --replace-block, --replace-allow,
-and --replace-blocked-licenses to replace an entire list with the flag's
-entries (pass a replace flag with no entries to clear that list).
+By default --block and --allow ADD to the policy's existing lists: a new
+--block purl is appended (duplicates are ignored) and a new --allow purl
+replaces any existing allow entry for the same purl. Use --remove-block and
+--remove-allow to drop entries, or --replace-block and --replace-allow to
+replace an entire list with the flag's entries (pass a replace flag with no
+entries to clear that list).
 
 Packages are identified by their package URL (purl); see
-"chainctl libraries policy create --help" for the supported purl formats and
-the blocked-license matching semantics.
+"chainctl libraries policy create --help" for the supported purl formats.
 
 ```
-chainctl libraries policy update POLICY [--cooldown-days N] [--block ...] [--allow ...] [--blocked-license ...] [--remove-block ...] [--remove-allow ...] [--remove-blocked-license ...] [--replace-block] [--replace-allow] [--replace-blocked-licenses] [flags]
+chainctl libraries policy update POLICY [--cooldown-days N] [--block ...] [--allow ...] [--remove-block ...] [--remove-allow ...] [--replace-block] [--replace-allow] [flags]
 ```
 
 ### Examples
@@ -55,35 +53,20 @@ chainctl libraries policy update POLICY [--cooldown-days N] [--block ...] [--all
   
   # Clear the allow list entirely
   chainctl libraries policy update trusted --parent=example.com --replace-allow
-  
-  # Add a license to the blocked-licenses list (existing entries are kept)
-  chainctl libraries policy update no-copyleft --parent=example.com \
-  --blocked-license=SSPL-1.0
-  
-  # Remove a license from the blocked-licenses list
-  chainctl libraries policy update no-copyleft --parent=example.com \
-  --remove-blocked-license=GPL-3.0
-  
-  # Clear the blocked-licenses list entirely
-  chainctl libraries policy update no-copyleft --parent=example.com \
-  --replace-blocked-licenses
 ```
 
 ### Options
 
 ```
-      --allow stringArray                    A package permitted to override gates, as comma-separated key=value pairs: purl=<package-url>[,override-cooldown=true][,override-malware=true][,justification="..."]. Added to the existing allow list, replacing any existing entry for the same purl (use --replace-allow to replace the whole list instead). Repeatable.
-      --block stringArray                    A package to always deny, as purl=<package-url> (pkg:pypi/<name>, pkg:npm/<name>, pkg:maven/<group>/<artifact>); append @<version> to block a single version. Added to the existing block list (use --replace-block to replace it instead). Repeatable.
-      --blocked-license stringArray          An SPDX license identifier to add to the blocked-licenses list (e.g. GPL-3.0). Added to the existing list (use --replace-blocked-licenses to replace it instead). Repeatable.
-      --cooldown-days int32                  The cooldown window in days (0 disables, 1-30 explicit, omit to inherit the default). (default -1)
-      --description string                   The updated description of the policy.
-      --parent string                        The name or id of the organization that owns the policy.
-      --remove-allow stringArray             A package to remove from the allow list, as a purl or purl=<package-url> (match the purl shown by 'describe'). Repeatable.
-      --remove-block stringArray             A package to remove from the block list, as a purl or purl=<package-url> (match the purl shown by 'describe'). Repeatable.
-      --remove-blocked-license stringArray   An SPDX license identifier to remove from the blocked-licenses list (case-insensitive). Repeatable.
-      --replace-allow                        Replace the entire allow list with the --allow entries instead of adding to it; pass with no --allow to clear the allow list.
-      --replace-block                        Replace the entire block list with the --block entries instead of adding to it; pass with no --block to clear the block list.
-      --replace-blocked-licenses             Replace the entire blocked-licenses list with the --blocked-license entries instead of adding to it; pass with no --blocked-license to clear the list.
+      --allow stringArray          A package permitted to override gates, as comma-separated key=value pairs: purl=<package-url>[,override-cooldown=true][,override-malware=true][,justification="..."]. Added to the existing allow list, replacing any existing entry for the same purl (use --replace-allow to replace the whole list instead). Repeatable.
+      --block stringArray          A package to always deny, as purl=<package-url> (pkg:pypi/<name>, pkg:npm/<name>, pkg:maven/<group>/<artifact>); append @<version> to block a single version. Added to the existing block list (use --replace-block to replace it instead). Repeatable.
+      --cooldown-days int32        The cooldown window in days (0 disables, 1-30 explicit, omit to inherit the default). (default -1)
+      --description string         The updated description of the policy.
+      --parent string              The name or id of the organization that owns the policy.
+      --remove-allow stringArray   A package to remove from the allow list, as a purl or purl=<package-url> (match the purl shown by 'describe'). Repeatable.
+      --remove-block stringArray   A package to remove from the block list, as a purl or purl=<package-url> (match the purl shown by 'describe'). Repeatable.
+      --replace-allow              Replace the entire allow list with the --allow entries instead of adding to it; pass with no --allow to clear the allow list.
+      --replace-block              Replace the entire block list with the --block entries instead of adding to it; pass with no --block to clear the block list.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
🤖 The AutoDocs run in #3626 published the `--blocked-license`, `--remove-blocked-license` and `--replace-blocked-licenses` flags onto the `chainctl libraries policy create` and `update` reference pages. The feature is not generally available yet, so the reference should not document it.

Only the license flags and their examples are removed. The block/allow list changes that landed in the same AutoDocs run are shipped and are left alone.

The Options tables are re-rendered using the generator's own column-padding rule for the reduced flag set rather than hand-trimmed, so the result matches what a future AutoDocs run will produce. `npm run build` passes.

A follow-up change upstream of AutoDocs is needed for this to persist past the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)