### PR TITLE
Fix broken image reference in dev-containers guide (DOCS-14)

### DIFF
--- a/content/chainguard/containers/how-to-use/dev-containers/index.md
+++ b/content/chainguard/containers/how-to-use/dev-containers/index.md
@@ -9,7 +9,7 @@ aliases:
 - /chainguard/containers/how-to-use/dev-containers/
 description: "Guide outlining how you can use Chainguard Containers as Dev Containers for secure development."
 date: 2025-03-10T11:07:52+02:00
-lastmod: 2025-03-08T11:07:52+02:00
+lastmod: 2026-08-20T15:25:39+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -115,7 +115,7 @@ If you do reopen the project in a dev container it may take a minute or so to bu
 
 If you run a webserver in your dev container you will be asked if you want to open the port in a local browser. Exactly as if you were running in a local container:
 
-<center><img src="dev-containers-1.png" alt="Screenshot of a VS Code window running helloserver and prompting the user to open the application in the browser." style="width:1000px;"></center>
+<center><img src="dev-containers-3.png" alt="Screenshot of a VS Code window running helloserver and prompting the user to open the application in the browser." style="width:1000px;"></center>
 <br />
 
 ## Building a Dev Container in other languages


### PR DESCRIPTION
## What

Fixes a broken image reference on the dev-containers guide.

The page shows three screenshots. The third `<img>` pointed at `dev-containers-1.png` (the "reopen in container" prompt) while its alt text — and the preceding sentence about running a webserver and opening the port in a browser — describe a different image: `dev-containers-3.png`. That file already exists in the page bundle but was never referenced. This points the third `<img>` at the correct file.

## Change

```diff
-<center><img src="dev-containers-1.png" alt="Screenshot of a VS Code window running helloserver and prompting the user to open the application in the browser." ...></center>
+<center><img src="dev-containers-3.png" alt="Screenshot of a VS Code window running helloserver and prompting the user to open the application in the browser." ...></center>
```

One line. No other content changes (the `lastmod` bump is from the pre-commit stamper).

## Context

Found during the DOCS-14 screenshot audit. `dev-containers-3.png` was initially a deletion candidate in the orphan-removal PR (#3809) because nothing referenced it; the narrative cross-check showed the file was correct and the *page* had the bug, so it was pulled from that PR and fixed here instead.

## Related

DOCS-14

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-20.
