### PR TITLE
Document --issuer-keys for self-managed GitLab assumable identities (DOCS-126)

### DIFF
--- a/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
+++ b/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
@@ -10,7 +10,7 @@ lead: ""
 description: "Procedural tutorial outlining how to create a Chainguard identity that can be assumed by a GitLab CI/CD pipeline."
 type: "article"
 date: 2023-06-28T08:48:45+00:00
-lastmod: 2026-08-18T13:54:24+00:00
+lastmod: 2026-08-18T14:29:28+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
@@ -76,7 +76,7 @@ This will return `cg-gitlab-id` listed among all your Chainguard identities.
 
 ### Self-managed GitLab instances
 
-The earlier example works for GitLab SaaS (`gitlab.com`) and for self-managed instances whose OIDC issuer is reachable from the public internet. To validate a pipeline's token, Chainguard's Security Token Service (STS) fetches the signing keys from the issuer's JWKS endpoint (`https://<your-gitlab-instance>/oauth/discovery/keys`). If your instance isn't reachable from the public internet, this fetch fails and the pipeline can't assume the identity.
+The previous example works for GitLab SaaS (`gitlab.com`) and for self-managed instances whose OIDC issuer is reachable from the public internet. To validate a pipeline's token, Chainguard's Security Token Service (STS) fetches the signing keys from the issuer's JWKS endpoint (`https://<your-gitlab-instance>/oauth/discovery/keys`). If your instance isn't reachable from the public internet, this fetch fails and the pipeline can't assume the identity.
 
 For a private instance, pin the signing keys when you create the identity by passing them to `--issuer-keys`. Export the JWKS from a host that can reach your instance and provide it inline:
 
@@ -93,8 +93,6 @@ chainctl iam identities create cg-gitlab-id \
 Set `--identity-issuer` and `--audience` to your instance's URL instead of `https://gitlab.com`.
 
 Because the keys are pinned rather than fetched on demand, the identity doesn't pick up key rotations automatically. GitLab rotates its signing keys, so `chainctl` creates a static identity that expires after a set period, 30 days by default. Recreate the identity with the current JWKS before it expires or whenever the keys rotate.
-
-With that, you can jump ahead to [testing the new identity](/chainguard/administration/assumable-ids/identity-examples/gitlab-identity/#testing-the-identity-with-a-gitlab-cicd-pipeline). You can also continue onto the next section and learn how to create another such identity with Terraform.
 
 ## Create an assumable identity with Terraform
 

--- a/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
+++ b/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
@@ -10,7 +10,7 @@ lead: ""
 description: "Procedural tutorial outlining how to create a Chainguard identity that can be assumed by a GitLab CI/CD pipeline."
 type: "article"
 date: 2023-06-28T08:48:45+00:00
-lastmod: 2025-06-14T08:48:45+00:00
+lastmod: 2026-08-18T13:54:24+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
@@ -73,6 +73,26 @@ chainctl iam identities ls
 ```
 
 This will return `cg-gitlab-id` listed among all your Chainguard identities.
+
+### Self-managed GitLab instances
+
+The earlier example works for GitLab SaaS (`gitlab.com`) and for self-managed instances whose OIDC issuer is reachable from the public internet. To validate a pipeline's token, Chainguard's Security Token Service (STS) fetches the signing keys from the issuer's JWKS endpoint (`https://<your-gitlab-instance>/oauth/discovery/keys`). If your instance isn't reachable from the public internet, this fetch fails and the pipeline can't assume the identity.
+
+For a private instance, pin the signing keys when you create the identity by passing them to `--issuer-keys`. Export the JWKS from a host that can reach your instance and provide it inline:
+
+```shell
+chainctl iam identities create cg-gitlab-id \
+  --parent=<organization> \
+  --identity-issuer="https://<your-gitlab-instance>" \
+  --issuer-keys="$(curl -s https://<your-gitlab-instance>/oauth/discovery/keys)" \
+  --subject="project_path:<group_name>/<project_name>:ref_type:branch:ref:main" \
+  --audience="https://<your-gitlab-instance>" \
+  --role=viewer
+```
+
+Set `--identity-issuer` and `--audience` to your instance's URL instead of `https://gitlab.com`.
+
+Because the keys are pinned rather than fetched on demand, the identity doesn't pick up key rotations automatically. GitLab rotates its signing keys, so `chainctl` creates a static identity that expires after a set period, 30 days by default. Recreate the identity with the current JWKS before it expires or whenever the keys rotate.
 
 With that, you can jump ahead to [testing the new identity](/chainguard/administration/assumable-ids/identity-examples/gitlab-identity/#testing-the-identity-with-a-gitlab-cicd-pipeline). You can also continue onto the next section and learn how to create another such identity with Terraform.
 


### PR DESCRIPTION
## What this does

Adds a **Self-managed GitLab instances** subsection to the GitLab assumable identity guide. It explains that when a self-managed GitLab instance's OIDC issuer isn't reachable from the public internet, Chainguard's Security Token Service (STS) can't fetch the issuer's JWKS to validate pipeline tokens — so the public `gitlab.com` example silently fails. The fix is to pin the signing keys with `--issuer-keys`.

## Why

Customer feedback in [DOCS-126](https://linear.app/chainguard/issue/DOCS-126) and a recent support case surfaced that this page assumes the SaaS/public issuer and gives no indication the example won't work for private instances. The ticket flags this as its single most important addition.

## This is an established, verified pattern — not a new workaround

The identical approach is already documented and in use for Kubernetes clusters whose issuer URL isn't reachable over the internet: see [Create an assumable identity for a Kubernetes cluster](https://edu.chainguard.dev/platform/administration/assumable-ids/identity-examples/kubernetes-identity/), which pins keys with `--issuer-keys` and carries the same key-rotation and static-identity-expiry caveat. This PR applies that proven pattern to GitLab. GitLab's issuer and JWKS endpoint (`/oauth/discovery/keys`) were confirmed against `gitlab.com`'s live OIDC discovery document.

## Scope

This covers the `--issuer-keys` gap only. Two related items from DOCS-126 — the API-token workflow confusion on the tag-history-API page, and the full self-managed OIDC-provider registration procedure — need a private GitLab test instance to verify and will follow separately.

Refs DOCS-126.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-18.
