### PR TITLE
fix(iac): pin google provider ~> 7.0 to unblock edu Cloud Run deploy (CUS-1229)

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -3,6 +3,23 @@ terraform {
     bucket = "chainguard-academy-terraform-state"
     prefix = "/ng-academy"
   }
+
+  # Pin below google v8: v8.0.0 changed the default load_balancing_scheme on
+  # google_compute_backend_service / google_compute_global_forwarding_rule from
+  # EXTERNAL to EXTERNAL_MANAGED. The serverless-gclb module leaves the field
+  # unset, so v8 plans an in-place classic->managed ALB flip that the GCP API
+  # rejects without its guided migration (CUS-1229). Remove once the backends
+  # are migrated to EXTERNAL_MANAGED.
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
+    }
+  }
 }
 
 provider "google" { project = var.project_id }


### PR DESCRIPTION
The Deploy to Cloud Run workflow has failed on `terraform apply` since ~2026-08-26, with the LB backends erroring on an EXTERNAL -> EXTERNAL_MANAGED scheme flip.

Root cause: google provider v8.0.0 changed the default `load_balancing_scheme` on `google_compute_backend_service` / `google_compute_global_forwarding_rule` from EXTERNAL to EXTERNAL_MANAGED. The `serverless-gclb` module (0.6.163) leaves the field unset, and iac/ has no provider pin or lock file, so CI resolved v8.0.0 and planned an in-place classic->managed ALB flip. GCP rejects that without its guided migration, so every merge to main goes red while content still deploys.

This pins google/google-beta to `~> 7.0`, reverting the default to EXTERNAL. The plan returns to a no-op with no change to live infrastructure. The classic->managed ALB migration remains the long-term fix; this pin is removed once the backends are migrated.