### PR TITLE
docs(registry): add a pull-your-first-container quickstart (DOCS-154)

### DIFF
--- a/content/chainguard/containers/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/containers/chainguard-registry/authenticating/index.md
@@ -4,7 +4,7 @@ linktitle: "Authenticate"
 type: "article"
 description: "A guide on authenticating to Chainguard's registry to get container images"
 date: 2023-03-21T15:10:16+00:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-08-31T16:48:20+00:00
 tags: ["Chainguard Containers", "Registry"]
 draft: false
 images: []
@@ -22,6 +22,34 @@ aliases:
 ## Public container images
 
 Chainguard offers a collection of images that are publicly available, don't require authentication, and are free to use by anyone. However, logging in with a Chainguard account and authenticating when pulling from the registry gives you access to the Chainguard Console, and provides a mechanism for Chainguard to contact you if there are any issues with images you are pulling. This may enable Chainguard to notify you of upcoming deprecations, changes in behavior, critical vulnerabilities and remediations for images you have recently pulled.
+
+## Quickstart: pull your first container
+
+These steps take you from nothing to a container image on your machine. Everything after this section covers the cases that need more than a local pull — CI systems, Kubernetes clusters, and registry mirrors.
+
+Before you start, [sign up for a Chainguard account](#signing-up) and [install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/), Chainguard's command-line tool.
+
+1. Configure the credential helper:
+
+    ```sh
+    chainctl auth configure-docker
+    ```
+
+    This points your Docker configuration at `chainctl` for `cgr.dev` credentials, then opens a browser window to authenticate you. You don't need to run `chainctl auth login` first; `configure-docker` authenticates you when no valid token is available. For headless machines and other login flows, refer to [Authentication options for `chainctl`](/platform/chainctl-usage/authentication-options/).
+
+2. Find the name of your organization:
+
+    ```sh
+    chainctl iam organizations list
+    ```
+
+3. Pull an image, replacing `$ORGANIZATION` with the name from the previous step:
+
+    ```sh
+    docker pull cgr.dev/$ORGANIZATION/python:latest
+    ```
+
+To see which repositories your organization can pull, run `chainctl images repos list`. To browse the full catalog, visit the [Chainguard Containers Directory](https://images.chainguard.dev/).
 
 ## Signing up
 
@@ -68,6 +96,30 @@ Pulls authenticated in this way are associated with a Chainguard identity, which
 You can also export the pull token details into environment variables for
 [authentication in automated
 systems](/chainguard/containers/features/packages/private-apk-repos/#pull-token-automation).
+
+### Using a pull token with Podman, Helm, and other tools
+
+The `docker login` command that `chainctl auth configure-docker --pull-token` prints contains the credentials for the token. The username is the Chainguard identity associated with the token, and the password is the token itself:
+
+```sh
+docker login "cgr.dev" \
+  --username "45a0c61ea6fd977f050c5fb9ac06a69eed764595/095b0c7ea9d68679" \
+  --password "eyJhbGciOiJSUzI1NiJ9..."
+```
+
+Save that pair and pass it to any tool that logs in to an OCI registry. For example, Podman:
+
+```sh
+podman login cgr.dev --username "$CHAINGUARD_IDENTITY" --password "$CHAINGUARD_TOKEN"
+```
+
+Or Helm:
+
+```sh
+helm registry login cgr.dev --username "$CHAINGUARD_IDENTITY" --password "$CHAINGUARD_TOKEN"
+```
+
+The same username and password work with registry mirroring tools such as Artifactory. Refer to the [pull-through guides](/chainguard/containers/chainguard-registry/pull-through-guides/) for tool-specific instructions.
 
 ### Note on multiple pull tokens
 


### PR DESCRIPTION
Fixes [DOCS-154](https://linear.app/chainguard/issue/DOCS-154/add-a-pull-your-first-image-quickstart-to-the-registry).

## Why

The registry authentication page never showed a plain `docker pull`. Its only three examples sat inside GitHub Actions, CircleCI, and Entra ID YAML blocks, so a reader pulling to a laptop found nothing that applied to them. One user in the Kapa data put it directly:

> How can I actually pull a chainguard image? I can see the documentation on logging in with chainctl, and can list images, but I don't see anything related to actually pulling images?

Authentication and pulling was the largest topic in Kapa's July 2026 export — 41 threads from 34 users out of 328 total. Kapa answered them from the support knowledge base 98 times, against 22 citations of this page.

## What changed

One file, two additions. No existing section was moved or reworded.

**A three-step quickstart**, placed after "Public container images": configure the credential helper, find your organization name, pull `cgr.dev/$ORGANIZATION/python:latest`. It links onward to the pull-token, CI, and Kubernetes sections for everything else.

**A pull-token subsection** for the adjacent gap. About a quarter of those threads wanted a plain username and password for `podman login`, `helm registry login`, or Artifactory. The page documented pull tokens but never named them as the answer to "what username and password do I type?" The new subsection does, and adds the Podman and Helm commands.

## On the `chainctl auth login` question

`chainctl auth configure-docker` runs its own authentication flow when no valid token exists, so `chainctl auth login` is not a prerequisite. Verified from a logged-out state — `chainctl auth status` reported `Valid | False`:

```
$ chainctl auth configure-docker --headless
Credential helper already configured for cgr.dev
Authenticating...
Visit this URL on any device with a browser to authenticate: https://issuer.enforce.dev/oauth?...
```

It writes the credential helper config first, then authenticates. `--headless` only sent the device-flow URL to stdout instead of opening a browser; the default flow behaves the same way.

The support KB article states **"Both steps are required."** That headline is wrong, and the quickstart now says so explicitly rather than leaving the contradiction implicit.

Worth being precise about, because the article errs in only one direction: its supporting sentence — that running `chainctl auth login` alone does *not* configure Docker — is **correct**, and worth keeping. The asymmetry:

| Command run alone | Result |
| --- | --- |
| `chainctl auth login` | Not enough. Authenticates, but doesn't configure Docker. |
| `chainctl auth configure-docker` | Sufficient. Configures Docker and authenticates if needed. |

Filed as [SUP-699](https://linear.app/chainguard/issue/SUP-699/correct-the-both-steps-are-required-claim-in-the-cgrdev-authentication) with Support, who own the article.

> **Note:** the commit message on this branch paraphrases the article as claiming "`configure-docker` alone is insufficient." That paraphrase came from the DOCS-154 description; the article doesn't literally say it. The substantive finding is unchanged. Left unamended rather than force-pushing over a paraphrase.

Three pages still show `chainctl auth login` immediately before `configure-docker` for the local-user case (the `chainctl` install page and both Helm chart pages). Running both is harmless, so those pages are redundant rather than wrong. Left alone here; raised for team discussion in [DOCS-162](https://linear.app/chainguard/issue/DOCS-162/discuss-three-pages-tell-readers-to-run-chainctl-auth-login-before).

## Testing

- `npx hugo` builds clean.
- Checked the rendered HTML: the ordered list produces three `<li>` elements each containing a `<pre><code class="language-sh">` child, with no stray indented code blocks.
- All four internal link targets resolve in the built output: `#signing-up`, `/platform/chainctl-usage/how-to-install-chainctl/`, `/platform/chainctl-usage/authentication-options/`, and `/chainguard/containers/chainguard-registry/pull-through-guides/`.
- Deploy preview checked visually.
- `chainctl auth configure-docker` behavior verified live, as described earlier.
- `chainctl iam organizations list` and `chainctl images repos list` confirmed against the generated `chainctl` reference docs. The `helm registry login` form matches the existing example in `use-chainguard-helm-charts`. **The Podman and authenticated-pull commands were not run live**, since doing so would have meant minting a pull token.

---
Created in collaboration with Claude Code running Opus 5 on 2026-08-31.
