### PR TITLE
Clarify changelog scope in intro and homepage callout

### DIFF
--- a/content/chainguard/changelog.md
+++ b/content/chainguard/changelog.md
@@ -15,6 +15,8 @@ tocEndLevel: 2
 
 This page logs Chainguard product updates week by week, newest first: product announcements, breaking changes, container images that reached end-of-life or are no longer available, and images newly added to the catalog. Each event is listed once, in the week it first appeared.
 
+Breaking changes and product announcements cover the entire Chainguard portfolio, while end-of-life, availability, and new-image entries relate specifically to Chainguard Containers. This page summarizes the changes most likely to affect your work rather than every change Chainguard ships. Routine updates, such as new tags for existing images, are not listed individually. For the current tags and versions of any container image, refer to its entry in the [Chainguard Directory](https://images.chainguard.dev/directory).
+
 ## Week of 2026-08-17
 
 {{< changelog-label "Product Announcements" >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -220,7 +220,7 @@
             <span class="changelog-callout-eyebrow">Updated weekly</span>
             <div class="changelog-callout-title">Chainguard products changelog</div>
             <p class="changelog-callout-text">
-              Product announcements, breaking changes, end-of-life notices, and new container images, published every week
+              Product announcements and breaking changes from across the Chainguard portfolio, plus end-of-life notices and new container images
             </p>
           </div>
           <span class="changelog-callout-cta">


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Add a scope paragraph to the changelog introduction
- Update the homepage changelog callout to match

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
Tell changelog readers what the page covers and what it leaves out, and point them to the Chainguard Directory for tag-level detail.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
The changelog is a curated selection, but the page never said so, which could read as a complete record of everything Chainguard ships. The page title also says "products" while the entries mix portfolio-wide announcements with Containers-only lifecycle events, leaving the scope ambiguous.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The changelog intro states that announcements and breaking changes span the portfolio, while end-of-life, availability, and new-image entries cover Containers
- The intro notes that routine updates such as new tags aren't listed individually, and links to the Chainguard Directory
- The homepage callout reflects the same portfolio/Containers split and no longer repeats "every week" beneath the "Updated weekly" eyebrow
- The callout text still fits on one row at desktop width and stacks cleanly below 768px

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Open `/chainguard/changelog/` and confirm the new paragraph reads correctly and the Directory link resolves
3. Open the homepage, scroll to the changelog callout, and check the text at both desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
