### PR TITLE
Fixes relating to Migration move

### DIFF
--- a/content/chainguard/containers/overview.md
+++ b/content/chainguard/containers/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Overview of Chainguard Containers"
-linktitle: "Overview"
+linktitle: "Containers overview"
 type: "article"
 description: "Learn about Chainguard Containers, distroless images, and how they provide enhanced security through minimal attack surface and comprehensive supply chain features."
 lead: "Chainguard Containers are security-hardened container images built with a distroless approach, containing only essential application components and runtime dependencies."

--- a/content/get-started/libraries-examples/_index.md
+++ b/content/get-started/libraries-examples/_index.md
@@ -2,7 +2,7 @@
 title: "Libraries examples"
 linktitle: "Libraries examples"
 lead: ""
-description: "Swap in your first secure dependency with Chainguard Libraries: a quickstart and migration walkthroughs for Java, JavaScript, and Python."
+description: "Swap in your first secure dependency with Chainguard Libraries: a quickstart plus ecosystem overviews for Java, JavaScript, and Python."
 type: "article"
 date: 2026-06-26T00:00:00+00:00
 lastmod: 2026-08-06T19:08:57+00:00
@@ -12,12 +12,12 @@ weight: 025
 crosslinks:
 - title: "Quickstart: swap in a library"
   url: "/chainguard/libraries/quickstart/"
-- title: "Migrate a Java project"
-  url: "/chainguard/libraries/java/migration/"
-- title: "Migrate a JavaScript project"
-  url: "/chainguard/libraries/javascript/migration/"
-- title: "Migrate a Python project"
-  url: "/chainguard/libraries/python/migration/"
+- title: "Java overview"
+  url: "/chainguard/libraries/java/overview/"
+- title: "JavaScript overview"
+  url: "/chainguard/libraries/javascript/overview/"
+- title: "Python overview"
+  url: "/chainguard/libraries/python/overview/"
 ---
 
 Point your package manager at Chainguard, reinstall, and ship — no breaking changes. Chainguard Libraries are rebuilt from verified source as drop-in replacements for the packages you already use.
@@ -27,9 +27,11 @@ These on-ramp guides link to the published Chainguard Libraries documentation. L
 ## On-ramp guides
 
 - **[Quickstart: swap in a library](/chainguard/libraries/quickstart/)** — point your package manager at Chainguard, reinstall, and ship.
-- **[Migrate a Java project](/chainguard/libraries/java/migration/)** — switch an existing Maven or Gradle project over to Chainguard Libraries.
-- **[Migrate a JavaScript project](/chainguard/libraries/javascript/migration/)** — switch an existing npm project over to Chainguard Libraries.
-- **[Migrate a Python project](/chainguard/libraries/python/migration/)** — switch an existing pip, uv, or Poetry project over to Chainguard Libraries.
+- **[Java](/chainguard/libraries/java/overview/)** — which Maven Central artifacts Chainguard rebuilds, and how Maven and Gradle reach them.
+- **[JavaScript](/chainguard/libraries/javascript/overview/)** — which npm packages Chainguard rebuilds, and how npm, pnpm, Yarn, and Bun reach them.
+- **[Python](/chainguard/libraries/python/overview/)** — which PyPI packages Chainguard rebuilds, and how pip, uv, and Poetry reach them.
+
+Moving an existing project rather than starting a new one? The [migration guides](/get-started/migration/) cover that path.
 
 ## Example projects
 

--- a/content/platform/administration/custom-idps/idp-providers/keycloak/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/keycloak/index.md
@@ -61,7 +61,7 @@ To configure Chainguard, make a note of the following details from your Keycloak
 
 * **Client ID**: This can be found on the **Settings** tab of the Keycloak Client.
 * **Client Secret**: This can be found on the **Credentials** tab of the Keycloak Client.
-* **Issuer**: Your **Issuer** url is defined by the following pattern `https://<keycloak_server_address>/realms/<realm_name>`
+* **Issuer**: Your **Issuer** URL is defined by the following pattern `https://<keycloak_server_address>/realms/<realm_name>`
 
 You will also need the UIDP for the Chainguard organization under which you want to install the identity provider.  Your selection won’t affect how your users authenticate but will have implications on who has permission to modify the SSO configuration.
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

This PR fixes up a few small things relating to the migration move we merged yesterday. Primarily, it switches out the docs listed under `Get started` => `Library examples` from the migration docs (now listed under `Get started` => `Migration`) to the respective overview docs. It also updates one linktitle and adds a small fix that should have been included in the MS Entra ID PR that was merged this morning but was accidentally left out

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
