### PR TITLE
docs(agent-skills): publish Public Skills MCP page

### DIFF
--- a/content/chainguard/agent-skills/public-skills-mcp.md
+++ b/content/chainguard/agent-skills/public-skills-mcp.md
@@ -5,7 +5,7 @@ description: "Connect an agent to Chainguard's Public Skills MCP server and use 
 type: "article"
 date: 2026-08-04T00:00:00+00:00
 lastmod: 2026-08-04T00:00:00+00:00
-draft: true
+draft: false
 tags: ["Agent Skills", "Overview"]
 images: []
 menu:


### PR DESCRIPTION
## What

The [Public Skills MCP page](https://github.com/chainguard-dev/edu/blob/main/content/chainguard/agent-skills/public-skills-mcp.md) was merged with `draft: true` in its frontmatter, so Hugo skips it in the production build and it never renders on the public site.

This flips it to `draft: false` so it publishes under the Agent Skills menu, matching its sibling pages (`public-registry.md`, `skills-registry.md`) which are all `draft: false`.

## Why

The page is complete and merged but invisible to users. No other frontmatter changes are needed — `menu`, `parent`, `weight`, and `type` already match the siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)