### PR TITLE
Clarify FIPS usage with helm charts

### DIFF
--- a/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
@@ -38,7 +38,11 @@ Before you can use a chart, it must be added to your organization. Catalog custo
 
 The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their Chainguard container images.
 
-You can use these Helm charts with Chainguard FIPS container images, but you will need to adjust the charts as they use the non-FIPS images by default. We build a single chart per application and validate that both FIPS and non-FIPS Chainguard Images work with it.
+You can use these Helm charts with Chainguard FIPS container images by choosing a FIPS chart version during install. For example:
+
+```
+helm install --version 3-fips ...
+```
 
 ## How chart updates deliver image updates
 

--- a/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -35,7 +35,7 @@ You can find iamguarded Helm charts in the [Chainguard Console](/platform/consol
 
 The following is an instructional guide for Chainguard users that are looking for Helm charts to use with their iamguarded Chainguard container images.
 
-You can use these Helm charts with Chainguard FIPS container images, but you will need to adjust the charts as they use the non-FIPS images by default. We build a single chart per application and validate that both FIPS and non-FIPS Chainguard Images work with it.
+If there is a FIPS version of the iamguarded image the chart needs, you can use these Helm charts with Chainguard FIPS container images, but you will need to set the image in the values because they use the non-FIPS images by default. We build a single chart per application and validate that both FIPS and non-FIPS Chainguard Images work with it. If there is no appropriate iamguarded-fips image then you cannot use a non-iamguarded FIPS image.
 
 ## Configuration requirements
 


### PR DESCRIPTION
[x] Check if this is a typo or other quick fix and ignore the rest :)

I've tried to tighten up the language with a more explicit "set the image in the values" rather than "adjust the charts" (the chart is not adjusted, the values are. And it doesn't say what to adjust)

Removed the comment about building a single version for non-iamguarded because we clearly have 2 versions now!

And made it clearer after a user complained about the elasticsearch-fips image not working with elasticsearch-iamguarded chart, that they can't swap them out.

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->

### Why are we making this change?
<!-- What larger problem does this PR address? -->

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
