### PR TITLE
Add FAQ about Nexus build failures to Python global config

### DIFF
--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T19:03:04+00:00
+lastmod: 2026-08-21T19:07:06+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -430,3 +430,23 @@ Finally, create a new repository group and add the repositories:
 Refer to the page on [build tool configuration for Chainguard Libraries for
 Python](/chainguard/libraries/python/build-configuration/#nexus) for information on
 accessing credentials and setting up build tools.
+
+## Troubleshooting and FAQ
+
+### Sonatype build failures and 404 errors for uv and pip requests ending in `.whl.metadata`
+
+Builds fail intermittently when Sonatype Nexus is configured as a PyPI proxy in front of `libraries.cgr.dev`, even though authentication, entitlements, and network connectivity all check out. The failures look like missing packages, but the packages themselves are present and downloadable. The Nexus outbound request logs show 404 responses specifically for URLs ending in `.whl.metadata`, while the same URL without the `.metadata` suffix succeeds.
+
+Modern Python installers (pip 23.1+, uv) implement [PEP 658](https://peps.python.org/pep-0658/) and request a small per-package metadata file by appending `.metadata` to the wheel's download URL, ahead of downloading the wheel itself. When Nexus is serving a stale cached index page, it can point clients at a metadata URL format that `libraries.cgr.dev` no longer honors. Chainguard's upstream returns 400 for that request, which Nexus in turn surfaces to the client as a 404. The result presents as a missing package, when the underlying issue is a stale cached index.
+
+#### Fix: Recreate the proxy repository
+
+To fix this, delete and recreate the Chainguard PyPI proxy repository in Nexus. This clears all cached index pages and metadata assets for that repository, forcing Nexus to pull fresh copies on the next request.
+
+Alternatively, you could add a Nexus routing rule to block metadata requests outright. Clients fall back to standard resolution automatically when the metadata request fails cleanly, without surfacing an error:
+
+1. In Nexus, go to **Administration** > **Routing Rules** and create a new rule.
+1. Set the Mode to `Block`.
+1. Set the matcher to `.*\.metadata$`.
+1. Assign the rule to your Chainguard PyPI proxy repository.
+1. Remove the routing rule once you've recreated the proxy repository, so clients can resume using PEP 658 metadata requests.


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to Python global config

### What should this PR do?
Add an FAQ explaining intermittent build failures and 404s for Nexus uv/pip requests ending in .whl.metadata

### Why are we making this change?
Solves this request: https://linear.app/chainguard/issue/DOCS-144/add-nexus-pypi-proxy-troubleshooting-to-libraries-python-docs

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
