### PR TITLE
Add chainctl authentication options page and reusable login shortcode

### DIFF
--- a/content/chainguard/containers/getting-started/gitlab/index.md
+++ b/content/chainguard/containers/getting-started/gitlab/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "GitLab"
 description: "Learn how to deploy GitLab using Chainguard's security-hardened container images with reduced vulnerabilities, verifiable provenance, and daily security updates"
 date: 2026-06-24T00:00:00+00:00
-lastmod: 2026-07-07T00:00:00+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -53,6 +53,8 @@ Log in to the Chainguard registry:
 ```shell
 chainctl auth login
 ```
+
+{{< blurb/chainctl-auth >}}
 
 Configure Docker to use your Chainguard credentials:
 

--- a/content/chainguard/containers/getting-started/wordpress.md
+++ b/content/chainguard/containers/getting-started/wordpress.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "WordPress"
 description: "Learn how to deploy WordPress using Chainguard's security-hardened container image with reduced vulnerabilities and distroless runtime options"
 date: 2024-07-19T11:07:52+02:00
-lastmod: 2026-06-09T00:09:59+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -47,6 +47,8 @@ The images in this guide require a free Chainguard account. Sign up at [chaingua
 ```shell
 chainctl auth login
 ```
+
+{{< blurb/chainctl-auth >}}
 
 If you encounter credential errors when pulling images, pull them individually before running `docker compose`:
 

--- a/content/chainguard/libraries/access.md
+++ b/content/chainguard/libraries/access.md
@@ -4,7 +4,7 @@ linktitle: "Access"
 description: "Learn how to access Chainguard Libraries for enhanced security in Java and Python dependencies, including authentication and organization setup"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -63,6 +63,8 @@ account:
 ```shell
 chainctl auth login
 ```
+
+{{< blurb/chainctl-auth >}}
 
 After authentication in a browser window, a successful login displays a message
 and a token:

--- a/content/chainguard/libraries/quickstart.md
+++ b/content/chainguard/libraries/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quickstart"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-08-07T13:45:43+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -51,6 +51,8 @@ Before getting started:
    ```bash
    chainctl auth login
    ```
+
+   {{< blurb/chainctl-auth >}}
 
 * Entitle access for yourself to Chainguard Libraries.
     * Chainguard Libraries are available to Catalog Starter and Free tier users,

--- a/content/get-started/getting-started-with-chainctl.md
+++ b/content/get-started/getting-started-with-chainctl.md
@@ -6,7 +6,7 @@ lead: "Chainguard's chainctl CLI enables more secure management of container ima
 description: "Get started with chainctl basics including authentication, organization management, and essential commands for Chainguard's container security platform"
 type: "article"
 date: 2025-03-03T08:49:15+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["chainctl", "Getting Started"]
 images: []
@@ -24,6 +24,8 @@ chainctl auth login
 ```
 
 This will present a list of identity providers for you to select from. Use the one that is tied to your Chainguard Account. Once you select the one you wish to use, such as Google, `chainctl` will open a browser window for you to log in with your credentials. Upon successful login, you will have the option to save this identity provider as your default for future logins. Then a token will be exchanged and you will be able to use `chainctl`.
+
+{{< blurb/chainctl-auth >}}
 
 To check your authentication status at any time, enter:
 

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2026-08-20T18:38:14+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -32,7 +32,7 @@ chainctl auth login --identity-provider=$IDP_ID
 
 You can retrieve all your identity provider's unique IDs by running `chainctl iam identity-providers list`.
 
-Note that you can also use the [`--headless` option](/chainguard/administration/iam-organizations/overview-of-chainguard-iam-model/#using-the-headless-login-flow) to log in with a custom IdP in an environment that doesn't have a browser installed, such as a container or a remote server. By including this option, `chainctl` will output a special URL. You can then navigate to the URL in another device's browser to log in with your custom IdP.
+Note that you can also use the [`--headless` option](/platform/chainctl-usage/authentication-options/#headless-device-code-login) to log in with a custom IdP in an environment that doesn't have a browser installed, such as a container or a remote server. By including this option, `chainctl` will output a special URL. You can then navigate to the URL in another device's browser to log in with your custom IdP.
 
 To log in with a custom IdP using the `--headless` option, you would run a command like the following:
 

--- a/content/platform/administration/iam-organizations/overview-of-chainguard-iam-model.md
+++ b/content/platform/administration/iam-organizations/overview-of-chainguard-iam-model.md
@@ -9,7 +9,7 @@ type: "article"
 description: "Learn how Chainguard's identity and access management (IAM) model works with organizations, folders, and role-based access control for more secure resource management"
 lead: "Chainguard's identity and access management (IAM) provides enterprise-grade access control for container registries and security resources through organizations, folders, and fine-grained permissions."
 date: 2022-07-15T15:22:20+01:00
-lastmod: 2025-07-23T16:52:56+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["Console", "Reference"]
 images: []
@@ -40,33 +40,4 @@ You can also create assumable identities. These are typically used to allow auto
 
 ## Logging in to the Chainguard platform
 
-There are several ways to authenticate to the Chainguard platform, each with a different focus.
-
-* [Interactive login](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/#using-the-interactive-login): This is easy and good for interactive use, but needs a browser available that the current shell can launch.
-* [Headless login](/platform/administration/iam-organizations/overview-of-chainguard-iam-model/#using-the-headless-login-flow): This is also easy and good for interactive use. It still requires access to a browser, but not directly from within the current shell or even from the current device.
-* [Assumable identities](/platform/administration/assumable-ids/assumable-ids/): These are designed for CI/CD and do not require any interaction, but they do require more setting up and are not ideal outside of CI/CD-style automation.
-* [Pull tokens](/chainguard/containers/chainguard-registry/authenticating/#authenticating-with-a-pull-token): These are ideal for pulling images and libraries and can be long-lived. Pull tokens can be created using the console or with chainctl.
-
-### Using the interactive login
-
-To authenticate into the Chainguard platform, run the following login command.
-
-```sh
-chainctl auth login
-```
-
-A web browser window will open to prompt you to log in via your chosen OIDC flow. Select the account which you wish to log in as, and you can then begin managing your Chainguard resources.
-
-### Using the headless login flow
-
-Note that you can also use `chainctl`'s `--headless` option to log in. This option allows you to log in to the Chainguard platform from a device that doesn't have a browser installed, such as a container or remote server.
-
-The headless login flow is when you invoke `chainctl auth login --headless` in the terminal.
-
-```sh
-chainctl auth login --headless
-```
-
-By including this option, `chainctl` will output an eight-character code as well as a URL ([`https://auth.chainguard.dev/activate`](https://auth.chainguard.dev/activate)). You can then navigate to the URL on another device's browser and enter the code, and then you can complete the login process to Chainguard from that device.
-
-Be aware that the `--headless` login code will only be valid for 900 seconds.
+You can authenticate to the Chainguard platform with `chainctl` in several ways, including interactive browser login, headless device-code login, social login providers, and assumable identities for CI/CD. For the full list of login flows and guidance on when to use each, see [Authentication options](/platform/chainctl-usage/authentication-options/).

--- a/content/platform/chainctl-usage/authentication-options.md
+++ b/content/platform/chainctl-usage/authentication-options.md
@@ -1,0 +1,69 @@
+---
+title: "Authentication options for chainctl"
+linktitle: "Authentication options"
+aliases:
+- /chainguard/chainctl-usage/authentication-options/
+type: "article"
+description: "Learn the login flows chainctl supports, including interactive browser login, headless device-code login, social login providers, and assumable identities."
+lead: "chainctl supports several ways to authenticate to the Chainguard platform, so you can log in from a laptop, a browserless server, or a CI/CD pipeline."
+date: 2026-08-21T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
+draft: false
+tags: ["chainctl"]
+images: []
+menu:
+  docs:
+    parent: "chainctl-usage"
+toc: true
+weight: 020
+---
+
+There are several ways to authenticate to the Chainguard platform with `chainctl`, each suited to a different environment:
+
+* **Interactive login**: Good for everyday interactive use, but needs a browser that the current shell can launch.
+* **Headless login**: Also good for interactive use. It still requires a browser, but not from within the current shell or even the current device.
+* **Social login**: Lets you choose which default identity provider (email, Google, GitHub, or GitLab) to authenticate with.
+* **Assumable identities**: Designed for CI/CD and require no interaction, but they need more setup and aren't ideal outside automation.
+* **Pull tokens**: Ideal for pulling images and libraries, and they can be long-lived.
+
+## Interactive browser login
+
+To authenticate to the Chainguard platform, run the following command:
+
+```sh
+chainctl auth login
+```
+
+A browser window opens and prompts you to log in through your chosen OIDC flow. Select the account you want to log in as, and then you can begin managing your Chainguard resources.
+
+## Headless device-code login
+
+If the shell can't launch a browser—for example, on a container or a remote server—use the `--headless` option to log in through a device-code flow:
+
+```sh
+chainctl auth login --headless
+```
+
+`chainctl` outputs an eight-character code and a URL, [`https://auth.chainguard.dev/activate`](https://auth.chainguard.dev/activate). Open the URL in a browser on any device, enter the code, and complete the login. You can then use Chainguard from the headless device.
+
+The `--headless` code is valid for 900 seconds.
+
+## Select an identity provider with --social-login
+
+To authenticate with a specific default identity provider, pass the `--social-login` flag. The value must be one of `email`, `google`, `github`, or `gitlab`:
+
+```sh
+chainctl auth login --social-login github
+```
+
+You can also set a default provider in your configuration with the `default.social-login` setting. See [Manage your chainctl configuration](/platform/chainctl-usage/manage-chainctl-config/).
+
+> Note: If your organization has configured a custom identity provider, authenticate with `--org-name` or `--identity-provider` instead. See [custom identity providers](/platform/administration/custom-idps/custom-idps/).
+
+## Assumable identities for CI/CD
+
+Assumable identities let automation tools like GitHub Actions or AWS Lambda connect to and manage Chainguard resources without interactive login. See the [guide on assumable identities](/platform/administration/assumable-ids/assumable-ids/).
+
+## Pull tokens
+
+Pull tokens are ideal for pulling images and libraries and can be long-lived. You can create them in the Chainguard Console or with `chainctl`. See [authenticating to the Chainguard registry](/chainguard/containers/chainguard-registry/authenticating/#authenticating-with-a-pull-token).

--- a/content/platform/chainctl-usage/how-to-install-chainctl.md
+++ b/content/platform/chainctl-usage/how-to-install-chainctl.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Learn how to install chainctl, Chainguard's command-line interface for managing container images, IAM resources, and security configurations across platforms"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2025-07-23T16:52:56+00:00
+lastmod: 2026-08-21T16:30:07+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -184,6 +184,8 @@ chainctl auth login
 ```
 
 This will open your browser window and take you through a workflow to login with your OIDC provider.
+
+{{< blurb/chainctl-auth >}}
 
 ### Authentication tokens
 

--- a/layouts/shortcodes/blurb/chainctl-auth.html
+++ b/layouts/shortcodes/blurb/chainctl-auth.html
@@ -1,0 +1,3 @@
+<blockquote>
+<p><strong>Note</strong>: <code>chainctl auth login</code> supports several login flows, including device-code login for machines without a browser and assumable identities for CI. If the default browser flow doesn't work in your environment, see <a href="/platform/chainctl-usage/authentication-options/">Authentication options</a>.{{ if eq (.Get "console") "true" }} You can also complete this task in the <a href="https://console.chainguard.dev/">Chainguard Console</a>.{{ end }}</p>
+</blockquote>


### PR DESCRIPTION
## Summary

Adds a standalone **Authentication options** page under chainctl usage and a reusable shortcode so that alternate `chainctl auth login` flows are discoverable, rather than buried under the IAM model overview.

- **New page** `content/platform/chainctl-usage/authentication-options.md` documents every login flow: interactive browser login, headless device-code login (`--headless`), selecting a provider with `--social-login`, assumable identities for CI/CD, and pull tokens.
- **Moved** the login content out of `overview-of-chainguard-iam-model.md` and replaced it with a short pointer to the new page.
- **New shortcode** `layouts/shortcodes/blurb/chainctl-auth.html`, with an optional `console="true"` variant for future pull-token reuse. Inserted on the six main interactive-login entry points.
- **Fixed** the custom IdP headless-login link, which pointed at an anchor that no longer exists, to target the new page's `#headless-device-code-login` anchor.

## Motivation

We received feedback that customers couldn't easily find alternate login methods such as `--social-login` and `--headless`. This surfaces them on a dedicated page and links to it from the places people first run `chainctl auth login`. This PR addresses https://linear.app/chainguard/issue/DOCS-35/clarify-chainctl-auth-usage-on-the-edu-site

## Needs verification

- The `--social-login` section is written conservatively from the flag reference (`chainctl_auth_login.md`), which documents only the accepted values (`email`, `google`, `github`, `gitlab`). The exact interactive behavior (whether it skips the provider prompt, how it handles an invalid value) is confirmed in the test plan below.

## Test plan

**Docs rendering**

1. Build the site locally with `npm run build`. Note: an unrelated `@docsearch/js` JS-bundling error may appear at the end; Hugo still renders all pages to `public/` before that step, so it doesn't affect this change. Alternatively, run `npm run start` and browse.
2. Confirm the new page renders at `/platform/chainctl-usage/authentication-options/` with these sections: Interactive browser login, Headless device-code login, Select an identity provider with `--social-login`, Assumable identities for CI/CD, and Pull tokens.
3. Confirm the login-options note renders on each of these pages: getting-started-with-chainctl, how-to-install-chainctl, libraries/access, libraries/quickstart, containers/getting-started/wordpress, and containers/getting-started/gitlab.
4. Follow the `--headless` link on the custom IdP page and confirm it lands on the new page's headless section.

**chainctl behavior**

5. Run `chainctl auth login` and confirm the browser flow opens and completes as described.
6. Run `chainctl auth login --headless` and confirm it prints an eight-character code and the `https://auth.chainguard.dev/activate` URL, and that the code expires after 900 seconds.
7. Run `chainctl auth login --social-login github` (and repeat for `email`, `google`, `gitlab`) and confirm each authenticates with the named provider. Note whether the flag skips the provider prompt and how an invalid value is handled, and update the page if behavior differs from the draft.

---
Created in collaboration with Claude Code running Opus 4.8 (1M context) on 2026-08-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
