### PR TITLE
Adding in JFrog Project ID details

### DIFF
--- a/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
+++ b/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
@@ -80,6 +80,7 @@ If you set **Project ID** to `chainguard` when creating the repository, omit tha
 ```sh
 docker pull <my-project>.jfrog.io/cgr-public/go
 ```
+
 Be sure the `docker pull` command you run includes the name of your project as well as your own repository key in place of `cgr-public`, if different.
 
 ## Setting up Artifactory as a pull-through cache for production containers

--- a/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
+++ b/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
@@ -53,7 +53,8 @@ To set up a remote repository in Artifactory from which you can pull Chainguard 
 This takes you to a **Basic** configuration tab where you can enter the following details for your new remote repository:
 
 * **Repository Key** — This is the name used to refer to your repository. You can choose whatever name you like here, but this guide's examples use the name `cgr-public`.
-* **URL** — This must be set to `https://cgr.dev/`.
+* **URL** — This must be set to `https://cgr.dev/`. This field **must not** include additional path components — setting it to something like `https://cgr.dev/chainguard/` will cause pulls to fail with a `manifest unknown` error. To shorten the pull path, use the **Project ID** field described below instead.
+* **Project ID** — Optional. If you set this to `chainguard`, Artifactory prepends that path segment to upstream requests and your users can omit it from their pull commands. Leave it empty to keep the `chainguard/` prefix in the pull path, as this guide's examples do.
 * **Include Patterns** — Ensure that you use the default value (`**/*`) in this field.
 * **Enable Token Authentication** — Ensure this setting (under **Docker Settings**) is enabled. This is required, as you must authenticate to the remote repository in order to pull Chainguard Containers through it.
 * **Block Mismatching Mime Types** — In the **Advanced** configuration tab, ensure that this option is checked.
@@ -74,7 +75,14 @@ After running the `docker login` command, you will be able to pull a Chainguard 
 docker pull <my-project>.jfrog.io/cgr-public/chainguard/go
 ```
 
+If you set **Project ID** to `chainguard` when creating the repository, omit that segment:
+
+```sh
+docker pull <my-project>.jfrog.io/cgr-public/go
+```
+
 Be sure the `docker pull` command you run includes the name of your project as well as your own repository key in place of `cgr-public`, if different.
+
 
 ## Setting up Artifactory as a pull-through cache for production containers
 
@@ -114,7 +122,8 @@ After noting your credentials, you can begin setting up an Artifactory repositor
 Next, enter the following details for your new remote repository in the **Basic** configuration tab:
 
 * **Repository Key** — Choose whatever name you like here, but this guide's examples use the name `cgr-private`.
-* **URL** — This must be set to `https://cgr.dev/`.
+* **URL** — This must be set to `https://cgr.dev/`. This field **must not** include additional path components — setting it to something like `https://cgr.dev/<organization>/` will cause pulls to fail with a `manifest unknown` error. To remove the organization from the pull path, use the **Project ID** field described below instead.
+* **Project ID** — Optional. Set this to your organization's name (for example, `example.com`) and Artifactory prepends it to upstream requests, letting your users omit it from their pull commands. Because this field is set per repository, you need one remote repository per Chainguard organization if you pull from more than one.
 * **User Name** — Enter the `<pull_token_ID>` value you noted from the `docker login` command.
 * **Password / Access Token** — Enter the `<password>` value you noted from the `docker login` command.
 * **Include Patterns** — Ensure that you use the default value (`**/*`) in this field.
@@ -135,6 +144,12 @@ After running the `docker login` command, you will be able to pull Chainguard Pr
 
 ```sh
 docker pull <my-project>.jfrog.io/cgr-private/<organization>/chainguard-base:latest
+```
+
+If you set **Project ID** to your organization's name when creating the repository, omit the organization from the pull path:
+
+```sh
+docker pull <my-project>.jfrog.io/cgr-private/chainguard-base:latest
 ```
 
 Be sure the `docker pull` command you run includes the name of your Artifactory project and the name of your organization's registry. Additionally, if you entered a different repository key in the setup section, use it in place of `cgr-private`.
@@ -185,13 +200,16 @@ docker pull <my-project>.jfrog.io/cgr-virt/<organization>/chainguard-base:latest
 
 For both of these commands, be sure the `docker pull` command you run includes the name of your Artifactory project and the name of your organization's registry. Also, if you used a different repository key, substitute it for `cgr-virt` in the previous commands.
 
+> **Note**: Take care when aggregating remote repositories that each set a **Project ID**. If both the free and private remotes strip their path prefixes, image names from different sources collapse into the same namespace within the virtual repository — for example, both `chainguard/go` and `<organization>/go` would resolve as `go`, and the virtual repository's resolution order determines which one you get.
+
+
 ## Debugging pull-through from Chainguard’s registry to Artifactory
 
 If you run into issues when trying to pull images from Chainguard's container registry to Artifactory, ensure the following requirements are met:
 
 * Ensure that all Containers [network requirements](/chainguard/containers/network-requirements/) are met.
 * If you attempt to pull a nonexistent image via pull-through, Artifactory will also make calls to `chainguard.dev` and `www.chainguard.dev`. Calls to these domains should not occur when pulling a valid image.
-* When configuring a remote Artifactory repository, ensure that the **URL** field is set to `https://cgr.dev/`. This field **must not** contain additional components.
+* When configuring a remote Artifactory repository, ensure that the **URL** field is set to `https://cgr.dev/`. This field **must not** contain additional components. Adding a path such as `https://cgr.dev/<organization>/` produces a `manifest unknown: The named manifest is not known to the registry` error, because Artifactory ignores the path portion of a Docker remote's URL. If your goal is to shorten the pull path, set the repository's **Project ID** to your organization's name instead.
 * You can troubleshoot by running `docker login` from another node (using the Artifactory pull token credentials) and then trying to pull a Container from `cgr.dev/chainguard/<image name>` or `cgr.dev/<organization>/<image name>`.
 * It may help to [clear the Artifactory cache](https://jfrog.com/help/r/artifactory-cleanup-best-practices/clearing-an-oversized-cache).
 * Your Artifactory repository may be misconfigured. In this case, create and configure a new remote Artifactory repository to test with.

--- a/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
+++ b/content/chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/index.md
@@ -80,9 +80,7 @@ If you set **Project ID** to `chainguard` when creating the repository, omit tha
 ```sh
 docker pull <my-project>.jfrog.io/cgr-public/go
 ```
-
 Be sure the `docker pull` command you run includes the name of your project as well as your own repository key in place of `cgr-public`, if different.
-
 
 ## Setting up Artifactory as a pull-through cache for production containers
 
@@ -201,7 +199,6 @@ docker pull <my-project>.jfrog.io/cgr-virt/<organization>/chainguard-base:latest
 For both of these commands, be sure the `docker pull` command you run includes the name of your Artifactory project and the name of your organization's registry. Also, if you used a different repository key, substitute it for `cgr-virt` in the previous commands.
 
 > **Note**: Take care when aggregating remote repositories that each set a **Project ID**. If both the free and private remotes strip their path prefixes, image names from different sources collapse into the same namespace within the virtual repository — for example, both `chainguard/go` and `<organization>/go` would resolve as `go`, and the virtual repository's resolution order determines which one you get.
-
 
 ## Debugging pull-through from Chainguard’s registry to Artifactory
 


### PR DESCRIPTION
Updating our EDU docs for setting up JFrog artifactory with Project ID to simplify the URL to include the organization so that users don't have to know the exact URL.
This will simplify the URL from
`docker pull <my-project>.jfrog.io/cgr-private/<organization>/chainguard-base:latest`
to 
`docker pull <my-project>.jfrog.io/cgr-private/chainguard-base:latest`