### PR TITLE
fix(deps): downgrade DocSearch to v4 to fix build and clear 13 alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Hold DocSearch at v4. v5 adds an "Ask AI" feature (unused here) that
+      # pulls the Vercel AI SDK -> undici, reintroducing 13 alerts, and ships
+      # CSS Level 4 range media queries that Hugo's built-in LibSass can't
+      # parse, breaking the Sass build. Revisit only alongside a Dart Sass
+      # migration. See PR reverting #3773/#3775.
+      - dependency-name: "@docsearch/css"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@docsearch/js"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@docsearch/css": "^5.0.1",
-        "@docsearch/js": "^5.0.1",
+        "@docsearch/css": "^4.7.0",
+        "@docsearch/js": "^4.7.0",
         "@scalar/api-reference": "^1.64.1",
         "bootstrap-icons": "^1.13.1"
       },
@@ -83,90 +83,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/react": {
-      "version": "2.0.240",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.240.tgz",
-      "integrity": "sha512-jUrJECM6+PAiWsBqYeTfMr4mk82ms+5jH6o+j5NkCvrk1+dyTG2SMQVCJ3ICglfKZqgTEGnMU8dVIP7qHy6nhA==",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.32",
-        "ai": "5.0.237",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
-        "zod": "^3.25.76 || ^4.1.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/gateway": {
-      "version": "2.0.134",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.134.tgz",
-      "integrity": "sha512-n+dVco86tzsoQ5Lq8YI62ALsNQw37P5jJa/1NuzCtezfZCzH1UfgDWE3EZ0U1U3rqHlHFWV1N8D3QD5KBY9myg==",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.32",
-        "@vercel/oidc": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.32.tgz",
-      "integrity": "sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6",
-        "undici": "^5.29.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/ai": {
-      "version": "5.0.237",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.237.tgz",
-      "integrity": "sha512-vhUJTINUVbmXA4djxDPeYXSmAkzF/dkixHzdCvaCyD+mDsWLemvokt+KWmfkdDwv4Htt2iCScFuB23lP30XALg==",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.134",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.32",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/vue": {
       "version": "3.0.33",
       "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
@@ -181,216 +97,6 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
-      }
-    },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
-      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
-      "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
-      }
-    },
-    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
-      },
-      "peerDependencies": {
-        "search-insights": ">= 1 < 3"
-      }
-    },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
-      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
-      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
-      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-insights": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
-      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
-      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
-      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
-      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/ingestion": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
-      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/monitoring": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
-      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/recommend": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
-      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
-      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
-      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
-      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -439,14 +145,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
@@ -458,74 +156,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@base-ui/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.2",
-        "@floating-ui/react-dom": "^2.1.9",
-        "@floating-ui/utils": "^0.2.12",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@base-ui/react/node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
-      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.12",
-        "reselect": "^5.2.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@base-ui/utils/node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.2",
@@ -857,137 +487,17 @@
         "@csstools/css-tokenizer": "^4.0.0"
       }
     },
-    "node_modules/@docsearch/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-2iQ8m9eqGhiSvxt+CotLLqCNxE36K3ks0ALXiirTdr09HKBzt2RKi+m9bMA911rXxWO2NCq9Ug8LJxCCB3XmNQ==",
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 20.0.0",
-        "react": ">= 16.8.0 < 20.0.0",
-        "react-dom": ">= 16.8.0 < 20.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docsearch/css": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-5.0.1.tgz",
-      "integrity": "sha512-q1HdKMkROnZIIN+/eSa2f6qtIn9VcBtXelVMScFuWTWPQwIMBt0evl/TJku0HsssMJkuT6jKzY6Yfet/RMG2Tg=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
+      "license": "MIT"
     },
     "node_modules/@docsearch/js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-5.0.1.tgz",
-      "integrity": "sha512-MPhohJzaTcbHpShOg7Xg2lck+URCv8XnHHr9kV9MTdXM3BVEXLzoaH7VPAZnaQ4jl3Q0diwLgspd9FnTDRxnsQ==",
-      "dependencies": {
-        "@docsearch/core": "5.0.1",
-        "@docsearch/react": "5.0.1"
-      }
-    },
-    "node_modules/@docsearch/react": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-5.0.1.tgz",
-      "integrity": "sha512-0gP+NZxQDNltW72LQiqTjmKMf0lffOY7UJndll8js9zhRvgfucs7iGaBJyQdP/wZL+4jeUskjyWspjSO1KbVbg==",
-      "dependencies": {
-        "@ai-sdk/react": "^2.0.30",
-        "@algolia/autocomplete-core": "1.19.2",
-        "@base-ui/react": "^1.5.0",
-        "@docsearch/core": "5.0.1",
-        "@docsearch/css": "5.0.1",
-        "ai": "^5.0.30",
-        "algoliasearch": "^5.28.0",
-        "marked": "^16.3.0",
-        "zod": "^4.1.8"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 20.0.0",
-        "react": ">= 16.8.0 < 20.0.0",
-        "react-dom": ">= 16.8.0 < 20.0.0",
-        "search-insights": ">= 1 < 3"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "search-insights": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@ai-sdk/gateway": {
-      "version": "2.0.134",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.134.tgz",
-      "integrity": "sha512-n+dVco86tzsoQ5Lq8YI62ALsNQw37P5jJa/1NuzCtezfZCzH1UfgDWE3EZ0U1U3rqHlHFWV1N8D3QD5KBY9myg==",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.32",
-        "@vercel/oidc": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.32.tgz",
-      "integrity": "sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6",
-        "undici": "^5.29.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/ai": {
-      "version": "5.0.237",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.237.tgz",
-      "integrity": "sha512-vhUJTINUVbmXA4djxDPeYXSmAkzF/dkixHzdCvaCyD+mDsWLemvokt+KWmfkdDwv4Htt2iCScFuB23lP30XALg==",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.134",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.32",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.7.0.tgz",
+      "integrity": "sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1147,14 +657,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -1181,18 +683,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
@@ -2803,30 +2293,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/algoliasearch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
-      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
-      "dependencies": {
-        "@algolia/abtesting": "1.22.0",
-        "@algolia/client-abtesting": "5.56.0",
-        "@algolia/client-analytics": "5.56.0",
-        "@algolia/client-common": "5.56.0",
-        "@algolia/client-insights": "5.56.0",
-        "@algolia/client-personalization": "5.56.0",
-        "@algolia/client-query-suggestions": "5.56.0",
-        "@algolia/client-search": "5.56.0",
-        "@algolia/ingestion": "1.56.0",
-        "@algolia/monitoring": "1.56.0",
-        "@algolia/recommend": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -6065,17 +5531,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/mathml-tag-names": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
@@ -7857,27 +7312,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.8"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8083,11 +7517,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
-    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -8200,12 +7629,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "peer": true
-    },
     "node_modules/scss-parser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/scss-parser/-/scss-parser-1.0.3.tgz",
@@ -8218,12 +7641,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "peer": true
     },
     "node_modules/select": {
       "version": "1.1.2",
@@ -8848,18 +8265,6 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
-    "node_modules/swr": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.1.tgz",
-      "integrity": "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/swrv": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.2.0.tgz",
@@ -8955,17 +8360,6 @@
       "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
       "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
       "dev": true
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -9162,17 +8556,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -9354,14 +8737,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9638,59 +9013,6 @@
         "eventsource-parser": "^3.0.6"
       }
     },
-    "@ai-sdk/react": {
-      "version": "2.0.240",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.240.tgz",
-      "integrity": "sha512-jUrJECM6+PAiWsBqYeTfMr4mk82ms+5jH6o+j5NkCvrk1+dyTG2SMQVCJ3ICglfKZqgTEGnMU8dVIP7qHy6nhA==",
-      "requires": {
-        "@ai-sdk/provider-utils": "3.0.32",
-        "ai": "5.0.237",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "dependencies": {
-        "@ai-sdk/gateway": {
-          "version": "2.0.134",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.134.tgz",
-          "integrity": "sha512-n+dVco86tzsoQ5Lq8YI62ALsNQw37P5jJa/1NuzCtezfZCzH1UfgDWE3EZ0U1U3rqHlHFWV1N8D3QD5KBY9myg==",
-          "requires": {
-            "@ai-sdk/provider": "2.0.3",
-            "@ai-sdk/provider-utils": "3.0.32",
-            "@vercel/oidc": "3.1.0"
-          }
-        },
-        "@ai-sdk/provider": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-          "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        },
-        "@ai-sdk/provider-utils": {
-          "version": "3.0.32",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.32.tgz",
-          "integrity": "sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==",
-          "requires": {
-            "@ai-sdk/provider": "2.0.3",
-            "@standard-schema/spec": "^1.0.0",
-            "eventsource-parser": "^3.0.6",
-            "undici": "^5.29.0"
-          }
-        },
-        "ai": {
-          "version": "5.0.237",
-          "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.237.tgz",
-          "integrity": "sha512-vhUJTINUVbmXA4djxDPeYXSmAkzF/dkixHzdCvaCyD+mDsWLemvokt+KWmfkdDwv4Htt2iCScFuB23lP30XALg==",
-          "requires": {
-            "@ai-sdk/gateway": "2.0.134",
-            "@ai-sdk/provider": "2.0.3",
-            "@ai-sdk/provider-utils": "3.0.32",
-            "@opentelemetry/api": "1.9.0"
-          }
-        }
-      }
-    },
     "@ai-sdk/vue": {
       "version": "3.0.33",
       "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
@@ -9699,168 +9021,6 @@
         "@ai-sdk/provider-utils": "4.0.5",
         "ai": "6.0.33",
         "swrv": "^1.0.4"
-      }
-    },
-    "@algolia/abtesting": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
-      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
-      "requires": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
-      }
-    },
-    "@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
-      "requires": {
-        "@algolia/autocomplete-shared": "1.19.2"
-      }
-    },
-    "@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
-      "requires": {}
-    },
-    "@algolia/client-abtesting": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
-      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/client-analytics": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
-      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/client-common": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
-      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg=="
-    },
-    "@algolia/client-insights": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
-      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/client-personalization": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
-      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/client-query-suggestions": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
-      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/client-search": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
-      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/ingestion": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
-      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/monitoring": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
-      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/recommend": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
-      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
-      "requires": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      }
-    },
-    "@algolia/requester-browser-xhr": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
-      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
-      "requires": {
-        "@algolia/client-common": "5.56.0"
-      }
-    },
-    "@algolia/requester-fetch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
-      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
-      "requires": {
-        "@algolia/client-common": "5.56.0"
-      }
-    },
-    "@algolia/requester-node-http": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
-      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
-      "requires": {
-        "@algolia/client-common": "5.56.0"
       }
     },
     "@babel/code-frame": {
@@ -9892,11 +9052,6 @@
         "@babel/types": "^7.29.8"
       }
     },
-    "@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
-    },
     "@babel/types": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
@@ -9904,43 +9059,6 @@
       "requires": {
         "@babel/helper-string-parser": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7"
-      }
-    },
-    "@base-ui/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
-      "requires": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.2",
-        "@floating-ui/react-dom": "^2.1.9",
-        "@floating-ui/utils": "^0.2.12",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "dependencies": {
-        "@floating-ui/utils": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-          "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
-        }
-      }
-    },
-    "@base-ui/utils": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
-      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
-      "requires": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.12",
-        "reselect": "^5.2.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "dependencies": {
-        "@floating-ui/utils": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-          "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
-        }
       }
     },
     "@borewit/text-codec": {
@@ -10179,83 +9297,15 @@
       "dev": true,
       "requires": {}
     },
-    "@docsearch/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-2iQ8m9eqGhiSvxt+CotLLqCNxE36K3ks0ALXiirTdr09HKBzt2RKi+m9bMA911rXxWO2NCq9Ug8LJxCCB3XmNQ==",
-      "requires": {}
-    },
     "@docsearch/css": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-5.0.1.tgz",
-      "integrity": "sha512-q1HdKMkROnZIIN+/eSa2f6qtIn9VcBtXelVMScFuWTWPQwIMBt0evl/TJku0HsssMJkuT6jKzY6Yfet/RMG2Tg=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw=="
     },
     "@docsearch/js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-5.0.1.tgz",
-      "integrity": "sha512-MPhohJzaTcbHpShOg7Xg2lck+URCv8XnHHr9kV9MTdXM3BVEXLzoaH7VPAZnaQ4jl3Q0diwLgspd9FnTDRxnsQ==",
-      "requires": {
-        "@docsearch/core": "5.0.1",
-        "@docsearch/react": "5.0.1"
-      }
-    },
-    "@docsearch/react": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-5.0.1.tgz",
-      "integrity": "sha512-0gP+NZxQDNltW72LQiqTjmKMf0lffOY7UJndll8js9zhRvgfucs7iGaBJyQdP/wZL+4jeUskjyWspjSO1KbVbg==",
-      "requires": {
-        "@ai-sdk/react": "^2.0.30",
-        "@algolia/autocomplete-core": "1.19.2",
-        "@base-ui/react": "^1.5.0",
-        "@docsearch/core": "5.0.1",
-        "@docsearch/css": "5.0.1",
-        "ai": "^5.0.30",
-        "algoliasearch": "^5.28.0",
-        "marked": "^16.3.0",
-        "zod": "^4.1.8"
-      },
-      "dependencies": {
-        "@ai-sdk/gateway": {
-          "version": "2.0.134",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.134.tgz",
-          "integrity": "sha512-n+dVco86tzsoQ5Lq8YI62ALsNQw37P5jJa/1NuzCtezfZCzH1UfgDWE3EZ0U1U3rqHlHFWV1N8D3QD5KBY9myg==",
-          "requires": {
-            "@ai-sdk/provider": "2.0.3",
-            "@ai-sdk/provider-utils": "3.0.32",
-            "@vercel/oidc": "3.1.0"
-          }
-        },
-        "@ai-sdk/provider": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-          "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        },
-        "@ai-sdk/provider-utils": {
-          "version": "3.0.32",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.32.tgz",
-          "integrity": "sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==",
-          "requires": {
-            "@ai-sdk/provider": "2.0.3",
-            "@standard-schema/spec": "^1.0.0",
-            "eventsource-parser": "^3.0.6",
-            "undici": "^5.29.0"
-          }
-        },
-        "ai": {
-          "version": "5.0.237",
-          "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.237.tgz",
-          "integrity": "sha512-vhUJTINUVbmXA4djxDPeYXSmAkzF/dkixHzdCvaCyD+mDsWLemvokt+KWmfkdDwv4Htt2iCScFuB23lP30XALg==",
-          "requires": {
-            "@ai-sdk/gateway": "2.0.134",
-            "@ai-sdk/provider": "2.0.3",
-            "@ai-sdk/provider-utils": "3.0.32",
-            "@opentelemetry/api": "1.9.0"
-          }
-        }
-      }
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.7.0.tgz",
+      "integrity": "sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -10358,11 +9408,6 @@
         "levn": "^0.4.1"
       }
     },
-    "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    },
     "@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -10392,14 +9437,6 @@
           "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
           "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
         }
-      }
-    },
-    "@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "requires": {
-        "@floating-ui/dom": "^1.8.0"
       }
     },
     "@floating-ui/utils": {
@@ -11579,27 +10616,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "algoliasearch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
-      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
-      "requires": {
-        "@algolia/abtesting": "1.22.0",
-        "@algolia/client-abtesting": "5.56.0",
-        "@algolia/client-analytics": "5.56.0",
-        "@algolia/client-common": "5.56.0",
-        "@algolia/client-insights": "5.56.0",
-        "@algolia/client-personalization": "5.56.0",
-        "@algolia/client-query-suggestions": "5.56.0",
-        "@algolia/client-search": "5.56.0",
-        "@algolia/ingestion": "1.56.0",
-        "@algolia/monitoring": "1.56.0",
-        "@algolia/recommend": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
       }
     },
     "ansi-regex": {
@@ -13775,11 +12791,6 @@
       "dev": true,
       "requires": {}
     },
-    "marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="
-    },
     "mathml-tag-names": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
@@ -14879,21 +13890,6 @@
         }
       }
     },
-    "react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "peer": true
-    },
-    "react-dom": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "peer": true,
-      "requires": {
-        "scheduler": "^0.27.0"
-      }
-    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15046,11 +14042,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
-    },
     "reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -15113,12 +14104,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "peer": true
-    },
     "scss-parser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/scss-parser/-/scss-parser-1.0.3.tgz",
@@ -15128,12 +14113,6 @@
         "invariant": "2.2.2",
         "lodash": "^4.17.4"
       }
-    },
-    "search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "peer": true
     },
     "select": {
       "version": "1.1.2",
@@ -15499,15 +14478,6 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
-    "swr": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.1.tgz",
-      "integrity": "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==",
-      "requires": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      }
-    },
     "swrv": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.2.0.tgz",
@@ -15582,11 +14552,6 @@
       "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
       "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
       "dev": true
-    },
-    "throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="
     },
     "through": {
       "version": "2.3.8",
@@ -15717,14 +14682,6 @@
         "through": "^2.3.8"
       }
     },
-    "undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
-      }
-    },
     "undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -15841,12 +14798,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "hugo": "0.152.1"
   },
   "dependencies": {
-    "@docsearch/css": "^5.0.1",
-    "@docsearch/js": "^5.0.1",
+    "@docsearch/css": "^4.7.0",
+    "@docsearch/js": "^4.7.0",
     "@scalar/api-reference": "^1.64.1",
     "bootstrap-icons": "^1.13.1"
   },


### PR DESCRIPTION
## What

Downgrade `@docsearch/js` and `@docsearch/css` from `^5.0.1` to `^4.7.0`,
and add a Dependabot rule to hold DocSearch at v4.

## Why

Merging the DocSearch v5 bumps (#3773, #3775) this morning did two things:

1. **Opened 13 Dependabot alerts.** DocSearch v5 adds an "Ask AI" feature
   that pulls the Vercel AI SDK, which depends on `undici`. undici 5.29.0
   is the last 5.x release and is unpatched for the CVEs behind alerts
   #139–143 and #145–151 (three high-severity). Alert #144
   (`@ai-sdk/provider-utils`) has no fix available at all.
2. **Broke the production build.** v5's CSS ships Level 4 range media
   queries (`@media (width<=768px)`). Hugo's built-in LibSass (EOL since
   2020) cannot parse them, so `npm run build` — the command Netlify runs
   — fails on `app.scss`.

edu uses plain DocSearch and never enables Ask AI. Reverting to v4 removes
the entire AI SDK chain (45 fewer packages), clearing all 13 alerts and
restoring the build in one change.

## Verification

- `npm ci` passes
- `npm audit` reports 0 vulnerabilities (was 13)
- `npm run build` succeeds: 1687 pages, DocSearch JS and CSS both bundled
- `lint:styles` clean

## Follow-up

The Dependabot ignore rule holds DocSearch at v4. Adopting v5 later
requires migrating the Sass build to Dart Sass first — LibSass is
abandoned and cannot parse modern CSS. Worth a DOCS ticket.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-17.
