### PR TITLE
Remove beta note from SCIM provisioning docs

### DIFF
--- a/content/platform/administration/custom-idps/scim-provisioning/ms-entra-id-scim/index.md
+++ b/content/platform/administration/custom-idps/scim-provisioning/ms-entra-id-scim/index.md
@@ -5,14 +5,12 @@ lead: ""
 description: "Procedural tutorial on how to set up SCIM provisioning and SSO from Microsoft Entra ID to the Chainguard platform."
 type: "article"
 date: 2026-08-11T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-20T13:54:50+00:00
 draft: false
 tags: ["Procedural"]
 images: []
 weight: 040
 ---
-
-{{< beta feature="SCIM user provisioning" >}}
 
 The Chainguard platform supports SCIM 2.0 provisioning from Microsoft Entra ID. With SCIM enabled, Entra ID creates, updates, and deactivates Chainguard users as you assign and unassign them in your directory, and Chainguard links each provisioned user to their single sign-on (SSO) identity the first time they log in.
 

--- a/content/platform/administration/custom-idps/scim-provisioning/okta-scim/index.md
+++ b/content/platform/administration/custom-idps/scim-provisioning/okta-scim/index.md
@@ -5,14 +5,12 @@ lead: ""
 description: "Procedural tutorial on how to set up SCIM provisioning from Okta to the Chainguard platform."
 type: "article"
 date: 2026-08-14T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-20T13:54:50+00:00
 draft: false
 tags: ["Procedural"]
 images: []
 weight: 039
 ---
-
-{{< beta feature="SCIM user provisioning" >}}
 
 The Chainguard platform supports SCIM 2.0 provisioning from Okta. With SCIM enabled, Okta creates, updates, and deactivates Chainguard users as you assign and unassign them, and Chainguard links each provisioned user to their single sign-on (SSO) login automatically.
 

--- a/content/platform/administration/custom-idps/scim-provisioning/scim-overview.md
+++ b/content/platform/administration/custom-idps/scim-provisioning/scim-overview.md
@@ -5,14 +5,12 @@ lead: ""
 description: "How SCIM provisioning to the Chainguard platform behaves, and how to manage the provisioning connection over its lifetime."
 type: "article"
 date: 2026-08-14T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-20T13:54:50+00:00
 draft: false
 tags: ["Conceptual", "Procedural"]
 images: []
 weight: 012
 ---
-
-{{< beta feature="SCIM user provisioning" >}}
 
 System for Cross-domain Identity Management (SCIM) is an open standard for automating the exchange of user identity information between systems. Chainguard uses SCIM to create and deactivate user accounts based on your identity provider (IdP). Connect your IdP's SCIM provisioning once; from then on, assigning a user to the application provisions them, and deactivating or unassigning them removes their Chainguard access. Accounts follow your IdP, so you manage access in one place.
 


### PR DESCRIPTION
Removes the `{{< beta feature="SCIM user provisioning" >}}` note from the top of the three SCIM provisioning pages. SCIM user provisioning is in Early Adoption, not Beta, and per Grace Larsen we don't need to flag EA status in these docs.

Pages updated:

- [SCIM overview](https://edu.chainguard.dev/platform/administration/custom-idps/scim-provisioning/)
- [Okta SCIM](https://edu.chainguard.dev/platform/administration/custom-idps/scim-provisioning/okta-scim/)
- [Microsoft Entra ID SCIM](https://edu.chainguard.dev/platform/administration/custom-idps/scim-provisioning/ms-entra-id-scim/)

Resolves DOCS-142. Requested by Grace Larsen in #docs.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-20.
