### PR TITLE
Cleanup: Move Scalar to shortcode

### DIFF
--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -48,9 +48,6 @@
   {{ $slice = $slice | append $alert -}}
 {{ end -}}
 
-{{ $scalarAPIReference := resources.Get "js/scalar-api-reference.js" | js.Build -}}
-{{ $slice = $slice | append $scalarAPIReference -}}
-
 {{ $js := $slice | resources.Concat "main.js" -}}
 
 {{ if eq (hugo.Environment) "development" -}}

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -71,3 +71,10 @@
     margin: 0 48px 0 48px;
   }
 </style>
+{{ $js := resources.Get "js/scalar-api-reference.js" | js.Build (dict "minify" (not hugo.IsDevelopment)) -}}
+{{ if hugo.IsDevelopment -}}
+  <script src="{{ $js.RelPermalink }}" defer></script>
+{{ else -}}
+  {{ $js = $js | fingerprint "sha512" -}}
+  <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous" defer></script>
+{{ end -}}


### PR DESCRIPTION
- Stop bundling `@scalar/api-reference` into the global `main.js` (`layouts/partials/footer/script-footer.html`). It was shipped to every page but only used by the three API spec pages; the production bundle drops from ~1.3 MB to ~315 KB
- Emit the Scalar script from the `openapi` shortcode instead (`layouts/shortcodes/openapi.html`), built with `js.Build`, minified and fingerprinted in production, loaded with `defer` alongside the stylesheet