### PR TITLE
docs(libraries): present update-hashes and lockfile regeneration as tabbed options

### DIFF
--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-25T20:14:45+00:00
+lastmod: 2026-08-31T14:23:56+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -226,7 +226,7 @@ chainctl libraries update-hashes
 npm install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `package-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes.
+As an alternative, you can remove the `node_modules` directory _and_ the `package-lock.json` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 **Clear caches**
 
@@ -513,7 +513,7 @@ chainctl libraries update-hashes
 pnpm install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `pnpm-lock.yaml` file, then reinstall. This will regenerate the lockfile and update the hashes.
+As an alternative, you can remove the `node_modules` directory _and_ the `pnpm-lock.yaml` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 **Clear pnpmn caches**
 
@@ -960,7 +960,7 @@ chainctl libraries update-hashes
 yarn install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `yarn-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes.
+As an alternative, you can remove the `node_modules` directory _and_ the `yarn-lock.json` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 Another option, after deleting `node_modules` and `yarn-lock.json`, is to run `yarn upgrade`. This updates all dependencies to their latest allowed
 versions and regenerates the lock file with updated hashes.
@@ -1110,7 +1110,7 @@ chainctl libraries update-hashes
 bun install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `bun-lock.json` file, then reinstall. This will regenerate the lockfile and update the hashes.
+As an alternative, you can remove the `node_modules` directory _and_ the `bun-lock.json` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 <a id="bun-minimal"></a>
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -226,7 +226,7 @@ chainctl libraries update-hashes
 npm install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `package-lock.json` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
+As an alternative, you can remove the `node_modules` directory _and_ the `package-lock.json` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and any new versions published within your configured cooldown window will return an error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 **Clear caches**
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -513,7 +513,7 @@ chainctl libraries update-hashes
 pnpm install
 ```
 
-As an alternative, you can remove the `node_modules` directory _and_ the `pnpm-lock.yaml` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
+As an alternative, you can remove the `node_modules` directory _and_ the `pnpm-lock.yaml` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and any new versions published within your configured cooldown window will return an error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
 **Clear pnpmn caches**
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -453,10 +453,8 @@ manager re-resolves all dependencies from scratch using the version constraints
 in `package.json`. If a constraint uses `^` or `~` (the npm default), the
 resolver picks the newest matching version, so you can lose your existing pins
 and pick up unintended upgrades that change your application's behavior.
-- Whether Chainguard has a resolved version available depends on the cooldown
-period you've configured. A version that Chainguard has not built yet, or one
-still inside your cooldown window, returns a 404 error that can be hard to
-diagnose. Check the cooldown period you've set before you regenerate.
+- Whether Chainguard has a resolved version available depends on the policies
+you've configured. For example, a version that was published upstream within your configured cooldown period will return an error. Check the cooldown period you've set before you regenerate.
 
 To regenerate — for example, to intentionally refresh your dependency
 versions — use the following commands:

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-25T20:14:45+00:00
+lastmod: 2026-08-31T14:23:56+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -402,7 +402,13 @@ your package manager's install command after changing the registry does **not**
 re-fetch already-resolved packages — the lockfile entries are treated as
 satisfied, and source URLs will still point to `registry.npmjs.org`.
 
-### Recommended: Update checksums in place
+You can update your lockfile in one of two ways. Update the checksums in place to
+keep your existing pinned versions, or regenerate the lockfile if you also want to
+refresh your dependency versions.
+
+{{< tabs >}}
+
+{{% tab title="Update checksums in place" %}}
 
 Use [`chainctl libraries update-hashes`](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes)
 to rewrite only the integrity hashes in your existing lockfile to match
@@ -434,22 +440,27 @@ reinstalling.
 Learn about using this command with repo managers in the [Global
 configuration](/chainguard/libraries/javascript/global-configuration/) page.
 
-### Alternative: Delete and regenerate the lockfile
+{{% /tab %}}
 
-Deleting the lockfile is **not recommended** as a first approach. Expand the section below to learn more about this approach.
+{{% tab title="Delete and regenerate the lockfile" %}}
 
-{{< details "Delete and regenerate the lockfile" >}}
+Regenerating the lockfile is another valid approach, and many teams use the
+migration as an opportunity to update dependencies at the same time. Before you
+regenerate, keep two things in mind.
 
-When npm regenerates a lockfile, it re-resolves all dependencies from scratch
-using the version constraints in `package.json`. If a constraint uses `^` or `~`
-(the npm default), the resolver picks the highest matching version. This may be
-a version that Chainguard has not yet built, or a version that is still within
-the cooldown window. Either case results in 404 errors that can be difficult to
-diagnose. Regenerating the lockfile can also introduce unintended dependency
-upgrades that break your application independently of the registry change.
+Pinning versions is a security best practice. When you regenerate, your package
+manager re-resolves all dependencies from scratch using the version constraints
+in `package.json`. If a constraint uses `^` or `~` (the npm default), the
+resolver picks the newest matching version, so you can lose your existing pins
+and pick up unintended upgrades that change your application's behavior.
 
-If you have a specific reason to regenerate — for example, if you are
-intentionally refreshing your dependency versions — use the following commands:
+Whether Chainguard has a resolved version available depends on the cooldown
+period you've configured. A version that Chainguard has not built yet, or one
+still inside your cooldown window, returns a 404 error that can be hard to
+diagnose. Check the cooldown period you've set before you regenerate.
+
+To regenerate — for example, to intentionally refresh your dependency
+versions — use the following commands:
 
 | Tool | Command |
 |---|---|
@@ -464,7 +475,9 @@ resolved version is not yet available in Chainguard Libraries or is still within
 the cooldown window. Refer to [Packages not available in Chainguard
 Libraries](#packages-not-available-in-chainguard-libraries) for next steps.
 
-{{< /details >}}
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## Step 4: Delete node_modules and clear caches
 
@@ -561,7 +574,7 @@ If this command is not available on your version of Bun, you can instead delete 
 Reinstall dependencies and confirm that the lockfile reflects Chainguard as the source. Resolved URLs should point to `libraries.cgr.dev/javascript` (direct access) or
 your repository manager host, not `registry.npmjs.org`.
 
-> Note: When using the `update-hashes` command, some package managers and tool versions default to appending the hash rather than replacing it. In some cases, the resulting dual-hash format fails on install. If you encounter integrity errors, [run the command again](#recommended-update-checksums-in-place) and include the `--replace` flag.
+> Note: When using the `update-hashes` command, some package managers and tool versions default to appending the hash rather than replacing it. In some cases, the resulting dual-hash format fails on install. If you encounter integrity errors, [run the command again](#step-3-update-your-lockfile) and include the `--replace` flag.
 
 {{< tabs >}}
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-08-31T14:23:56+00:00
+lastmod: 2026-08-31T14:57:37+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -408,7 +408,7 @@ refresh your dependency versions.
 
 {{< tabs >}}
 
-{{% tab title="Update checksums in place" %}}
+{{% tab title="Update in place" %}}
 
 Use [`chainctl libraries update-hashes`](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes)
 to rewrite only the integrity hashes in your existing lockfile to match
@@ -442,19 +442,18 @@ configuration](/chainguard/libraries/javascript/global-configuration/) page.
 
 {{% /tab %}}
 
-{{% tab title="Delete and regenerate the lockfile" %}}
+{{% tab title="Regenerate lockfile" %}}
 
 Regenerating the lockfile is another valid approach, and many teams use the
 migration as an opportunity to update dependencies at the same time. Before you
-regenerate, keep two things in mind.
+regenerate, consider the following:
 
-Pinning versions is a security best practice. When you regenerate, your package
+- Pinning versions is a security best practice. When you regenerate, your package
 manager re-resolves all dependencies from scratch using the version constraints
 in `package.json`. If a constraint uses `^` or `~` (the npm default), the
 resolver picks the newest matching version, so you can lose your existing pins
 and pick up unintended upgrades that change your application's behavior.
-
-Whether Chainguard has a resolved version available depends on the cooldown
+- Whether Chainguard has a resolved version available depends on the cooldown
 period you've configured. A version that Chainguard has not built yet, or one
 still inside your cooldown window, returns a 404 error that can be hard to
 diagnose. Check the cooldown period you've set before you regenerate.

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-25T20:14:45+00:00
+lastmod: 2026-08-31T14:23:56+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -388,6 +388,8 @@ If necessary, you can fix or even regenerate your `poetry.lock` file:
 poetry lock
 poetry lock --regenerate
 ```
+
+Regenerating re-resolves your dependencies, so it can change your pinned versions, and a release still inside your configured cooldown window returns a 404 error. See [Update your lockfile](/chainguard/libraries/python/migration/#step-2-update-your-lockfile).
 
 Proceed to build your project:
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-31T14:23:56+00:00
+lastmod: 2026-08-31T14:57:37+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -316,7 +316,7 @@ You can update your lockfile in one of two ways. Update the checksums in place t
 
 {{< tabs >}}
 
-{{% tab title="Update checksums in place" %}}
+{{% tab title="Update in place" %}}
 
 Use `chainctl libraries update-hashes` to rewrite only the integrity hashes in your existing lockfile or requirements file to match Chainguard's artifacts, without re-resolving your dependency graph. Supported formats include `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 
@@ -346,12 +346,13 @@ By default, Chainguard hashes are appended alongside your existing hashes rather
 
 {{% /tab %}}
 
-{{% tab title="Regenerate the lockfile" %}}
+{{% tab title="Regenerate lockfile" %}}
 
-Regenerating the lockfile is another valid approach, and many teams use the migration as an opportunity to update dependencies at the same time. Before you regenerate, keep two things in mind:
+Regenerating the lockfile is another valid approach, and many teams use the migration as an opportunity to update dependencies at the same time. Before you regenerate, consider the following:
 
 * Pinning versions is a security best practice. Regenerating re-resolves your dependencies and can change versions, so you lose your existing pins unless you re-pin afterward.
-* Resolvers pick the newest version that satisfies each constraint. Whether Chainguard has that version available depends on the cooldown period you've configured: a release still inside your cooldown window isn't available yet and returns a 404 error. Check the cooldown period you've set before you regenerate.
+* Resolvers pick the newest version that satisfies each constraint. Whether Chainguard has that version available depends on the [cooldown
+period you've configured](/chainguard/libraries/overview/#cooldown-period): a release still inside your cooldown window isn't available yet and returns a 404 error.
 
 To regenerate — for example, to intentionally refresh your dependency versions — use the following commands.
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-25T20:14:45+00:00
+lastmod: 2026-08-31T14:23:56+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -312,7 +312,11 @@ For authentication details specific to your repository manager, refer to the [gl
 
 Your existing lockfile or hash-pinned `requirements.txt` contains checksums generated against packages downloaded from PyPI or through your repository manager. Because Chainguard rebuilds packages from verified source as well as providing security controls for upstream artifacts, checksums differ even for identical version numbers. If your file uses `--hash` entries or `--require-hashes`, installation will fail with a hash mismatch after switching to Chainguard until these are updated.
 
-### Recommended: Update checksums in place
+You can update your lockfile in one of two ways. Update the checksums in place to keep your existing pinned versions, or regenerate the lockfile if you also want to refresh your dependency versions.
+
+{{< tabs >}}
+
+{{% tab title="Update checksums in place" %}}
 
 Use `chainctl libraries update-hashes` to rewrite only the integrity hashes in your existing lockfile or requirements file to match Chainguard's artifacts, without re-resolving your dependency graph. Supported formats include `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 
@@ -340,13 +344,16 @@ chainctl libraries update-hashes
 
 By default, Chainguard hashes are appended alongside your existing hashes rather than replacing them. If your installer fails on a dual-hash entry, use the `--replace` flag.
 
-### Alternative: Regenerate the lockfile
+{{% /tab %}}
 
-Regenerating is **not recommended** as a first approach. Dependency resolvers pick the newest version satisfying your constraints, which may not yet be available from Chainguard, and may also introduce unrelated dependency upgrades. Expand the following section for instructions on regenerating lockfiles.
+{{% tab title="Regenerate the lockfile" %}}
 
-{{< details "Delete and regenerate a lockfile" >}}
+Regenerating the lockfile is another valid approach, and many teams use the migration as an opportunity to update dependencies at the same time. Before you regenerate, keep two things in mind:
 
-If you have a specific reason to regenerate - for example, if you are intentionally refreshing your dependency versions - use the following commands:
+* Pinning versions is a security best practice. Regenerating re-resolves your dependencies and can change versions, so you lose your existing pins unless you re-pin afterward.
+* Resolvers pick the newest version that satisfies each constraint. Whether Chainguard has that version available depends on the cooldown period you've configured: a release still inside your cooldown window isn't available yet and returns a 404 error. Check the cooldown period you've set before you regenerate.
+
+To regenerate — for example, to intentionally refresh your dependency versions — use the following commands.
 
 pip:
 
@@ -357,7 +364,7 @@ pip-compile --generate-hashes --index-url https://libraries.cgr.dev/python/simpl
 uv:
 
 ```bash
-rm -f uv.lock  
+rm -f uv.lock
 uv sync
 ```
 
@@ -373,7 +380,9 @@ Poetry 2.x:
 poetry lock
 ```
 
-{{< /details >}}
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## Step 3: Clear caches
 


### PR DESCRIPTION
## Summary

Reframes the lockfile step in the Python and JavaScript migration guides so that updating checksums in place and regenerating the lockfile are presented as two tabbed options rather than a "recommended" path and a "not recommended" alternative. `chainctl libraries update-hashes` stays the first tab; nothing is labeled "not recommended."

This reflects field feedback: many customers delete and regenerate their lockfiles during the initial migration, and many use the migration as a forcing function to update dependencies. The docs now treat that as a valid choice while keeping the version-pinning and cooldown caveats attached to it.

## Changes

- **`python/migration.md`** / **`javascript/migration.md`** — lockfile step is now a two-tab choice (**Update checksums in place** / **Regenerate the lockfile**), with the full pinning + cooldown caveat in the regenerate tab.
- **`javascript/build-configuration.md`** (4 tool sections) and **`python/build-configuration.md`** (`poetry lock --regenerate`) — short caveat plus a link to the migration guide at each regenerate spot.
- Repointed the JavaScript Step 5 note's anchor to `#step-3-update-your-lockfile`, since the old heading is now a tab title.
- Java is intentionally unchanged: it has no lockfile or regenerate path, and its migration guide already documents cooldown.

## Test plan

Run against a project with an existing lockfile pinned to upstream hashes and an entitlement to Chainguard Libraries (Python or JavaScript).

**Setup**
1. Configure authentication and registry per Step 1 of the migration guide.

**Path A — update checksums in place (first tab)**
2. Run `chainctl libraries update-hashes`.
3. Clear caches and reinstall per the following steps.
4. Confirm the lockfile now references Chainguard artifacts and that pinned versions are unchanged.

**Path B — regenerate the lockfile (second tab)**
5. Delete the lockfile and reinstall to regenerate it.
6. Confirm the resolver re-resolves dependencies and the new lockfile carries Chainguard hashes.

**Exercise the caveat (validates the open questions above)**
7. Confirm or set a cooldown policy, and pick a dependency that has a newer upstream release still inside the cooldown window.
8. Regenerate, and confirm the newer version returns a 404 — matching the caveat text.

**Docs rendering**
9. Run `npm start` and open the four changed pages. Confirm: both migration pages show `update-hashes` as the first tab; the caveats render; and the internal links resolve (JavaScript Step 5 note → Step 3 anchor, and the build-configuration caveat links → migration guides).

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-08-31.
