### PR TITLE
Add consistent upstream-fallback messaging before repo manager sections

### DIFF
--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Java in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T18:17:54+00:00
+lastmod: 2026-08-20T19:03:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 images: []
@@ -54,7 +54,7 @@ information.
 
 ## Configure access with a repository manager
 
-See the Build configuration docs for instructions on configuring repository manager access for [Maven](/chainguard/libraries/java/build-configuration/#repo-manager-maven), [Gradle](/chainguard/libraries/java/build-configuration/#repo-manager-gradle), and [Bazel](/chainguard/libraries/java/build-configuration/#repo-manager-bazel).
+Refer to the Build configuration docs for instructions on configuring repository manager access for [Maven](/chainguard/libraries/java/build-configuration/#repo-manager-maven), [Gradle](/chainguard/libraries/java/build-configuration/#repo-manager-gradle), and [Bazel](/chainguard/libraries/java/build-configuration/#repo-manager-bazel).
 
 ## Manually managing fallback
 
@@ -304,7 +304,7 @@ Configure a remote repository for the Chainguard Libraries for Java repository:
     * **URL**: `https://libraries.cgr.dev/java/`
     * **User Name** and **Password / Access Token**: Set to the [values as retrieved with chainctl](/chainguard/libraries/access/).
     * Deactivate **Maven Settings - Handle Snapshots**.
-1. Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
+1. Note: The **Test** button is not a reliable indicator; to verify your setup, refer to the [validation steps](#validate-the-remote-repository) later on this page.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.
@@ -439,7 +439,7 @@ The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 configuring a single proxy repository pointed at
 `https://libraries.cgr.dev/java/` rather than adding a separate Maven Central
-proxy. See [Manually managing fallback](#manually-managing-fallback) if you need
+proxy. Refer to [Manually managing fallback](#manually-managing-fallback) if you need
 to control fallback ordering yourself.
 
 ### Initial configuration

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Java in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T18:08:04+00:00
+lastmod: 2026-08-20T18:17:54+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 images: []
@@ -437,10 +437,10 @@ Libraries for Java repository for production use.
 
 The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
-configuring a single proxy repository pointed at `https://libraries.cgr.dev/java/`
-rather than adding a separate Maven Central proxy. Chainguard has tested this
-approach with Nexus. See [Manually managing fallback](#manually-managing-fallback)
-if you need to control fallback ordering yourself.
+configuring a single proxy repository pointed at
+`https://libraries.cgr.dev/java/` rather than adding a separate Maven Central
+proxy. See [Manually managing fallback](#manually-managing-fallback) if you need
+to control fallback ordering yourself.
 
 ### Initial configuration
 

--- a/content/chainguard/libraries/java/global-configuration.md
+++ b/content/chainguard/libraries/java/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Java in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T15:07:13+00:00
+lastmod: 2026-08-20T18:08:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 images: []
@@ -435,16 +435,21 @@ information.
 If you are using this group, you can add a proxy repository for Chainguard
 Libraries for Java repository for production use.
 
+The recommended approach is to rely on Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+configuring a single proxy repository pointed at `https://libraries.cgr.dev/java/`
+rather than adding a separate Maven Central proxy. Chainguard has tested this
+approach with Nexus. See [Manually managing fallback](#manually-managing-fallback)
+if you need to control fallback ordering yourself.
+
 ### Initial configuration
 
 Use the following steps to add Chainguard Libraries for Java as a proxy repository.
 
-The recommended approach is to use the Chainguard Repository's [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls). If
-you are instead configuring your own fallback in your repo manager, for initial
-testing it is advised to create a separate proxy repository for the Maven
-Central Repository, a separate proxy repository Chainguard Libraries for Java
-repository, and a separate repository group.
+If you are configuring your own fallback rather than using upstream fallback,
+for initial testing create a separate proxy repository for the Maven Central
+Repository, a separate proxy repository for Chainguard Libraries for Java, and a
+separate repository group.
 
 1. Log in as a user with administrator privileges.
 1. Click the gear icon in the top navigation bar to access **Server administration**.

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-20T18:08:04+00:00
+lastmod: 2026-08-20T19:03:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -101,7 +101,7 @@ by defining multiple upstream repositories.
 The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 configuring a single upstream proxy pointed at `https://libraries.cgr.dev/javascript/`
-rather than adding a separate public npm proxy. See [Manually managing
+rather than adding a separate public npm proxy. Refer to [Manually managing
 fallback](#manually-managing-fallback) if you need to control fallback ordering
 yourself.
 
@@ -215,7 +215,7 @@ repository:
 1. Set the **URL** to `https://libraries.cgr.dev/javascript/`.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-    * Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
+    * Note: The **Test** button is not a reliable indicator; to verify your setup, refer to the [validation steps](#validate-the-remote-repository) later on this page.
 1. Click the **Advanced** configuration tab, then configure the following settings:
     * In the **Network** section:
         * Confirm **Lenient Host Authentication** is unchecked, so that your credentials are not forwarded across the redirect.

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-20T15:07:13+00:00
+lastmod: 2026-08-20T18:08:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -97,6 +97,13 @@ Upstream
 documentation](https://help.cloudsmith.io/docs/upstream-proxying-caching#create-a-npm-upstream)
 for Cloudsmith for more information. Cloudsmith supports combining repositories
 by defining multiple upstream repositories.
+
+The recommended approach is to rely on Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+configuring a single upstream proxy pointed at `https://libraries.cgr.dev/javascript/`
+rather than adding a separate public npm proxy. See [Manually managing
+fallback](#manually-managing-fallback) if you need to control fallback ordering
+yourself.
 
 ### Initial configuration
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T15:07:13+00:00
+lastmod: 2026-08-20T18:08:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -97,10 +97,17 @@ documentation](https://help.cloudsmith.io/docs/python-repository) and the
 repository](https://help.cloudsmith.io/docs/create-a-repository) for more
 information.
 
+The recommended approach is to rely on Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+configuring a single upstream proxy pointed at `https://libraries.cgr.dev/python/`
+rather than adding a separate public PyPI proxy. See [Manually managing
+fallback](#manually-managing-fallback) if you need to control fallback ordering
+yourself.
+
 ### Initial configuration
 
-Use the following steps to add a repository with both Chainguard Libraries for
-Python and PyPI as upstream sources.
+Use the following steps to add a repository with Chainguard Libraries for
+Python as the upstream source.
 
 First, create a repository:
 
@@ -159,11 +166,17 @@ Use the [Python package documentation for Google Artifact
 Registry](https://cloud.google.com/artifact-registry/docs/python) as the starting
 point for more details.
 
+The recommended approach is to rely on Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+configuring a single remote repository pointed at `https://libraries.cgr.dev/python/`
+rather than adding a separate public PyPI remote. See [Manually managing
+fallback](#manually-managing-fallback) if you need to control fallback ordering
+yourself.
+
 ### Initial configuration
 
-Use the following steps to add the Pypi Package Index and the Chainguard
-Libraries for Python repository as remote repositories and combine them as a
-virtual repository.
+Use the following steps to add the Chainguard Libraries for Python repository
+as a remote repository and expose it through a virtual repository.
 
 1. Log in to the Google Cloud console as a user with administrator privileges.
 1. Navigate to your project and find the **Artifact Registry** with the search.
@@ -204,7 +217,7 @@ authentication details, and the URL
 
 If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI.
 
-Combine the repositories in a new virtual repository:
+Combine the repository into a new virtual repository:
 
 1. Click **+** to add another repository.
 1. Set the **Name** to `python-all`.
@@ -214,14 +227,13 @@ Combine the repositories in a new virtual repository:
 1. Click **Browse**, then locate and select the `python-chainguard`
    repository as **Repository 1** and set the **Policy name 1** to
    `python-chainguard`.
-1. Click **Browse**, then locate and select the `python-public` repository
-   as **Repository 2** and set the **Policy name 2** to `python-public`.
-1. Click **Add upstream repository** in **Virtual upstream repositories**.
-1. Set the **Priority** value for the `python-chainguard` policy name to a higher
-   value than the `python-public` priority value.
-1. Choose the same suitable **Region** for your development in **Location type**
-   as configured for the `python-public` repository.
+1. Choose a **Region** for your development in **Location type**.
 1. Click **Create**.
+
+If you are manually managing fallback rather than using the recommended
+[upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+add the public PyPI index as a second remote repository (`python-public`) and
+give the `python-chainguard` policy a higher priority than `python-public`.
 
 <a id="artifactory"></a>
 
@@ -367,11 +379,17 @@ for merging multiple remote repositories as a repository group. The below
 instructions are based on the [Nexus documentation for
 PyPI](https://help.sonatype.com/en/pypi-repositories.html)
 
+The recommended approach is to rely on Chainguard Repository's [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
+configuring a single proxy repository pointed at `https://libraries.cgr.dev/python/`
+rather than adding a separate public PyPI proxy. See [Manually managing
+fallback](#manually-managing-fallback) if you need to control fallback ordering
+yourself.
+
 ### Initial configuration
 
-The following steps create remote repositories for Chainguard Libraries for
-Python, a remote repository for the public PyPI index, and a repository group
-combining these sources.
+The following steps create a remote repository for Chainguard Libraries for
+Python and a repository group that exposes it to your build tools.
 
 First, log in to Sonatype Nexus as a user with administrator privileges and
 access the **Server administration** and configuration section within the gear

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T18:08:04+00:00
+lastmod: 2026-08-20T18:17:54+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -217,7 +217,7 @@ authentication details, and the URL
 
 If you are manually managing fallback rather than using the [Chainguard Repository's built-in fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), configure an additional remote repository for the public PyPI.
 
-Combine the repository into a new virtual repository:
+Combine the `python-chainguard` repository, and optionally the `python-chainguard-remediated` repository, into a new virtual repository:
 
 1. Click **+** to add another repository.
 1. Set the **Name** to `python-all`.

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T18:17:54+00:00
+lastmod: 2026-08-20T19:03:04+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -100,7 +100,7 @@ information.
 The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 configuring a single upstream proxy pointed at `https://libraries.cgr.dev/python/`
-rather than adding a separate public PyPI proxy. See [Manually managing
+rather than adding a separate public PyPI proxy. Refer to [Manually managing
 fallback](#manually-managing-fallback) if you need to control fallback ordering
 yourself.
 
@@ -169,7 +169,7 @@ point for more details.
 The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 configuring a single remote repository pointed at `https://libraries.cgr.dev/python/`
-rather than adding a separate public PyPI remote. See [Manually managing
+rather than adding a separate public PyPI remote. Refer to [Manually managing
 fallback](#manually-managing-fallback) if you need to control fallback ordering
 yourself.
 
@@ -275,7 +275,7 @@ Configure a remote repository for the Chainguard Libraries for Python index:
    URL also needs to cover the `/python-upstream/` paths for upstream fallback packages.
 1. Set **User Name** and **Password / Access Token** to the [values as retrieved
    with chainctl](/chainguard/libraries/access/).
-    * Note: The **Test** button is not a reliable indicator; to verify your setup, see the [validation steps](#validate-the-remote-repository) later on this page.
+    * Note: The **Test** button is not a reliable indicator; to verify your setup, refer to the [validation steps](#validate-the-remote-repository) later on this page.
 1. Set the **PyPI Settings - Registry URL** to
    `https://libraries.cgr.dev/`.
 1. Set the **PyPI Settings - Registry Index Location URL Suffix** to `python/simple`.
@@ -382,7 +382,7 @@ PyPI](https://help.sonatype.com/en/pypi-repositories.html)
 The recommended approach is to rely on Chainguard Repository's [upstream
 fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 configuring a single proxy repository pointed at `https://libraries.cgr.dev/python/`
-rather than adding a separate public PyPI proxy. See [Manually managing
+rather than adding a separate public PyPI proxy. Refer to [Manually managing
 fallback](#manually-managing-fallback) if you need to control fallback ordering
 yourself.
 


### PR DESCRIPTION
## Type of change

Documentation consistency update, covering the repo manager sections of the Python, Java, and JavaScript Libraries global configuration pages.

### What should this PR do?

Extends the pattern introduced in #3800 so that *every* repo manager section on the three global configuration pages opens with a brief mention of the recommended approach — Chainguard's upstream fallback — and treats the manual public-registry fallback as a conditional alternative rather than the default.

- **Python:** Adds a recommended-approach mention after the Cloudsmith, Google Artifact Registry, and Nexus headings, and demotes the manual public-PyPI steps to brief conditionals. The Google Artifact Registry virtual-repository steps now build around `python-chainguard` alone, with `python-public` as a trailing option.
- **Java:** Moves the Nexus mention up to follow the section heading, matching the Artifactory placement, and reframes the leftover text as manual-fallback-only guidance. The Cloudsmith and Google Artifact Registry sections keep their existing "not yet tested" notes, since upstream fallback isn't officially supported for those tools yet.
- **JavaScript:** Adds a mention after the Cloudsmith heading. The Google Artifact Registry and AWS CodeArtifact sections are unchanged — both are labeled "not officially supported" and already carry their own upstream-fallback framing.

### Why are we making this change?

After #3800 added the recommended-approach mention before the Artifactory (and some Sonatype) sections, the messaging was uneven across the three pages: some repo manager sections recommended upstream fallback while others still presented a manual public-registry fallback as the default. This PR makes the upstream-fallback recommendation consistent before every repo manager section, while honoring the tools that aren't officially supported for upstream fallback yet.

### What are the acceptance criteria?

- Every repo manager section on the three pages opens with a recommended-approach mention, except the sections explicitly marked "not officially supported."
- Manual public-registry fallback appears only as a conditional alternative.
- Java's untested tools (Cloudsmith, Google Artifact Registry) retain their "not yet tested" notes.
- All `#manually-managing-fallback` and upstream-fallback overview links resolve.

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

Steps specific to this PR:

1. Build the site and confirm no template or link errors:
   ```bash
   hugo --gc --minify
   ```
2. Serve locally and open each page:
   ```bash
   hugo server -D
   ```
   - `/chainguard/libraries/python/global-configuration/`
   - `/chainguard/libraries/java/global-configuration/`
   - `/chainguard/libraries/javascript/global-configuration/`
3. On each page, confirm every repo manager section opens with a recommended-approach mention (except the "not officially supported" sections), and that the "Manually managing fallback" and upstream-fallback overview links resolve and jump to the correct anchors.
4. **Python Google Artifact Registry (changed procedure):** In a test GCP project, follow the restructured Initial configuration — create the `python-chainguard` remote, create the `python-all` virtual repository with only `python-chainguard`, then confirm `pip install` resolves through it. Separately, follow the trailing conditional to add `python-public` and confirm the priority ordering behaves as described.
5. **Java Nexus:** Confirm the single-upstream `java-chainguard` proxy plus `java-all` group resolves a build, matching the promoted recommended-approach mention.

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-08-20.
