### PR TITLE
fix(hugo): clear deprecation warnings before they break the build (DOCS-150)

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -5,7 +5,7 @@ disableHugoGeneratorInject = true
 enableEmoji = false
 enableGitInfo = false
 enableRobotsTXT = true
-languageCode = "en-US"
+locale = "en-US"
 [pagination]
   pagerSize = 7
 rssLimit = 10
@@ -133,7 +133,7 @@ notAlternative = true
   [[module.mounts]]
     source = "node_modules/@scalar/api-reference/dist"
     target = "assets/css/vendor/scalar"
-    includeFiles = ["/style.css"]
+    files = ["/style.css"]
   [[module.mounts]]
     source = "node_modules/bootstrap-icons/font/fonts"
     target = "static/fonts"

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -1,5 +1,5 @@
 [en]
-  languageName = "English"
+  label = "English"
   contentDir = "content"
   weight = 10
   [en.params]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.LanguageCode | default "en" }}">
+<html lang="{{ .Site.Language.Locale | default "en" }}">
   {{ partial "head/head.html" . }}
   {{ if eq .Kind "home" -}}
     {{ .Scratch.Set "class" "home" -}}

--- a/layouts/partials/notice.html
+++ b/layouts/partials/notice.html
@@ -1,6 +1,6 @@
 {{ $page := .Page }}
 
-{{ $notices := $.Site.Data.notices }}
+{{ $notices := hugo.Data.notices }}
 
 {{ $previewmessage := "This is a preview of an unreleased feature. This documentation is subject to change." }}
 

--- a/layouts/shortcodes/package-mappings/debian-packages.html
+++ b/layouts/shortcodes/package-mappings/debian-packages.html
@@ -14,7 +14,7 @@
           </tr>
         </thead>
         <tbody>
-        {{ range $debian, $chainguard := index $.Site.Data "package-mappings" "packages" "debian" }}
+        {{ range $debian, $chainguard := index hugo.Data "package-mappings" "packages" "debian" }}
           <tr>
             <td><code>{{ $debian }}</code></td>
             <td>
@@ -35,4 +35,3 @@
 </div>
 
 <!-- LLM-friendly: Full table content is in DOM, just CSS hidden for humans -->
-

--- a/layouts/shortcodes/package-mappings/fedora-packages.html
+++ b/layouts/shortcodes/package-mappings/fedora-packages.html
@@ -14,7 +14,7 @@
           </tr>
         </thead>
         <tbody>
-        {{ range $fedora, $chainguard := index $.Site.Data "package-mappings" "packages" "fedora" }}
+        {{ range $fedora, $chainguard := index hugo.Data "package-mappings" "packages" "fedora" }}
           <tr>
             <td><code>{{ $fedora }}</code></td>
             <td>

--- a/layouts/shortcodes/package-mappings/image-mappings.html
+++ b/layouts/shortcodes/package-mappings/image-mappings.html
@@ -14,7 +14,7 @@
           </tr>
         </thead>
         <tbody>
-        {{ range $upstream, $chainguard := index $.Site.Data "package-mappings" "images" }}
+        {{ range $upstream, $chainguard := index hugo.Data "package-mappings" "images" }}
           <tr>
             <td><code>{{ $upstream }}</code></td>
             <td><code>{{ $chainguard }}</code></td>


### PR DESCRIPTION
## What

Clears the five Hugo deprecation warnings surfaced by the move to `hugo-extended` under Dependabot management (see #3858 and the 0.164.0 compat fix #3864). None block the build today, but each becomes a hard error in a future Hugo release — exactly as `getjson` and `.Site.Author` did in 0.164.0.

Resolves [DOCS-150](https://linear.app/chainguard/issue/DOCS-150/resolve-hugo-deprecation-warnings-before-they-break-the-build).

## Changes

| Deprecated | Since | Replacement | File |
| -- | -- | -- | -- |
| `languageCode` config key | v0.158.0 | `locale` | `config/_default/config.toml` |
| `languages.en.languageName` | v0.158.0 | `label` | `config/_default/languages.toml` |
| `module.mounts.includeFiles` | v0.153.0 | `files` | `config/_default/config.toml` |
| `.Site.Data` | v0.156.0 | `hugo.Data` | `layouts/partials/notice.html`, `layouts/shortcodes/package-mappings/{image,fedora,debian}-*.html` |
| `.Site.LanguageCode` | v0.158.0 | `.Site.Language.Locale` | `layouts/_default/baseof.html` |

A repo-wide grep of `config/` and `layouts/` confirms these were the only occurrences of all five patterns.

## Verification

Built with Hugo **0.164.0** (`npm ci && npm run build`):

- Zero `deprecated:` lines in the output (was 5).
- Build succeeds: 1633 pages, no errors.
- Rendered output unchanged: `<html lang=en-US>` renders identically (the new `locale` value feeds `.Site.Language.Locale`), and the package-mappings tables still render their data via `hugo.Data`.

0.164.0 is also the latest published `hugo-extended` on npm, so pinned and latest are the same today.

Out of scope: the Dart Sass `@import`/`darken()`/slash-div warnings are a separate deprecation track (Bootstrap + our SCSS, not Hugo config).

---
Created in collaboration with Claude Code running Claude Opus 4.8 on 2026-08-28.
