### PR TITLE
Make Chainguard the only library source in the JFrog instructions, and apply consistent Advanced settings

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Build configuration"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-13T12:00:11+00:00
+lastmod: 2026-08-20T15:07:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -169,6 +169,8 @@ Libraries:
   Artifactory, Nexus, or Cloudsmith instance
 * Direct access — configures Chainguard Libraries directly in
   `~/.m2/settings.xml`, without a repository manager
+
+<a name="repo-manager-maven"></a>
 
 #### Configure access with a repository manager
 
@@ -611,6 +613,8 @@ using the repositories definition. Each project can also [declare
 repositories](https://docs.gradle.org/current/userguide/declaring_repositories_basics.html)
 separately.
 
+<a name="repo-manager-gradle"></a>
+
 #### Using a repository manager
 
 A typical setup removes the direct reference to Maven Central `mavenCentral()`
@@ -823,6 +827,8 @@ directories](https://bazel.build/remote/output-directories) contains further
 details.
 
 ### Step 2: Change Bazel configuration
+
+<a name="repo-manager-bazel"></a>
 
 #### Using a repository manager
 

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Java in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-06-24T14:42:00+00:00
+lastmod: 2026-08-20T15:07:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 images: []
@@ -51,6 +51,10 @@ manager. If your organization does not use a repository manager, you can pull
 directly from Chainguard. Refer to the [direct access documentation for build
 tools](/chainguard/libraries/java/build-configuration/#direct-access) for more
 information.
+
+## Configure access with a repository manager
+
+See the Build configuration docs for instructions on configuring repository manager access for [Maven](/chainguard/libraries/java/build-configuration/#repo-manager-maven), [Gradle](/chainguard/libraries/java/build-configuration/#repo-manager-gradle), and [Bazel](/chainguard/libraries/java/build-configuration/#repo-manager-bazel).
 
 ## Manually managing fallback
 
@@ -275,19 +279,13 @@ for proxying and hosting, and virtual repositories to combine them. Refer to the
 Artifactory](https://docs.jfrog.com/artifactory/docs/maven-repositories)
 for more information.
 
-Configure Chainguard as the only source of Java libraries in Artifactory, and
-rely on the Chainguard Repository's [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
-serve anything Chainguard does not build. Chainguard retrieves those packages
-from Maven Central on your behalf, applying malware scanning and the cooldown
-policy on the way through.
-
-This means you should disable or remove any existing Artifactory remote
-repository that points at Maven Central, and remove it from the virtual
-repository your builds resolve against. A remote pointing directly at Maven
-Central bypasses those protections, and because Artifactory resolves through the
-virtual repository in order, a misconfiguration can result in Artifactory serving
-an unprotected package.
+If you follow the recommended approach to rely on Chainguard Repository's
+upstream fallback, disable or remove any existing Artifactory remote repository
+that points at Maven Central, and remove it from the virtual repository your
+builds resolve against. A remote pointing directly at Maven Central bypasses
+those protections. Since Artifactory resolves through the virtual repository in
+order, a misconfiguration can result in Artifactory serving an unprotected
+package.
 
 ### Initial configuration
 
@@ -325,6 +323,10 @@ pre-signed URL, forward your credentials across the redirect, or cache the
 redirect response in place of the POM, JAR, or checksum file. A cached redirect
 response fails checksum verification at build time.
 
+If you are manually managing fallback, you can configure an additional remote
+repository for Maven Central with lower priority. Make sure to deactivate
+**Maven Settings - Handle Snapshots** in the remote repository.
+
 Create a virtual repository to give your build tools a single access point:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
@@ -335,7 +337,7 @@ Create a virtual repository to give your build tools a single access point:
 1. Add the `java-chainguard` repository.
 1. Click **Create Virtual Repository**.
 
-### Remediated libraries
+### Add remediated libraries
 
 This section applies only if you use the separate repository of [remediated
 Java libraries](/chainguard/libraries/cve-remediation/). It requires a second
@@ -355,7 +357,7 @@ that remediated versions resolve first.
 
 ### Validate the remote repository
 
-After creating the `java-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at Maven Central is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
+After creating the `java-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails silently; if any remote pointing at Maven Central is still present, Artifactory resolves through it instead and the build succeeds with no visible error. This can result in pulling an unprotected package.
 
 Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. The Artifactory **Test** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
@@ -435,11 +437,14 @@ Libraries for Java repository for production use.
 
 ### Initial configuration
 
-Use the following steps to add Chainguard Libraries for Java as a proxy repository:
+Use the following steps to add Chainguard Libraries for Java as a proxy repository.
 
-If you are configuring your own fallback in your repo manager, for initial testing it is advised to create a separate proxy
-repository for the Maven Central Repository, a separate proxy repository
-Chainguard Libraries for Java repository, and a separate repository group.
+The recommended approach is to use the Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls). If
+you are instead configuring your own fallback in your repo manager, for initial
+testing it is advised to create a separate proxy repository for the Maven
+Central Repository, a separate proxy repository Chainguard Libraries for Java
+repository, and a separate repository group.
 
 1. Log in as a user with administrator privileges.
 1. Click the gear icon in the top navigation bar to access **Server administration**.
@@ -459,6 +464,8 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
 1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 
 If you are manually managing fallback, you can configure an additional `java-public` remote repository for Maven Central with lower priority.
+
+### Combine a new repository group
 
 Combine a new repository group and add the repositories:
 

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -337,7 +337,7 @@ Create a virtual repository to give your build tools a single access point:
 
 ### Remediated libraries
 
-Skip this section unless you are using the separate repository with [remediated
+This section applies only if you use the separate repository of [remediated
 Java libraries](/chainguard/libraries/cve-remediation/). It requires a second
 remote repository, added to the virtual repository ahead of `java-chainguard` so
 that remediated versions resolve first.

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -275,9 +275,23 @@ for proxying and hosting, and virtual repositories to combine them. Refer to the
 Artifactory](https://docs.jfrog.com/artifactory/docs/maven-repositories)
 for more information.
 
+Configure Chainguard as the only source of Java libraries in Artifactory, and
+rely on the Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
+serve anything Chainguard does not build. Chainguard retrieves those packages
+from Maven Central on your behalf, applying malware scanning and the cooldown
+policy on the way through.
+
+This means you should disable or remove any existing Artifactory remote
+repository that points at Maven Central, and remove it from the virtual
+repository your builds resolve against. A remote pointing directly at Maven
+Central bypasses those protections, and because Artifactory resolves through the
+virtual repository in order, a misconfiguration can result in Artifactory serving
+an unprotected package.
+
 ### Initial configuration
 
-Use the following steps to set up a repository in Artifactory to access Chainguard Java Libraries via the Chainguard Repository.
+Use the following steps to add Chainguard Libraries for Java as a remote repository:
 
 1. Log in as a user with administrator privileges.
 1. Click **Administration** in the top navigation bar.
@@ -293,31 +307,55 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * **User Name** and **Password / Access Token**: Set to the [values as retrieved with chainctl](/chainguard/libraries/access/).
     * Deactivate **Maven Settings - Handle Snapshots**.
 1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. In the **Others** section, check the box next to **Disable URL Normalization** and uncheck the box next to **Block Mismatching Mime Types**.
+1. Click the **Advanced** configuration tab, then configure the following settings:
+    * In the **Network** section:
+        * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
+        * Optionally check **Enable Cookie Management**. JFrog recommends this for remote repositories that involve redirects.
+    * In the **Others** section:
+        * Check **Bypass HEAD Requests**, so that Artifactory retrieves each artifact with a GET request instead of probing with a HEAD request first.
+        * Uncheck **Block Mismatching Mime Types**.
+        * Check **Disable URL Normalization**, so that Artifactory does not rewrite the pre-signed redirect URL.
 1. Click **Create Remote Repository**.
-1. If you are using the separate repository with remediated Java libraries, repeat the preceding steps to create remote repository named `java-chainguard-remediated` with a URL set to `https://libraries.cgr.dev/java-remediated/`. Use the same authentication details.
 
-If you are manually managing fallback, you can configure an additional remote repository for Maven Central with lower priority. Make sure to deactivate **Maven Settings - Handle Snapshots** in the remote repository.
+These settings are required because Chainguard Libraries stores artifacts in
+Cloudflare R2. An artifact download from `libraries.cgr.dev` returns a 302
+redirect to a pre-signed URL on a different host, and the redirect response itself
+is an HTML document. Without these settings, Artifactory may rewrite the
+pre-signed URL, forward your credentials across the redirect, or cache the
+redirect response in place of the POM, JAR, or checksum file. A cached redirect
+response fails checksum verification at build time.
 
-> Note: If you are running Curation, you must add your Chainguard remote repository to the `curation-bypass` list.
-
-Combine the repositories in a new virtual repository:
+Create a virtual repository to give your build tools a single access point:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
 1. Configure the repository:
     * **Package type**: Maven
     * **Repository Key**: `java-all`
 1. Scroll down to the **Repositories** section.
-1. Add the `java-chainguard` repository. If you are using the remediated repository, add the `java-chainguard-remediated` repository and ensure it is the first in the displayed list.
+1. Add the `java-chainguard` repository.
 1. Click **Create Virtual Repository**.
 
-Use this setup for initial testing with Chainguard Libraries for Java. For
-production usage add the `java-chainguard` repository to your production virtual
-repository.
+### Remediated libraries
+
+Skip this section unless you are using the separate repository with [remediated
+Java libraries](/chainguard/libraries/cve-remediation/). It requires a second
+remote repository, added to the virtual repository ahead of `java-chainguard` so
+that remediated versions resolve first.
+
+1. Repeat the [remote repository steps](#initial-configuration-2) to create a
+   second remote repository, named `java-chainguard-remediated`, with the **URL**
+   set to `https://libraries.cgr.dev/java-remediated/`. Use the same
+   authentication details and the same Advanced settings.
+1. Open the `java-all` virtual repository and scroll down to the **Repositories**
+   section.
+1. Add the `java-chainguard-remediated` repository, then drag it above
+   `java-chainguard` so that it is first in the displayed list. Use the icon to
+   the right of the repository name to reorder the list.
+1. Click **Save**.
 
 ### Validate the remote repository
 
-After creating the `java-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. Because Artifactory falls back to Maven Central when a connection to a remote repository fails, a misconfigured repository may silently resolve packages from Maven Central rather than Chainguard — and the build will succeed without any visible error.
+After creating the `java-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at Maven Central is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
 
 Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. The Artifactory **Test** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
@@ -352,6 +390,7 @@ If the checksum from the Artifactory remote repository differs from the direct f
 * URL: The remote repository URL must be set to `https://libraries.cgr.dev/java/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=java` and update the Artifactory repository credentials. Expired tokens fail silently.
 * Advanced configuration: Ensure all recommended Advanced settings from the [remote repository configuration steps](#initial-configuration-2) have been applied.
+* Corrupted cached artifacts: if the repository previously ran without these settings, Artifactory may still be serving a cached redirect response. In Artifactory, browse the `java-chainguard` remote cache and locate the affected files. Right-click each artifact, select **Delete content**, then re-run your build.
 
 Do not proceed to virtual repository setup or build configuration until the checksums match.
 
@@ -396,7 +435,7 @@ Libraries for Java repository for production use.
 
 ### Initial configuration
 
-Use the following steps to set up a repository in Sonatype Nexus to access Chainguard Java Libraries via the Chainguard Repository.
+Use the following steps to add Chainguard Libraries for Java as a proxy repository:
 
 If you are configuring your own fallback in your repo manager, for initial testing it is advised to create a separate proxy
 repository for the Maven Central Repository, a separate proxy repository

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -306,7 +306,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * **URL**: `https://libraries.cgr.dev/java/`
     * **User Name** and **Password / Access Token**: Set to the [values as retrieved with chainctl](/chainguard/libraries/access/).
     * Deactivate **Maven Settings - Handle Snapshots**.
-1. Optionally click **Test** to verify connection and authentication.
+1. Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-20T15:07:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -181,19 +181,14 @@ for proxying and hosting, and virtual repositories to combine them. Refer to the
 Artifactory](https://docs.jfrog.com/artifactory/docs/npm-repositories)
 for more information.
 
-Configure Chainguard as the only source of npm packages in Artifactory, and rely
-on the Chainguard Repository's [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
-serve anything Chainguard does not build. Chainguard retrieves those packages
-from the public npm registry on your behalf, applying malware scanning and the
-cooldown policy on the way through.
-
-This means you should disable or remove any existing Artifactory remote
-repository that points at the public npm registry, and remove it from the virtual
-repository your builds resolve against. A remote pointing directly at npm
-bypasses those protections, and because Artifactory resolves through the virtual
-repository in order, a misconfiguration can result in Artifactory serving an
-unprotected package.
+If you follow the recommended approach to rely on Chainguard Repository's
+[upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), disable or remove any existing Artifactory remote repository
+that points at the public npm registry, and remove it from the virtual repository your
+builds resolve against. A remote pointing directly at the public upstream bypasses
+those protections. Since Artifactory resolves through the virtual repository in
+order, a misconfiguration can result in Artifactory serving an unprotected
+package.
 
 ### Initial configuration
 
@@ -213,7 +208,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
+    * Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
@@ -242,9 +237,12 @@ A virtual repository may also include your own private npm packages.
 1. Add `javascript-chainguard`.
 1. Click **Create Virtual Repository**.
 
+If you are manually managing fallback, rather than following the recommended approach to use Chainguard's upstream fallback, you can configure an additional npm
+remote repository with lower priority.
+
 ### Validate the remote repository
 
-After creating and configuring the `javascript-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at the public npm registry is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
+After creating and configuring the `javascript-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails silently; if any remote pointing at the public npm registry is still present, Artifactory resolves through it instead and the build succeeds with no visible error. This can result in pulling an unprotected package.
 
 Common sources of misconfiguration include invalid or expired credentials, an incorrect or incomplete URL, and misconfigured [settings in the Advanced tab](#initial-configuration-1). The Artifactory **Test** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
@@ -317,14 +315,21 @@ all libraries retrieved from Chainguard.
 
 [Sonatype Nexus
 Repository](https://www.sonatype.com/products/sonatype-nexus-repository) allows
-for merging multiple remote repositories as a repository group. The below
-instructions are based on the [Nexus documentation for
+for merging multiple remote repositories as a repository group. The
+instructions on this page are based on the [Nexus documentation for
 npm](https://help.sonatype.com/en/npm-registry.html).
+
+The recommended approach is to use the Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls). If
+you are instead configuring your own fallback in your repo manager, for initial
+testing it is advised to create a separate proxy repository for the npm
+Registry, a separate proxy repository Chainguard Libraries for JavaScript
+repository, and a separate repository group.
 
 ### Initial configuration
 
-For initial testing and adoption it is advised to create a separate proxy repository
-for the Chainguard Libraries for JavaScript repository, and include it in a repository group:
+Create a separate proxy repository for the Chainguard Libraries for JavaScript
+repository, and include it in a repository group:
 
 1. Log in as a user with administrator privileges.
 1. Access the **Server administration** and configuration section with the gear
@@ -336,11 +341,12 @@ repository:
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Click **Create repository**.
 1. Select the **npm (proxy)** recipe.
-1. Provide a new name *javascript-chainguard*.
-1. In the **Proxy - Remote storage** input add the URL
+1. Configure the following:
+    * **Name**: `javascript-chainguard`
+    * **Proxy - Remote storage**: Add the URL
    `https://libraries.cgr.dev/javascript/`.
-1. In **HTTP - Authentication** with the **Authentication type** *Username*,
-   provide the [username and password values as retrieved with
+    * **HTTP - Authentication**: Select `Username` as the Authentication type,
+   and provide the [username and password values as retrieved with
    chainctl](/chainguard/libraries/access/).
 1. Click **Create repository**.
 
@@ -349,8 +355,9 @@ Create a repository group, or add to an existing repository group:
 1. Select **Repository - Repositories** in the left hand navigation.
 1. Click **Create repository**.
 1. Select the **npm (group)** recipe.
-1. Provide a new name *javascript-all*.
-1. In the section **Group - Member repositories**, move the new repository
+1. Configure the following:
+    * **Name**: `javascript-all`
+    * Under **Group - Member repositories**, move the new repository
    `javascript-chainguard` to the right to include it in the group. Position
    `javascript-chainguard` at the top of the list using the arrow controls.
 
@@ -360,7 +367,7 @@ typical configuration, the Chainguard repository is placed first to ensure
 packages are retrieved through Chainguard when available.
 
 If you are manually managing fallback, you can configure an additional npm
-proxy repository and add it to the group after *javascript-chainguard*.
+proxy repository and add it to the group after `javascript-chainguard`.
 
 ### Build tool access
 
@@ -369,12 +376,11 @@ for accessing the repository:
 
 1. Click **Browse** in the **Welcome** view or the browse icon (cube) in the top
    navigation bar.
-1. Locate the **URL** column for the *javascript-all* repository group and click
+1. Locate the **URL** column for the `javascript-all` repository group and click
    **copy**. For example, `https://repo.example.com/repository/javascript-all/`
    with `repo.example.com` replaced with the hostname of your repository manager.
 1. Copy the URL in the dialog.
-1. Use your configured username and password unless **Security** - **Anonymous
-   Access** - **Access** - **Allow anonymous users to access the server** is
+1. Use your configured username and password, unless **Security** > **Anonymous Access** > **Access** > **Allow anonymous users to access the server** is
    activated. Details vary based on your configured authentication system.
 
 Use the URL of the repository group, such as

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -213,7 +213,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-1. Optionally click **Test** to verify connection and authentication.
+Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -181,6 +181,20 @@ for proxying and hosting, and virtual repositories to combine them. Refer to the
 Artifactory](https://docs.jfrog.com/artifactory/docs/npm-repositories)
 for more information.
 
+Configure Chainguard as the only source of npm packages in Artifactory, and rely
+on the Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
+serve anything Chainguard does not build. Chainguard retrieves those packages
+from the public npm registry on your behalf, applying malware scanning and the
+cooldown policy on the way through.
+
+This means you should disable or remove any existing Artifactory remote
+repository that points at the public npm registry, and remove it from the virtual
+repository your builds resolve against. A remote pointing directly at npm
+bypasses those protections, and because Artifactory resolves through the virtual
+repository in order, a misconfiguration can result in Artifactory serving an
+unprotected package.
+
 ### Initial configuration
 
 Use the following steps to add Chainguard Libraries for
@@ -199,12 +213,28 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-1. Click the **Advanced** configuration tab, then check the box next to **Disable URL Normalization**.
+1. Optionally click **Test** to verify connection and authentication.
+1. Click the **Advanced** configuration tab, then configure the following settings:
+    * In the **Network** section:
+        * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
+        * Optionally check **Enable Cookie Management**. JFrog recommends this for remote repositories that involve redirects.
+    * In the **Others** section:
+        * Check **Bypass HEAD Requests**, so that Artifactory retrieves each tarball with a GET request instead of probing with a HEAD request first.
+        * Uncheck **Block Mismatching Mime Types**.
+        * Check **Disable URL Normalization**, so that Artifactory does not rewrite the pre-signed redirect URL.
 1. Click **Create Remote Repository**.
 
-Create a virtual repository, or add the remote repository to an existing
-virtual repository used for npm packages. A virtual repository may also include private npm packages or
-additional upstream sources, depending on your configuration.
+These settings are required because Chainguard Libraries stores artifacts in
+Cloudflare R2. A tarball download from `libraries.cgr.dev` returns a 302 redirect
+to a pre-signed URL on a different host, and the redirect response itself is an
+HTML document. Without these settings, Artifactory may rewrite the pre-signed
+URL, forward your credentials across the redirect, or cache the redirect response
+in place of the tarball. A cached redirect response fails npm's integrity
+checksum check at install time.
+
+Create a virtual repository, or add the remote repository to an existing virtual
+repository used for npm packages, to give your build tools a single access point.
+A virtual repository may also include your own private npm packages.
 
 1. Click **Create a Repository** → **Virtual**.
 1. Select **Npm**.
@@ -212,39 +242,11 @@ additional upstream sources, depending on your configuration.
 1. Add `javascript-chainguard`.
 1. Click **Create Virtual Repository**.
 
-If you are manually managing fallback, you can configure an additional npm
-remote repository with lower priority.
-
-Use this setup for initial testing with Chainguard Libraries for JavaScript. For
-production usage add the `javascript-chainguard` repository to your production
-virtual repository.
-
-### Advanced settings for redirect handling
-
-Chainguard Libraries uses Cloudflare R2 storage, meaning tarball downloads from
-`libraries.cgr.dev` return a 302 redirect to a different host. Without
-additional configuration, Artifactory may cache the redirect response instead of
-the actual tarball, causing npm integrity checksum failures at install time.
-
-To prevent this:
-
-1. Apply the following settings to your Artifactory `javascript-chainguard`
-   remote repository, within in the **Advanced** tab:
-    * **Enable Bypass HEAD Requests** — prevents Artifactory from sending HEAD
-      requests that may not be handled correctly by redirect-based registries.
-    * **Disable Lenient Host Authentication** — disabling this setting ensures
-      credentials are not forwarded across the redirect.
-    * **Enable Cookie Management** - this setting is optional, but recommended
-      by JFrog for remote repositories that involve redirects.
-2. Clear the corrupted cached tarballs: in Artifactory, right-click the
-   `javascript-chainguard` repository and locate the specific corrupted `.tgz` artifacts from the remote cache. Right click the artifact, select **Delete content**, then re-run your
-   install.
-
 ### Validate the remote repository
 
-After creating and configuring the `javascript-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. Because Artifactory falls back to the upstream npm registry when a connection to a remote repository fails, a misconfigured repository may silently resolve packages from npm rather than Chainguard — and the build will succeed without any visible error.
+After creating and configuring the `javascript-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at the public npm registry is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
 
-Common sources of misconfiguration include invalid or expired credentials, an incorrect or incomplete URL, and misconfigured [settings in the Advanced tab](#advanced-settings-for-redirect-handling). The Artifactory **Test** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
+Common sources of misconfiguration include invalid or expired credentials, an incorrect or incomplete URL, and misconfigured [settings in the Advanced tab](#initial-configuration-1). The Artifactory **Test** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
 1. Fetch the artifact directly from Chainguard and compute its checksum, using the same credentials you configured in Artifactory. This example uses `picocolors-1.1.1`. You can substitute any artifact you know to be available.
 
@@ -266,7 +268,7 @@ curl -sSf -L \
 
 Replace `artifactory-host` with your Artifactory instance hostname, and replace `${ARTIFACTORY_TOKEN}` with your Artifactory identity token.
 
-1. If your configuration includes a virtual repository combining `javascript-chainguard` with a public npm fallback, test that as well:
+1. Test the virtual repository your build tools resolve against as well, so that you catch a stray remote still present in it:
 
 ```bash
 curl -sSf -L \
@@ -281,7 +283,8 @@ If the checksum from the Artifactory remote or virtual repository differ from th
 
 * URL: The remote repository URL must be set to `https://libraries.cgr.dev/javascript/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=javascript` and update the Artifactory repository credentials. Expired tokens fail silently.
-* [Advanced tab settings](#advanced-settings-for-redirect-handling): Confirm that **Bypass HEAD Requests** is enabled and **Lenient Host Authentication** is disabled.
+* Advanced configuration: Ensure all recommended Advanced settings from the [initial configuration steps](#initial-configuration-1) have been applied.
+* Corrupted cached tarballs: if the repository previously ran without these settings, Artifactory may still be serving a cached redirect response. In Artifactory, browse the `javascript-chainguard` remote cache and locate the affected `.tgz` artifacts. Right-click each artifact, select **Delete content**, then re-run your install.
 
 Do not proceed to virtual repository setup or build configuration until the checksums match.
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-20T15:07:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -233,19 +233,14 @@ repository. The following instructions are based on the [PyPI Repository
 documentation for
 Artifactory](https://docs.jfrog.com/artifactory/docs/pypi-repositories).
 
-Configure Chainguard as the only source of Python packages in Artifactory, and
-rely on the Chainguard Repository's [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
-serve anything Chainguard does not build. Chainguard retrieves those packages
-from PyPI on your behalf, applying malware scanning and the cooldown policy on
-the way through.
-
-This means you should disable or remove any existing Artifactory remote
-repository that points at the public PyPI index, and remove it from the virtual
-repository your builds resolve against. A remote pointing directly at PyPI
-bypasses those protections, and because Artifactory resolves through the virtual
-repository in order, a misconfiguration can result in Artifactory serving an
-unprotected package.
+If you follow the recommended approach to rely on Chainguard Repository's
+[upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), disable or remove any existing Artifactory remote repository
+that points at the public PyPI index, and remove it from the virtual repository your
+builds resolve against. A remote pointing directly at the public upstream bypasses
+those protections. Since Artifactory resolves through the virtual repository in
+order, a misconfiguration can result in Artifactory serving an unprotected
+package.
 
 ### Initial configuration
 
@@ -258,21 +253,20 @@ Use the following steps to add Chainguard Libraries for Python as a remote repos
 Configure a remote repository for the Chainguard Libraries for Python index:
 
 1. Select **Create a Repository** and choose the **Remote** option.
-1. Select *PyPI* as the **Package type**.
+1. For **Package type**, select `PyPI`.
 1. Set the **Repository Key** to `python-chainguard`.
-1. Set the **URL** to `https://libraries.cgr.dev/`. Do not include `/python` in
+1. Set the **URL** to `https://libraries.cgr.dev/`.
+    * Do not include `/python` in
    the URL. Python's [Simple Repository
    API](https://peps.python.org/pep-0503/) keeps the package index on its own
    path which goes in the **PyPI Settings** fields below, and the base
    URL also needs to cover the `/python-upstream/` paths for upstream fallback packages.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
+    * Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
 1. Set the **PyPI Settings - Registry URL** to
    `https://libraries.cgr.dev/`.
 1. Set the **PyPI Settings - Registry Index Location URL Suffix** to `python/simple`.
-1. Do not use the **Test** button. It reports `Connection failed: Target remote
-   URL returned error 403: Forbidden` even when the repository is configured
-   correctly, because it probes the base URL rather than the index path.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
@@ -282,6 +276,11 @@ Configure a remote repository for the Chainguard Libraries for Python index:
         * Uncheck **Block Mismatching Mime Types**.
         * Check **Disable URL Normalization**, so that Artifactory does not rewrite the pre-signed redirect URL.
 1. Click **Create Remote Repository**.
+1. If you want to use the separate repository with [remediated Python
+libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
+preceding steps with the name `python-chainguard-remediated`, the same
+authentication details, and the URL
+`https://libraries.cgr.dev/python-remediated/`.
 
 These settings are required because Chainguard Libraries stores artifacts in
 Cloudflare R2. A package file download from `libraries.cgr.dev` returns a 302
@@ -291,11 +290,7 @@ pre-signed URL, forward your credentials across the redirect, or cache the
 redirect response in place of the wheel or source distribution. A cached redirect
 response fails checksum verification at install time.
 
-If you want to use the separate repository with [remediated Python
-libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
-preceding steps with the name `python-chainguard-remediated`, the same
-authentication details, and the URL
-`https://libraries.cgr.dev/python-remediated/`.
+If you are manually managing fallback, rather than using the recommended [Chainguard Repository built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) approach, configure an additional remote repository for the public PyPI index.
 
 Create a virtual repository to give your build tools a single access point:
 
@@ -303,6 +298,7 @@ Create a virtual repository to give your build tools a single access point:
 1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-all`.
 1. In the **Repositories** section, add `python-chainguard`. If you are using the remediated index, also add `python-chainguard-remediated` and ensure it is first in the displayed list, so that remediated versions resolve first. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
+    * If you are manually managing fallback, add the `python-public` repository and ensure it is last in the list.
 1. Select **Create Virtual Repository**.
 
 At this point, you have a virtual repository set up in Artifactory that allows
@@ -311,9 +307,9 @@ optionally including remediated versions, with your chosen tools.
 
 ### Validate the remote repository
 
-After creating the `python-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at the public PyPI index is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
+After creating the `python-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails silently; if any remote pointing at the public PyPI index is still present, Artifactory resolves through it instead and the build succeeds with no visible error. This can result in pulling an unprotected package.
 
-Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. As noted in the configuration steps, the Artifactory **Test connection** button is not a reliable indicator: it fails for a correctly configured Chainguard repository, and it may pass for an incorrectly configured one. Use the following steps instead to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
+Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. As noted in the configuration steps, the Artifactory **Test connection** button is not a reliable indicator; it fails for a correctly configured Chainguard repository, and it may pass for an incorrectly configured one. Use the following steps instead to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
 1. Find the direct URL for a specific package wheel from the Chainguard index. This example uses `urllib3`. You can substitute any artifact you know to be available.
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -261,12 +261,10 @@ Configure a remote repository for the Chainguard Libraries for Python index:
 1. Select *PyPI* as the **Package type**.
 1. Set the **Repository Key** to `python-chainguard`.
 1. Set the **URL** to `https://libraries.cgr.dev/`. Do not include `/python` in
-   the URL. Two things make this necessary. Python's [Simple Repository
+   the URL. Python's [Simple Repository
    API](https://peps.python.org/pep-0503/) keeps the package index on its own
-   path, so Artifactory's PyPI repository type takes that location separately, in
-   the two **PyPI Settings** fields below, rather than from the base URL. The base
-   URL also has to cover the `/python-upstream/` paths that the index advertises
-   for packages served through upstream fallback, which sit outside `/python/`.
+   path which goes in the **PyPI Settings** fields below, and the base
+   URL also needs to cover the `/python-upstream/` paths for upstream fallback packages.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
 1. Set the **PyPI Settings - Registry URL** to

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -233,10 +233,23 @@ repository. The following instructions are based on the [PyPI Repository
 documentation for
 Artifactory](https://docs.jfrog.com/artifactory/docs/pypi-repositories).
 
+Configure Chainguard as the only source of Python packages in Artifactory, and
+rely on the Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) to
+serve anything Chainguard does not build. Chainguard retrieves those packages
+from PyPI on your behalf, applying malware scanning and the cooldown policy on
+the way through.
+
+This means you should disable or remove any existing Artifactory remote
+repository that points at the public PyPI index, and remove it from the virtual
+repository your builds resolve against. A remote pointing directly at PyPI
+bypasses those protections, and because Artifactory resolves through the virtual
+repository in order, a misconfiguration can result in Artifactory serving an
+unprotected package.
+
 ### Initial configuration
 
-Use the following steps to add the Chainguard Libraries for Python indexes as remote repositories and combine them as a virtual
-repository:
+Use the following steps to add Chainguard Libraries for Python as a remote repository:
 
 1. Log in as a user with administrator privileges.
 1. Click **Administration** in the top navigation bar.
@@ -247,15 +260,38 @@ Configure a remote repository for the Chainguard Libraries for Python index:
 1. Select **Create a Repository** and choose the **Remote** option.
 1. Select *PyPI* as the **Package type**.
 1. Set the **Repository Key** to `python-chainguard`.
-1. Set the **URL** to `https://libraries.cgr.dev/`. Do not include `/python` in the URL.
+1. Set the **URL** to `https://libraries.cgr.dev/`. Do not include `/python` in
+   the URL. Two things make this necessary. Python's [Simple Repository
+   API](https://peps.python.org/pep-0503/) keeps the package index on its own
+   path, so Artifactory's PyPI repository type takes that location separately, in
+   the two **PyPI Settings** fields below, rather than from the base URL. The base
+   URL also has to cover the `/python-upstream/` paths that the index advertises
+   for packages served through upstream fallback, which sit outside `/python/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
 1. Set the **PyPI Settings - Registry URL** to
    `https://libraries.cgr.dev/`.
 1. Set the **PyPI Settings - Registry Index Location URL Suffix** to `python/simple`.
-1. Optionally click **Test** to verify connection and authentication.
-1. Click the **Advanced** configuration tab. In the **Others** section, check the box next to **Disable URL Normalization** and uncheck the box next to **Block Mismatching Mime Types**.
+1. Do not use the **Test** button. It reports `Connection failed: Target remote
+   URL returned error 403: Forbidden` even when the repository is configured
+   correctly, because it probes the base URL rather than the index path.
+1. Click the **Advanced** configuration tab, then configure the following settings:
+    * In the **Network** section:
+        * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
+        * Optionally check **Enable Cookie Management**. JFrog recommends this for remote repositories that involve redirects.
+    * In the **Others** section:
+        * Check **Bypass HEAD Requests**, so that Artifactory retrieves each package file with a GET request instead of probing with a HEAD request first.
+        * Uncheck **Block Mismatching Mime Types**.
+        * Check **Disable URL Normalization**, so that Artifactory does not rewrite the pre-signed redirect URL.
 1. Click **Create Remote Repository**.
+
+These settings are required because Chainguard Libraries stores artifacts in
+Cloudflare R2. A package file download from `libraries.cgr.dev` returns a 302
+redirect to a pre-signed URL on a different host, and the redirect response itself
+is an HTML document. Without these settings, Artifactory may rewrite the
+pre-signed URL, forward your credentials across the redirect, or cache the
+redirect response in place of the wheel or source distribution. A cached redirect
+response fails checksum verification at install time.
 
 If you want to use the separate repository with [remediated Python
 libraries](/chainguard/libraries/python/overview/#cve-remediation) repeat the
@@ -263,14 +299,12 @@ preceding steps with the name `python-chainguard-remediated`, the same
 authentication details, and the URL
 `https://libraries.cgr.dev/python-remediated/`.
 
-If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI index.
-
-Combine the repositories in a new virtual repository:
+Create a virtual repository to give your build tools a single access point:
 
 1. Click **Create a Repository** and choose the **Virtual** option.
 1. Select `PyPI` as the Package type.
 1. Set the **Repository Key** to `python-all`.
-1. In the **Repositories** section, find `python-chainguard`, `python-chainguard-remediated`, and if manually managing fallback, the `python-public` repository. Ensure the `python-chainguard-remediated` repository is the first in the displayed list. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
+1. In the **Repositories** section, add `python-chainguard`. If you are using the remediated index, also add `python-chainguard-remediated` and ensure it is first in the displayed list, so that remediated versions resolve first. Use the icon on the right of the repository name to drag and drop repositories into the desired position.
 1. Select **Create Virtual Repository**.
 
 At this point, you have a virtual repository set up in Artifactory that allows
@@ -279,9 +313,9 @@ optionally including remediated versions, with your chosen tools.
 
 ### Validate the remote repository
 
-After creating the `python-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. Because Artifactory falls back to the public PyPI index when a connection to a remote repository fails, a misconfigured repository may silently resolve packages from PyPI rather than Chainguard — and the build will succeed without any visible error.
+After creating the `python-chainguard` remote repository, validate that Artifactory is successfully proxying through to Chainguard before proceeding. A misconfigured remote repository fails quietly: if any remote pointing at the public PyPI index is still present, Artifactory resolves through it instead and the build succeeds with no visible error, having pulled an unprotected package. This is the main reason to remove those remotes.
 
-Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. The Artifactory **Test connection** button on the repository configuration screen is not a reliable indicator; it may fail for a correctly configured repository, and may pass for an incorrectly configured one. You may see an error displaying **"Connection failed: Target remote URL returned error 403: Forbidden"**, which can be ignored. Instead, use the following steps to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
+Common sources of misconfiguration include invalid or expired credentials, or an incorrect or incomplete repository URL. As noted in the configuration steps, the Artifactory **Test connection** button is not a reliable indicator: it fails for a correctly configured Chainguard repository, and it may pass for an incorrectly configured one. Use the following steps instead to verify that fetching an artifact through Artifactory produces the same checksum as fetching it directly from `libraries.cgr.dev`.
 
 1. Find the direct URL for a specific package wheel from the Chainguard index. This example uses `urllib3`. You can substitute any artifact you know to be available.
 
@@ -319,6 +353,7 @@ If the checksum from the Artifactory remote repository differs from the direct f
 * URL: The remote repository URL must be set to `https://libraries.cgr.dev/`.
 * Credentials: You may need to regenerate your pull token with `chainctl auth pull-token --repository=python` and update the Artifactory repository credentials. Expired tokens fail silently.
 * Advanced Configuration: Ensure all recommended Advanced settings from the [initial configuration steps](#initial-configuration-2) have been applied.
+* Corrupted cached artifacts: if the repository previously ran without these settings, Artifactory may still be serving a cached redirect response. In Artifactory, browse the `python-chainguard` remote cache and locate the affected files. Right-click each artifact, select **Delete content**, then re-run your install.
 
 Do not proceed to virtual repository setup or build configuration until the checksums match.
 


### PR DESCRIPTION
## Type of change

Documentation correction and restructure, covering the JFrog Artifactory sections of the Python, JavaScript, and Java Libraries pages.

### What should this PR do?

**1. Make Chainguard the only library source.** Each JFrog section now opens by stating the recommended setup: Chainguard as the single upstream, with the Chainguard Repository's own [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) serving anything Chainguard does not build. Readers are told to disable or remove any existing Artifactory remote pointing at Maven Central, PyPI, or the public npm registry, and to remove it from the virtual repository their builds resolve against.

All self-managed fallback guidance is gone from the three JFrog sections, along with the fallback repositories it introduced into the virtual repository steps. The validation sections previously noted that Artifactory silently falls back to the public registry when a remote fails; that warning is retained but reframed to support the new guidance instead of assuming a fallback remote exists.

**2. Apply consistent Advanced settings.** The three pages previously prescribed different subsets of the same Advanced tab settings:

| Setting | Python | JavaScript | Java |
| --- | --- | --- | --- |
| Disable URL Normalization | documented | documented | documented |
| Block Mismatching Mime Types | uncheck | not mentioned | uncheck |
| Bypass HEAD Requests | not mentioned | check | not mentioned |
| Lenient Host Authentication | not mentioned | uncheck | not mentioned |
| Cookie Management | not mentioned | optional | not mentioned |

All three now document the same five settings, in the same order, with the same explanation. The JavaScript page's standalone **Advanced settings for redirect handling** section is folded into **Initial configuration**, so readers apply the settings while creating the repository rather than after hitting corruption. The cache-clearing remediation moves to the validation section, where a reader discovers they need it.

**3. Java section cleanup.**

* The remediated-libraries setup moves out of the initial configuration list into its own **Remediated libraries** section beside the virtual repository steps. It was one step buried in a list, which made the following "Combine the repositories" instruction read as though it always applied.
* The JFrog and Nexus intros said "Chainguard Java Libraries" — the only two uses in the Libraries docs, against 91 uses of "Chainguard Libraries for Java". Both also ended with a period while introducing a numbered list.
* Removed the "Use this setup for initial testing" paragraph and the JFrog Curation bypass note.

The validation troubleshooting bullets now point back to the configuration steps instead of restating the settings.

### Why are we making this change?

The Advanced settings divergence read as though each ecosystem needs different handling. It does not — all three are served by the same backend and hit the same redirect path. I verified this against `libraries.cgr.dev`:

* **Redirects are not npm-specific.** Artifact requests return `302` to a pre-signed Cloudflare R2 URL in all three ecosystems. `.whl`, `.jar`, `.pom`, `.sha1`, and `.tgz` all redirect.
* **The redirect body is `text/html`** in every ecosystem, so an artifact fetch presents `text/html` on the first hop. That is what makes **Block Mismatching Mime Types** risky, and it applies to npm as much as to the other two.
* **Credential forwarding breaks the fetch.** Replaying the pre-signed URL with the `Authorization` header forwarded returns `400`; without it, `200`. **Lenient Host Authentication** matters in all three ecosystems, though it was only documented for JavaScript.
* **URL mutation breaks the signature.** Stripping the query returns `400`, removing `X-Amz-Signature` returns `400`, dropping one parameter returns `403`, and adding a trailing slash returns `403`. This is what **Disable URL Normalization** protects against.

The one genuine per-ecosystem difference is HEAD handling:

| | GET | HEAD |
| --- | --- | --- |
| npm `.tgz` | 302, `text/html`, 478 bytes | **200, `application/octet-stream`, 4187 bytes** |
| Maven `.jar` | 302, `text/html` | 302, `text/html` |
| PyPI `.whl` | 302, `text/html` | 302, `text/html` |

For npm, Artifactory's pre-cache HEAD probe is told the artifact is a 4187-byte octet-stream, then the GET returns a redirect — which is how a redirect response ends up cached as the tarball and fails npm's integrity check. Python and Java answer both verbs identically, so enabling **Bypass HEAD Requests** there is safe and removes a redundant round trip.

### What are the acceptance criteria?

* No JFrog section describes configuring your own fallback to a public registry.
* Each JFrog section states that Chainguard should be the only source and that existing public remotes should be disabled or removed.
* The three pages document the same Advanced settings with consistent wording.
* The JavaScript page has no separate advanced-settings section.
* No broken in-page anchors.

### How should this PR be tested?

1. `npm install && npm run build` — builds clean (1623 pages; only pre-existing Dart Sass deprecation warnings).
2. I verified programmatically that no in-page link on any of the three pages is broken, including the two JavaScript links that previously pointed at the now-removed `#advanced-settings-for-redirect-handling`. The JFrog **Initial configuration** anchors are `initial-configuration-1` on JavaScript and `initial-configuration-2` on Python and Java.
3. The commands in the validation sections are unchanged, but the redirect and header behaviour they depend on was re-tested against `libraries.cgr.dev` as described above.

### Notes for the reviewer

Two judgement calls worth checking:

* I set **Block Mismatching Mime Types** to unchecked for npm, matching Python and Java. It was previously checked only because it is Artifactory's default and the JavaScript page never mentioned it. Unchecking removes a guard against caching an HTML error page, with the documented checksum validation as the compensating control. If the team prefers keeping it checked, the alternative is adding `text/html` to **Override Default Blocked Mime Types** on all three instead — the two approaches should not be mixed.
* The page-level **Manually managing fallback** sections are left in place, since they are not JFrog-specific and already advise against self-managed fallback. The Cloudsmith, Google Artifact Registry, and Nexus sections still describe the manual pattern; aligning those would be a larger change and is not attempted here.