### PR TITLE
docs(chainctl): update for Windows non-admin fixes (DOCS-146)

### DIFF
--- a/content/chainguard/containers/network-requirements.md
+++ b/content/chainguard/containers/network-requirements.md
@@ -10,7 +10,7 @@ lead: "Using Chainguard Containers with firewalls, access control lists, and pro
 type: "article"
 description: "Using Chainguard Containers with firewalls, access control lists, and proxies."
 date: 2023-09-08T08:49:31+00:00
-lastmod: 2025-06-17T15:22:20+01:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["Chainguard Containers", "Reference"]
 images: []
@@ -46,10 +46,11 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 
 This table lists the third-party DNS hostnames, associated ports, and protocols that will need to be allowed through firewalls and proxies to use Chainguard Containers:
 
-| Hostname                                                  | Port | Protocol | IP      | Notes                        |
-|-----------------------------------------------------------|------|----------|---------|------------------------------|
-| 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com | 443  | HTTPS    | v4 & v6 | Blob storage for *.cgr.dev   |
-| support.chainguard.dev                                    | 443  | HTTPS    | v4      | Support access for customers |
+| Hostname                                                  | Port | Protocol | IP      | Notes                                                    |
+|-----------------------------------------------------------|------|----------|---------|----------------------------------------------------------|
+| 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com | 443  | HTTPS    | v4 & v6 | Blob storage for *.cgr.dev                               |
+| support.chainguard.dev                                    | 443  | HTTPS    | v4      | Support access for customers                             |
+| tuf-repo-cdn.sigstore.dev                                 | 443  | HTTPS    | v4      | Sigstore trust root for `chainctl` signature verification |
 
 > Note that the `9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com` host is used to serve both image data and packages via `*.cgr.dev`.
 

--- a/content/chainguard/libraries/network-requirements.md
+++ b/content/chainguard/libraries/network-requirements.md
@@ -4,7 +4,7 @@ linktitle: "Network requirements"
 description: "Learn the network requirements for accessing Chainguard Libraries, including domains needed for authentication, package downloads, and verification tools"
 type: "article"
 date: 2025-06-04T09:30:00+00:00
-lastmod: 2026-08-03T13:34:48+00:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["Chainguard Libraries", "Reference"]
 menu:
@@ -18,9 +18,8 @@ toc: true
 
 ## Access for chainctl and other tools
 
-For initial configuration with chainctl and for verification of
-downloaded libraries with cosign and other tools, you must allow HTTPS access to
-the following domains:
+For initial configuration with chainctl and for in-process verification of
+downloaded libraries, you must allow HTTPS access to the following domains:
 
 * `dl.enforce.dev` for download and update of chainctl
 * `issuer.enforce.dev` for authentication with the Chainguard Console and with chainctl
@@ -28,6 +27,8 @@ the following domains:
   your Chainguard accounts.
 * `console.chainguard.dev` for the Chainguard Console to administrate and use your
   Chainguard accounts.
+* `tuf-repo-cdn.sigstore.dev` for the Sigstore trust root that `chainctl libraries verify`
+  uses to verify library signatures.
 
 ## Access for repository managers
 

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-08-25T13:24:30+00:00
+lastmod: 2026-08-25T13:40:33+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -44,11 +44,10 @@ installed and available on your path:
   details also in the [reference
   documentation](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/).
 
-`chainctl libraries verify` checks signatures in-process, so you no longer need
-a separate `cosign` binary on your `PATH`. To fetch the Sigstore trust root, the
-command needs network access to `tuf-repo-cdn.sigstore.dev`. See [network
-requirements](/chainguard/libraries/network-requirements/) for the full list of
-domains.
+`chainctl libraries verify` checks signatures in-process. To fetch the Sigstore
+trust root, the command needs network access to `tuf-repo-cdn.sigstore.dev`.
+Refer to [network requirements](/chainguard/libraries/network-requirements/) for
+the full list of domains.
 
 You also need:
 

--- a/content/chainguard/libraries/verification.md
+++ b/content/chainguard/libraries/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -43,8 +43,12 @@ installed and available on your path:
   Chainguard-maintained tool that includes the `libraries verify` command,
   details also in the [reference
   documentation](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/).
-- [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) — A
-  Sigstore-maintained tool used to verify signatures.
+
+`chainctl libraries verify` checks signatures in-process, so you no longer need
+a separate `cosign` binary on your `PATH`. To fetch the Sigstore trust root, the
+command needs network access to `tuf-repo-cdn.sigstore.dev`. See [network
+requirements](/chainguard/libraries/network-requirements/) for the full list of
+domains.
 
 You also need:
 
@@ -53,15 +57,10 @@ You also need:
 - Your organization [must include entitlement for access to Chainguard
   Libraries](/chainguard/libraries/access/#entitlement)
 
-Confirm that `chainctl` and `cosign` are installed and available on the `PATH`
-with the following commands:
+Confirm that `chainctl` is installed and available on the `PATH`:
 
 ```sh
 chainctl version
-```
-
-```sh
-cosign version
 ```
 
 ## Authentication and configuration
@@ -272,7 +271,7 @@ Replace `PACKAGE`
 and `VERSION` with the package name and version (for example, `@eslint-js`
 and `9.0.0`)
 
-Verification uses SLSA provenance attestations. `chainctl` computes a SHA-512 digest of the tarball locally, fetches the signed attestation bundle, and uses `cosign` to confirm that the signature is valid, the certificate chains to the Sigstore root, the signer identity matches the Chainguard JavaScript builder, and the digest matches what was attested at build time.
+Verification uses SLSA provenance attestations. `chainctl` computes a SHA-512 digest of the tarball locally, fetches the signed attestation bundle, and verifies in-process that the signature is valid, the certificate chains to the Sigstore root, the signer identity matches the Chainguard JavaScript builder, and the digest matches what was attested at build time.
 
 #### Verify an npm cache
 

--- a/content/get-started/getting-started-with-chainctl.md
+++ b/content/get-started/getting-started-with-chainctl.md
@@ -6,7 +6,7 @@ lead: "Chainguard's chainctl CLI enables more secure management of container ima
 description: "Get started with chainctl basics including authentication, organization management, and essential commands for Chainguard's container security platform"
 type: "article"
 date: 2025-03-03T08:49:15+00:00
-lastmod: 2026-08-21T16:30:07+00:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["chainctl", "Getting Started"]
 images: []
@@ -65,7 +65,7 @@ To update your `chainctl` installation, use:
 chainctl update
 ```
 
-Updating requires administrative privileges, so be prepared to enter your machine's admin password.
+Because this replaces the installed binary, you need write access to the directory where `chainctl` lives. On Linux and macOS, updating a system-wide install such as `/usr/local/bin` requires administrative privileges (for example, with `sudo`). The command also verifies the downloaded binary's signature in-process before installing it; see [Updating chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl) for details.
 
 ## Configure chainctl
 

--- a/content/get-started/getting-started-with-chainctl.md
+++ b/content/get-started/getting-started-with-chainctl.md
@@ -6,7 +6,7 @@ lead: "Chainguard's chainctl CLI enables more secure management of container ima
 description: "Get started with chainctl basics including authentication, organization management, and essential commands for Chainguard's container security platform"
 type: "article"
 date: 2025-03-03T08:49:15+00:00
-lastmod: 2026-08-25T13:24:30+00:00
+lastmod: 2026-08-25T13:40:33+00:00
 draft: false
 tags: ["chainctl", "Getting Started"]
 images: []
@@ -65,7 +65,7 @@ To update your `chainctl` installation, use:
 chainctl update
 ```
 
-Because this replaces the installed binary, you need write access to the directory where `chainctl` lives. On Linux and macOS, updating a system-wide install such as `/usr/local/bin` requires administrative privileges (for example, with `sudo`). The command also verifies the downloaded binary's signature in-process before installing it; see [Updating chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl) for details.
+Because this replaces the installed binary, you need write access to the directory where `chainctl` lives. On Linux and macOS, updating a system-wide install such as `/usr/local/bin` requires administrative privileges (for example, with `sudo`). The command also verifies the downloaded binary's signature in-process before installing it; refer to [Updating chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl) for details.
 
 ## Configure chainctl
 

--- a/content/platform/chainctl-usage/chainctl-version-update.md
+++ b/content/platform/chainctl-usage/chainctl-version-update.md
@@ -6,7 +6,7 @@ lead: "Keep your chainctl CLI updated to access the latest Chainguard security f
 description: "Learn how to check your chainctl version and update to the latest release for enhanced security features and improved container management capabilities"
 type: "article"
 date: 2025-03-06T08:49:15+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -134,3 +134,5 @@ Temporary files may need to be removed manually:
   rm -f /root/.cache/chainctl/chainctl.bak
 
 ```
+
+`chainctl update` verifies the signature of the downloaded binary in-process before installing it, so you don't need a separate `cosign` binary on your `PATH`. Verification needs network access to `dl.enforce.dev` and, at least on first use, to the Sigstore trust root at `tuf-repo-cdn.sigstore.dev`. If verification fails or those hosts are unreachable, the update stops and your current installation is left in place.

--- a/content/platform/chainctl-usage/how-to-install-chainctl.md
+++ b/content/platform/chainctl-usage/how-to-install-chainctl.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Learn how to install chainctl, Chainguard's command-line interface for managing container images, IAM resources, and security configurations across platforms"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2026-08-21T16:30:07+00:00
+lastmod: 2026-08-25T13:24:30+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -229,7 +229,7 @@ If you installed `chainctl` to a directory that needs root permissions and run a
 
 ### Docker credential helper on Windows
 
-On Windows, `chainctl auth configure-docker` updates your Docker config, but Docker also expects a `docker-credential-cgr.exe` helper to be available on your `PATH`. To make Docker pulls work, perform the following steps:
+On Windows, Docker expects a `docker-credential-cgr.exe` helper to be available on your `PATH`. `chainctl auth configure-docker` creates this helper for you by copying `chainctl.exe` to `docker-credential-cgr.exe` in the same directory. Because it copies the binary rather than creating a symbolic link, a standard, non-administrator account can run it without enabling Developer Mode or running PowerShell as an administrator. To make Docker pulls work, perform the following steps:
 
 #### 1. Add `chainctl.exe` to the `PATH` (replace `C:\Tools` with the actual directory you used):
 
@@ -246,15 +246,7 @@ chainctl auth login
 chainctl auth configure-docker
 ```
 
-#### 3. Create the Docker credential helper symlink in the same directory as `chainctl.exe`:
-
-```PowerShell
-New-Item -ItemType SymbolicLink -Path "docker-credential-cgr.exe" -Target "chainctl.exe"
-```
-
-If this command fails with a permissions error, try running PowerShell as Administrator or ensure that Windows Developer Mode is enabled so you can create symbolic links.
-
-Following this, you can verify Docker pulls from Chainguard by pulling a private image.
+`chainctl auth configure-docker` creates `docker-credential-cgr.exe` next to `chainctl.exe` and updates your Docker config to use it. Following this, you can verify Docker pulls from Chainguard by pulling a private image.
 
 ## Updating `chainctl`
 
@@ -264,6 +256,6 @@ When your version of `chainctl` is a few weeks old or older, you may consider up
 sudo chainctl update
 ```
 
-The update command automatically verifies the cosign signature of the downloaded binary before replacing your existing installation. If signature verification fails (for example, due to a network issue), the update will not proceed and the unverified binary will be removed.
+The update command verifies the signature of the downloaded binary in-process before replacing your existing installation, so you don't need a separate `cosign` binary on your `PATH`. Verification needs network access to the download host (`dl.enforce.dev`) and, at least on first use, to the Sigstore trust root at `tuf-repo-cdn.sigstore.dev`. If verification fails or those hosts are unreachable, the update stops, the unverified binary is removed, and your current installation is left in place.
 
 Keeping `chainctl` up to date will ensure that you are using the most up to date version.


### PR DESCRIPTION
## Summary

Updates the docs to reflect the chainctl changes shipped in the [chainctl Windows improvements — P0/Urgent fixes](https://linear.app/chainguard/project/chainctl-windows-improvements-p0urgent-fixes-49906fef6768) project. Resolves [DOCS-146](https://linear.app/chainguard/issue/DOCS-146).

These are the customer-facing behavior changes that had documentation still describing the old behavior.

## Changes

- **`chainctl libraries verify` no longer requires the `cosign` CLI.** Verification now runs in-process, so the cosign prerequisite and the `cosign version` check are removed from the Libraries verification page. (CUS-972, CUS-1067)
- **`chainctl update` verifies the downloaded binary in-process.** No separate `cosign` binary on `PATH` is required. Reworded the install and version-update pages to match, and aligned the getting-started page. (CUS-944, CUS-1064)
- **New required endpoint: `tuf-repo-cdn.sigstore.dev`.** Added to both the Chainguard Containers and Chainguard Libraries network-requirements pages — it's the Sigstore trust root the in-process verifier fetches. (BREAK-204)
- **Windows Docker credential helper no longer needs admin rights.** `chainctl auth configure-docker` now creates `docker-credential-cgr.exe` by copying the binary instead of creating a symlink, so the manual `New-Item … SymbolicLink` step and the "run as Administrator / enable Developer Mode" caveat are removed. Standard, non-administrator accounts work. (CUS-943)

## Files

- `content/chainguard/libraries/verification.md`
- `content/platform/chainctl-usage/how-to-install-chainctl.md`
- `content/chainguard/libraries/network-requirements.md`
- `content/chainguard/containers/network-requirements.md`
- `content/platform/chainctl-usage/chainctl-version-update.md`
- `content/get-started/getting-started-with-chainctl.md`

## Testing

- Local Hugo build passes (`hugo --gc --minify`, exit 0; only the pre-existing SCSS deprecation warnings).
- Confirmed the rendered output: the new `#updating-chainctl` cross-link anchor resolves, `tuf-repo-cdn.sigstore.dev` renders in both network-requirements tables, and the cosign prerequisite is gone from the Libraries verification page.
- Verified the endpoint's IP-version column with `dig`: `tuf-repo-cdn.sigstore.dev` publishes an A record and no AAAA record, so it's listed as IPv4 only — matching the sibling `dl.enforce.dev` entry.

## Notes

- The auto-generated CLI reference pages (`chainctl_update.md`, `chainctl_libraries_verify.md`, `chainctl_auth_configure-docker.md`) are intentionally untouched; they regenerate from the CLI source.
- The Windows auth-token path (`%USERPROFILE%\.chainguard\token`, CUS-945) is deliberately deferred to [DOCS-147](https://linear.app/chainguard/issue/DOCS-147) pending confirmation of the exact path on a real Windows environment.

---
Created in collaboration with Claude Code running Opus 4.8 on 2026-08-25.