### PR TITLE
actions/telemetry: remove unsourced advertising/third-party claim

### DIFF
--- a/content/chainguard/actions/telemetry.md
+++ b/content/chainguard/actions/telemetry.md
@@ -23,8 +23,6 @@ We collect this data for two reasons:
 - **Billing**: usage events show which repositories use Chainguard hardened actions, so we can meter usage against your entitlements and bill accurately.
 - **Security**: verified usage records help us confirm that requests come from legitimate workflows, identify where our actions run, and detect anomalous or unauthorized use.
 
-We do not use this data for advertising or sell it to third parties.
-
 ## What we collect
 
 What we collect depends on whether your workflow grants `id-token: write`:


### PR DESCRIPTION
Follow-up to #3887: removes the sentence "We do not use this data for advertising or sell it to third parties." from the Actions telemetry page.

While it's likely true, it's a public privacy commitment that was added without a sourced legal/privacy basis. Trimming the section to the documented billing and security rationale until legal/privacy provides approved language for broader claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)