### PR TITLE
docs(get-started): add "Onboard your teams" page (DOCS-34)

### DIFF
--- a/content/get-started/_index.md
+++ b/content/get-started/_index.md
@@ -3,7 +3,7 @@ title: "Get started"
 lead: "New to Chainguard? Start here. Orient yourself, then pick the path that matches what you're trying to do — build with containers, build with libraries, evaluate trust, or migrate an organization."
 description: "Get started with Chainguard: orient yourself, then choose your path — build with containers, build with libraries, evaluate trust, or migrate an existing organization."
 date: 2026-06-09T08:48:23+00:00
-lastmod: 2026-06-26T00:00:00+00:00
+lastmod: 2026-08-26T13:07:29+00:00
 draft: false
 images: []
 weight: 1
@@ -22,6 +22,10 @@ Swap your existing dependencies for Chainguard Libraries — rebuilt from verifi
 ## Evaluate trust
 
 Deciding whether Chainguard is right for your organization? Review how Chainguard Containers are built, what guarantees they carry, and how they compare on CVEs.
+
+## Onboard your teams
+
+Already adopted Chainguard and need to bring your developers on board? Learn what your teams can pull, how access depends on your subscription, and how to retrieve SBOMs and provenance in the guide to [onboarding your teams](/get-started/onboard-your-teams/).
 
 ## Migrate an organization
 

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -1,0 +1,112 @@
+---
+title: "Onboard your teams"
+linktitle: "Onboard your teams"
+lead: "Your organization has adopted Chainguard. This guide helps administrators and software engineers understand what your teams can pull from Chainguard Containers and Chainguard Libraries, how that depends on your subscription, and how to retrieve the SBOMs and provenance that ship with every image and package."
+description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
+type: "article"
+date: 2026-08-26T00:00:00+00:00
+lastmod: 2026-08-26T00:00:00+00:00
+draft: false
+tags: ["Getting Started"]
+images: []
+weight: 010
+toc: true
+---
+
+Your organization has adopted Chainguard, and now you need to bring your teams on board. This guide explains what your teams can pull from Chainguard Containers and Chainguard Libraries, why that depends on your subscription, and how to retrieve the SBOMs and provenance that ship with every image and package.
+
+It's written for two readers:
+
+- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with Console access, so your teams rely on you to communicate how this works.
+- **Software engineers** who were pointed here and want to know how to find and pull the resources they're cleared to use.
+
+To decide where to start, identify which Chainguard products your organization uses; many use both. Read [Chainguard Containers](#chainguard-containers) if your teams pull container images, or [Chainguard Libraries](#chainguard-libraries) if they pull language dependencies for Java, Python, or JavaScript. Your administrators know which subscriptions apply.
+
+## Chainguard Containers
+
+### What you can browse compared to what you can pull
+
+There are two different surfaces, and it helps to keep them separate.
+
+The **Chainguard Directory** at [images.chainguard.dev](https://images.chainguard.dev) is public. Anyone can browse the entire catalog there, inspect tags and metadata, and view the SBOM and provenance for each image. Browsing the Directory does not mean your organization can pull every image it lists.
+
+Your **organization's registry** is what your teams pull from, and it holds only the images your organization has access to. Authenticated production images live under your organization's namespace:
+
+```shell
+cgr.dev/$ORGANIZATION/$IMAGE:$TAG
+```
+
+For example, an organization registered as `example.com` pulls its Python image from `cgr.dev/example.com/python`. Public Starter images remain available to everyone under `cgr.dev/chainguard/`. See the [registry overview](/chainguard/containers/chainguard-registry/overview/) for the access tiers and [authentication](/chainguard/containers/chainguard-registry/authenticating/) to set up your credentials.
+
+Your organization may also front the registry with a pull-through cache, such as Artifactory. In that case, the concepts here still hold, but you pull from your cache's address instead of `cgr.dev` directly. Ask your administrators for the path.
+
+### What your organization can pull
+
+Whether an image is available to pull depends on your subscription. If a pull fails for an image you can see in the Directory, it most likely hasn't been added to your organization yet.
+
+**Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; see [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
+
+**Per-image customers.** A per-image subscription covers a specific, licensed set of images rather than the whole catalog. You can browse everything in the Directory, but only your licensed images are permitted for builds, deployments, and production workloads. To add an image that isn't in your set, ask your administrators to start a request; once they approve it, they add the image to your organization's registry.
+
+### Access SBOMs and provenance
+
+Every Chainguard container image ships with a signed SBOM and provenance attestations. You can retrieve them three ways; the [full guide](/chainguard/containers/how-to-use/retrieve-image-sboms/) covers each in detail.
+
+- **From the Chainguard Directory.** Open an image at [images.chainguard.dev](https://images.chainguard.dev), then download the SBOM from the **SBOM** tab in SPDX or CycloneDX format. This needs no tooling and works for any image in the catalog.
+- **With `cosign`.** Download the SBOM attestation for an image directly from the registry:
+
+  ```shell
+  cosign download attestation \
+    --platform linux/amd64 \
+    --predicate-type https://spdx.dev/Document \
+    cgr.dev/$ORGANIZATION/$IMAGE | jq -r '.payload' | base64 -d | jq -r '.predicate'
+  ```
+
+- **With `syft`.** Generate an SBOM locally from an image you've pulled. Use this for images you've customized, where you want an SBOM of the final artifact.
+
+To pin what you pull so builds stay reproducible, reference images by digest. See [container image digests](/chainguard/containers/how-to-use/container-image-digests/).
+
+## Chainguard Libraries
+
+Chainguard Libraries is a secure catalog of language dependencies for Java, Python, and JavaScript. Each package is rebuilt from verified upstream source in the Chainguard Factory and is a drop-in replacement for the one you'd normally pull from Maven Central, PyPI, or npm. See the [overview](/chainguard/libraries/overview/) for how they're built and what guarantees they carry.
+
+### What your organization can access
+
+Libraries don't have a public browse site like the Chainguard Directory. Instead, you browse the packages your organization is entitled to by signing in to the [Chainguard Console](/chainguard/libraries/browse/). Access is granted per language: your organization is entitled to Java, Python, or JavaScript individually, so which ecosystems you can pull depends on your subscription. There's no catalog-versus-per-image distinction as there is for containers.
+
+### Pull libraries into your project
+
+You consume Chainguard Libraries by pointing your package manager at your organization's Chainguard repository and authenticating with a pull token. Each ecosystem has its own endpoint under `libraries.cgr.dev`:
+
+```shell
+https://libraries.cgr.dev/java/
+https://libraries.cgr.dev/python/
+https://libraries.cgr.dev/javascript/
+```
+
+The [quickstart](/chainguard/libraries/quickstart/) walks through creating a pull token and configuring your build tools, and [access and authentication](/chainguard/libraries/access/) covers the details.
+
+### Verify provenance and SBOMs
+
+Every Chainguard library ships with a signed SBOM and SLSA provenance, attached alongside each package. Verify any artifact you've pulled with:
+
+```shell
+chainctl libraries verify /path/to/artifact
+```
+
+See [verifying Chainguard Libraries](/chainguard/libraries/verification/) for what the command checks and for retrieving the SBOM and attestation files directly.
+
+## Other products your company may have adopted
+
+Chainguard's platform reaches beyond containers and libraries. Your organization may also use one or more of these:
+
+- **[Chainguard Agent Skills](/chainguard/agent-skills/overview/)** — hardened AI agent skills that Chainguard reviews, scopes, and publishes with a full audit trail, so your teams can install them without inheriting unknown risk.
+- **[Chainguard Actions](/chainguard/actions/overview/)** — hardened, drop-in replacements for popular GitHub Actions that protect your CI/CD pipelines from supply chain attacks.
+- **[Chainguard Guardener](/chainguard/guardener/)** — a tool for managing and hardening your source code through a suite of capabilities you opt into independently.
+
+## Next steps
+
+- New to the platform? Start with [What is Chainguard?](/get-started/what-is-chainguard/).
+- Ready to pull your first container image? Work through a [language- or service-specific example](/get-started/containers-examples/).
+- Adopting Chainguard Libraries? Follow the [libraries on-ramp](/get-started/libraries-examples/).
+- Managing resources from the command line? See [Get started with chainctl](/get-started/getting-started-with-chainctl/).

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-08-26T00:00:00+00:00
+lastmod: 2026-08-26T13:38:22+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -17,7 +17,7 @@ Your organization has adopted Chainguard, and now you need to bring your teams o
 
 It's written for two readers:
 
-- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with Console access, so your teams rely on you to communicate how this works.
+- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/) access, so your teams rely on you to communicate how this works.
 - **Software engineers** who were pointed here and want to know how to find and pull the resources they're cleared to use.
 
 To decide where to start, identify which Chainguard products your organization uses; many use both. Read [Chainguard Containers](#chainguard-containers) if your teams pull container images, or [Chainguard Libraries](#chainguard-libraries) if they pull language dependencies for Java, Python, or JavaScript. Your administrators know which subscriptions apply.
@@ -44,7 +44,7 @@ Your organization may also front the registry with a pull-through cache, such as
 
 Whether an image is available to pull depends on your subscription. If a pull fails for an image you can see in the Directory, it most likely hasn't been added to your organization yet.
 
-**Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; see [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
+**Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; refer to [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
 
 **Per-image customers.** A per-image subscription covers a specific, licensed set of images rather than the whole catalog. You can browse everything in the Directory, but only your licensed images are permitted for builds, deployments, and production workloads. To add an image that isn't in your set, ask your administrators to start a request; once they approve it, they add the image to your organization's registry.
 
@@ -68,7 +68,7 @@ To pin what you pull so builds stay reproducible, reference images by digest. Se
 
 ## Chainguard Libraries
 
-Chainguard Libraries is a secure catalog of language dependencies for Java, Python, and JavaScript. Each package is rebuilt from verified upstream source in the Chainguard Factory and is a drop-in replacement for the one you'd normally pull from Maven Central, PyPI, or npm. See the [overview](/chainguard/libraries/overview/) for how they're built and what guarantees they carry.
+Chainguard Libraries is a secure catalog of language dependencies for Java, Python, and JavaScript. Each package goes through multiple layers of defense, including malicious behavior scanning, building from source, and configurable policies. A package pulled from Chainguard is a drop-in replacement for the one you'd normally pull from Maven Central, PyPI, or npm. See the [overview](/chainguard/libraries/overview/) for how they're built and what guarantees they carry.
 
 ### What your organization can access
 
@@ -88,7 +88,7 @@ The [quickstart](/chainguard/libraries/quickstart/) walks through creating a pul
 
 ### Verify provenance and SBOMs
 
-Every Chainguard library ships with a signed SBOM and SLSA provenance, attached alongside each package. Verify any artifact you've pulled with:
+Every package that Chainguard builds from source ships with a signed SBOM and SLSA provenance, attached alongside each package. Use a command similar to the following to verify which of your dependencies were built by Chainguard:
 
 ```shell
 chainctl libraries verify /path/to/artifact

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-08-26T13:41:10+00:00
+lastmod: 2026-08-26T13:43:22+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -17,7 +17,7 @@ Your organization has adopted Chainguard, and now you need to bring your teams o
 
 It's written for two readers:
 
-- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/images-directory) access, so your teams rely on you to communicate how this works.
+- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/images-directory/) access, so your teams rely on you to communicate how this works.
 - **Software engineers** who were pointed here and want to know how to find and pull the resources they're cleared to use.
 
 To decide where to start, identify which Chainguard products your organization uses; many use both. Read [Chainguard Containers](#chainguard-containers) if your teams pull container images, or [Chainguard Libraries](#chainguard-libraries) if they pull language dependencies for Java, Python, or JavaScript. Your administrators know which subscriptions apply.

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-08-26T13:43:22+00:00
+lastmod: 2026-08-26T13:50:01+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -17,7 +17,7 @@ Your organization has adopted Chainguard, and now you need to bring your teams o
 
 It's written for two readers:
 
-- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/images-directory/) access, so your teams rely on you to communicate how this works.
+- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/platform/console/) access, so your teams rely on you to communicate how this works.
 - **Software engineers** who were pointed here and want to know how to find and pull the resources they're cleared to use.
 
 To decide where to start, identify which Chainguard products your organization uses; many use both. Read [Chainguard Containers](#chainguard-containers) if your teams pull container images, or [Chainguard Libraries](#chainguard-libraries) if they pull language dependencies for Java, Python, or JavaScript. Your administrators know which subscriptions apply.

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-08-26T13:38:22+00:00
+lastmod: 2026-08-26T13:41:10+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -17,7 +17,7 @@ Your organization has adopted Chainguard, and now you need to bring your teams o
 
 It's written for two readers:
 
-- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/) access, so your teams rely on you to communicate how this works.
+- **Platform and security administrators** who manage Chainguard for the organization and need to explain it to the teams they support. Early on, you may be the only people with [Chainguard Console](/chainguard/platform/console/images-directory) access, so your teams rely on you to communicate how this works.
 - **Software engineers** who were pointed here and want to know how to find and pull the resources they're cleared to use.
 
 To decide where to start, identify which Chainguard products your organization uses; many use both. Read [Chainguard Containers](#chainguard-containers) if your teams pull container images, or [Chainguard Libraries](#chainguard-libraries) if they pull language dependencies for Java, Python, or JavaScript. Your administrators know which subscriptions apply.

--- a/content/get-started/what-is-chainguard.md
+++ b/content/get-started/what-is-chainguard.md
@@ -5,7 +5,7 @@ lead: "A high-level introduction to Chainguard: the problem it solves, the produ
 description: "An overview of Chainguard: its mission to be the secure source for open source, its products (Containers, Libraries, and OS), and the Factory that builds them."
 type: "article"
 date: 2026-07-23T00:00:00+00:00
-lastmod: 2026-07-23T00:00:00+00:00
+lastmod: 2026-08-26T13:07:29+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -53,3 +53,4 @@ Compared with using artifacts from public repositories, Chainguard gives you:
 - Ready to try an image? Work through a [container example](/get-started/containers-examples/) for your language or service.
 - Replacing dependencies instead? Start with the [libraries on-ramp](/get-started/libraries-examples/).
 - Moving existing workloads over? Step through the [migration guides](/chainguard/migration/).
+- Rolling Chainguard out to your teams? See how to [onboard your teams](/get-started/onboard-your-teams/).


### PR DESCRIPTION
## Summary

Adds a new Get started page, "Onboard your teams," for customers who have just adopted Chainguard and need to bring their developers on board. Early on, only a few administrators have Console access, and their teams rely on them to explain how access works. This page gives both administrators and software engineers one place to learn:

- What an organization can pull from Chainguard Containers and Chainguard Libraries, and how that depends on the subscription (Catalog compared with per-image for containers; per-language entitlement for libraries).
- The difference between browsing the public catalog and pulling from your organization's registry.
- How to retrieve SBOMs and provenance for both containers and libraries.

The page adapts a customer success onboarding template (tracked in DOCS-34), lifting the generic, non-customer-specific guidance into the docs where it can help more customers. Customer-specific infrastructure, such as an Artifactory pull-through cache, is generalized to the Chainguard Registry, with pull-through caching noted as an option an organization may add.

It closes with a short list of other products a customer's organization may have adopted (Chainguard Agent Skills, Chainguard Actions, and Chainguard Guardener), each linked to its overview.

## Changes

- **New:** `content/get-started/onboard-your-teams.md` — the page (weight 010, placed after Self-serve).
- **Modified:** `content/get-started/_index.md` — add an "Onboard your teams" path to the section landing page.
- **Modified:** `content/get-started/what-is-chainguard.md` — add an onward-navigation link so administrators rolling Chainguard out have a signposted next step.

## Testing

- Clean local Hugo build (vendored v0.152.1 extended with Dart Sass); Dart Sass deprecation warnings only.
- Verified all 18 internal links on the new page resolve (HTTP 200) against the local server.
- Confirmed both cross-links render on the landing page and the What is Chainguard? page.

## Related

- Linear: DOCS-34

---
Created in collaboration with Claude Code running claude-opus-4-8 on 2026-08-26.
