### PR TITLE
docs: add a Get support page

### DIFF
--- a/content/chainguard/containers/about/catalog-starter.md
+++ b/content/chainguard/containers/about/catalog-starter.md
@@ -4,7 +4,7 @@ linktitle: "Catalog Starter"
 type: "article"
 description: "Learn about Chainguard Catalog Starter, an offering allowing teams to try out five Chainguard container images for free."
 date: 2026-03-09T07:52:00+02:00
-lastmod: 2026-08-18T15:48:57+00:00
+lastmod: 2026-09-01T16:09:44+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -120,7 +120,7 @@ Catalog Starter allows users to try out Chainguard Containers, but it comes with
     * [FIPS-validated images](/chainguard/fips/fips-images/)
     * Images that fall under the [EOL grace period](/chainguard/containers/features/eol-gp-overview/#understanding-chainguards-eol-grace-period)
     * Images whose software is part of [Chainguard EmeritOSS](https://github.com/chainguard-forks/)
-* Teams using Chainguard Catalog Starter will not have access to the support services available to paying customers: they will not be added to Chainguard's support platform, be able to create support tickets, or have access to root cause analysis (RCA) or phone escalations.
+* Teams using Chainguard Catalog Starter will not have access to the support services available to paying customers: they will not be added to Chainguard's support platform, be able to create support tickets, or have access to root cause analysis (RCA).
     * Catalog Starter users will still have access to Chainguard resources like our [documentation](https://edu.chainguard.dev/), [courses](https://courses.chainguard.dev/), the [Community Slack channel](https://www.chainguard.dev/unchained/the-chainguard-slack-community-is-here), and the [public support knowledge base](https://support.chainguard.dev/hc/en-us).
 * [Chainguard's CVE SLA](https://www.chainguard.dev/legal/cve-policy) does not apply to container images obtained through Catalog Starter.
 * The free plan does not support user management or role-based access control (RBAC). If a colleague from the same company signs up for Catalog Starter, your organization's administrator receives an email with instructions for adding them. You cannot add users directly. Any additional users in your organization have access to the five images selected by the first user and cannot change them.

--- a/content/get-started/_index.md
+++ b/content/get-started/_index.md
@@ -3,7 +3,7 @@ title: "Get started"
 lead: "New to Chainguard? Start here. Orient yourself, then pick the path that matches what you're trying to do — build with containers, build with libraries, evaluate trust, or migrate an organization."
 description: "Get started with Chainguard: orient yourself, then choose your path — build with containers, build with libraries, evaluate trust, or migrate an existing organization."
 date: 2026-06-09T08:48:23+00:00
-lastmod: 2026-09-01T15:25:57+00:00
+lastmod: 2026-09-01T16:18:53+00:00
 draft: false
 images: []
 weight: 1
@@ -33,4 +33,4 @@ Already convinced and ready to move existing workloads over? Step through the [m
 
 ## Get help
 
-Stuck on something the documentation doesn't cover? [Get support](/get-started/get-support/) explains which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do.
+Stuck on something the documentation doesn't cover? [Get support](/get-started/get-support/) explains what to check first, which channel handles your kind of request, and how to open a support ticket when you need one.

--- a/content/get-started/_index.md
+++ b/content/get-started/_index.md
@@ -3,7 +3,7 @@ title: "Get started"
 lead: "New to Chainguard? Start here. Orient yourself, then pick the path that matches what you're trying to do — build with containers, build with libraries, evaluate trust, or migrate an organization."
 description: "Get started with Chainguard: orient yourself, then choose your path — build with containers, build with libraries, evaluate trust, or migrate an existing organization."
 date: 2026-06-09T08:48:23+00:00
-lastmod: 2026-08-26T13:07:29+00:00
+lastmod: 2026-09-01T15:25:57+00:00
 draft: false
 images: []
 weight: 1
@@ -30,3 +30,7 @@ Already adopted Chainguard and need to bring your developers on board? Learn wha
 ## Migrate an organization
 
 Already convinced and ready to move existing workloads over? Step through the [migration guides](/get-started/migration/).
+
+## Get help
+
+Stuck on something the documentation doesn't cover? [Get support](/get-started/get-support/) explains which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do.

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -5,7 +5,7 @@ lead: "Chainguard offers several ways to get help, and the right one depends on 
 description: "Get help from Chainguard: choose the right support channel, meet the prerequisites for the support portal, and open a ticket a support engineer can act on."
 type: "article"
 date: 2026-09-01T00:00:00+00:00
-lastmod: 2026-09-01T00:00:00+00:00
+lastmod: 2026-09-01T16:02:47+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -45,7 +45,7 @@ Many questions already have a published answer you can find in seconds:
 
 The support portal has two prerequisites.
 
-First, your organization needs a paid plan. Catalog Starter doesn't include support tickets, root cause analysis, or phone escalation. For what the free plan does cover, see [Chainguard Catalog Starter](/chainguard/containers/about/catalog-starter/).
+First, your organization needs a paid plan. Catalog Starter doesn't include support tickets or root cause analysis. For what the free plan does cover, see [Chainguard Catalog Starter](/chainguard/containers/about/catalog-starter/).
 
 Second, your identity has to be linked to an organization. The portal identifies you through your Chainguard Console account, and an unlinked identity produces an error. To check, sign in to the [Chainguard Console](https://console.chainguard.dev) and look for your organization in the left sidebar. If it isn't there, ask an administrator in your organization to invite you, then open the invitation email and complete the setup flow. Signing in without completing that flow leaves your identity unlinked.
 

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -1,0 +1,88 @@
+---
+title: "Get support"
+linktitle: "Get support"
+lead: "Chainguard offers several ways to get help, and the right one depends on your situation. This guide covers which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do."
+description: "Get help from Chainguard: choose the right support channel, meet the prerequisites for the support portal, and open a ticket a support engineer can act on."
+type: "article"
+date: 2026-09-01T00:00:00+00:00
+lastmod: 2026-09-01T00:00:00+00:00
+draft: false
+tags: ["Getting Started"]
+images: []
+weight: 015
+toc: true
+---
+
+When the documentation doesn't answer your question, Chainguard offers several ways to get help. This guide covers which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do.
+
+## Where to send your request
+
+The support portal handles most requests, but it isn't the only route, and for some situations it isn't the right one. Find your situation in the following list:
+
+- **You have a problem with a Chainguard product or with your organization's configuration.** Open a ticket in the [support portal](https://support.chainguard.dev/).
+
+- **You can't sign in to the Chainguard Console, and your organization uses single sign-on — for example, you've lost the device running your authenticator app.** Contact the identity provider administrator at your own organization. When you sign in through Google, GitHub, GitLab, or a corporate identity provider, that provider manages your multi-factor authentication, and Chainguard can neither see it nor change it.
+
+- **You can't sign in at all, so you can't reach the portal.** Email [support@chainguard.dev](mailto:support@chainguard.dev).
+
+- **Your organization uses Catalog Starter.** Use the [knowledge base](https://support.chainguard.dev/hc/en-us), the [community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw), and the free [Chainguard courses](https://courses.chainguard.dev/). Catalog Starter doesn't include ticket access.
+
+- **Your request concerns your subscription or what your organization is licensed for — for example, whether a particular image is included in your entitlements.** Contact your account team, meaning the customer success manager or solutions architect assigned to your organization.
+
+## Before you open a ticket
+
+Many questions already have a published answer you can find in seconds:
+
+- **This documentation site.** Search from the box at the top of any page.
+
+- **Ask AI.** Click **Ask AI** in the upper-right corner of any page on this site and ask your question in plain language. The assistant draws on Chainguard's documentation and support content and cites its sources. Review the answer and its sources before you act on it.
+
+- **The [Chainguard knowledge base](https://support.chainguard.dev/hc/en-us).** Chainguard support engineers publish articles there for problems that come up repeatedly.
+
+## Open a ticket
+
+### Confirm that you can reach the portal
+
+The support portal has two prerequisites.
+
+First, your organization needs a paid plan. Catalog Starter doesn't include support tickets, root cause analysis, or phone escalation. For what the free plan does cover, see [Chainguard Catalog Starter](/chainguard/containers/about/catalog-starter/).
+
+Second, your identity has to be linked to an organization. The portal identifies you through your Chainguard Console account, and an unlinked identity produces an error. To check, sign in to the [Chainguard Console](https://console.chainguard.dev) and look for your organization in the left sidebar. If it isn't there, ask an administrator in your organization to invite you, then open the invitation email and complete the setup flow. Signing in without completing that flow leaves your identity unlinked.
+
+{{< note >}}
+Administrators can invite users from the Console under **Settings > Users > Invite users**, or from the command line. See [How to manage IAM organizations in Chainguard](/platform/administration/iam-organizations/how-to-manage-iam-organizations-in-chainguard/).
+{{< /note >}}
+
+### Submit the request
+
+1. Sign in to the [Chainguard Console](https://console.chainguard.dev).
+
+1. In the left sidebar, click **Support**. You can also go to [support.chainguard.dev](https://support.chainguard.dev/) directly.
+
+1. Fill in the request form. Before you submit, the portal offers relevant documentation and a generated answer. If that resolves your question, you're finished. Otherwise, submit the request as usual.
+
+### If the portal returns an error
+
+Work through the following steps:
+
+1. Open the Console and the support portal in a private browsing window.
+
+1. Clear your browser cache and cookies.
+
+1. Confirm that you're signing in with the same identity you were invited with.
+
+If the error persists, email [support@chainguard.dev](mailto:support@chainguard.dev) with a screenshot of the error, the email address of the account you're trying to use, and the invitation link if you still have it.
+
+## What to include in your request
+
+A support engineer can start on a problem instead of asking you for more information when your request includes:
+
+- Your organization name.
+
+- The image or package name and tag, and the digest if you have it.
+
+- The command you ran and its complete output, including any error message.
+
+- The `chainctl` version, if the problem involves the command-line tool. Run `chainctl version` to get it.
+
+- What you expected to happen instead.

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -1,11 +1,11 @@
 ---
 title: "Get support"
 linktitle: "Get support"
-lead: "Chainguard offers several ways to get help, and the right one depends on your situation. This guide covers which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do."
-description: "Get help from Chainguard: choose the right support channel, meet the prerequisites for the support portal, and open a ticket a support engineer can act on."
+lead: "Chainguard offers several ways to get help, and the right one depends on your situation. This guide covers what to check first, which channel handles your kind of request, and how to open a support ticket when you need one."
+description: "Get help from Chainguard: check the self-service options, choose the right support channel, and open a ticket a support engineer can act on."
 type: "article"
 date: 2026-09-01T00:00:00+00:00
-lastmod: 2026-09-01T16:02:47+00:00
+lastmod: 2026-09-01T16:18:53+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -13,7 +13,17 @@ weight: 015
 toc: true
 ---
 
-When the documentation doesn't answer your question, Chainguard offers several ways to get help. This guide covers which channel handles your kind of request, what you need in place before you can open a support ticket, and what to include when you do.
+When the documentation doesn't answer your question, Chainguard offers several ways to get help. This guide covers what to check first, which channel handles your kind of request, and how to open a support ticket when you need one.
+
+## Before you open a ticket
+
+Many questions already have a published answer you can find in seconds:
+
+- **This documentation site.** Search from the box at the top of any page.
+
+- **Ask AI.** Click **Ask AI** in the upper-right corner of any page on this site and ask your question in plain language. The assistant draws on Chainguard's documentation and support content and cites its sources. Review the answer and its sources before you act on it.
+
+- **The [Chainguard knowledge base](https://support.chainguard.dev/hc/en-us).** Chainguard support engineers publish articles there for problems that come up repeatedly.
 
 ## Where to send your request
 
@@ -28,16 +38,6 @@ The support portal handles most requests, but it isn't the only route, and for s
 - **Your organization uses Catalog Starter.** Use the [knowledge base](https://support.chainguard.dev/hc/en-us), the [community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw), and the free [Chainguard courses](https://courses.chainguard.dev/). Catalog Starter doesn't include ticket access.
 
 - **Your request concerns your subscription or what your organization is licensed for — for example, whether a particular image is included in your entitlements.** Contact your account team, meaning the customer success manager or solutions architect assigned to your organization.
-
-## Before you open a ticket
-
-Many questions already have a published answer you can find in seconds:
-
-- **This documentation site.** Search from the box at the top of any page.
-
-- **Ask AI.** Click **Ask AI** in the upper-right corner of any page on this site and ask your question in plain language. The assistant draws on Chainguard's documentation and support content and cites its sources. Review the answer and its sources before you act on it.
-
-- **The [Chainguard knowledge base](https://support.chainguard.dev/hc/en-us).** Chainguard support engineers publish articles there for problems that come up repeatedly.
 
 ## Open a ticket
 

--- a/content/platform/console/use-chainguard-notifications/index.md
+++ b/content/platform/console/use-chainguard-notifications/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to configure Chainguard Notifications"
 lead: "A primer on how to configure Chainguard Notifications in the Chainguard Console"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-08-17T15:44:58+00:00
+lastmod: 2026-09-01T15:25:57+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -82,14 +82,18 @@ Include the private channel in your actions in the next section.
 
 Email notifications are not yet available to all customers.
 
+Use this procedure to change which notification topics are sent, change who receives them, or unsubscribe an address from them entirely.
+
 To perform this task, you must use a user account for the Chainguard Console that is configured with the *owner* role for the organization. Then, follow these steps:
 
 1. In the Chainguard Console, open **Settings \> Activity Center**.
 
 1. Next to the **Email** section heading, click **Edit**.
-  You can then change settings for what notification topics will be sent and to whom, either an individual or perhaps to an email alias for a group.
+  You can then change settings for what notification topics will be sent and to whom, either an individual or perhaps to an email alias for a group. To unsubscribe an address, remove it here.
 
 1. When you are done, click **Save changes**.
+
+If you don't have the *owner* role, ask an owner in your organization to make the change for you. If you can't reach an owner, see [Get support](/get-started/get-support/).
 
 ## Notification categories
 


### PR DESCRIPTION
Adds `/get-started/get-support/`. edu had no page about how to get help from Chainguard — no file under `content/` matched `*support*`, `*ticket*`, or `*help*`.

In July's Kapa data, "Submitting Support Tickets" ran 8 threads from 6 unique users. Kapa cited no edu page in 7 of the 8 and hedged or deflected in 7 of 8, the worst ratio of any cluster in the dataset, falling back to two Zendesk articles instead. This gives Kapa and site search an edu page to answer from, and gives customers the portal's prerequisites before they hit an error trying to reach it.

## What the page covers

- **Where to send your request.** The support portal; your own identity provider administrator for SSO sign-in problems; `support@chainguard.dev` when you can't sign in at all; community resources for Catalog Starter, which doesn't include ticket access; and your account team for subscription questions.
- **Before you open a ticket.** Site search, Ask AI, and the knowledge base.
- **Open a ticket.** The two prerequisites — a paid plan, and an identity linked to an organization — then the steps, and what to do when the portal still returns an error.
- **What to include in your request.**

The page documents the process for contacting support rather than indexing individual issues. DOCS-156 listed recurring cases as candidate content (2FA recovery, organization rename, domain change, SLA reporting); those are support-owned procedures that would go stale on a docs page. Two examples survive, both because they disambiguate a routing boundary rather than document a procedure.

## Also in this PR

- Adds "unsubscribe" wording to the *Manage email notifications* procedure and routes readers without the `owner` role to an owner, then to the new page. The Kapa data included three consecutive follow-ups on a single unresolved unsubscribe ticket.
- Adds a "Get help" entry to the Get started landing page.

No menu configuration was needed. The sidebar entry comes from the section weight.

## Verification

`npm run build` completes clean, with only the pre-existing Sass deprecation warnings. Checked in the local dev server: the page renders, the `note` shortcode renders, the TOC builds, and every internal link resolves in `public/`.

## Notes for reviewers

- The page says click **Ask AI**, which matches the widget's actual button label on this site (`data-button-text="Ask AI"` in `layouts/partials/head/script-header.html`). The support announcement article calls it "Ask Linky AI." If support prefers the branded name, that's a deliberate change rather than a correction.
- The knowledge base article on resetting MFA is access-restricted, so the page states the SSO boundary in its own words rather than linking to it.
- The account team routing line is the least-sourced statement on the page and is the one most worth a support review.

Roughly a dozen existing pages link straight to `support.chainguard.dev`. Routing those through this page is a coherent follow-up, left out here to keep the diff reviewable.

Resolves DOCS-156.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-01.
