### PR TITLE
docs: stop presenting chainctl auth login as a configure-docker prerequisite

### DIFF
--- a/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-09-01T13:37:32+00:00
+lastmod: 2026-09-01T13:50:18+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "Product"]
 images: []
@@ -79,11 +79,10 @@ global:
 To begin, generate a pull token.
 
 ```sh
-chainctl auth login
 chainctl auth configure-docker --pull-token --save --ttl=24h
 ```
 
-`chainctl auth login` is optional here; `configure-docker` authenticates you when no valid token is available.
+You don't need to run `chainctl auth login` first; `configure-docker` authenticates you when no valid token is available.
 
 This token expires in 24 hours by default, which can be modified using the
 `--ttl` flag. It sets the duration for the validity of the token. The maximum

--- a/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-09-01T13:37:32+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "Product"]
 images: []
@@ -76,12 +76,14 @@ global:
 
 ### Deploy a Chainguard Helm chart using a Kubernetes pull secret
 
-To begin, authenticate with chainctl and generate a pull token.
+To begin, generate a pull token.
 
 ```sh
 chainctl auth login
 chainctl auth configure-docker --pull-token --save --ttl=24h
 ```
+
+`chainctl auth login` is optional here; `configure-docker` authenticates you when no valid token is available.
 
 This token expires in 24 hours by default, which can be modified using the
 `--ttl` flag. It sets the duration for the validity of the token. The maximum

--- a/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-01T13:37:32+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "iamguarded", "Product"]
 images: []
@@ -94,12 +94,14 @@ global:
 
 ### Deploy a Chainguard Helm chart using a Kubernetes pull secret
 
-To begin, authenticate with chainctl and generate a pull token.
+To begin, generate a pull token.
 
 ```sh
 chainctl auth login
 chainctl auth configure-docker --pull-token --save --ttl=24h
 ```
+
+`chainctl auth login` is optional here; `configure-docker` authenticates you when no valid token is available.
 
 This token expires in 24 hours by default, which can be modified using the
 `--ttl` flag. It sets the duration for the validity of the token. The maximum

--- a/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-09-01T13:37:32+00:00
+lastmod: 2026-09-01T13:50:18+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "iamguarded", "Product"]
 images: []
@@ -97,11 +97,10 @@ global:
 To begin, generate a pull token.
 
 ```sh
-chainctl auth login
 chainctl auth configure-docker --pull-token --save --ttl=24h
 ```
 
-`chainctl auth login` is optional here; `configure-docker` authenticates you when no valid token is available.
+You don't need to run `chainctl auth login` first; `configure-docker` authenticates you when no valid token is available.
 
 This token expires in 24 hours by default, which can be modified using the
 `--ttl` flag. It sets the duration for the validity of the token. The maximum

--- a/content/platform/chainctl-usage/how-to-install-chainctl.md
+++ b/content/platform/chainctl-usage/how-to-install-chainctl.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Learn how to install chainctl, Chainguard's command-line interface for managing container images, IAM resources, and security configurations across platforms"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2026-08-25T15:44:47+00:00
+lastmod: 2026-09-01T13:37:32+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -251,11 +251,10 @@ For a persistent setup, add that directory to your user or system `PATH` via the
 #### 2. Authenticate and configure Docker credentials:
 
 ```PowerShell
-chainctl auth login
 chainctl auth configure-docker
 ```
 
-`chainctl auth configure-docker` creates `docker-credential-cgr.exe` next to `chainctl.exe` and updates your Docker config to use it. Following this, you can verify Docker pulls from Chainguard by pulling a private image.
+`chainctl auth configure-docker` creates `docker-credential-cgr.exe` next to `chainctl.exe` and updates your Docker configuration to use it. You don't need to run `chainctl auth login` first; `configure-docker` authenticates you when no valid token is available. Following this, you can verify Docker pulls from Chainguard by pulling a private image.
 
 ## Updating `chainctl`
 


### PR DESCRIPTION
Aligns three pages with the `chainctl auth configure-docker` behavior established in #3876 (DOCS-154).

`chainctl auth configure-docker` authenticates on its own when no valid token exists, so `chainctl auth login` is not a prerequisite. All three pages now carry the same sentence the registry authentication page uses:

> You don't need to run `chainctl auth login` first; `configure-docker` authenticates you when no valid token is available.

Note the asymmetry that makes this a one-directional fix:

| Command run alone | Result |
| --- | --- |
| `chainctl auth login` | Not enough. Authenticates, but doesn't configure Docker. |
| `chainctl auth configure-docker` | Sufficient. Configures Docker and authenticates if needed. |

Pairing the two commands was redundant, not wrong — nothing broke for a reader who followed these pages literally. The problem was the implied prerequisite, which contradicted the registry authentication page.

## Changes

The redundant `chainctl auth login` line is removed from all three pages:

- `content/platform/chainctl-usage/how-to-install-chainctl.md` (Windows section)
- `content/chainguard/containers/how-to-use/use-chainguard-helm-charts/index.md`
- `content/chainguard/containers/how-to-use/use-chainguard-iamguarded-helm-charts/index.md`

## Why the Helm pages were safe to change

DOCS-162 held the two Helm pages back on an open question: `chainctl auth login` might have been doing real work by forcing the org/folder selection prompt that those procedures depend on. Settled by live test on 2026-09-01.

From a fully logged-out state (`chainctl auth status` → `Valid | False`), running only the documented command:

```
$ chainctl auth configure-docker --pull-token --save --ttl=24h
Opening browser to https://issuer.enforce.dev/oauth?...

  > [<org>] ...
    ├ [charts]
    ├ [iamguarded-charts]
    ...
    ↑/k up • ↓/j down • / filter • q quit • ? more
```

It authenticated and then raised the folder prompt on its own, with no `chainctl auth login` involved. The prompt is driven entirely by `configure-docker`. Two supporting details from `--help`: `configure-docker` has its own `--parent` flag ("The IAM organization or folder with which the pull-token identity is associated"), and `chainctl auth login` has no folder concept at all.

The test was stopped at the selection prompt, so no pull token was minted.

## Deliberately not changed

Three CI pages pair the same two commands with `--identity-token`. There, `chainctl auth login` assumes a specific identity and does real work:

- `platform/administration/assumable-ids/identity-examples/jenkins-terraform/index.md`
- `platform/administration/assumable-ids/identity-examples/buildkite-identity.md`
- `platform/administration/assumable-ids/identity-examples/bitbucket-identity.md`

A bare grep for `chainctl auth login` returns 12+ files and is not a safe work-list for this change.

## Testing

`npm run build` completes with exit 0 over 1647 pages, with only the expected Dart Sass `@import` deprecation warnings. The new text renders correctly on all three pages. A `check-related-pages` scan found no other page that frames `auth login` as a prerequisite to `configure-docker`, and no bare `auth login` + `configure-docker` pair remains anywhere in `content/`.

Resolves DOCS-162. SUP-699 corrects the same misconception in the Zendesk KB article, which is the likely origin of the pattern.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-01.
