### PR TITLE
Add changelog week of 2026-08-17

### DIFF
--- a/content/chainguard/changelog.md
+++ b/content/chainguard/changelog.md
@@ -4,7 +4,7 @@ linktitle: "Changelog"
 type: "article"
 description: "Weekly changelog of Chainguard product updates — product announcements, breaking changes, container images reaching end-of-life or leaving the catalog, and images newly added to it."
 date: 2026-07-28T00:00:00+00:00
-lastmod: 2026-08-10T00:00:00+00:00
+lastmod: 2026-08-17T00:00:00+00:00
 draft: false
 tags: ["Chainguard Containers", "Changelog"]
 images: []
@@ -14,6 +14,81 @@ tocEndLevel: 2
 ---
 
 This page logs Chainguard product updates week by week, newest first: product announcements, breaking changes, container images that reached end-of-life or are no longer available, and images newly added to the catalog. Each event is listed once, in the week it first appeared.
+
+## Week of 2026-08-17
+
+{{< changelog-label "Product Announcements" >}}
+
+### Clearer npm errors for blocked packages
+
+_Launched August 13, 2026._
+
+When Chainguard Libraries withholds an npm package or version — because of detected malware or greyware, a pending malware scan, or a policy block such as a cooldown — npm now returns a `403` naming the specific reason, for example `MALWARE_DETECTED`, instead of the unexplained `404` it returned before. The other supported package managers (pnpm, yarn, uv, poetry, Maven, and Gradle) still report a blocked version as a generic not-found error, and a `409` when an entire package is blocked for malware.
+
+For more information, refer to [Error messages](/chainguard/libraries/errors/#package-manager-behavior).
+
+### Guardener GitHub App (beta)
+
+_Launched August 12, 2026._
+
+Chainguard Guardener, the automated migration tool, now covers GitHub Actions as well as container images. The GitHub App inventories the Actions in use across your organization's repositories, maps them to hardened Chainguard equivalents, and opens pull requests to swap them in, pinned to a specific SHA rather than a mutable tag. It runs in two modes: an upfront pass that surfaces existing Actions usage and opens migration pull requests, and ongoing standardization that watches workflow files and suggests Chainguard equivalents as new upstream Actions appear.
+
+For more information, refer to [Getting started with Chainguard Guardener](/chainguard/guardener/github/getting-started/).
+
+{{< changelog-label "Breaking Changes" >}}
+
+### Chainguard Libraries build pinning
+
+_Effective August 24, 2026._
+
+Chainguard Repository can serve two copies of the same package version: the upstream copy mirrored from the public registry, and Chainguard's copy rebuilt from source. The two have different checksums, and each request resolves independently, so when Chainguard publishes a rebuild of a version your organization already pulled, the next resolution moves you to the rebuild and its checksum no longer matches your lockfile — surfacing client-side as errors such as `EINTEGRITY` in npm. As of August 24, 2026, build pinning records which copy your organization received the first time it downloads a package version and keeps resolving that version to the same copy until you choose to move forward. Malware and policy blocks apply independently: a version that is later blocked stops being served rather than being replaced with a different copy.
+
+- **Affected:** organizations using Chainguard Libraries with upstream fallback, across JavaScript, Python, and Java. Organizations without upstream fallback see no change.
+- **Action:** none required. To keep the current behavior, run `chainctl libraries cache opt-out`. Both `opt-out` and `chainctl libraries cache opt-in` accept `--ecosystem`, and pinning state is tracked per organization and ecosystem. To see which copy each held version came from, run `chainctl libraries cache list`.
+
+For more information, refer to [`chainctl libraries cache`](/platform/chainctl/chainctl-docs/chainctl_libraries_cache/).
+
+{{< changelog-label "EOL" >}}
+
+Chainguard offers [a grace period](/chainguard/containers/features/eol-gp-overview/) for eligible end-of-life images: up to six months of continued rebuilds and security updates while you complete your upgrade.
+
+### Images that are no longer available
+
+The following container images reached the end of their grace period and are no longer available:
+
+| Image | End-of-life | Grace period ended |
+| --- | --- | --- |
+| `prometheus:3.9` | 2026-02-17 | 2026-08-17 |
+
+### Images that have reached end-of-life
+
+The following container images reached end-of-life and entered their grace period:
+
+| Image | End-of-life | Grace period ends |
+| --- | --- | --- |
+| `mattermost:10.11` | 2026-08-15 | 2027-02-15 |
+
+{{< changelog-label "New Images" >}}
+
+Chainguard built 17 new container images this week, including both standard and FIPS variants.
+
+<table class="cl-images">
+<thead><tr><th>Image</th><th>Tier</th><th>Added</th></tr></thead>
+<tbody>
+<tr><td><a href="https://images.chainguard.dev/directory/image/azurite/versions"><code>azurite</code></a></td><td>application</td><td>2026-08-10</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/k0s-cni-node/versions"><code>k0s-cni-node</code></a></td><td>application +fips</td><td>2026-08-10</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/peerdb-ui/versions"><code>peerdb-ui</code></a></td><td>application +fips</td><td>2026-08-10</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/scc/versions"><code>scc</code></a></td><td>application +fips</td><td>2026-08-10</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/zitadel-login/versions"><code>zitadel-login</code></a></td><td>application</td><td>2026-08-11</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/aws-lambda-nodejs/versions"><code>aws-lambda-nodejs</code></a></td><td>application +fips</td><td>2026-08-12</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/localstack/versions"><code>localstack</code></a></td><td>application</td><td>2026-08-12</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/kserve-router-fips/versions"><code>kserve-router-fips</code></a></td><td>fips</td><td>2026-08-13</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/jdk-openssl-fips/versions"><code>jdk-openssl-fips</code></a></td><td>fips</td><td>2026-08-14</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/jre-openssl-fips/versions"><code>jre-openssl-fips</code></a></td><td>fips</td><td>2026-08-14</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/kube-router/versions"><code>kube-router</code></a></td><td>application +fips</td><td>2026-08-14</td></tr>
+<tr><td><a href="https://images.chainguard.dev/directory/image/commercial-nginx-ingress-plus/versions"><code>commercial-nginx-ingress-plus</code></a></td><td>commercial</td><td>2026-08-17</td></tr>
+</tbody>
+</table>
 
 ## Week of 2026-08-10
 


### PR DESCRIPTION
Appends the week of 2026-08-17 to the Chainguard products changelog.

## What's in this week

**Product announcements**

- Clearer npm errors for blocked packages (launched August 13, 2026) — blocked npm pulls now return a `403` naming the reason instead of an unexplained `404`.
- Guardener GitHub App, beta (launched August 12, 2026) — Guardener now migrates GitHub Actions as well as container images.

**Breaking change**

- Chainguard Libraries build pinning, effective August 24, 2026. Worded so it reads correctly both before and after that date, since the effective date falls a week after publish.

**Image lifecycle**

- `prometheus:3.9` reached the end of its grace period and is no longer available.
- `mattermost:10.11` reached end-of-life and entered its grace period.
- 17 new images, rendered as 12 rows after the FIPS fold.

## Other change

Corrects the grace-period link to `/chainguard/containers/features/eol-gp-overview/`. The generator emitted the older `/chainguard/chainguard-images/` path, which redirects via an alias but disagreed with the three previously published weeks. The generator itself is fixed locally; `.claude/` is gitignored, so that part is not in this diff.

## Reviewer note: image directory links 404, and they are not healing

All 12 new-image links in this week's table 404, as do 8 links on the already-published page. Of the 51 image links now on the page, 20 are dead.

This was previously assumed to be a short indexing lag that corrects itself. That assumption does not hold. The 2026-08-10 run recorded 8 of that week's 19 links 404ing, with a clean cutoff at images added on or before 2026-08-05. Seven days later the same 8 are still 404 and the cutoff has not moved:

- images added 2026-08-05 or earlier resolve (31 of 51)
- images added 2026-08-06 or later almost all do not (20 of 51), including `claude`, `codex`, `opencode`, `acm-controller`, and `zalando-pgbouncer`

So some images in the changelog feed appear never to get a public directory page, rather than arriving late. Worth deciding how the generator should link new images before this becomes a larger set of dead links. That decision is out of scope here; this PR keeps the existing linking behavior so the week is consistent with those already published.

Generated from a BigQuery `changelog_events_v4` snapshot (278 rows, 276 in scope, load day 2026-08-17). `markdownlint-cli2` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
