### PR TITLE
docs: point support links at Get support, and welcome attachments

### DIFF
--- a/content/chainguard/containers/about/images-testing.md
+++ b/content/chainguard/containers/about/images-testing.md
@@ -9,7 +9,7 @@ aliases:
 type: "article"
 description: "A conceptual article outlining testing requirements for Chainguard Containers."
 date: 2024-03-21T11:07:52+02:00
-lastmod: 2026-02-17T11:07:52+02:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Overview", "Chainguard Containers"]
 images: []
@@ -76,4 +76,4 @@ Additionally, Chainguard performs automated tests on every *package* included in
 
 Chainguard's rigorous container image testing standards and frequent updates ensure that they will work as expected with few (and often zero) vulnerabilities. If you're having trouble working with a specific Chainguard Container, we encourage you to check out its relevant Overview page in our [Chainguard Containers Directory](https://images.chainguard.dev/directory?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-images-testing).
 
-For general help with using Chainguard Containers, you can refer to our [Debugging distroless container images](/chainguard/containers/debugging-distroless-images/) guide or our [Chainguard Containers FAQs](/chainguard/containers/faq/). For help with specific issues or questions not covered in these resources, please [contact our support team](https://support.chainguard.dev?utm=docs).
+For general help with using Chainguard Containers, you can refer to our [Debugging distroless container images](/chainguard/containers/debugging-distroless-images/) guide or our [Chainguard Containers FAQs](/chainguard/containers/faq/). For help with specific issues or questions not covered in these resources, please [contact our support team](https://support.chainguard.dev?utm=docs). See [Get support](/get-started/get-support/) for the portal's prerequisites.

--- a/content/chainguard/containers/about/images-testing.md
+++ b/content/chainguard/containers/about/images-testing.md
@@ -9,7 +9,7 @@ aliases:
 type: "article"
 description: "A conceptual article outlining testing requirements for Chainguard Containers."
 date: 2024-03-21T11:07:52+02:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["Overview", "Chainguard Containers"]
 images: []
@@ -76,4 +76,4 @@ Additionally, Chainguard performs automated tests on every *package* included in
 
 Chainguard's rigorous container image testing standards and frequent updates ensure that they will work as expected with few (and often zero) vulnerabilities. If you're having trouble working with a specific Chainguard Container, we encourage you to check out its relevant Overview page in our [Chainguard Containers Directory](https://images.chainguard.dev/directory?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-images-testing).
 
-For general help with using Chainguard Containers, you can refer to our [Debugging distroless container images](/chainguard/containers/debugging-distroless-images/) guide or our [Chainguard Containers FAQs](/chainguard/containers/faq/). For help with specific issues or questions not covered in these resources, please [contact our support team](https://support.chainguard.dev?utm=docs). See [Get support](/get-started/get-support/) for the portal's prerequisites.
+For general help with using Chainguard Containers, you can refer to our [Debugging distroless container images](/chainguard/containers/debugging-distroless-images/) guide or our [Chainguard Containers FAQs](/chainguard/containers/faq/). For help with specific issues or questions not covered in these resources, please [contact our support team](https://support.chainguard.dev?utm=docs). Refer to [Get support](/get-started/get-support/) for the portal's prerequisites.

--- a/content/chainguard/containers/about/versions.md
+++ b/content/chainguard/containers/about/versions.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -132,7 +132,7 @@ This change ensures that Chainguard can provide the most up-to-date patches to
 all packages for our Containers customers. Note that specific package versions
 can be made available in Production Containers. If you have a request for a
 specific package version, please [contact
-support](https://support.chainguard.dev?utm=docs). See [Get
+support](https://support.chainguard.dev?utm=docs). Refer to [Get
 support](/get-started/get-support/) for the portal's prerequisites.
 
 ## Versions available by tier

--- a/content/chainguard/containers/about/versions.md
+++ b/content/chainguard/containers/about/versions.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2025-11-28T06:30:00+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -132,7 +132,8 @@ This change ensures that Chainguard can provide the most up-to-date patches to
 all packages for our Containers customers. Note that specific package versions
 can be made available in Production Containers. If you have a request for a
 specific package version, please [contact
-support](https://support.chainguard.dev?utm=docs).
+support](https://support.chainguard.dev?utm=docs). See [Get
+support](/get-started/get-support/) for the portal's prerequisites.
 
 ## Versions available by tier
 

--- a/content/chainguard/containers/features/ca-docs/custom-assembly-gitops.md
+++ b/content/chainguard/containers/features/ca-docs/custom-assembly-gitops.md
@@ -4,7 +4,7 @@ linktitle: "Manage with GitOps"
 type: "article"
 description: "How to use GitOps to manage Custom Assembly resources."
 date: 2026-01-29T11:07:52+02:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
 images: []
@@ -325,4 +325,4 @@ To test your GitHub Action:
 * [apko overview](/open-source/build-tools/apko/overview/)
 * [Assumable identity documentation](/chainguard/administration/assumable-ids/assumable-ids/)
 * [Demo Repository: custom-assembly-as-code](https://github.com/chainguard-demo/custom-assembly-as-code)
-* [Chainguard Support](https://support.chainguard.dev)
+* [Get support](/get-started/get-support/)

--- a/content/chainguard/containers/features/unique-tags/index.md
+++ b/content/chainguard/containers/features/unique-tags/index.md
@@ -13,7 +13,7 @@ aliases:
 type: "article"
 description: "Learn about Chainguard's unique tags feature for production container images, enabling precise version tracking and automated deployment workflows with timestamped tags"
 date: 2024-02-29T08:49:31+00:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -28,7 +28,7 @@ Chainguard's unique tags feature provides unique timestamped tags for every cont
 
 To help with cases like this, Chainguard offers Unique Tags for private registries. Unique Tags are ideal for organizations that require a strict tag per release or update of their images. They benefit teams looking for precise tracking and management of container images.
 
-Unique Tags are an opt-in feature that is only available for private registries. If your organization is interested in using Unique Tags, please [contact support](https://support.chainguard.dev/) and we will enable this feature for you.
+Unique Tags are an opt-in feature that is only available for private registries. If your organization is interested in using Unique Tags, please [contact support](https://support.chainguard.dev/) and we will enable this feature for you. See [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 This guide provides an overview of what these Unique Tags are, the kinds of problems they aim to solve, and how you can access them in the Chainguard Console.
 

--- a/content/chainguard/containers/features/unique-tags/index.md
+++ b/content/chainguard/containers/features/unique-tags/index.md
@@ -13,7 +13,7 @@ aliases:
 type: "article"
 description: "Learn about Chainguard's unique tags feature for production container images, enabling precise version tracking and automated deployment workflows with timestamped tags"
 date: 2024-02-29T08:49:31+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -28,7 +28,7 @@ Chainguard's unique tags feature provides unique timestamped tags for every cont
 
 To help with cases like this, Chainguard offers Unique Tags for private registries. Unique Tags are ideal for organizations that require a strict tag per release or update of their images. They benefit teams looking for precise tracking and management of container images.
 
-Unique Tags are an opt-in feature that is only available for private registries. If your organization is interested in using Unique Tags, please [contact support](https://support.chainguard.dev/) and we will enable this feature for you. See [Get support](/get-started/get-support/) for the portal's prerequisites.
+Unique Tags are an opt-in feature that is only available for private registries. If your organization is interested in using Unique Tags, please [contact support](https://support.chainguard.dev/) and we will enable this feature for you. Refer to [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 This guide provides an overview of what these Unique Tags are, the kinds of problems they aim to solve, and how you can access them in the Chainguard Console.
 

--- a/content/chainguard/containers/staying-secure/cve-risk.md
+++ b/content/chainguard/containers/staying-secure/cve-risk.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Learn strategies for minimizing CVE risk in container images, including how Chainguard's approach to minimal images and rapid patching helps reduce vulnerabilities"
 date: 2023-11-16T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Conceptual", "Chainguard Containers", "CVE"]
 images: []
@@ -80,7 +80,7 @@ If you're looking for a certain image that isn't included in Chainguard's librar
 
 Wolfi includes a fully declarative build system and provides a high-quality, build-time SBOM as standard for all packages. Its packages are designed to be granular and independent — in order to support minimal images — and uses the proven and reliable `apk` package format.
 
-Please note that as of March of 2024, Chainguard will maintain one version of each Wolfi package at a time. These track the latest version of the upstream software in the package. Chainguard does not provide patch support for previous versions of packages in Wolfi. Existing packages will not be removed from Wolfi and you may continue to use them, but be aware that older packages will no longer be updated and will accrue vulnerabilities over time. This change ensures that Chainguard can provide the most up-to-date patches to all packages for our container images users. Note that specific package versions can be made available in Production Containers, if you have a request for a specific package version, please [contact support](https://support.chainguard.dev?utm=docs).
+Please note that as of March of 2024, Chainguard will maintain one version of each Wolfi package at a time. These track the latest version of the upstream software in the package. Chainguard does not provide patch support for previous versions of packages in Wolfi. Existing packages will not be removed from Wolfi and you may continue to use them, but be aware that older packages will no longer be updated and will accrue vulnerabilities over time. This change ensures that Chainguard can provide the most up-to-date patches to all packages for our container images users. Note that specific package versions can be made available in Production Containers, if you have a request for a specific package version, please [contact support](https://support.chainguard.dev?utm=docs). See [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 ## Learn more
 

--- a/content/chainguard/containers/staying-secure/cve-risk.md
+++ b/content/chainguard/containers/staying-secure/cve-risk.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Learn strategies for minimizing CVE risk in container images, including how Chainguard's approach to minimal images and rapid patching helps reduce vulnerabilities"
 date: 2023-11-16T11:07:52+02:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["Conceptual", "Chainguard Containers", "CVE"]
 images: []
@@ -80,7 +80,7 @@ If you're looking for a certain image that isn't included in Chainguard's librar
 
 Wolfi includes a fully declarative build system and provides a high-quality, build-time SBOM as standard for all packages. Its packages are designed to be granular and independent — in order to support minimal images — and uses the proven and reliable `apk` package format.
 
-Please note that as of March of 2024, Chainguard will maintain one version of each Wolfi package at a time. These track the latest version of the upstream software in the package. Chainguard does not provide patch support for previous versions of packages in Wolfi. Existing packages will not be removed from Wolfi and you may continue to use them, but be aware that older packages will no longer be updated and will accrue vulnerabilities over time. This change ensures that Chainguard can provide the most up-to-date patches to all packages for our container images users. Note that specific package versions can be made available in Production Containers, if you have a request for a specific package version, please [contact support](https://support.chainguard.dev?utm=docs). See [Get support](/get-started/get-support/) for the portal's prerequisites.
+Please note that as of March of 2024, Chainguard will maintain one version of each Wolfi package at a time. These track the latest version of the upstream software in the package. Chainguard does not provide patch support for previous versions of packages in Wolfi. Existing packages will not be removed from Wolfi and you may continue to use them, but be aware that older packages will no longer be updated and will accrue vulnerabilities over time. This change ensures that Chainguard can provide the most up-to-date patches to all packages for our container images users. Note that specific package versions can be made available in Production Containers, if you have a request for a specific package version, please [contact support](https://support.chainguard.dev?utm=docs). Refer to [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 ## Learn more
 

--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -4,7 +4,7 @@ lead: "AI-ready documentation bundle for development"
 description: "Compiled Chainguard documentation optimized for use with AI coding assistants"
 type: "article"
 date: 2025-07-29T10:00:00+00:00
-lastmod: 2026-08-04T16:23:13+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 images: []
 weight: 50
@@ -233,6 +233,6 @@ The bundle is rebuilt weekly. The compilation date appears at the top of the dow
 
 If you have questions or need assistance:
 
-- Visit [Chainguard Support](https://support.chainguard.dev?utm=docs)
+- Read [Get support](/get-started/get-support/) to find the right channel and open a ticket
 - Join our [community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw)
 - Browse the [documentation site](https://edu.chainguard.dev)

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -5,7 +5,7 @@ lead: "Chainguard offers several ways to get help, and the right one depends on 
 description: "Get help from Chainguard: check the self-service options, choose the right support channel, and open a ticket a support engineer can act on."
 type: "article"
 date: 2026-09-01T00:00:00+00:00
-lastmod: 2026-09-01T16:18:53+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -86,3 +86,5 @@ A support engineer can start on a problem instead of asking you for more informa
 - The `chainctl` version, if the problem involves the command-line tool. Run `chainctl version` to get it.
 
 - What you expected to happen instead.
+
+- Anything else you think might help: logs, screenshots, or a short screen recording.

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -5,7 +5,7 @@ lead: "Model Context Protocol server for Chainguard documentation"
 description: "Access Chainguard documentation through MCP for AI assistants and automation"
 type: "article"
 date: 2026-01-02T21:00:00+00:00
-lastmod: 2026-08-04T18:22:06+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 images: []
 weight: 600
@@ -404,6 +404,6 @@ docker pull ghcr.io/chainguard-dev/ai-docs:latest
 
 ## Need help?
 
-- [Chainguard Support](https://support.chainguard.dev?utm=docs)
+- [Get support](/get-started/get-support/)
 - [Community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw)
 - [GitHub Issues](https://github.com/chainguard-dev/edu/issues)

--- a/content/platform/api/api-v2-migration.md
+++ b/content/platform/api/api-v2-migration.md
@@ -6,7 +6,7 @@ linktitle: "API v1 to v2 Migration"
 type: "article"
 description: "How to migrate a direct integration with the Chainguard API from v1 to the GA API v2."
 date: 2026-07-20T00:00:00+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["Chainguard Console", "Procedural"]
 images: []
@@ -195,4 +195,4 @@ This guide. If you're on the account or support team and hit something this guid
 
 - [Chainguard API v2 Tutorial](/platform/api/api-v2-tutorial/): worked examples of the v2 endpoints you'll be migrating to.
 - [Chainguard API v2 Specification](/platform/api/spec-api-v2/): full OpenAPI reference.
-- If you run into issues migrating, reach out to your Chainguard account team or see [Get support](/get-started/get-support/).
+- If you run into issues migrating, reach out to your Chainguard account team or refer to [Get support](/get-started/get-support/).

--- a/content/platform/api/api-v2-migration.md
+++ b/content/platform/api/api-v2-migration.md
@@ -6,7 +6,7 @@ linktitle: "API v1 to v2 Migration"
 type: "article"
 description: "How to migrate a direct integration with the Chainguard API from v1 to the GA API v2."
 date: 2026-07-20T00:00:00+00:00
-lastmod: 2026-08-07T13:02:36+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["Chainguard Console", "Procedural"]
 images: []
@@ -195,4 +195,4 @@ This guide. If you're on the account or support team and hit something this guid
 
 - [Chainguard API v2 Tutorial](/platform/api/api-v2-tutorial/): worked examples of the v2 endpoints you'll be migrating to.
 - [Chainguard API v2 Specification](/platform/api/spec-api-v2/): full OpenAPI reference.
-- Reach out to your Chainguard account team or [Chainguard Support](https://support.chainguard.dev/) if you run into issues migrating.
+- If you run into issues migrating, reach out to your Chainguard account team or see [Get support](/get-started/get-support/).

--- a/content/platform/fips/non-approved-algorithms.md
+++ b/content/platform/fips/non-approved-algorithms.md
@@ -6,7 +6,7 @@ linktitle: "FIPS and non-approved algorithms"
 type: "article"
 description: "Technical deep-dive into Chainguard FIPS images access to non-approved algorithms such as MD5 and SHA1"
 date: 2025-10-28T08:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-01T16:34:19+00:00
 draft: false
 tags: ["FIPS", "MD5"]
 images: []
@@ -111,7 +111,7 @@ Error setting context
 
 There are some caveats and bypasses, some digital signature algorithms allow signing raw data, or prehashed values. Such operations may succeed and raise a dynamic service indicator that such operation is non-approved, as the module cannot guess what data was signed. In such cases, one can calculate the MD5 hash out of band, pad it according to PKCSv1.5 and RSA2048 modulus size, and execute raw RSA signing operation. Such a service is non-approved, and it is not possible to know whether it is being abused to sign an MD5 hash instead of SHA256. *Please don't do this* (your FIPS auditors will require that you change it). Higher level one-shot EVP APIs typically accept a message to sign, perform hashing and padding internally, and correctly block creating MD5 signatures. This again highlights that FIPS is about consent: one should use FIPS cryptography intentionally. This is not a hypothetical example. This technique is used to trick FIPS-approved Cloud KMS in GCP to create valid MD5 and SHA1 signatures, even though the message based API only supports SHA256 signatures and up.
 
-If there is C/C++ software that uses OpenSSL APIs and needs access to MD5 and doesn't support `-fips` property query string, please [open a support request](https://support.chainguard.dev/) for Chainguard engineering to look into adding support.
+If there is C/C++ software that uses OpenSSL APIs and needs access to MD5 and doesn't support `-fips` property query string, please [open a support request](https://support.chainguard.dev/) for Chainguard engineering to look into adding support. See [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 ### Python FIPS and MD5
 

--- a/content/platform/fips/non-approved-algorithms.md
+++ b/content/platform/fips/non-approved-algorithms.md
@@ -6,7 +6,7 @@ linktitle: "FIPS and non-approved algorithms"
 type: "article"
 description: "Technical deep-dive into Chainguard FIPS images access to non-approved algorithms such as MD5 and SHA1"
 date: 2025-10-28T08:00:00+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-01T16:56:22+00:00
 draft: false
 tags: ["FIPS", "MD5"]
 images: []
@@ -111,7 +111,7 @@ Error setting context
 
 There are some caveats and bypasses, some digital signature algorithms allow signing raw data, or prehashed values. Such operations may succeed and raise a dynamic service indicator that such operation is non-approved, as the module cannot guess what data was signed. In such cases, one can calculate the MD5 hash out of band, pad it according to PKCSv1.5 and RSA2048 modulus size, and execute raw RSA signing operation. Such a service is non-approved, and it is not possible to know whether it is being abused to sign an MD5 hash instead of SHA256. *Please don't do this* (your FIPS auditors will require that you change it). Higher level one-shot EVP APIs typically accept a message to sign, perform hashing and padding internally, and correctly block creating MD5 signatures. This again highlights that FIPS is about consent: one should use FIPS cryptography intentionally. This is not a hypothetical example. This technique is used to trick FIPS-approved Cloud KMS in GCP to create valid MD5 and SHA1 signatures, even though the message based API only supports SHA256 signatures and up.
 
-If there is C/C++ software that uses OpenSSL APIs and needs access to MD5 and doesn't support `-fips` property query string, please [open a support request](https://support.chainguard.dev/) for Chainguard engineering to look into adding support. See [Get support](/get-started/get-support/) for the portal's prerequisites.
+If there is C/C++ software that uses OpenSSL APIs and needs access to MD5 and doesn't support `-fips` property query string, please [open a support request](https://support.chainguard.dev/) for Chainguard engineering to look into adding support. Refer to [Get support](/get-started/get-support/) for the portal's prerequisites.
 
 ### Python FIPS and MD5
 


### PR DESCRIPTION
Two follow-ups to [#3885](https://github.com/chainguard-dev/edu/pull/3885).

## DOCS-166: route generic "contact support" links through Get support

Pages across the repo sent readers straight to `support.chainguard.dev` without mentioning what they need in place first. An identity that isn't linked to an organization produces an error at the portal, which [Get support](https://edu.chainguard.dev/get-started/get-support/) now explains.

The links fall into two kinds, and they get different treatment:

**Resource lists** — "Need help?" style lists where the reader is looking for somewhere to go. These now link Get support, because that is the orientation page.

- `content/developer-resources.md`
- `content/mcp-server-ai-docs.md`
- `content/chainguard/containers/features/ca-docs/custom-assembly-gitops.md`
- `content/platform/api/api-v2-migration.md`

**Inline calls to action** — these follow a specific problem ("if you need this package version, contact support"), so the reader has a concrete ask and wants the form. They keep their direct portal link and gain one sentence pointing at the prerequisites, so nobody loses a click.

- `content/platform/fips/non-approved-algorithms.md`
- `content/chainguard/containers/about/images-testing.md`
- `content/chainguard/containers/about/versions.md`
- `content/chainguard/containers/staying-secure/cve-risk.md`
- `content/chainguard/containers/features/unique-tags/index.md`

### Deliberately unchanged

Four instances match the same string but are not support calls to action. A find-and-replace would have broken them:

- `content/chainguard/containers/network-requirements.md:60` — `support.chainguard.dev` as a hostname in the required-endpoints table, not a link.
- `content/chainguard/containers/staying-secure/security-advisories/how-to-use/index.md:149` and `content/chainguard/containers/staying-secure/working-with-scanners/false-results.md:37` — deep links to a specific knowledge base article on scanner discrepancies.
- `content/chainguard/containers/about/catalog-starter.md:124` — links to the knowledge base root as a resource for Catalog Starter users, who cannot open tickets.

### One judgment call worth flagging

`non-approved-algorithms.md` has three support calls to action. Adding the same pointer to all three would read as noise on one page, so it appears once, at the first occurrence.

## Fan Yang's addition to Get support

Fan Yang asked in Slack, after #3885 merged, that the page invite supporting material — missing context costs support a round of back-and-forth before an investigation can start. Added as a final bullet under **What to include in your request**:

> - Anything else you think might help: logs, screenshots, or a short screen recording.

The section's opening line already says why this matters ("A support engineer can start on a problem instead of asking you for more information"), so the bullet does not repeat the rationale.

## Verification

`npm run build` completes clean. Link accounting after the change: 4 replaced, 5 pointers added, 7 direct portal links deliberately retained, 4 non-CTA instances untouched. Verified the new bullet and all rewritten links render, and that `/get-started/get-support/` resolves from every page that now points at it.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-01.
