### PR TITLE
docs: add container and version availability troubleshooting

### DIFF
--- a/content/chainguard/containers/about/_index.md
+++ b/content/chainguard/containers/about/_index.md
@@ -4,7 +4,7 @@ linktitle: "About"
 description: "Conceptual articles and resources on Chainguard Containers"
 type: "article"
 date: 2024-12-19T08:49:15+00:00
-lastmod: 2025-04-07T08:49:15+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 images: []
 weight: 015
@@ -46,6 +46,11 @@ tutorials: [
     title: "Product release lifecycle",
     description: "",
     url: "/chainguard/containers/about/versions/"
+  },
+  {
+    title: "Availability troubleshooting",
+    description: "",
+    url: "/chainguard/containers/about/container-version-troubleshooting/"
   },
 ]
 

--- a/content/chainguard/containers/about/container-version-troubleshooting.md
+++ b/content/chainguard/containers/about/container-version-troubleshooting.md
@@ -1,0 +1,149 @@
+---
+title: "Troubleshoot container and version availability"
+linktitle: "Availability troubleshooting"
+type: "article"
+description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
+date: 2026-09-02T00:00:00+00:00
+lastmod: 2026-09-02T13:22:28+00:00
+draft: false
+tags: ["Chainguard Containers"]
+images: []
+menu:
+  docs:
+    parent: "about"
+weight: 026
+toc: true
+---
+
+You need a container image, or a particular version of one, and you can't pull it. The right next step depends on why it's missing, and there are four distinct reasons. This guide helps you tell them apart and resolve each one.
+
+Start by separating the two surfaces involved, because they aren't the same thing:
+
+* The [Chainguard Containers Directory](https://images.chainguard.dev/) at `images.chainguard.dev` is public. It lists every container image Chainguard builds, along with the tags, sizes, and metadata for each. Anyone can browse it.
+* Your organization's registry at `cgr.dev/$ORGANIZATION/` holds only the images your organization has access to. This is what your teams pull from.
+
+Browsing an image in the Directory doesn't mean your organization can pull it. For a fuller explanation of that distinction and how it relates to your subscription, see [Onboard your teams](/get-started/onboard-your-teams/).
+
+## Find your situation
+
+Look up the image in the Directory, then match what you see to the following table:
+
+| What you find | Go to |
+| --- | --- |
+| The image is in the Directory, but the Console shows **Unavailable to organization**, **Add to organization for access**, or **Request image for access** | [The container isn't in your organization's catalog](#the-container-isnt-in-your-organizations-catalog) |
+| The image isn't in the Directory at all | [Chainguard doesn't build the container](#chainguard-doesnt-build-the-container) |
+| The image is in the Directory, but not the version you need | [The version you need isn't listed](#the-version-you-need-isnt-listed) |
+| The version is listed with a pause icon, an **Expired** status, or an end-of-life date that has passed | [The version has reached end of life](#the-version-has-reached-end-of-life) |
+
+## The container isn't in your organization's catalog
+
+Chainguard builds the image, but your organization hasn't added it yet. What you do next depends on your subscription.
+
+**Catalog customers.** A Catalog subscription covers the whole catalog, but only a subset of images is loaded into your organization's registry at any time. Administrators add more as teams need them. If you have the `owner` role, you can add the image yourself from the Console: go to **Images**, then click **Add image** on the **Organization** tab, or **Add to org** on the **Chainguard catalog** tab. The image appears in your catalog after a few minutes.
+
+Self-serve adds require a role with the `repo (create, list, update)` capabilities, and the `registry.entitlement (list)` capability is useful for understanding what your organization is entitled to. The `owner` role is the only built-in role that carries all of them. For the full walkthrough and the role details, see [Chainguard container catalog pricing](/chainguard/containers/about/pricing/) and [Overview of roles and role-bindings](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/).
+
+If you don't have the `owner` role, ask an administrator in your organization to add the image.
+
+**Per-image customers.** A per-image subscription covers a specific licensed set of images rather than the whole catalog. You can browse everything in the Directory, but only your licensed images are permitted for builds, deployments, and production workloads. Ask your administrators to start a request; once they approve it, they add the image to your organization's registry.
+
+Questions about what your organization is licensed for go to your account team, meaning the customer success manager or solutions architect assigned to your organization.
+
+## Chainguard doesn't build the container
+
+If the image doesn't appear in the Directory, Chainguard doesn't build it yet, and you can ask for it. Submit the request from the **Requests** section of the Chainguard Console, where you can also see what Chainguard is already building and upvote requests from other customers. Chainguard prioritizes requests by demand, so upvoting an existing request helps more than filing a duplicate.
+
+Submitting requests requires membership in a [verified organization](/platform/administration/iam-organizations/verified-orgs/). The form asks for the resource type, the resource's existing public name, and a link to the upstream open source repository.
+
+Some requests can't be fulfilled. Chainguard won't build resources from proprietary code, won't build projects that no longer receive upstream updates, and can't always produce a FIPS variant. For the full process and the current limitations, see [Requesting new Chainguard resources](/chainguard/containers/features/request-resources/).
+
+## The version you need isn't listed
+
+This is the most common case, and often the version you're asking for isn't the one you need. Before you request anything, it's worth understanding how Chainguard versions its container images, because that determines what's available.
+
+### How Chainguard maintains versions
+
+Chainguard actively maintains the latest patch release of each supported upstream version stream, not every patch that stream has ever released. If Python maintains 3.11, 3.12, and 3.13 upstream, Chainguard maintains all three streams; within each one, only the current patch is rebuilt. So `python:3.13` tracks the newest patch of the 3.13 stream, which was `3.13.9` when this was written.
+
+Chainguard Containers also use *floating tags*. A tag points at the most recent build within its version stream rather than at a fixed image, so a tag's contents change as Chainguard rebuilds it. No tag stays pinned to one specific upstream patch release.
+
+That combination explains most missing-version reports. If you need `7.79.2` and the stream has moved on to `7.80.1`, the supported path is the stream tag, which gives you that stream's latest patch with current security fixes applied. Requesting the older patch tag gets you an image that is no longer rebuilt and will accumulate CVEs.
+
+Two related points follow from how tags float:
+
+* A newer epoch tag supersedes the previous one. Once `1.14.5-r4` exists, `1.14.5-r3` stops being updated. Epoch tags aren't a locking mechanism.
+* To list what's actually maintained for an image, run `chainctl image repo list --repo=$IMAGE -o json | jq -r '.items[].activeTags'`. See [Chainguard Containers product release lifecycle](/chainguard/containers/about/versions/) for more on tags, epochs, and how to inspect them.
+
+### Pin to a specific build with a digest
+
+If your reason for wanting a specific patch version is reproducibility, use a digest instead of a tag. A digest is a content-addressed reference to one exact build, and it never changes:
+
+```shell
+docker pull cgr.dev/$ORGANIZATION/node@sha256:ede7ef4ca485553f5313f7a02ad3537db1fe337079fc7cfb879f44cf709326db
+```
+
+Retrieve the digest for a tag with `crane`:
+
+```shell
+crane digest --full-ref cgr.dev/$ORGANIZATION/node:latest
+```
+
+A digest identifies one build and keeps identifying that same build even after the tag that pointed to it has moved on. Note the tradeoff: a pinned digest also stops receiving patches, so pair digest pinning with a process for updating the pin. See [Container image digests](/chainguard/containers/how-to-use/container-image-digests/) for the full workflow.
+
+### If an actively maintained tag is missing from your organization
+
+When the Directory shows a tag as actively maintained but that tag isn't available in your organization's registry, that's worth reporting. [Open a support request](#open-a-support-request) with the image name and the exact tag.
+
+The Console makes the same point from the image's **Versions** tab. Below the tag table is a link labeled **Looking for older tags?**, which explains that only actively supported tags are available when an image is added to your organization, and asks you to try a supported tag before opening a request.
+
+## The version has reached end of life
+
+When an upstream project stops maintaining a version, Chainguard generally stops patching it. New builds are no longer published, and vulnerabilities accumulate in that version over time. Chainguard doesn't build or maintain end-of-life versions, so requesting one isn't a path forward. Move to an actively maintained version instead.
+
+Chainguard also doesn't retroactively build versions that had already reached end of life before Chainguard began maintaining an image. If an upstream project released a version years before the image entered the catalog, that version was never built and can't be added.
+
+### Check the end-of-life date
+
+Use `chainctl` to see the end-of-life date and grace period end date for each release track:
+
+```shell
+chainctl package versions list python --show-active
+```
+
+```output
+ VERSION |  EOL DATE  | EOL GRACE PERIOD END DATE
+---------|------------|---------------------------
+ 3.10    | 2026-10-31 | 2027-05-01
+ 3.11    | 2027-10-31 | 2028-05-01
+ 3.12    | 2028-10-31 | 2029-05-01
+ 3.13    | 2029-10-31 | 2030-05-01
+ 3.14    | 2030-10-31 | 2031-05-01
+```
+
+The [endoflife.date](https://endoflife.date) website lists the release tracks and product lifecycles of many open source projects, and its information generally aligns with the lifecycle of the corresponding Chainguard container image. If the date you see from Chainguard differs from the one on the upstream project's own site, the two are probably using different definitions of a support tier.
+
+Several signals tell you a version is no longer being rebuilt:
+
+* In the Console, an inactive tag appears in gray text with a pause icon beside its name. Hovering the icon shows the message `This tag is no longer considered active.`
+* On the **Organization** tab under **Images**, the **Status** column shows **Expired** for images your organization no longer has access to.
+* The **Vulnerabilities** tab reports that a tag is no longer being scanned. Scanning stops because the image contents have stopped changing.
+
+None of these mean the image was deleted. They mean the version has been superseded, and you should move to the current version of that stream.
+
+### Continue past end of life with the EOL Grace Period
+
+Sometimes you can't upgrade on Chainguard's schedule, whether because a version reaches end of life ahead of your release cycle or because a later version has a problem that blocks you.
+
+For these cases, the End-of-Life Grace Period gives eligible containers up to six more months of new builds after the primary package reaches end of life. Eligibility depends on several requirements, and you can query grace period status through the Chainguard API. See the [EOL Grace Period overview](/chainguard/containers/features/eol-gp-overview/) for the requirements and the API.
+
+## Open a support request
+
+Open a support request when:
+
+* An actively maintained tag appears in the Directory but is missing from your organization.
+* A version isn't end of life upstream but doesn't appear in the Directory. Chainguard may not have it in the build matrix yet, or it may be a recent upstream release still moving through the build pipeline. Support can confirm whether a build is planned.
+* A tag that used to be available in your organization has disappeared unexpectedly.
+
+Include the image name, the exact tag you need, and the date you need it by. For the full list of what to include and the portal's prerequisites, see [Get support](/get-started/get-support/).
+
+Questions about your subscription or entitlements, including whether a particular image is covered, go to your account team rather than the support portal.

--- a/content/chainguard/containers/about/container-version-troubleshooting.md
+++ b/content/chainguard/containers/about/container-version-troubleshooting.md
@@ -4,7 +4,7 @@ linktitle: "Availability troubleshooting"
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-02T14:52:06+00:00
+lastmod: 2026-09-02T16:33:19+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -124,7 +124,7 @@ The [endoflife.date](https://endoflife.date) website lists the release tracks an
 
 Several signals tell you a version is no longer being rebuilt:
 
-* In the Console, an inactive tag appears in gray text with a pause icon beside its name. Hovering the icon shows the message `This tag is no longer considered active.`
+* In the Console, an inactive tag appears in gray text with a pause icon beside its name. Hovering the icon shows the message `This tag is no longer considered active.` [Open a support request](#open-a-support-request) if you want to request an inactive tag. Specify all the tags you need in a single request if requesting more than one to save time.
 * On the **Organization** tab under **Images**, the **Status** column shows **Expired** for images your organization no longer has access to.
 * The **Vulnerabilities** tab reports that a tag is no longer being scanned. Scanning stops because the image contents have stopped changing.
 

--- a/content/chainguard/containers/about/container-version-troubleshooting.md
+++ b/content/chainguard/containers/about/container-version-troubleshooting.md
@@ -4,7 +4,7 @@ linktitle: "Availability troubleshooting"
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-02T13:22:28+00:00
+lastmod: 2026-09-02T14:52:06+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -17,7 +17,7 @@ toc: true
 
 You need a container image, or a particular version of one, and you can't pull it. The right next step depends on why it's missing, and there are four distinct reasons. This guide helps you tell them apart and resolve each one.
 
-Start by separating the two surfaces involved, because they aren't the same thing:
+First, distinguish between the public container registry and your organization's registry:
 
 * The [Chainguard Containers Directory](https://images.chainguard.dev/) at `images.chainguard.dev` is public. It lists every container image Chainguard builds, along with the tags, sizes, and metadata for each. Anyone can browse it.
 * Your organization's registry at `cgr.dev/$ORGANIZATION/` holds only the images your organization has access to. This is what your teams pull from.

--- a/content/chainguard/containers/about/container-version-troubleshooting.md
+++ b/content/chainguard/containers/about/container-version-troubleshooting.md
@@ -4,7 +4,7 @@ linktitle: "Availability troubleshooting"
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-02T16:33:19+00:00
+lastmod: 2026-09-02T16:34:51+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -124,7 +124,7 @@ The [endoflife.date](https://endoflife.date) website lists the release tracks an
 
 Several signals tell you a version is no longer being rebuilt:
 
-* In the Console, an inactive tag appears in gray text with a pause icon beside its name. Hovering the icon shows the message `This tag is no longer considered active.` [Open a support request](#open-a-support-request) if you want to request an inactive tag. Specify all the tags you need in a single request if requesting more than one to save time.
+* In the Console, an inactive tag appears in gray text with a pause icon beside its name. Hovering the icon shows the message `This tag is no longer considered active.` You may [open a support request](#open-a-support-request) if you want to request an inactive tag. Specify all the tags you need in a single request if requesting more than one to save time. Note that inactive versions are not supported and may contain CVEs and/or functional bugs that we are not able to fix. This is why we don't add them automatically.
 * On the **Organization** tab under **Images**, the **Status** column shows **Expired** for images your organization no longer has access to.
 * The **Vulnerabilities** tab reports that a tag is no longer being scanned. Scanning stops because the image contents have stopped changing.
 

--- a/content/chainguard/containers/about/versions.md
+++ b/content/chainguard/containers/about/versions.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2026-09-01T16:56:22+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -54,6 +54,10 @@ This document provides an overview of Chainguard’s approach to updates,
 releases, and versions within Chainguard Containers. For more specific guidance,
 please [contact
 us](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).
+
+This page explains the policy. If you're trying to resolve a specific container
+image or version you can't pull, refer to [Troubleshoot container and version
+availability](/chainguard/containers/about/container-version-troubleshooting/).
 
 ## How versions are maintained
 
@@ -250,6 +254,11 @@ Containers organization directory will continue to have previously purchased
 container images available, new builds will no longer be published and
 vulnerabilities are expected to accumulate in those Containers over time. It is
 recommended to move to an up-to-date, actively maintained version.
+
+If you need a version that has reached EOL, or one Chainguard never built, refer
+to [Troubleshoot container and version
+availability](/chainguard/containers/about/container-version-troubleshooting/)
+for the options available to you.
 
 For software applications that maintain multiple concurrent release tracks,
 Chainguard will endeavor to provide [reasonable

--- a/content/chainguard/containers/features/request-resources/index.md
+++ b/content/chainguard/containers/features/request-resources/index.md
@@ -4,7 +4,7 @@ linktitle: "Requesting resources"
 type: "article"
 description: "How to submit requests for Chainguard to build new resources in the Console."
 date: 2026-02-26T11:07:52+02:00
-lastmod: 2026-02-26T11:07:52+02:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 tags: ["Chainguard Containers", "Chainguard Console"]
 images: []
@@ -85,3 +85,5 @@ There are a few limitations you should consider before submitting a new request:
 * There are cases where Chainguard cannot fulfill a FIPS request and be FIPS compliant. In such cases the standard variant can often still be built but the FIPS variant will get marked as **Won't build**.
 
 Finally, be aware that requesting that Chainguard build a software artifact does not mean it will automatically be accessible to your organization. Once the resource is built, you can reach out to our sales team to add it to your organization; alternatively, if your organization has [Catalog pricing](/chainguard/containers/about/pricing/) enabled, you can add it yourself after it's built.
+
+Note that the **Requests** section is for resources Chainguard doesn't build at all. If Chainguard already builds the container image and you need a version that isn't listed, or the image isn't in your organization's catalog yet, refer to [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/) instead.

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -5,7 +5,7 @@ lead: "Chainguard offers several ways to get help, and the right one depends on 
 description: "Get help from Chainguard: check the self-service options, choose the right support channel, and open a ticket a support engineer can act on."
 type: "article"
 date: 2026-09-01T00:00:00+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -38,6 +38,8 @@ The support portal handles most requests, but it isn't the only route, and for s
 - **Your organization uses Catalog Starter.** Use the [knowledge base](https://support.chainguard.dev/hc/en-us), the [community Slack](https://join.slack.com/t/chainguardcommunity/shared_invite/zt-3nttdr807-V9BJHayWvsB0KbHsfZO5Rw), and the free [Chainguard courses](https://courses.chainguard.dev/). Catalog Starter doesn't include ticket access.
 
 - **Your request concerns your subscription or what your organization is licensed for — for example, whether a particular image is included in your entitlements.** Contact your account team, meaning the customer success manager or solutions architect assigned to your organization.
+
+- **You can't pull a container image or a specific version of one.** Work through [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/) first. It tells you which cases you can resolve yourself and which need a ticket.
 
 ## Open a ticket
 

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-09-02T13:21:35+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -42,7 +42,7 @@ Your organization may also front the registry with a pull-through cache, such as
 
 ### What your organization can pull
 
-Whether an image is available to pull depends on your subscription. If a pull fails for an image you can see in the Directory, it most likely hasn't been added to your organization yet.
+Whether an image is available to pull depends on your subscription. If a pull fails for an image you can see in the Directory, it most likely hasn't been added to your organization yet. To work through the possible causes, including a missing version rather than a missing image, see [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/).
 
 **Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Containers Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; refer to [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
 

--- a/content/get-started/onboard-your-teams.md
+++ b/content/get-started/onboard-your-teams.md
@@ -5,7 +5,7 @@ lead: "Your organization has adopted Chainguard. This guide helps administrators
 description: "Onboard your teams to Chainguard Containers and Chainguard Libraries: what your organization can pull, how subscriptions differ, and how to retrieve SBOMs and provenance."
 type: "article"
 date: 2026-08-26T00:00:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-02T13:21:35+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -28,7 +28,7 @@ To decide where to start, identify which Chainguard products your organization u
 
 There are two different surfaces, and it helps to keep them separate.
 
-The **Chainguard Directory** at [images.chainguard.dev](https://images.chainguard.dev) is public. Anyone can browse the entire catalog there, inspect tags and metadata, and view the SBOM and provenance for each image. Browsing the Directory does not mean your organization can pull every image it lists.
+The **Chainguard Containers Directory** at [images.chainguard.dev](https://images.chainguard.dev) is public. Anyone can browse the entire catalog there, inspect tags and metadata, and view the SBOM and provenance for each image. Browsing the Directory does not mean your organization can pull every image it lists.
 
 Your **organization's registry** is what your teams pull from, and it holds only the images your organization has access to. Authenticated production images live under your organization's namespace:
 
@@ -44,7 +44,7 @@ Your organization may also front the registry with a pull-through cache, such as
 
 Whether an image is available to pull depends on your subscription. If a pull fails for an image you can see in the Directory, it most likely hasn't been added to your organization yet.
 
-**Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; refer to [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
+**Catalog customers.** A Catalog subscription covers the full Chainguard catalog. Even so, only a subset of images is loaded into your organization's registry at any given time, and administrators add more as teams need them. To use an image that isn't there yet, find it in the [Chainguard Containers Directory](https://images.chainguard.dev) and ask an administrator to add it. If you have the `owner` role, you can add it yourself from the Console; refer to [Catalog pricing](/chainguard/containers/about/pricing/) for the steps and the roles required.
 
 **Per-image customers.** A per-image subscription covers a specific, licensed set of images rather than the whole catalog. You can browse everything in the Directory, but only your licensed images are permitted for builds, deployments, and production workloads. To add an image that isn't in your set, ask your administrators to start a request; once they approve it, they add the image to your organization's registry.
 
@@ -52,7 +52,7 @@ Whether an image is available to pull depends on your subscription. If a pull fa
 
 Every Chainguard container image ships with a signed SBOM and provenance attestations. You can retrieve them three ways; the [full guide](/chainguard/containers/how-to-use/retrieve-image-sboms/) covers each in detail.
 
-- **From the Chainguard Directory.** Open an image at [images.chainguard.dev](https://images.chainguard.dev), then download the SBOM from the **SBOM** tab in SPDX or CycloneDX format. This needs no tooling and works for any image in the catalog.
+- **From the Chainguard Containers Directory.** Open an image at [images.chainguard.dev](https://images.chainguard.dev), then download the SBOM from the **SBOM** tab in SPDX or CycloneDX format. This needs no tooling and works for any image in the catalog.
 - **With `cosign`.** Download the SBOM attestation for an image directly from the registry:
 
   ```shell
@@ -72,7 +72,7 @@ Chainguard Libraries is a secure catalog of language dependencies for Java, Pyth
 
 ### What your organization can access
 
-Libraries don't have a public browse site like the Chainguard Directory. Instead, you browse the packages your organization is entitled to by signing in to the [Chainguard Console](/chainguard/libraries/introduction/browse/). Access is granted per language: your organization is entitled to Java, Python, or JavaScript individually, so which ecosystems you can pull depends on your subscription. There's no catalog-versus-per-image distinction as there is for containers.
+Libraries don't have a public browse site like the Chainguard Containers Directory. Instead, you browse the packages your organization is entitled to by signing in to the [Chainguard Console](/chainguard/libraries/introduction/browse/). Access is granted per language: your organization is entitled to Java, Python, or JavaScript individually, so which ecosystems you can pull depends on your subscription. There's no catalog-versus-per-image distinction as there is for containers.
 
 ### Pull libraries into your project
 

--- a/content/get-started/self-serve/helm-charts.md
+++ b/content/get-started/self-serve/helm-charts.md
@@ -4,7 +4,7 @@ linktitle: "Self-serve Helm charts"
 description: "Provision Chainguard Helm charts and their required images from the Chainguard Console as a Catalog customer"
 type: "article"
 date: 2026-08-06T00:00:01+00:00
-lastmod: 2026-08-06T18:00:35+00:00
+lastmod: 2026-09-02T13:33:15+00:00
 draft: false
 weight: 020
 toc: true
@@ -13,7 +13,7 @@ toc: true
 Catalog customers can provision Chainguard Helm charts, along with the container images each chart depends on, directly from the Chainguard Console. This replaces the previous manual request process, which required coordination with Chainguard sales, customer success, and support and could take 1 to 4 days.
 
 {{< note >}}
-This capability is available to Catalog customers whose plan includes the APPLICATION tier. It does not apply to the free [Catalog Starter](/chainguard/chainguard-images/about/catalog-starter/) plan. Customers on per-image pricing can request charts through a support workflow, described in [Per-image pricing customers](#per-image-pricing-customers).
+This capability is available to Catalog customers whose plan includes the APPLICATION tier. It does not apply to the free [Catalog Starter](/chainguard/containers/about/catalog-starter/) plan. Customers on per-image pricing can request charts through a support workflow, described in [Per-image pricing customers](#per-image-pricing-customers).
 {{< /note >}}
 
 ## Add a chart in the Chainguard Console

--- a/content/get-started/self-serve/overview.md
+++ b/content/get-started/self-serve/overview.md
@@ -6,7 +6,7 @@ lead: ""
 description: "Overview of the self-serve options for provisioning Chainguard products, including Catalog Starter and self-serve Helm charts"
 type: "article"
 date: 2026-05-12T01:00:01+00:00
-lastmod: 2026-08-18T15:48:57+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 weight: 010
 ---
@@ -17,5 +17,5 @@ involvement from Chainguard employees.
 
 This section covers the self-serve options available today:
 
-- **[Catalog Starter](/chainguard/chainguard-images/about/catalog-starter/)** is a free plan that lets you try up to five Chainguard container images. Any Helm charts that depend on those images are included.
+- **[Catalog Starter](/chainguard/containers/about/catalog-starter/)** is a free plan that lets you try up to five Chainguard container images. Any Helm charts that depend on those images are included.
 - **[Self-serve Helm charts](/get-started/self-serve/helm-charts/)** lets Catalog customers provision Chainguard Helm charts, along with the container images they depend on, directly from the Chainguard Console.

--- a/content/platform/console/images-directory/index.md
+++ b/content/platform/console/images-directory/index.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "A walkthrough of the Chainguard Console."
 date: 2024-02-23T11:07:52+02:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-02T13:31:42+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -58,6 +58,8 @@ The **Chainguard catalog** tab has a table with four columns:
 
 Note that if your organization has signed up for catalog pricing, there will be another column containing buttons labeled **Add to org**, allowing you to provision Chainguard Containers independently without having to reach out to Chainguard. Check out our doc on [Chainguard container catalog pricing](/chainguard/containers/about/pricing/) for more information.
 
+If an image you need doesn't appear in your organization's catalog, or appears without the version you need, refer to [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/).
+
 The **Organization** tab doesn't have a **Description** column, but has two additional columns. The first of these, labeled **Status** specifies what resources an organization has purchased and has access to. This column can show one of two possible values: **Active**, meaning that your organization is able to download and use the container image, or **Expired**, meaning that your organization had access to the container image in the past but not anymore.
 
 The other additional column is labeled **Pull URL**, and contains a URL you can use to pull the given image, as in a `docker pull` command.
@@ -82,7 +84,7 @@ Each container image details page has several tabs that provide information abou
 The default page for each image is the **Tags** tab which contains information about the version tags available for each image. This contains a table with columns:
 
 * **Tag**: this column lists each tag available for the container image
-* **Pull URL**: the URL you can use to download each version of the image. In the Console, Production containers you don't already have access to will show a message reading `Add to organization for access` if you're logged in under an organization with access to Production Containers; if you're logged in under an unverified organization, the message reads `Request image for access`.
+* **Pull URL**: the URL you can use to download each version of the image. In the Console, Production containers you don't already have access to will show a message reading `Add to organization for access` if you're logged in under an organization with access to Production Containers; if you're logged in under an unverified organization, the message reads `Request image for access`. For what to do about either message, refer to [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/).
 * **Compressed size**: the size of the image, in megabytes
 * **Last changed**: when each version of the image was last updated
 

--- a/content/platform/console/images-directory/index.md
+++ b/content/platform/console/images-directory/index.md
@@ -84,7 +84,7 @@ Each container image details page has several tabs that provide information abou
 The default page for each image is the **Tags** tab which contains information about the version tags available for each image. This contains a table with columns:
 
 * **Tag**: this column lists each tag available for the container image
-* **Pull URL**: the URL you can use to download each version of the image. In the Console, Production containers you don't already have access to will show a message reading `Add to organization for access` if you're logged in under an organization with access to Production Containers; if you're logged in under an unverified organization, the message reads `Request image for access`. For what to do about either message, refer to [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/).
+* **Pull URL**: the URL you can use to download each version of the Container. In the Console, Production Containers you don't already have access to will show a message reading `Add to organization` if you're logged in under an organization with access to Production Containers; if you're logged in under an organization without entitlement, the message reads `Request image` or `Request chart`. For what to do about either message, refer to [Troubleshoot container and version availability](/chainguard/containers/about/container-version-troubleshooting/).
 * **Compressed size**: the size of the image, in megabytes
 * **Last changed**: when each version of the image was last updated
 


### PR DESCRIPTION
A customer who can't pull a container image, or a specific version of one, now has a page that tells them which of four situations they're in and which ones they can resolve without Chainguard. Three of the four are self-service — add the image from the Console, move to the stream tag, or pin a digest — and the page says plainly which single case needs a support ticket.

Per the Kapa.ai July 2026 export analyzed in DOCS-145, "Request for Older and Missing Image Tags" was the second-largest topic at 18 threads from 14 unique users, and the worst-served: Kapa hedged or deflected to support in 16 of 18 threads, and 10 of 18 cited no edu page at all. No page covered this ground, so Kapa answered from the support knowledge base instead.

## Changes

**New page** — `chainguard/containers/about/container-version-troubleshooting/`, "Troubleshoot container and version availability." It routes on what the Console actually shows, then covers four cases:

1. The image is in the Chainguard Containers Directory but not in your organization's catalog.
2. Chainguard doesn't build the image at all.
3. The image is there, but not the version you need.
4. The version has reached end of life.

Case 3 carries the weight, because it's where the question is usually mis-stated. Chainguard actively maintains the latest patch of each supported stream, and tags float, so a reader asking for an older patch tag is asking for an image that's no longer rebuilt and will accrue CVEs. Readers who want a specific patch for reproducibility are routed to digests. The page mirrors the Console's own guidance to try a supported tag before opening a request.

**Cross-links** from the six pages that describe the states the new page explains:

- Product release lifecycle, at the top and in the EOL section. That page covers the policy thoroughly but never says what to do about a specific missing version.
- Using the Chainguard Console, from both the **Add to org** column and the **Pull URL** access messages.
- Requesting new Chainguard resources, clarifying that the **Requests** section is for resources Chainguard doesn't build at all. Its form asks for a public project name and an upstream repository, so it has no notion of requesting a version of something we already build.
- Onboard your teams, from the failed-pull paragraph.
- Get support, as a new routing case under "Where to send your request."
- The About Chainguard Containers section index.

**Terminology** — standardized on "Chainguard Containers Directory" in Onboard your teams, matching the rest of that section. Left the other files alone to keep this reviewable.

**Path fixes** — two pre-rename links to `/chainguard/chainguard-images/about/catalog-starter/`, in the self-serve overview and the self-serve Helm charts page. Both redirect, but the canonical path is `/chainguard/containers/about/catalog-starter/`.

## Verification

`npm run build` clean at 1653 pages. All in-page anchors resolve to real heading IDs, and all nine outbound links from the new page hit real built pages with no redirects — two needed correcting to the canonical `/platform/administration/...` paths. `check-related-pages` found the second stale `catalog-starter` link, which is why that fix is here.

## Sources

Deliberately not linked from the page itself, since the docs should be the authoritative reference for this:

- The support knowledge base article "How Chainguard Image Tags, Versions, and EOL Work," which documents the request path and the no-retroactive-EOL-builds policy.
- The GTM support runbook's missing-version-tag procedure.
- Zendesk ticket traffic, including a case where a customer asked for a version released well before Chainguard began maintaining the image.

Console strings were read from `console-ui/app/src/pkg/images/details/Versions.tsx` and confirmed against the live Console: the **Looking for older tags?** dialog below the tag table, the pause icon tooltip `This tag is no longer considered active.`, and the **Pull URL** access labels.

Two things I did not put in the page, deliberately. The support knowledge base states that Chainguard doesn't prune digests from the registry; that reads as a durability commitment, and commitments belong in contracts, so the digest guidance stands on content-addressing alone. Support also occasionally adds unsupported older tags for specific customers; that's a rare, customer-initiated exception and not something to advertise.

## Follow-ups, not in this PR

- The two Console strings disagree with each other: the dialog says "made available to your organization" and the tooltip says "added to your organization." The page uses "added to." Worth settling in `console-ui`.
- "Chainguard Directory" versus "Chainguard Containers Directory" is still split across nine other files.

DOCS-155

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
