### PR TITLE
Fix broken Renovate custom jsonata manager link

### DIFF
--- a/content/chainguard/containers/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/containers/staying-secure/updating-images/renovate/index.md
@@ -63,7 +63,7 @@ You can now configure `hostRules` in Renovate to support the Chainguard registry
 }
 ```
 
-Be aware that you **SHOULD NOT** check this file into source control with the exposed secret. Instead, you can use environment variables which you pass in at runtime if you use a `config.js` file:
+Be aware that you **SHOULD NOT** check this file into source control with the exposed secret. Instead, you can use environment variables that you pass in at runtime if you use a `config.js` file:
 
 ```json
 module.exports = {
@@ -78,13 +78,13 @@ module.exports = {
 };
 ```
 
-But an even more secure solution would be to create a script which automatically updates the configuration with the correct values by calling `chainctl`. If you do this, you should also set the credential lifetime to a much shorter period with the `--ttl` flag:
+But an even more secure solution would be to create a script that automatically updates the configuration with the correct values by calling `chainctl`. If you do this, you should also set the credential lifetime to a much shorter period with the `--ttl` flag:
 
 ```shell
 chainctl auth configure-docker --pull-token --ttl 10m
 ```
 
-This sets the pull token's lifetime to 10 minutes, which limits the risk posed if the token should leak. You can also set the lifetime to a longer period for more manual configurations.
+This sets the pull token's lifetime to 10 minutes, which limits the risk posed if the token leaks. You can also set the lifetime to a longer period for more manual configurations.
 
 ## Updating versioned container images
 
@@ -154,7 +154,7 @@ The following example Renovate configuration includes this option:
 }
 ```
 
-This configures Renovate to open PRs that will pin a reference like `cgr.dev/chainguard/python:3.12` to a digest like the following:
+This configures Renovate to open PRs that pin a reference like `cgr.dev/chainguard/python:3.12` to a digest like the following:
 
 ```
 cgr.dev/chainguard/python:3.12@sha256:e3b524a97c37c32ba590aae0ebcebe3a983c1f69a5093b670fdba980f97a09b3
@@ -186,7 +186,7 @@ Here is an example Renovate configuration that does this:
 
 This configures Renovate to update the digest for a reference but not the tag.
 
-The benefit of this approach is that it allows you to define your update strategy for each image reference by the use of a mutable tag, rather than having separate rules for different images in your Renovate configuration, similar to Chainguard's [Digestabot](https://github.com/chainguard-dev/digestabot) Github Action.
+The benefit of this approach is that it allows you to define your update strategy for each image reference by the use of a mutable tag, rather than having separate rules for different images in your Renovate configuration, similar to Chainguard's [Digestabot](https://github.com/chainguard-dev/digestabot) GitHub Action.
 
 ## Updating Chainguard Helm charts in Helmfiles
 
@@ -442,18 +442,18 @@ jobs:
 This workflow performs the following steps:
 
 * Installs chainctl and logs in as the assumable identity you created.
-* Exports a short lived token for cgr.dev as `RENOVATE_DOCKER_CGR_DEV_PASSWORD`.
-* Runs renovate with `RENOVATE_DETECT_HOST_RULES_FROM_ENV=true` so that it uses the password exported by the previous step.
+* Exports a short-lived token for cgr.dev as `RENOVATE_DOCKER_CGR_DEV_PASSWORD`.
+* Runs Renovate with `RENOVATE_DETECT_HOST_RULES_FROM_ENV=true` so that it uses the password exported by the previous step.
 
 Push this file to your repository's `main` branch.
 
 This workflow is scheduled to run at 3:00 a.m. every morning. You can trigger it manually by navigating to **Actions > Renovate** and selecting **Run workflow**.
 
-Once the workflow has ran successfully, you will find pull requests in your repository for any image references that need to be updated.
+Once the workflow has run successfully, you'll find pull requests in your repository for any image references that need to be updated.
 
 ## Running Renovate with Docker
 
-Chainguard provide [an image for Renovate](https://images.chainguard.dev/directory/image/renovate/overview). This is an example of how you can run this image to keep references to Chainguard images up to date in a GitHub repository.
+Chainguard provides [an image for Renovate](https://images.chainguard.dev/directory/image/renovate/overview). This is an example of how you can run this image to keep references to Chainguard images up to date in a GitHub repository.
 
 > **Note**: To follow along with this section, you must have access to Chainguard's `renovate` container image.
 
@@ -467,7 +467,7 @@ export RENOVATE_TOKEN=ghp_XXXXXXXXXXXXXXXXXX
 
 Next, create a Renovate configuration file at the root of any GitHub repositories you want to target with Renovate. Refer to the [official documentation](https://docs.renovatebot.com/configuration-options/) for all the supported options.
 
-This is an example of the most minimal configuration:
+This is an example of a minimal configuration:
 
 ```json
 {
@@ -536,7 +536,7 @@ DEBUG: found labels in manifest (repository=local)
 
 ### Connection errors
 
-If you have problems getting Renovate to monitor `cgr.dev`, please double check the connection details. Make sure the token is still valid (you can verify with `chainctl iam identities list`) and it has access to the repository you are referring to. You can test these credentials by running a `docker login` and `docker pull` in a clean environment.
+If you have problems getting Renovate to monitor `cgr.dev`, please double-check the connection details. Make sure the token is still valid (you can verify with `chainctl iam identities list`) and it has access to the repository you are referring to. You can test these credentials by running a `docker login` and `docker pull` in a clean environment.
 
 ### getReleaseList error
 

--- a/content/chainguard/containers/staying-secure/updating-images/renovate/index.md
+++ b/content/chainguard/containers/staying-secure/updating-images/renovate/index.md
@@ -249,7 +249,7 @@ Configure Renovate with the example below, replacing every instance of `cgr.dev/
 
 Renovate supports updating [ArgoCD](https://argo-cd.readthedocs.io/) `Application` manifests with its [built-in `argocd` manager](https://docs.renovatebot.com/modules/manager/argocd/). However, it doesn't presently support updating [digest references](/chainguard/containers/how-to-use/container-image-digests/) for OCI chart URLs, which is a [recommended practice when deploying Chainguard Helm charts](/chainguard/containers/how-to-use/use-chainguard-helm-charts/#pin-to-digest). See [renovatebot/renovate#45055](https://github.com/renovatebot/renovate/discussions/45055) for more details.
 
-To pin Chainguard Helm charts to digests and update them with Renovate, you can use a [custom `jsonata` manager](https://docs.renovatebot.com/modules/manager/custom.jsonata/) as a workaround.
+To pin Chainguard Helm charts to digests and update them with Renovate, you can use a [custom `jsonata` manager](https://docs.renovatebot.com/modules/manager/jsonata/) as a workaround.
 
 Given `Application` manifests such as:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Fixes a 404 link to Renovate's custom `jsonata` manager documentation
- Corrects spelling, grammar, and style issues in the same page

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-108/chainlink-check-links-on-educhainguarddev

Points the Renovate guide at the current URL for the custom `jsonata` manager docs and cleans up prose errors on the page.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
A link check found that `https://docs.renovatebot.com/modules/manager/custom.jsonata/` returns a 404. Renovate moved those docs to `https://docs.renovatebot.com/modules/manager/jsonata/`. The page also carried several long-standing prose errors, including "Chainguard provide" and "the workflow has ran."

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- Both custom `jsonata` manager links on the Renovate page resolve to a live Renovate docs page
- No other links on the page are changed
- Prose fixes read correctly and don't alter technical meaning

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Navigate to **Chainguard Containers > Staying Secure > Updating Images > Using Renovate** and follow the "custom `jsonata` manager" links in both the Helmfiles and ArgoCD sections
