### PR TITLE
docs(libraries): reframe build config pages as build-tool references

### DIFF
--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-25T19:48:13+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -26,13 +26,12 @@ Jenkins, TeamCity, or GitHub Actions.
 
 The `https://libraries.cgr.dev/java/` endpoint is also the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint for Java. By default, it serves only Chainguard-built artifacts. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is enabled for your organization, the same endpoint can also serve requested versions from Maven Central under Chainguard security controls.
 
-Refer to the following guides depending on your goals:
+This guide outlines how to configure your build tool. If you are looking for something else, refer to the following guides depending on your goals:
 
 | If you want to... | Use this page |
 | --- | --- |
 | Understand what Chainguard Libraries for Java is and how it works | [Java overview](/chainguard/libraries/java/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/java/global-configuration/) |
-| Look up how to configure a specific build tool (Maven, Gradle, Bazel) | This page |
 | Migrate an existing project step by step | [Java migration guide](/chainguard/libraries/java/migration/) |
 
 If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/errors/) for more details.

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T19:48:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -26,9 +26,9 @@ Jenkins, TeamCity, or GitHub Actions.
 
 The `https://libraries.cgr.dev/java/` endpoint is also the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint for Java. By default, it serves only Chainguard-built artifacts. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is enabled for your organization, the same endpoint can also serve requested versions from Maven Central under Chainguard security controls.
 
-**Choose the right page**
+Refer to the following guides depending on your goals:
 
-| To do this | Use this page |
+| If you want to... | Use this page |
 | --- | --- |
 | Understand what Chainguard Libraries for Java is and how it works | [Java overview](/chainguard/libraries/java/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/java/global-configuration/) |

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -1,10 +1,10 @@
 ---
-title: "Build configuration"
-linktitle: "Build configuration"
+title: "Configure Java build tools"
+linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T15:07:13+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -15,33 +15,27 @@ weight: 053
 toc: true
 ---
 
-The configuration for the use of Chainguard Libraries depends on your build
-tools, continuous integration, and continuous deployment setups
+Chainguard Libraries for Java works with your existing build tools — Maven,
+Gradle, and Bazel — through a repository configuration change. This page is a
+reference for configuring each supported build tool. It covers repository
+access, authentication, cache clearing, and minimal example projects.
 
-At a high level adopting the use of Chainguard Libraries consists of the
-following steps:
-
-* Remove local caches on workstations and CI/CD pipelines. This step ensures that
-  any libraries that were already sourced from other repositories are requested
-  again and the version from Chainguard Libraries is used instead of other
-  binaries.
-* Change configuration to access Chainguard Libraries via your repository
-  manager after the changes from the [global
-  configuration](/chainguard/libraries/java/global-configuration/) are
-  implemented.
-
-These changes must be performed on all workstations of individual developers and
-other engineers running relevant application builds. They must also be performed
-on any build server such as Jenkins, TeamCity, GitHub or other infrastructure
-that builds the applications or otherwise downloads and uses relevant libraries.
+Apply these changes on every workstation and build server that builds your
+applications or downloads libraries, including CI/CD infrastructure such as
+Jenkins, TeamCity, or GitHub Actions.
 
 The `https://libraries.cgr.dev/java/` endpoint is also the [Chainguard Repository](/chainguard/chainguard-repository/overview/) endpoint for Java. By default, it serves only Chainguard-built artifacts. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is enabled for your organization, the same endpoint can also serve requested versions from Maven Central under Chainguard security controls.
 
-If you are migrating an existing project to Chainguard Libraries, follow the
-[Java migration guide](/chainguard/libraries/java/migration/) for a step-by-step
-walkthrough.
+**Choose the right page**
 
-If a package or version is blocked by a policy or malware scan, your build tool returns an error. See the [Error messages documentation](/chainguard/libraries/errors/) for more details.
+| To do this | Use this page |
+| --- | --- |
+| Understand what Chainguard Libraries for Java is and how it works | [Java overview](/chainguard/libraries/java/overview/) |
+| Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/java/global-configuration/) |
+| Look up how to configure a specific build tool (Maven, Gradle, Bazel) | This page |
+| Migrate an existing project step by step | [Java migration guide](/chainguard/libraries/java/migration/) |
+
+If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/errors/) for more details.
 
 ## Library access approaches
 

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-08-20T19:51:12+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -22,6 +22,8 @@ This guide walks through migrating an existing Java project to Chainguard Librar
 - Repository manager — your build tool connects to a repository manager ([Cloudsmith](/chainguard/libraries/java/global-configuration/#cloudsmith), [Google Artifact Registry](/chainguard/libraries/java/global-configuration/#google-artifact-registry), [JFrog Artifactory](/chainguard/libraries/java/global-configuration/#jfrog-artifactory), or [Sonatype Nexus](/chainguard/libraries/java/global-configuration/#sonatype-nexus-repository)), which proxies requests to Chainguard Libraries.
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for Java demo repository](https://github.com/chainguard-demo/chainguard-libraries-java). It provides Maven and Gradle example projects, including a minimal Spring Boot application and CVE remediation demos.
+
+For a reference of the configuration options for each supported build tool, refer to [Configure Java build tools](/chainguard/libraries/java/build-configuration/).
 
 ## Prerequisites
 

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -23,7 +23,7 @@ This guide walks through migrating an existing Java project to Chainguard Librar
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for Java demo repository](https://github.com/chainguard-demo/chainguard-libraries-java). It provides Maven and Gradle example projects, including a minimal Spring Boot application and CVE remediation demos.
 
-For a reference of the configuration options for each supported build tool, refer to [Configure Java build tools](/chainguard/libraries/java/build-configuration/).
+For a reference of the configuration options for each supported build tool, check out [Configure Java build tools](/chainguard/libraries/java/build-configuration/).
 
 ## Prerequisites
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T19:48:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -24,9 +24,9 @@ Apply these changes on every workstation and build server that builds your
 applications or downloads libraries, including CI/CD infrastructure such as
 Jenkins, TeamCity, or GitHub Actions.
 
-**Choose the right page**
+Refer to the following guides depending on your goals:
 
-| To do this | Use this page |
+| If you want to... | Use this page |
 | --- | --- |
 | Understand what Chainguard Libraries for JavaScript is and how it works | [JavaScript overview](/chainguard/libraries/javascript/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/javascript/global-configuration/) |

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-25T19:48:13+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -24,7 +24,14 @@ Apply these changes on every workstation and build server that builds your
 applications or downloads libraries, including CI/CD infrastructure such as
 Jenkins, TeamCity, or GitHub Actions.
 
-Refer to the following guides depending on your goals:
+The `https://libraries.cgr.dev/javascript` endpoint is also the [Chainguard
+Repository](/chainguard/chainguard-repository/overview/) endpoint for JavaScript. By
+default, it serves only Chainguard-built artifacts. When [upstream
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
+enabled for your organization, the same endpoint can also serve requested
+versions from upstream, under Chainguard security controls.
+
+This guide outlines how to configure your build tool. If you are looking for something else, refer to the following guides depending on your goals:
 
 | If you want to... | Use this page |
 | --- | --- |

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -1,10 +1,10 @@
 ---
-title: "Build configuration"
-linktitle: "Build configuration"
+title: "Configure JavaScript build tools"
+linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -15,21 +15,25 @@ weight: 053
 toc: true
 ---
 
-The configuration for the use of Chainguard Libraries depends on your build
-tools, continuous integration, and continuous deployment setups. This page is a
-configuration reference for each supported JavaScript build tool. It covers
-registry configuration, authentication, cache clearning, and minimal example
-projects for npm, pnpm, Yarn, and Bun. The changes described on this page must
-be performed on all workstations of individual developers and other engineers
-running relevant application builds. They must also be performed on any build
-server such as Jenkins, TeamCity, GitHub or other infrastructure that builds the
-applications or otherwise downloads and uses relevant libraries.
+Chainguard Libraries for JavaScript works with your existing build tools — npm,
+pnpm, Yarn, and Bun — through a registry configuration change. This page is a
+reference for configuring each supported build tool. It covers registry
+configuration, authentication, cache clearing, and minimal example projects.
 
-If you are migrating an existing project to Chainguard Libraries, follow the
-[JavaScript migration guide](/chainguard/libraries/javascript/migration/) for a
-step-by-step walkthrough.
+Apply these changes on every workstation and build server that builds your
+applications or downloads libraries, including CI/CD infrastructure such as
+Jenkins, TeamCity, or GitHub Actions.
 
-If a package or version is blocked by a policy or malware scan, your build tool returns an error. See the [Error messages documentation](/chainguard/libraries/errors/) for more details.
+**Choose the right page**
+
+| To do this | Use this page |
+| --- | --- |
+| Understand what Chainguard Libraries for JavaScript is and how it works | [JavaScript overview](/chainguard/libraries/javascript/overview/) |
+| Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/javascript/global-configuration/) |
+| Look up how to configure a specific build tool (npm, pnpm, Yarn, Bun) | This page |
+| Migrate an existing project step by step | [JavaScript migration guide](/chainguard/libraries/javascript/migration/) |
+
+If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/errors/) for more details.
 
 ## JFrog Artifactory
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-20T19:51:12+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -31,6 +31,8 @@ Libraries, covering the two most common setups:
   Chainguard Libraries. This option is recommended for teams and organizations.
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for JavaScript demo repository](https://github.com/chainguard-demo/chainguard-libraries-javascript). It provides example projects for npm, pnpm, Yarn, and Bun, each with a `demo.sh` script that configures access and installs sample packages.
+
+For a reference of the configuration options for each supported build tool, refer to [Configure JavaScript build tools](/chainguard/libraries/javascript/build-configuration/).
 
 ## Prerequisites
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -32,7 +32,7 @@ Libraries, covering the two most common setups:
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for JavaScript demo repository](https://github.com/chainguard-demo/chainguard-libraries-javascript). It provides example projects for npm, pnpm, Yarn, and Bun, each with a `demo.sh` script that configures access and installs sample packages.
 
-For a reference of the configuration options for each supported build tool, refer to [Configure JavaScript build tools](/chainguard/libraries/javascript/build-configuration/).
+For a reference of the configuration options for each supported build tool, check out [Configure JavaScript build tools](/chainguard/libraries/javascript/build-configuration/).
 
 ## Prerequisites
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-25T19:48:13+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -31,7 +31,7 @@ fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled for your organization, the same endpoint can also serve requested
 versions from PyPI under Chainguard security controls.
 
-Refer to the following guides depending on your goals:
+This guide outlines how to configure your build tool. If you are looking for something else, refer to the following guides depending on your goals:
 
 | If you wnat to... | Use this page |
 | --- | --- |

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T19:48:13+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -31,9 +31,9 @@ fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled for your organization, the same endpoint can also serve requested
 versions from PyPI under Chainguard security controls.
 
-**Choose the right page**
+Refer to the following guides depending on your goals:
 
-| To do this | Use this page |
+| If you wnat to... | Use this page |
 | --- | --- |
 | Understand what Chainguard Libraries for Python is and how it works | [Python overview](/chainguard/libraries/python/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/python/global-configuration/) |

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -1,10 +1,10 @@
 ---
-title: "Build configuration"
-linktitle: "Build configuration"
+title: "Configure Python build tools"
+linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-05T19:13:35+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -15,18 +15,14 @@ weight: 053
 toc: true
 ---
 
-The configuration for the use of Chainguard Libraries depends on how you've set up your build tools and CI/CD workflows. At a high level, adopting the use of Chainguard Libraries in your development, build, and deployment workflows involves the following steps:
+Chainguard Libraries for Python works with your existing build tools — pip,
+Poetry, and uv — through a repository configuration change. This page is a
+reference for configuring each supported build tool. It covers repository
+access, authentication, cache clearing, and minimal example projects.
 
-- If you or an administrator have not done so already, [set up your organization's repository manager to use Chainguard Libraries for Python](/chainguard/libraries/python/global-configuration/).
-- Log into your organization's repository manager and retrieve credentials for the build tool you are configuring.
-- Configure your development or build tool with this information.
-- Remove local caches on workstations and CI/CD pipelines. This step ensures that dependencies are preferentially sourced from Chainguard Libraries.
-- Finally, confirm that your development tools and CI/CD workflows are correctly ingesting dependencies from Chainguard Libraries.
-
-These changes must be performed on all workstations of individual developers and
-other engineers running relevant application builds. They must also be performed
-on any build tool such as Jenkins, TeamCity, GitHub Actions, or other
-infrastructure that draws in dependencies.
+Apply these changes on every workstation and build server that builds your
+applications or downloads libraries, including CI/CD infrastructure such as
+Jenkins, TeamCity, or GitHub Actions.
 
 The `https://libraries.cgr.dev/python/` endpoint is also the [Chainguard
 Repository](/chainguard/chainguard-repository/overview/) endpoint for Python. By
@@ -35,13 +31,18 @@ fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled for your organization, the same endpoint can also serve requested
 versions from PyPI under Chainguard security controls.
 
-If you are migrating an existing project to Chainguard Libraries, follow the
-[Python migration guide](/chainguard/libraries/python/migration/) for a
-step-by-step walkthrough.
+**Choose the right page**
+
+| To do this | Use this page |
+| --- | --- |
+| Understand what Chainguard Libraries for Python is and how it works | [Python overview](/chainguard/libraries/python/overview/) |
+| Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/python/global-configuration/) |
+| Look up how to configure a specific build tool (pip, Poetry, uv) | This page |
+| Migrate an existing project step by step | [Python migration guide](/chainguard/libraries/python/migration/) |
 
 Refer to the [minimal example projects](#minimal-example-projects) on this page for demonstrations using `uv` and `pip`.
 
-If a package or version is blocked by a policy or malware scan, your build tool returns an error. See the [Error messages documentation](/chainguard/libraries/errors/) for more details.
+If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/errors/) for more details.
 
 ## Step 1: Retrieve authentication credentials
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-20T19:51:12+00:00
+lastmod: 2026-08-25T19:43:07+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -22,6 +22,8 @@ This guide walks through migrating an existing Python project to Chainguard Libr
 * **Repository manager**: Your build tool connects to a repository manager (such as JFrog Artifactory or Sonatype Nexus), which proxies requests to Chainguard Libraries. This option is recommended for teams and organizations.
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for Python demo repository](https://github.com/chainguard-demo/chainguard-libraries-python). It provides example projects for pip, uv, and Poetry, each with a `demo.sh` script that configures access and installs sample packages.
+
+For a reference of the configuration options for each supported build tool, refer to [Configure Python build tools](/chainguard/libraries/python/build-configuration/).
 
 ## Prerequisites
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-25T19:43:07+00:00
+lastmod: 2026-08-25T20:14:45+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -23,7 +23,7 @@ This guide walks through migrating an existing Python project to Chainguard Libr
 
 To follow along with a ready-made project instead of your own, use the [Chainguard Libraries for Python demo repository](https://github.com/chainguard-demo/chainguard-libraries-python). It provides example projects for pip, uv, and Poetry, each with a `demo.sh` script that configures access and installs sample packages.
 
-For a reference of the configuration options for each supported build tool, refer to [Configure Python build tools](/chainguard/libraries/python/build-configuration/).
+For a reference of the configuration options for each supported build tool, check out [Configure Python build tools](/chainguard/libraries/python/build-configuration/).
 
 ## Prerequisites
 


### PR DESCRIPTION
## What changed

The JavaScript, Java, and Python build configuration pages overlapped with the newer migration guides. This reframes them as build-tool **references** and makes the migration guides the clear path for a step-by-step migration.

- Retitled each page to an actionable **Configure `<language>` build tools** (sidebar label: **Configure build tools**).
- Rewrote each intro to frame the page as a per-tool reference and added a **Choose the right page** table routing readers to the overview, global configuration, this reference, or the migration guide.
- Added a reciprocal link from each migration guide back to its build-tool reference page.
- Switched newly added "See" link phrasing to "Refer to" for accessibility.

Reference content below the intros is unchanged. Inbound links that call these pages "build configuration" were intentionally left as-is (targets are unchanged, so nothing breaks).

## Testing plan

1. Build the site locally (`hugo server`) and open the local preview.
2. For each of JavaScript, Java, and Python:
   - Open the build-tool reference page. Confirm the title reads **Configure `<language>` build tools** and the left-nav label reads **Configure build tools**.
   - Confirm the **Choose the right page** table renders and all four links resolve (overview, global configuration, migration guide, and the "This page" row as text).
   - Confirm the **Error messages** link resolves.
   - Open the migration guide and confirm the new "refer to Configure `<language>` build tools" link resolves to the reference page.
3. Confirm no broken internal links (`hugo --printPathWarnings` or the site's link check, if configured).

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-08-25.