### PR TITLE
Fix broken links in the Java and Python dependency maintenance pages

### DIFF
--- a/content/chainguard/libraries/java/management.md
+++ b/content/chainguard/libraries/java/management.md
@@ -4,7 +4,7 @@ linktitle: "Dependency maintenance"
 description: "Manage Chainguard Libraries for Java dependencies after setup, including verification, cache refreshes, and checksum changes."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-28T14:09:22+00:00
+lastmod: 2026-08-28T19:09:28+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 images: []
@@ -18,7 +18,7 @@ toc: true
 
 Chainguard Libraries for Java operates transparently after configuring your [repository manager](/chainguard/libraries/java/global-configuration/) or [your build tool](/chainguard/libraries/java/build-configuration/), automatically providing security-enhanced versions of your Maven dependencies. After you configure Chainguard Libraries for Java, use this page for recurring maintenance tasks.
 
-Chainguard Libraries serves Chainguard-built artifacts when they are available. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls/) is enabled, an artifact that Chainguard has not yet built may first be served through Chainguard’s upstream tier. With [build pinning](/chainguard/libraries/build-pinning/), the exact package version remains pinned to the artifact tier your organization first received, so a previously downloaded upstream artifact is not immediately replaced when Chainguard publishes a built equivalent.
+Chainguard Libraries serves Chainguard-built artifacts when they are available. When [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is enabled, an artifact that Chainguard has not yet built may first be served through Chainguard’s upstream tier. With [build pinning](/chainguard/libraries/build-pinning/), the exact package version remains pinned to the artifact tier your organization first received, so a previously downloaded upstream artifact is not immediately replaced when Chainguard publishes a built equivalent.
 
 Existing artifacts may already be present in a developer’s local Maven cache or in a repository manager cache, so a previously downloaded upstream artifact is not automatically replaced just because a Chainguard-built equivalent becomes available.
 
@@ -52,7 +52,7 @@ over time. If an artifact was already retrieved from the Maven Central
 Repository and is available in your repository manager or local repository it is
 not automatically replaced with the equivalent Chainguard Library version.
 
-To adopt a newer Chainguard-built artifact, check out the [build pinning documentation](/libraries/build-pinning/#adopt-a-chainguard-build-after-removing-a-pin) for instructions on removing existing pinned versions.
+To adopt a newer Chainguard-built artifact, refer to the [build pinning documentation](/chainguard/libraries/build-pinning/#adopt-a-chainguard-build-after-removing-a-pin) for instructions on removing existing pinned versions.
 
 Refreshing cached artifacts may also be necessary to solve other issues, such as stale or corrupted artifacts or metadata, repository configuration changes, and resolution troubleshooting. To refresh the same artifact your organization is already using:
 
@@ -69,9 +69,9 @@ Prefer removing only the affected artifact or dependency subtree. Avoid broadly 
 
 A checksum identifies the exact bytes of a library artifact. Chainguard-built artifacts have different checksums from upstream artifacts with the same Maven coordinates and version because they are rebuilt in a secured environment.
 
-During initial migration if your project records checksums or integrity values, update those values as a part of migration or cache refresh, then run your normal tests and verification checks. For a full migration sequence, including cache and project-configuration handling, check out the [migration guide for Chainguard Libraries for Java](/chainguard/libraries/java/migration/).
+During initial migration, if your project records checksums or integrity values, update those values as part of the migration or cache refresh, then run your normal tests and verification checks. For a full migration sequence, including cache and project-configuration handling, refer to the [migration guide for Chainguard Libraries for Java](/chainguard/libraries/java/migration/).
 
-For organizations that use Chainguard's [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls/), build pinning keeps the exact artifact previously served for that package version. This prevents a later Chainguard rebuild from unexpectedly changing the checksum. You must remove the pin to adopt a newer Chainguard build. Refer to [Build pinning](/chainguard/libraries/build-pinning/) for more information.
+For organizations that use Chainguard's [upstream fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls), build pinning keeps the exact artifact previously served for that package version. This prevents a later Chainguard rebuild from unexpectedly changing the checksum. You must remove the pin to adopt a newer Chainguard build. Refer to [Build pinning](/chainguard/libraries/build-pinning/) for more information.
 
 ## Security and policy guidance
 

--- a/content/chainguard/libraries/python/management.md
+++ b/content/chainguard/libraries/python/management.md
@@ -1,10 +1,10 @@
 ---
-title: "Managem and update dependencies"
+title: "Manage and update dependencies"
 linktitle: "Dependency maintenance"
 description: "Manage Chainguard Libraries for Python dependencies after setup, including package updates, verification, and monitoring security improvements"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-27T20:36:28+00:00
+lastmod: 2026-08-28T19:09:28+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -27,7 +27,7 @@ for deciding where to troubleshoot when a dependency changes.
 
 Chainguard Libraries serves Chainguard-built artifacts when they are available.
 When [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls/) is
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls) is
 enabled, an artifact that Chainguard has not yet built may first be served
 through Chainguard’s upstream tier. With [build
 pinning](/chainguard/libraries/build-pinning/), the exact package version
@@ -78,8 +78,8 @@ over time. If an artifact was already retrieved from the PyPI
 Repository and is available in your repository manager or local repository it is
 not automatically replaced with the equivalent Chainguard Library version.
 
-To adopt new Chainguard-built artifacts, check out the [build pinning
-documentation](/libraries/build-pinning/#adopt-a-chainguard-build-after-removing-a-pin)
+To adopt new Chainguard-built artifacts, refer to the [build pinning
+documentation](/chainguard/libraries/build-pinning/#adopt-a-chainguard-build-after-removing-a-pin)
 for instructions on removing existing pinned versions.
 
 Refreshing cached artifacts may also be necessary to solve other issues, such as
@@ -105,16 +105,16 @@ A hash identifies the exact bytes of a downloaded Python artifact.
 Chainguard-built artifacts have different hashes from the equivalent upstream
 artifacts because they are rebuilt in a secure environment.
 
-During initial migration if your project uses hash-pinned lockfiles, update those values with [the `chainctl libraries
-update-hashes`
+During initial migration, if your project uses hash-pinned lockfiles, update
+those values with [the `chainctl libraries update-hashes`
 command](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/),
 then run your normal tests and verification checks. For a full migration
-sequence, including cache and project-configuration handling, check out the
+sequence, including cache and project-configuration handling, refer to the
 [migration guide for Chainguard Libraries for
 Python](/chainguard/libraries/python/migration/).
 
 For organizations that use Chainguard's [upstream
-fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls/),
+fallback](/chainguard/libraries/overview/#upstream-fallback-and-controls),
 build pinning keeps the exact artifact previously served for that package
 version. This prevents a later Chainguard rebuild from unexpectedly changing the
 hash. You must remove the pin to adopt a newer Chainguard build. Refer to [Build


### PR DESCRIPTION
[ x ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Bug Fix**
- Fixes a 404 link to the build pinning guide on the Java and Python dependency maintenance pages
- Removes a trailing slash from four upstream fallback anchor links that stopped the anchor from resolving
- Corrects the Python page title, which read "Managem and update dependencies"

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-143/chainlink-check-links-on-educhainguarddev

Repairs the broken internal links found while checking links across Chainguard Academy.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
A link-check sweep of edu.chainguard.dev turned up one 404: both the Java and Python dependency maintenance pages linked to the build pinning guide as `/libraries/build-pinning/`, missing the `/chainguard` path prefix. Reviewing those two files surfaced four more links where a trailing slash after the anchor (`#upstream-fallback-and-controls/`) prevented the anchor from resolving, plus a typo in the Python page's title.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The build pinning links on both maintenance pages resolve and land on the "Adopt a Chainguard build after removing a pin" section
- All upstream fallback links jump to the "Upstream fallback and controls" section of the Libraries overview
- The Python page title reads "Manage and update dependencies"

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. On `/chainguard/libraries/java/management/` and `/chainguard/libraries/python/management/`, click every "build pinning" and "upstream fallback" link and confirm each lands on the correct section
3. Confirm the Python page's browser tab and heading read "Manage and update dependencies"
