### PR TITLE
Add eks-add-on "known limitations" to address govcloud constraints

### DIFF
--- a/content/platform/fips/eks-add-ons.md
+++ b/content/platform/fips/eks-add-ons.md
@@ -91,8 +91,8 @@ Once subscribed, deployment follows the standard EKS Helm workflow, and you can 
 
 For step-by-step installation guidance, refer to the deployment instructions included with each add-on listing in AWS Marketplace.
 
-### Known Limitations
+### Known limitations
 
-AWS GovCloud: Third-party Marketplace container products (including EKS add-ons) are not available in GovCloud. The AWS GovCloud User Guide states explicitly: "Currently, container products and Amazon Machine Learning products are not available." (https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-marketplace.html) So Chainguard's EKS add-ons cannot be listed or deployed via Marketplace in GovCloud.
+AWS Marketplace container products, including EKS add-ons, are not available in AWS GovCloud. As noted in the [AWS GovCloud User Guide](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-marketplace.html), "Currently, container products and Amazon Machine Learning products are not available." Consequently, you cannot deploy Chainguard EKS add-ons through AWS Marketplace in GovCloud.
 
-Self-managed charts through helm or rendered manifests is the way forward for GovCloud right now. Editing the images in the addons after deployment the addons will fail to update altogether, as it is one of the few fields that is effectively immutable.
+Instead, deploy the add-ons using self-managed Helm charts or rendered manifests. Do not modify an add-on’s image references after deployment. These fields are effectively immutable, and modifying them prevents the add-on from receiving updates.

--- a/content/platform/fips/eks-add-ons.md
+++ b/content/platform/fips/eks-add-ons.md
@@ -90,3 +90,9 @@ Chainguard EKS add-ons are listed in AWS Marketplace and can be found within the
 Once subscribed, deployment follows the standard EKS Helm workflow, and you can deploy the add-ons with AWS CLI or in your GitOps workflows. Unlike a standalone Helm chart, which is self-managed, EKS will automatically handle lifecycle management of your add-ons. No new tooling, no Chainguard account, and no changes to your existing Kubernetes manifests are required.
 
 For step-by-step installation guidance, refer to the deployment instructions included with each add-on listing in AWS Marketplace.
+
+### Known Limitations
+
+AWS GovCloud: Third-party Marketplace container products (including EKS add-ons) are not available in GovCloud. The AWS GovCloud User Guide states explicitly: "Currently, container products and Amazon Machine Learning products are not available." (https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-marketplace.html) So Chainguard's EKS add-ons cannot be listed or deployed via Marketplace in GovCloud.
+
+Self-managed charts through helm or rendered manifests is the way forward for GovCloud right now. Editing the images in the addons after deployment the addons will fail to update altogether, as it is one of the few fields that is effectively immutable.


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

### Type of change
Documentation update

### What should this PR do?
Add additional information about known limitations with EKS Add-ons

### Why are we making this change?
There are known, undocumented limitations with deploying Chainguard EKS Add-ons via the AWS MarketPlace in GovCloud. Customers are caught off-guard by this after being able to purchase those add-ons in the marketplace, and then being pushed towards a manual deployment model (vs. the AWS managed model)

### What are the acceptance criteria?
Review by documentation team
Suggest adding @JoeNorth for review as well, as the language is derived from Slack threads he contributed to.
@benprouty may need to be aware of this as well

### How should this PR be tested?
Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [edu repo's README](https://github.com/chainguard-dev/edu#testing).

Review it for technical accuracy and determine if it is indeed worthwhile adding, and adding in this way (e.g. a known limitation section, etc.)