### PR TITLE
actions/telemetry: explain why we collect telemetry data

### DIFF
--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -18,12 +18,12 @@ Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that r
 
 ## Why we collect this data
 
-We collect this data for billing and security purposes:
+We collect this data for two reasons:
 
-- **Billing**: usage events let us meter which repositories are using Chainguard hardened actions so we can bill customers accurately for their usage and entitlements.
-- **Security**: verified usage records help us confirm that requests come from legitimate workflows, understand where our actions are running, and detect anomalous or unauthorized use.
+- **Billing**: usage events show which repositories use Chainguard hardened actions, so we can meter usage against your entitlements and bill accurately.
+- **Security**: verified usage records help us confirm that requests come from legitimate workflows, identify where our actions run, and detect anomalous or unauthorized use.
 
-We do not use this data for advertising, and we do not sell it to third parties.
+We do not use this data for advertising or sell it to third parties.
 
 ## What we collect
 

--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -1,10 +1,10 @@
 ---
 title: "Chainguard Actions telemetry and privacy"
 linktitle: "Telemetry and privacy"
-description: "Learn what usage telemetry Chainguard hardened actions send, what data is collected, and how to control it."
+description: "Learn what usage telemetry Chainguard hardened actions send, why we collect it, and how to control it."
 type: "article"
 date: 2026-07-16T00:00:00+00:00
-lastmod: 2026-07-16T00:00:00+00:00
+lastmod: 2026-09-01T00:00:00+00:00
 draft: false
 tags: ["Chainguard Actions", "Telemetry", "Privacy"]
 menu:
@@ -15,6 +15,15 @@ toc: true
 ---
 
 Every Chainguard hardened action runs a best-effort "phone-home" pre-hook that records a usage event to `https://actions.enforce.dev/actions/v1/record`. The hook is fire-and-forget, with a 2 second timeout that fails open, so it cannot break your build.
+
+## Why we collect this data
+
+We collect this data for billing and security purposes:
+
+- **Billing**: usage events let us meter which repositories are using Chainguard hardened actions so we can bill customers accurately for their usage and entitlements.
+- **Security**: verified usage records help us confirm that requests come from legitimate workflows, understand where our actions are running, and detect anomalous or unauthorized use.
+
+We do not use this data for advertising, and we do not sell it to third parties.
 
 ## What we collect
 

--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Chainguard Actions telemetry and privacy"
 linktitle: "Telemetry and privacy"
-description: "Learn what usage telemetry Chainguard hardened actions send, why we collect it, and how to control it."
+description: "Learn what telemetry Chainguard hardened actions send, why we collect it, and how to control it."
 type: "article"
 date: 2026-07-16T00:00:00+00:00
 lastmod: 2026-09-01T00:00:00+00:00


### PR DESCRIPTION
Updates the Chainguard Actions telemetry and privacy page (https://edu.chainguard.dev/chainguard/actions/telemetry/) to explain *why* the usage data is collected — for billing and security purposes.

Changes:
- Adds a "Why we collect this data" section covering billing (usage metering/entitlements) and security (verifying legitimate workflow usage, detecting anomalous use), plus a note that the data is not used for advertising or sold.
- Updates the page description and `lastmod` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)