### PR TITLE
Fix and unify AI-docs image extraction (DOCS-138)

### DIFF
--- a/scripts/generate_image_catalog.py
+++ b/scripts/generate_image_catalog.py
@@ -25,8 +25,34 @@ from typing import Any, Dict, List, Optional, Set
 try:
     import yaml
 except ImportError:
-    print("Error: pyyaml is required. Install with: pip install pyyaml", file=sys.stderr)
+    print(
+        "Error: pyyaml is required. Install with: pip install pyyaml", file=sys.stderr
+    )
     sys.exit(1)
+
+
+def extract_image_names(container_section: str) -> List[str]:
+    """Return image names from the compiled '## Container Images' section text.
+
+    compile_docs.py writes each image as
+        ### <name>
+        <README content>
+        <!-- IMAGE_SEPARATOR -->
+    so we split on the separator and take the first '### ' heading of each block.
+    This is robust to '###' subheadings inside a README (which defeated the older
+    regexes) and to image names containing underscores (e.g. sql_exporter).
+    Uppercase scaffolding directories such as TEMPLATE are excluded by the
+    lowercase-only name pattern.
+
+    NOTE: keep this identical to extract_image_names in scripts/mcp-server.py.
+    The catalog and the MCP server must agree on the image set; see DOCS-138.
+    """
+    names = []
+    for block in container_section.split("<!-- IMAGE_SEPARATOR -->"):
+        heading = re.search(r"^### (\S+)\s*$", block, re.MULTILINE)
+        if heading and re.fullmatch(r"[a-z0-9][a-z0-9_-]*", heading.group(1)):
+            names.append(heading.group(1))
+    return names
 
 
 def extract_images_from_docs(docs_path: str) -> Dict[str, Dict[str, Any]]:
@@ -47,29 +73,12 @@ def extract_images_from_docs(docs_path: str) -> Dict[str, Dict[str, Any]]:
     if not container_section:
         return images
 
-    section_content = content[container_section.end():]
-
-    # Image READMEs contain their own ## headings, so we can't use ## as a
-    # section boundary. Instead, use the IMAGE_SEPARATOR markers that
-    # compile_docs.py inserts between images, and extract ### names from
-    # the text between the section header and the first separator (plus
-    # all separator-delimited blocks).
-    # Each image entry starts with "### image-name\n" followed by its README
-    # content (which may contain ## headings), then "<!-- IMAGE_SEPARATOR -->".
-    for match in re.finditer(r"\n### ([a-z0-9][\-a-z0-9]*)\n", section_content):
-        name = match.group(1)
-        # Only include entries that are followed by IMAGE_SEPARATOR
-        # (i.e., actual image entries, not random ### headings in content)
-        rest = section_content[match.end():]
-        next_h3 = re.search(r"\n### [a-z]", rest)
-        next_sep = rest.find("<!-- IMAGE_SEPARATOR -->")
-        # If there's a separator before the next ### heading, this is a real image
-        if next_sep != -1 and (next_h3 is None or next_sep < next_h3.start()):
-            images[name] = {
-                "name": name,
-                "registry_ref": f"cgr.dev/chainguard/{name}",
-                "has_documentation": True,
-            }
+    for name in extract_image_names(content[container_section.end() :]):
+        images[name] = {
+            "name": name,
+            "registry_ref": f"cgr.dev/chainguard/{name}",
+            "has_documentation": True,
+        }
 
     return images
 
@@ -99,15 +108,11 @@ def build_catalog(
                 else:
                     packages[distro][os_pkg] = []
 
-    total_packages = sum(
-        len(pkg_map) for pkg_map in packages.values() if pkg_map
-    )
+    total_packages = sum(len(pkg_map) for pkg_map in packages.values() if pkg_map)
 
     catalog = {
         "metadata": {
-            "generated_at": datetime.now(timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "source_commit": commit or "unknown",
             "total_images": len(images),
             "total_packages_mapped": total_packages,
@@ -128,7 +133,9 @@ def scrape_registry_tags(catalog: Dict[str, Any]) -> Dict[str, Any]:
     import urllib.request
     import urllib.error
 
-    print("Scraping registry for tag metadata (this may take a while)...", file=sys.stderr)
+    print(
+        "Scraping registry for tag metadata (this may take a while)...", file=sys.stderr
+    )
     updated = 0
 
     for name, entry in catalog["images"].items():
@@ -136,7 +143,9 @@ def scrape_registry_tags(catalog: Dict[str, Any]) -> Dict[str, Any]:
         try:
             req = urllib.request.Request(registry_url, method="GET")
             req.add_header("Accept", "application/json")
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            # nosec B310: registry_url is a hardcoded https://cgr.dev/... reference,
+            # not attacker-controlled and never file:/ or a custom scheme.
+            with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310
                 data = json.loads(resp.read().decode())
                 tags = data.get("tags", [])
                 entry["registry_tags"] = tags[:20]
@@ -144,7 +153,9 @@ def scrape_registry_tags(catalog: Dict[str, Any]) -> Dict[str, Any]:
         except (urllib.error.URLError, urllib.error.HTTPError, Exception):
             entry["registry_tags"] = []
 
-    print(f"  Scraped tags for {updated}/{len(catalog['images'])} images", file=sys.stderr)
+    print(
+        f"  Scraped tags for {updated}/{len(catalog['images'])} images", file=sys.stderr
+    )
     return catalog
 
 

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -47,6 +47,31 @@ MAX_INPUT_LEN = 500
 MAX_RESULTS_CAP = 20
 
 
+def extract_image_names(container_section: str) -> List[str]:
+    """Return image names from the compiled '## Container Images' section text.
+
+    compile_docs.py writes each image as
+        ### <name>
+        <README content>
+        <!-- IMAGE_SEPARATOR -->
+    so we split on the separator and take the first '### ' heading of each block.
+    This is robust to '###' subheadings inside a README (which defeated the older
+    regexes) and to image names containing underscores (e.g. sql_exporter).
+    Uppercase scaffolding directories such as TEMPLATE are excluded by the
+    lowercase-only name pattern.
+
+    NOTE: keep this identical to extract_image_names in
+    scripts/generate_image_catalog.py. The MCP server and the catalog must agree
+    on the image set; see DOCS-138.
+    """
+    names = []
+    for block in container_section.split("<!-- IMAGE_SEPARATOR -->"):
+        heading = re.search(r"^### (\S+)\s*$", block, re.MULTILINE)
+        if heading and re.fullmatch(r"[a-z0-9][a-z0-9_-]*", heading.group(1)):
+            names.append(heading.group(1))
+    return names
+
+
 class ChaguardDocsIndex:
     """Index of Chainguard documentation sections for efficient retrieval."""
 
@@ -85,8 +110,11 @@ class ChaguardDocsIndex:
             section_content = self.content[start_pos:]
 
             # Use regex to find all image sections (### header followed by content until next separator or end)
-            # Pattern: ### image-name followed by content until <!-- IMAGE_SEPARATOR --> or end of string
-            image_pattern = r"### ([a-z0-9\-]+)\n(.*?)(?=\n<!-- IMAGE_SEPARATOR -->|\Z)"
+            # Pattern: ### image-name followed by content until <!-- IMAGE_SEPARATOR --> or end of string.
+            # Name class allows underscores to match images like sql_exporter (DOCS-138).
+            image_pattern = (
+                r"### ([a-z0-9][a-z0-9_-]*)\n(.*?)(?=\n<!-- IMAGE_SEPARATOR -->|\Z)"
+            )
             for match in re.finditer(image_pattern, section_content, re.DOTALL):
                 image_name = match.group(1)
                 image_content = f"### {image_name}\n{match.group(2).strip()}"
@@ -96,32 +124,19 @@ class ChaguardDocsIndex:
 
     def _extract_images(self) -> List[str]:
         """Extract list of container image names from docs."""
-        images = set()
-
-        # Find the "## Container Images" section and extract all ### headers with simple names
         container_images_match = re.search(
             r"^## Container Images\n", self.content, re.MULTILINE
         )
-
         if container_images_match:
-            # Start from the Container Images section
-            start_pos = container_images_match.end()
-            # Get content from Container Images section to the end
-            section_content = self.content[start_pos:]
+            names = extract_image_names(self.content[container_images_match.end() :])
+            if names:
+                return sorted(set(names))
 
-            # Extract all ### headers that match image name pattern
-            # Image names are simple: lowercase letters, numbers, and hyphens
-            image_pattern = r"\n### ([a-z0-9\-]+)\n"
-            for match in re.finditer(image_pattern, section_content):
-                images.add(match.group(1))
-
-        # Fallback: also look for cgr.dev references if no images found from headers
-        if not images:
-            pattern = r"cgr\.dev/chainguard/([a-z0-9\-]+)"
-            for match in re.finditer(pattern, self.content):
-                images.add(match.group(1))
-
-        return sorted(list(images))
+        # Fallback: look for cgr.dev references if no images found from headers
+        images = set()
+        for match in re.finditer(r"cgr\.dev/chainguard/([a-z0-9\-]+)", self.content):
+            images.add(match.group(1))
+        return sorted(images)
 
     def search(self, query: str, max_results: int = 5) -> List[Dict[str, str]]:
         """Search documentation for relevant content."""


### PR DESCRIPTION
## What

Unify and fix the container-image extraction used by the AI Docs bundle so the MCP server and the catalog generator agree on one correct image set.

Fixes the image-count problem reported by a Solutions Architect ([Slack](https://chainguard-dev.slack.com/archives/C03H64P08UT/p1787118504865669)), tracked in DOCS-138.

## Why

The server startup logged two *different* counts — `Found 1555 container images` (from `mcp-server.py`) and `Catalog loaded: 1531 images` (from `image-catalog.json`) — and both undercounted. Root cause: the two scripts parsed the compiled docs' `## Container Images` section with two different, fragile regexes:

- Image names with underscores (`sql_exporter`, `k8s_gateway`, `php-fpm_exporter`, `pgpool2_exporter`, `chrony_exporter`, and their `-fips` twins) failed the `[a-z0-9\-]+` class.
- The catalog's "separator before the next `###`" heuristic dropped ~14 more real images whose READMEs contain a lowercase `###` subheading (`clickhouse`, `nats`, `syft`, `graalvm`, `wiremock`, `cilium-envoy`, …).
- `TEMPLATE`/`TEMPLATE_GROUP` scaffolding dirs were counted as images.

## What changed

- New shared `extract_image_names()` (identical, cross-referenced copy in each script — the container copies `mcp-server.py` in standalone, so a shared import would add a Dockerfile `COPY` + runtime import; a cross-referenced twin is the smaller-surface fix). It splits the section on the `<!-- IMAGE_SEPARATOR -->` markers `compile_docs.py` emits and takes the first `###` heading of each block, validating against `[a-z0-9][a-z0-9_-]*`.
- `mcp-server.py`: `_extract_images` now uses it; `_parse_sections` name class widened so `get_image_docs` can retrieve underscore-named images.
- Added a `# nosec B310` annotation (with justification) to the pre-existing `urllib.urlopen` in `scrape_registry_tags` — the URL is a hardcoded `https://cgr.dev/...`. Touching the file made bandit scan it; the repo already uses `# nosec` elsewhere.

## Verification

Ran both extractors against the compiled bundle and compared to independently-computed ground truth (split on `IMAGE_SEPARATOR`, first heading per block):

- Both return **1876** and match ground truth exactly (0 diff). The two counts are now equal by construction — executable logic is AST-identical across the two copies.
- Recovered images confirmed present; `TEMPLATE*` correctly excluded.

## Scope note

This is a correctness fix, capped by whatever the source bundle contains. On the live pipeline the deployed number stays pinned until DOCS-139 (a broken `images-private` → GCS export, WIF auth failing since ~2026-06-29) is fixed. The two together bring the deployed count current (~1876).

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-19.
