### PR TITLE
Fix the changelog rotation workflow's gh calls

### DIFF
--- a/.github/workflows/changelog-rotation.yaml
+++ b/.github/workflows/changelog-rotation.yaml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'chainguard-dev/edu'
 
     permissions:
-      contents: read # Read the workflow's own repository
+      contents: read # Baseline read access for the job's token
       issues: write # Open the reminder issue and assign it
 
     steps:
@@ -76,6 +76,9 @@ jobs:
       - name: Open the issue
         env:
           GH_TOKEN: ${{ github.token }}
+          # The job never checks the repository out, so gh has no git remote to
+          # read. Without this it fails with "not a git repository".
+          GH_REPO: ${{ github.repository }}
           OWNER: ${{ steps.rota.outputs.owner }}
           WEEK_OF: ${{ steps.rota.outputs.week_of }}
           TITLE: "Update the changelog: week of ${{ steps.rota.outputs.week_of }}"


### PR DESCRIPTION
The workflow added in #3838 failed on its first manual dispatch:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 1.
```

The job never checks the repository out, so `gh` had no git remote to infer the target repository from, and both `gh issue list` and `gh issue create` failed.

Setting `GH_REPO` fixes it without adding a checkout step. The job only talks to the API; it has no use for the working tree.

Verified by running the same `gh issue list` pipeline from a directory outside any git repository with `GH_REPO` set — it returns cleanly. The `automated` label exists and all three roster accounts are collaborators, so nothing else in `gh issue create` should fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)