### PR TITLE
Fix relative image src on landingpage section targets (DOCS-14)

### DIFF
--- a/content/open-source/octo-sts/overview/index.md
+++ b/content/open-source/octo-sts/overview/index.md
@@ -5,7 +5,7 @@ type: "article"
 lead: "A security token service that eliminates the need for GitHub personal access tokens by enabling OIDC-based federation for GitHub API access"
 description: "Learn about Octo STS, an open source security token service for GitHub that uses OIDC federation to eliminate long-lived personal access tokens"
 date: 2025-12-23T15:04:05+01:00
-lastmod: 2025-12-24T15:04:05+01:00
+lastmod: 2026-08-20T18:38:14+00:00
 tags: ["octo-sts", "Overview", "OIDC", "Security"]
 draft: false
 images: []
@@ -46,7 +46,7 @@ The Octo STS app needs to request a large number of permissions. This set of per
 
 This sequence diagram outlines the token exchange process in Octo STS:
 
-<center><img src="octo-arch.webp" alt="Octo STS sequence diagram showing order of network requests" style="width:950px;"></center>
+<center><img src="/open-source/octo-sts/overview/octo-arch.webp" alt="Octo STS sequence diagram showing order of network requests" style="width:950px;"></center>
 
 ## Common use cases
 

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2026-07-29T15:22:20+01:00
+lastmod: 2026-08-20T18:38:14+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -98,7 +98,7 @@ To authenticate with the Chainguard Console, [open the login screen](https://con
 - To use a third-party identity provider, click the corresponding option from the list.
 - To use your email and a password, enter your email and click **Continue**.
 
-<center><img src="cg-all-signin-24.png" alt="Screenshot showing an example Chainguard login box, with all described options shown." style="width:600px;"></center>
+<center><img src="/platform/administration/custom-idps/custom-idps/cg-all-signin-24.png" alt="Screenshot showing an example Chainguard login box, with all described options shown." style="width:600px;"></center>
 
 In each of these cases, you will be redirected to an external identity provider to authenticate and then returned to the Chainguard Console. If you are using your email and a password, authentication is handled by and credentials are stored with [Auth0](https://auth0.com/).
 


### PR DESCRIPTION
## What

Fixes two docs images that render on their own page but 404 on the section-index URL.

Several section index pages render a child page's body inline via the `landingpage` frontmatter param (`layouts/_default/list.html` → `single-body.html`). When the embedded page uses a **relative** image `src`, the browser resolves it against the *section* URL rather than the child page's URL, so the image is missing on the section index.

Two pages were affected:

| Section index | Image |
| --- | --- |
| `/platform/administration/custom-idps/` | `cg-all-signin-24.png` |
| `/open-source/octo-sts/` | `octo-arch.webp` |

Both `<img>` tags now point at their absolute published paths, so they display on the child page and the section index alike.

## How this was found

While fixing the same issue on the Chainguard Console walkthrough (`platform/console`, in a separate PR), a repo-wide check of every `landingpage` target turned up these two as the only other pages with relative-src raster images. The remaining ~18 landingpage targets are clean.

## Verification

- Built the site and confirmed both section-index pages now emit the absolute `src`, and both images are published at those paths.
- No other content changed.

## Related

DOCS-14

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-20.
