### PR TITLE
Fix Hugo 0.164.0 compatibility: cache key and RSS author field

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -89,7 +89,7 @@ baseName = "concepts"
 isPlainText = true
 notAlternative = true
 [caches]
-  [caches.getjson]
+  [caches.getresource]
     dir = ":cacheDir/:project"
     maxAge = "10s"
 [sitemap]

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -5,9 +5,9 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.Params.languageTag | default "en-US" }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Params.copyRight }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Params.copyRight }}
     <copyright>{{ . | safeHTML }}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -18,7 +18,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>


### PR DESCRIPTION
## What

Two small changes so the site builds on Hugo 0.164.0:

- `config/_default/config.toml`: rename `[caches.getjson]` to `[caches.getresource]`. Hugo removed the `getjson` cache name and consolidated it into `getresource`.
- `layouts/rss.xml`: migrate `.Site.Author.{email,name}` to `.Site.Params.author.*`. Hugo removed the `.Site.Author` field.

## Why

Dependabot #3858 bumps `hugo-extended` 0.155.3 → 0.164.0. That build fails twice:

1. `failed to decode "caches": "getjson" is not a valid cache name` (config load)
2. `can't evaluate field Author in type page.Site` (`rss.xml` render)

Both are removals, not deprecations, so they hard-fail the build. This PR clears both. It needs to merge before #3858 (or #3858 needs a rebase afterward) for that PR's checks to pass.

## Safety

Both changes are behavior-preserving. There is no `[author]` block in the config, so the RSS `author`/`managingEditor`/`webMaster` fields already emit nothing; the migration keeps that output identical. `getresource` is a valid cache name on both the current 0.155.3 and 0.164.0.

## Testing

Faithful `npm ci && npm run build` (matching CI), all clean:

| Hugo | Config | Result |
| --- | --- | --- |
| 0.155.3 (current `main`) | both fixes | ✅ 1633 pages, 0 errors |
| 0.164.0 (#3858) | both fixes | ✅ 1633 pages, 0 errors |
| 0.164.0 | unfixed | ❌ reproduces both CI errors |

## Follow-up (not this PR)

The 0.164.0 build still emits deprecation warnings that will become breakage in a future Hugo: the `languageCode`/`languageName` config keys, `module.mounts.includeFiles`, `.Site.Data`, and `.Site.LanguageCode`. Worth a separate tracking ticket.

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-28.
