### PR TITLE
fix(ci): check-latest + chainlink dependabot coverage (CUS-1262)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,20 @@ updates:
         update-types:
           - "patch"
 
+  - package-ecosystem: gomod
+    directory: "./tools/chainlink"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    assignees:
+      - "matthewhelmke"
+    groups:
+      gomod:
+        update-types:
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: tools/chainlink/go.mod
+          check-latest: true
 
       - name: Run chainlink
         run: go run . -contentDir ../../content -hostname edu.chainguard.dev -method GET -checkAll


### PR DESCRIPTION
## What

Two CI-hygiene changes for the edu Go tooling (CUS-1262):

- `check-links.yaml`: add `check-latest: true` to the Go setup. It already reads
  the version from `tools/chainlink/go.mod`; this makes CI install the latest
  patch of that Go line instead of the exact declared version. Mirrors the
  existing `rumble-vulnerability-data.yaml` setup.
- `dependabot.yml`: add a `gomod` entry for `./tools/chainlink` so it gets
  routine weekly patch version-updates, the same as `./tools/rumble`.

## Context

The exact toolchain pin that prompted this (`toolchain go1.24.1`) is already
gone on `main` — chainlink is `go 1.25.0` with no toolchain directive, and
check-links already reads go.mod (#3619). chainlink's module deps are already
covered by Dependabot *security* updates (that path runs on every manifest);
this adds routine *version* updates for parity. The Go toolchain version itself
is not modeled by Dependabot either way — `check-latest` keeps the CI runtime
on the newest patch; advancing the declared floor still needs a periodic bump.

## Verification

RAN (2): chainlink builds on a floated Go (`GOTOOLCHAIN=local go build`,
go1.26.5, current no-toolchain go.mod); `dependabot.yml` parses with both gomod
directories present (`yq`).
READ (4): check-latest semantics (rumble parity, setup-go v7); valid v7 syntax;
no exact-patch consumers of check-links; chainlink version-update entry is a
verbatim copy of the rumble block.

Not verified:
- [context] no edu AGENTS/CONTRIBUTING documents the CI Go-version convention.
- [budget] future 1.25.x patch compatibility relies on Go's patch-compat guarantee, not tested.

---
Linear: [CUS-1262](https://linear.app/chainguard/issue/CUS-1262/review-go-toolchain-pin-and-vulnerability-coverage)
