### PR TITLE
Update chainctl policies override command in Container Policies page

### DIFF
--- a/content/chainguard/chainguard-repository/container-policies.md
+++ b/content/chainguard/chainguard-repository/container-policies.md
@@ -8,7 +8,7 @@ linktitle: "Container pull policies"
 type: "article"
 description: "Configure and enforce policies that control which Chainguard container and artifact versions your organization can pull, using chainctl"
 date: 2026-05-21T08:48:45+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-08-26T19:27:38+00:00
 draft: false
 tags: ["Overview"]
 images: []
@@ -247,12 +247,12 @@ Waive a policy for a specific image, identified by digest, with a reason:
 ```shell
 chainctl policies override create \
   --policy=no-eol \
-  --digest=sha256:abc123... \
+  --artifact_id=sha256:abc123... \
   --reason="approved exception, ticket OPS-42" \
   --parent=$ORGANIZATION
 ```
 
-The `--digest` value must be a manifest digest rather than a tag, so the waiver targets one exact artifact. A given policy and image can carry at most one override; to change an existing one, delete it and create it again.
+The `--artifact_id` value must be a manifest digest rather than a tag, so the waiver targets one exact artifact. A given policy and image can carry at most one override; to change an existing one, delete it and create it again.
 
 Review the active overrides for an organization to see what has been waived, by whom, and why:
 
@@ -893,13 +893,13 @@ Create an override for each of the denied digests:
 ```shell
 chainctl policies override create \
   --policy=cooldown \
-  --digest=sha256:609aeb... \
+  --artifact_id=sha256:609aeb... \
   --reason="approved exception, ticket OPS-42" \
   --parent=$ORGANIZATION
 
 chainctl policies override create \
   --policy=cooldown \
-  --digest=sha256:db532b... \
+  --artifact_id=sha256:db532b... \
   --reason="approved exception, ticket OPS-42" \
   --parent=$ORGANIZATION
 ```

--- a/content/chainguard/chainguard-repository/container-policies.md
+++ b/content/chainguard/chainguard-repository/container-policies.md
@@ -8,7 +8,7 @@ linktitle: "Container pull policies"
 type: "article"
 description: "Configure and enforce policies that control which Chainguard container and artifact versions your organization can pull, using chainctl"
 date: 2026-05-21T08:48:45+00:00
-lastmod: 2026-08-26T19:27:38+00:00
+lastmod: 2026-08-27T18:04:21+00:00
 draft: false
 tags: ["Overview"]
 images: []
@@ -252,7 +252,7 @@ chainctl policies override create \
   --parent=$ORGANIZATION
 ```
 
-The `--artifact_id` value must be a manifest digest rather than a tag, so the waiver targets one exact artifact. A given policy and image can carry at most one override; to change an existing one, delete it and create it again.
+The `--artifact_id` value must be a manifest digest rather than a tag, so the waiver targets one exact artifact. A given policy and image can carry at most one override; to change an existing one, delete it and create it again. For `chainctl` versions 0.2.337 and earlier, use the `--digest` tag instead of `--artifact_id`.
 
 Review the active overrides for an organization to see what has been waived, by whom, and why:
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Update to container policy docs

### What should this PR do?
Change the `--digest` flag to `--artifact_id` for the `chainctl policies override` command

### Why are we making this change?
Product update

### What are the acceptance criteria? 
Page should render as expected, any instances of this command should be updated

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
