### PR TITLE
Link to vulnerability scanners KB article in the Containers docs

### DIFF
--- a/content/chainguard/containers/staying-secure/security-advisories/how-to-use/index.md
+++ b/content/chainguard/containers/staying-secure/security-advisories/how-to-use/index.md
@@ -15,7 +15,7 @@ aliases:
 type: "article"
 description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Container Directory."
 date: 2023-12-27T11:07:52+02:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-08-31T15:18:48+00:00
 draft: false
 tags: ["Chainguard Containers", "CVE"]
 images: []
@@ -145,3 +145,5 @@ As this output indicates, `CVE-2023-44487` is no longer present in later version
 The Security Advisories page serves as a helpful resource for anyone who wants to learn more about CVEs reported within Chainguard Containers. You can search the database of advisories to learn more about any CVEs you encounter as you work with Chainguard Containers.
 
 Additionally, we encourage you to explore the [Chainguard Containers Directory](https://images.chainguard.dev/), the parent site of the Security Advisories page. The Directory allows users to explore the complete inventory of Chainguard Containers. Finally, we encourage you to learn more about [noisy scan results](/chainguard/containers/scanners/false-results/) when scanning Chainguard Containers.
+
+To learn more about why scan results may differ between your scanner and the Chainguard Console, refer to [the support article "Understanding Vulnerability Scanner Discrepancies with Chainguard Images."](https://support.chainguard.dev/hc/en-us/articles/49564106705819-Understanding-Vulnerability-Scanner-Discrepancies-with-Chainguard-Images)

--- a/content/chainguard/containers/staying-secure/working-with-scanners/false-results.md
+++ b/content/chainguard/containers/staying-secure/working-with-scanners/false-results.md
@@ -14,7 +14,7 @@ description: "An overview of the formation of false positive and false negative 
 lead: "An overview of the formation of false positive and false negative vulnerability results in container image scanners"
 type: "article"
 date: 2023-09-14T16:59:04+00:00
-lastmod: 2023-09-14T16:59:04+00:00
+lastmod: 2026-08-31T15:18:48+00:00
 contributors: ["Michelle McAveety"]
 draft: false
 tags: ["CVE", "Overview", "Conceptual"]
@@ -33,6 +33,8 @@ The goal of a vulnerability scanner is to identify the vulnerabilities that impa
 The presence of false positive and negative vulnerabilities can add a tricky layer to the vulnerability remediation process. False positive vulnerabilities can be "noisy" and distract you from remediating the vulnerabilities that are actively impacting your containers. Additionally, false negative vulnerabilities can silently affect you, making them a hidden threat to your container image security.
 
 This article aims to explain the formation of false positive and false negative vulnerabilities, allowing you to better understand what they mean, how they impact you, and how you can use tools to fine-tune your scanner to improve the accuracy of your scan results.
+
+> To learn more about why scan results may differ between your scanner and the Chainguard Console, refer to [the support article "Understanding Vulnerability Scanner Discrepancies with Chainguard Images."](https://support.chainguard.dev/hc/en-us/articles/49564106705819-Understanding-Vulnerability-Scanner-Discrepancies-with-Chainguard-Images)
 
 ## How false positives and false negatives occur
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Updates to:
- content/chainguard/containers/staying-secure/security-advisories/how-to-use/index.md
- content/chainguard/containers/staying-secure/working-with-scanners/false-results.md

### What should this PR do?
Link to the support article ["Understanding vulnerability scanner discrepancies with Chainguard Images"](https://support.chainguard.dev/hc/en-us/articles/49564106705819-Understanding-Vulnerability-Scanner-Discrepancies-with-Chainguard-Images)

### Why are we making this change?
Kapa noted a coverage gap for customers asking about outstanding CVEs and why scanners disagree with Chainguard's reports. This information was already captured in a support article, so I'm making that article easier to find from the docs.

### What are the acceptance criteria? 
Text and links should render as expected

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
