### PR TITLE
containers: document tarballs.cgr.dev as a required endpoint (OS-490)

### DIFF
--- a/content/chainguard/containers/network-requirements.md
+++ b/content/chainguard/containers/network-requirements.md
@@ -10,7 +10,7 @@ lead: "Using Chainguard Containers with firewalls, access control lists, and pro
 type: "article"
 description: "Using Chainguard Containers with firewalls, access control lists, and proxies."
 date: 2023-09-08T08:49:31+00:00
-lastmod: 2026-08-25T13:24:30+00:00
+lastmod: 2026-08-28T00:00:00+00:00
 draft: false
 tags: ["Chainguard Containers", "Reference"]
 images: []
@@ -39,6 +39,14 @@ This table lists the DNS hostnames, associated ports, and protocols that will ne
 | virtualapk.cgr.dev      | 443  | HTTPS    | v4      | Package repository                    |
 | packages.cgr.dev        | 443  | HTTPS    | v4      | Package repository (Extra packages)   |
 | packages.wolfi.dev      | 443  | HTTPS    | v4 & v6 | Package repository (Free containers)  |
+| tarballs.cgr.dev        | 443  | HTTPS    | v4      | Upstream source archives referenced by SBOM `downloadLocation` fields |
+
+Most of these hosts are needed to pull containers and packages. `tarballs.cgr.dev` is the
+exception: it is only needed if you resolve the source archives that Chainguard SBOMs point
+at. Where an upstream project has no stable, downloadable source archive, Chainguard mirrors
+a source tarball and records that URL as the package's SPDX `downloadLocation`. Tooling that
+follows those URLs (source-provenance checks, license and compliance scanners, air-gapped
+source mirroring) needs egress to this host. Container and package pulls do not.
 
 > If you experience networking issues while trying to use Chainguard Containers, please ensure that your firewall allows traffic to and from these hosts, and that it doesn't have any rules to block `.dev` domains.
 


### PR DESCRIPTION
Closes [OS-490](https://linear.app/chainguard/issue/OS-490/document-tarballscgrdev-as-a-required-endpoint-in-network-requirements)

> [!WARNING]
> **This change was written by an AI agent (Claude) working through the Q3 OS PMAI backlog, and has not been checked by a human yet.** The wording in particular is a judgement call about what we tell customers, so please read it properly rather than waving it through.

## What and why

INC-137 follow-up. `tarballs.cgr.dev` serves the upstream source archives that Chainguard SBOMs point at via the SPDX `downloadLocation` field, but it was not listed in the containers network requirements table, so customers had no way to know they needed egress to it.

Adds the table row, plus a short note that this host is unlike the others on the page: it is only needed by tooling that follows those SBOM URLs (source-provenance checks, license and compliance scanners, air-gapped source mirroring). Container and package pulls do not touch it.

## Where the claim comes from

`mono/build/internal/sbom/spdx/upstream.go` constructs the URL when a package's upstream has no stable downloadable archive:

```go
const tarballMirror = "https://tarballs.cgr.dev"
...
downloadLocation = fmt.Sprintf("%s/%s/%s-%s.tar.gz", tarballMirror, name[:1], sha256Hex(name), ref)
```

## Please check

- **Is the distinction worth drawing at all?** I called it out as "not needed for pulls" so people do not over-scope their firewall rules. The opposite argument is that a caveat invites customers to skip it and then hit the exact INC-137 confusion later. Happy to drop the paragraph and just add the row.
- Marked `v4` only, matching the other `*.cgr.dev` rows. I did not verify whether the backend bucket has AAAA records.
- Should the same row go on the Libraries network requirements page? I only touched the Containers one, since the tarball mirror is populated from APK SBOMs.
