### PR TITLE
Clarify private self-managed GitLab uses key-pinning, not IdP registration (DOCS-137)

### DIFF
--- a/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
+++ b/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
@@ -10,7 +10,7 @@ lead: ""
 description: "Procedural tutorial outlining how to create a Chainguard identity that can be assumed by a GitLab CI/CD pipeline."
 type: "article"
 date: 2023-06-28T08:48:45+00:00
-lastmod: 2026-08-18T14:29:28+00:00
+lastmod: 2026-08-18T17:17:24+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
@@ -93,6 +93,8 @@ chainctl iam identities create cg-gitlab-id \
 Set `--identity-issuer` and `--audience` to your instance's URL instead of `https://gitlab.com`.
 
 Because the keys are pinned rather than fetched on demand, the identity doesn't pick up key rotations automatically. GitLab rotates its signing keys, so `chainctl` creates a static identity that expires after a set period, 30 days by default. Recreate the identity with the current JWKS before it expires or whenever the keys rotate.
+
+> **Note**: You don't need to register your self-managed GitLab as a [custom identity provider](/platform/administration/custom-idps/custom-idps/) to assume an identity from a pipeline. Custom identity providers federate human sign-in to Chainguard, whereas a pipeline assumes an identity through the OIDC token exchange described above. Registering a private instance as an identity provider won't work in any case, because Chainguard can't reach its issuer to validate it — the same reachability limit that requires you to pin the keys with `--issuer-keys`.
 
 ## Create an assumable identity with Terraform
 


### PR DESCRIPTION
## What this changes

Adds a note to the **Self-managed GitLab instances** section clarifying that you don't register a self-managed GitLab as a custom identity provider to assume an identity from a pipeline — and that registering an identity provider can't work for a private instance anyway.

## Why

[DOCS-137](https://linear.app/chainguard/issue/DOCS-137) originally proposed documenting a customer's full "register GitLab as an OIDC identity provider" procedure. Testing showed that procedure doesn't apply to the audience that needs it. For a private, internet-unreachable instance, registering an identity provider fails, and a non-pinned identity stalls at assumption. The pinned-key flow (already documented in #3795) is the only path that works. So the useful change is a short signpost steering private-instance users to `--issuer-keys`, not a new procedure.

## How this was tested

On a private self-managed GitLab test instance (local k3s, issuer unreachable by Chainguard's STS):

| Attempt | Result |
|---------|--------|
| `chainctl iam identity-providers create --oidc-issuer=https://<private>` | Fails: `issuer could not be validated` |
| Non-pinned `identities create` (no `--issuer-keys`) | Creates, but the pipeline assumption stalls |
| Pinned `--issuer-keys` + `--audience` (the #3795 flow) | Works end-to-end |

Full data and the three self-managed cases are on DOCS-137.

Refs DOCS-137.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-18.
