### PR TITLE
Cleanup: Add override for `adm-zip@^0.5.16`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,13 +2197,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ai": {
@@ -9944,9 +9944,9 @@
       "requires": {}
     },
     "adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true
     },
     "ai": {
@@ -11211,7 +11211,7 @@
       "integrity": "sha512-nzGmsgnOdeOGDgtpPHEPZ1PVizDHPU3240UdRmxu0b9vT+A7iB9toaUGcUQXQ/PVURq6y8lIuoTFsI4xfDoLLA==",
       "dev": true,
       "requires": {
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "tar": "^7.5.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "check": "hugo version",
     "postinstall": "node scripts/link-dart-sass.js"
   },
+  "overrides": {
+    "adm-zip": "^0.6.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@fullhuman/postcss-purgecss": "^8.0",


### PR DESCRIPTION
- Force transitive `adm-zip` to 0.6.0 via npm override to fix CVE-2026-39244