### PR TITLE
Fix check_image_freshness: authenticate to cgr.dev, report digest and build date

### DIFF
--- a/content/developer-resources.md
+++ b/content/developer-resources.md
@@ -4,7 +4,7 @@ lead: "AI-ready documentation bundle for development"
 description: "Compiled Chainguard documentation optimized for use with AI coding assistants"
 type: "article"
 date: 2025-07-29T10:00:00+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-03T16:05:01+00:00
 draft: false
 images: []
 weight: 50
@@ -92,7 +92,7 @@ docker run --rm -i ghcr.io/chainguard-dev/ai-docs:latest serve-mcp
 - `get_security_docs` — return CVE and security information
 - `get_tool_docs` — return Wolfi, apko, melange, or chainctl docs
 - `find_package_equivalent` — map a Debian, Fedora, or Alpine package to its Wolfi equivalent
-- `check_image_freshness` — query the registry for current image tags
+- `check_image_freshness` — query the registry for an image's current digest, build date, and tags
 
 **Claude Desktop configuration:**
 

--- a/content/mcp-server-ai-docs.md
+++ b/content/mcp-server-ai-docs.md
@@ -5,7 +5,7 @@ lead: "Model Context Protocol server for Chainguard documentation"
 description: "Access Chainguard documentation through MCP for AI assistants and automation"
 type: "article"
 date: 2026-01-02T21:00:00+00:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-03T16:05:01+00:00
 draft: false
 images: []
 weight: 600
@@ -208,7 +208,9 @@ Find the Wolfi package that replaces a Debian, Fedora, or Alpine package. Use th
 
 ### `check_image_freshness`
 
-Query `cgr.dev` for an image's availability and current tags. Falls back to catalog data if the registry is unreachable.
+Query `cgr.dev` for how current an image is. Returns the digest and build date of the image's `latest` tag, along with the repository's tags. Falls back to catalog data if the registry is unreachable.
+
+Tag lists omit the `sha256-` attachment tags that carry each image's signature, attestation, and SBOM, because they outnumber the image's real tags by several hundred to one.
 
 **Parameters:**
 
@@ -216,13 +218,14 @@ Query `cgr.dev` for an image's availability and current tags. Falls back to cata
 
 **Example prompts:**
 
+- "When was the Python image last built?"
 - "What tags are available for the Python image?"
 - "Show me the available tags for the nginx image"
 - "Is the golang image available on cgr.dev?"
 
 ## Image catalog
 
-The `list_images`, `find_package_equivalent`, and `check_image_freshness` tools draw from a pre-built catalog that ships with the server. The catalog includes:
+The `list_images` and `find_package_equivalent` tools draw from a pre-built catalog that ships with the server. The `check_image_freshness` tool queries the registry directly, and uses the catalog only to report whether an image has documentation. The catalog includes:
 
 - Every Chainguard container image with its registry reference, sourced from the image documentation
 - Package mappings from Debian, Fedora, and Alpine to their Wolfi equivalents
@@ -259,11 +262,12 @@ apk add build-base
 ```
 
 ```
-You: What tags are available for the python image?
+You: Is the python image up to date?
 
 Claude: [Uses check_image_freshness tool]
-The Chainguard Python image (cgr.dev/chainguard/python) is available with these tags:
-latest, latest-dev, 3.13, 3.13-dev, ...
+The Chainguard Python image (cgr.dev/chainguard/python) was built today. The
+current digest of latest is sha256:ecf07c37..., and the repository's tags are
+latest and latest-dev.
 ```
 
 ## Standalone installation (without Docker)

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+from datetime import datetime, timezone
 from typing import Any, Annotated, Dict, List, Literal, Optional
 
 # MCP SDK imports (2.0 high-level API)
@@ -45,6 +46,32 @@ CATALOG_PATH = os.getenv("CATALOG_PATH", "/docs/image-catalog.json")
 # Input length limits to prevent CPU DoS on string operations
 MAX_INPUT_LEN = 500
 MAX_RESULTS_CAP = 20
+
+# Registry details for the anonymous cgr.dev pull path. The Docker Registry v2
+# API requires a bearer token even for public images, so every live check is a
+# token exchange followed by the real request. cgr.dev issues these tokens to
+# unauthenticated callers, so this needs no credential (DOCS-173).
+REGISTRY_DOMAIN = "cgr.dev"
+REGISTRY_HOST = f"https://{REGISTRY_DOMAIN}"
+REGISTRY_NAMESPACE = "chainguard"
+REGISTRY_TIMEOUT = 10.0
+
+# Accept both OCI and Docker manifest media types, index types first: Chainguard
+# images are multi-arch, so `latest` resolves to an image index rather than to a
+# single-platform manifest.
+MANIFEST_ACCEPT = ", ".join(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
+
+# A signed image carries three cosign attachment tags per digest
+# (`sha256-<digest>.sig`, `.att` and `.sbom`), which outnumber real tags by
+# roughly 500 to 1. They are filtered out of tag listings.
+COSIGN_ATTACHMENT_PREFIX = "sha256-"
 
 
 def extract_image_names(container_section: str) -> List[str]:
@@ -299,16 +326,142 @@ class ImagesCatalog:
 
     @staticmethod
     def _is_valid_image_name(name: str) -> bool:
-        """Validate image name to prevent path traversal or injection."""
-        return bool(re.fullmatch(r"[a-z0-9][a-z0-9\-]{0,127}", name))
+        """Validate image name to prevent path traversal or injection.
+
+        Underscores are allowed because real image names use them (sql_exporter,
+        chrony_exporter); keep this name class in step with extract_image_names
+        above, so an underscore name reports what the registry says rather than
+        "Invalid image name" (DOCS-138, DOCS-173).
+        """
+        return bool(re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,127}", name))
+
+    @staticmethod
+    def _fetch_pull_token(client: Any, repo: str) -> Dict[str, Any]:
+        """Return an anonymous pull token for a repository.
+
+        The token endpoint is where entitlement is enforced: it answers 403 for a
+        repository the anonymous caller cannot pull, which is how an image that
+        exists only in a private organization catalog presents itself here.
+        """
+        resp = client.get(
+            f"{REGISTRY_HOST}/token",
+            params={"scope": f"repository:{repo}:pull", "service": REGISTRY_DOMAIN},
+        )
+        if resp.status_code == 403:
+            return {
+                "token": None,
+                "error": (
+                    f"`{repo}` is not available for anonymous pull from the public "
+                    f"{REGISTRY_DOMAIN} catalog. Images published only to a private "
+                    "organization catalog are not visible to this server."
+                ),
+            }
+        if resp.status_code != 200:
+            return {
+                "token": None,
+                "error": (
+                    f"Registry returned HTTP {resp.status_code} for the pull token"
+                ),
+            }
+        return {"token": resp.json().get("token"), "error": None}
+
+    @staticmethod
+    def _age_in_days(built: str) -> Optional[int]:
+        """Return whole days since an RFC 3339 build timestamp, or None."""
+        try:
+            # Normalize the "Z" suffix: fromisoformat rejects it before 3.11.
+            stamp = datetime.fromisoformat(built.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return (datetime.now(timezone.utc) - stamp).days
+
+    def _fetch_latest_metadata(
+        self, client: Any, repo: str, headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        """Return the digest and build date of a repository's `latest` tag."""
+        meta: Dict[str, Any] = {
+            "digest": None,
+            "built": None,
+            "age_days": None,
+            "error": None,
+        }
+
+        resp = client.get(
+            f"{REGISTRY_HOST}/v2/{repo}/manifests/latest",
+            headers={**headers, "Accept": MANIFEST_ACCEPT},
+        )
+        if resp.status_code == 404:
+            meta["error"] = (
+                f"No `latest` tag for {repo} in the public {REGISTRY_DOMAIN} catalog. "
+                "Images published only to a private organization catalog are not "
+                "visible to this server."
+            )
+            return meta
+        if resp.status_code != 200:
+            meta["error"] = (
+                f"Registry returned HTTP {resp.status_code} for the manifest"
+            )
+            return meta
+
+        meta["digest"] = resp.headers.get("Docker-Content-Digest")
+
+        # Chainguard's build pipeline stamps the index with its build time. If an
+        # image lacks the annotation, report the digest without a date rather
+        # than inferring one.
+        annotations = resp.json().get("annotations") or {}
+        built = annotations.get("org.opencontainers.image.created")
+        if built:
+            meta["built"] = built
+            meta["age_days"] = self._age_in_days(built)
+
+        return meta
+
+    @staticmethod
+    def _fetch_real_tags(
+        client: Any, repo: str, headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        """Return a repository's tags with cosign attachment tags removed."""
+        listing: Dict[str, Any] = {"tags": [], "truncated": False, "error": None}
+
+        resp = client.get(
+            f"{REGISTRY_HOST}/v2/{repo}/tags/list",
+            headers={**headers, "Accept": "application/json"},
+        )
+        if resp.status_code != 200:
+            listing["error"] = (
+                f"Registry returned HTTP {resp.status_code} for the tag list"
+            )
+            return listing
+
+        listing["tags"] = [
+            tag
+            for tag in resp.json().get("tags") or []
+            if not tag.startswith(COSIGN_ATTACHMENT_PREFIX)
+        ]
+
+        # The registry pages at 1000 tags and points to the next page with a Link
+        # header. Rather than walking every page of attachment tags to find a
+        # handful of real ones, flag the list as partial so a caller does not
+        # read it as complete.
+        listing["truncated"] = 'rel="next"' in resp.headers.get("Link", "")
+
+        return listing
 
     def check_live_image(self, name: str) -> Dict[str, Any]:
-        """Check image freshness via live registry query to cgr.dev."""
-        result = {
+        """Check image freshness via live registry query to cgr.dev.
+
+        Reports the digest and build date of `latest` — the two facts that show
+        whether an image is current — plus the repository's real tags.
+        """
+        result: Dict[str, Any] = {
             "name": name,
-            "registry_ref": f"cgr.dev/chainguard/{name}",
+            "registry_ref": f"{REGISTRY_DOMAIN}/{REGISTRY_NAMESPACE}/{name}",
             "live_check": False,
             "tags": [],
+            "tags_truncated": False,
+            "digest": None,
+            "built": None,
+            "age_days": None,
             "error": None,
         }
 
@@ -327,16 +480,36 @@ class ImagesCatalog:
             result["error"] = "httpx not available; returning catalog data only"
             return result
 
+        repo = f"{REGISTRY_NAMESPACE}/{name}"
         try:
-            url = f"https://cgr.dev/v2/chainguard/{name}/tags/list"
-            with httpx.Client(timeout=10.0) as client:
-                resp = client.get(url, headers={"Accept": "application/json"})
-                if resp.status_code == 200:
-                    data = resp.json()
-                    result["live_check"] = True
-                    result["tags"] = data.get("tags", [])[:20]
-                else:
-                    result["error"] = f"Registry returned HTTP {resp.status_code}"
+            with httpx.Client(timeout=REGISTRY_TIMEOUT) as client:
+                auth = self._fetch_pull_token(client, repo)
+                if not auth["token"]:
+                    result["error"] = (
+                        auth["error"]
+                        or f"Could not get an anonymous pull token from {REGISTRY_DOMAIN}"
+                    )
+                    return result
+
+                headers = {"Authorization": f"Bearer {auth['token']}"}
+
+                metadata = self._fetch_latest_metadata(client, repo, headers)
+                if metadata["error"]:
+                    result["error"] = metadata["error"]
+                    return result
+
+                result["digest"] = metadata["digest"]
+                result["built"] = metadata["built"]
+                result["age_days"] = metadata["age_days"]
+
+                listing = self._fetch_real_tags(client, repo, headers)
+                result["tags"] = listing["tags"]
+                result["tags_truncated"] = listing["truncated"]
+                result["error"] = listing["error"]
+
+                # The manifest came back, so the live data above is good even if
+                # the tag listing failed.
+                result["live_check"] = True
         except Exception as e:
             result["error"] = f"Live check failed: {str(e)}"
 
@@ -559,7 +732,7 @@ def find_package_equivalent(
 
 
 @server.tool(
-    description="Check a Chainguard image's availability and tags via live registry query to cgr.dev (falls back to catalog data if no network)"
+    description="Check how current a Chainguard image is via live registry query to cgr.dev: reports the digest and build date of `latest` plus the repository's tags (falls back to catalog data if no network)"
 )
 @safe_tool
 def check_image_freshness(
@@ -576,12 +749,27 @@ def check_image_freshness(
     response += (
         f"- **Live check**: {'Success' if result['live_check'] else 'Not performed'}\n"
     )
+    if result.get("digest"):
+        response += f"- **Current digest** of `latest`: `{result['digest']}`\n"
+    if result.get("built"):
+        age = result.get("age_days")
+        age_note = ""
+        if age == 0:
+            age_note = " (today)"
+        elif age is not None:
+            age_note = f" ({age} day{'' if age == 1 else 's'} ago)"
+        response += f"- **Built**: {result['built']}{age_note}\n"
     if result.get("error"):
         response += f"- **Note**: {result['error']}\n"
     if result.get("tags"):
         response += (
             f"- **Tags** ({len(result['tags'])}): {', '.join(result['tags'][:10])}\n"
         )
+        if result.get("tags_truncated"):
+            response += (
+                "- **Tag list**: partial. The registry paged the response, so more "
+                "tags may exist beyond those listed.\n"
+            )
     if result.get("has_documentation") is not None:
         response += f"- **Has documentation**: {'Yes' if result['has_documentation'] else 'No'}\n"
     return response


### PR DESCRIPTION
## What this fixes

`check_image_freshness` has never returned live data. Jason Bishay reported it returning no tags for any image, for a customer who cannot use Guardener and is using the AI Docs MCP server for container migrations instead.

The cause is in `ImagesCatalog.check_live_image()`: it issued an unauthenticated `GET` to `/v2/chainguard/<name>/tags/list`. The Docker Registry v2 API requires a bearer token even for public images, so `cgr.dev` answered 401 on every call and the tool reported `Live check: Not performed` with an empty tag list.

```
$ curl -s -D - -o /dev/null https://cgr.dev/v2/chainguard/python/tags/list
HTTP 401
www-authenticate: Bearer realm="https://cgr.dev/token",service="cgr.dev",scope="repository:chainguard/python:pull"
```

This does the anonymous token exchange first. `cgr.dev` issues pull tokens to unauthenticated callers for the public catalog, so **no credential is added to the Cloud Run service**.

## Also in this PR

Three defects that fixing the auth alone would have left in place:

- **Report the digest and build date of `latest`.** That is what "freshness" means, and tags cannot show it — public repositories carry only `latest`-style tags. Both facts come from one manifest request: the digest from the `Docker-Content-Digest` header, the build date from the index's `org.opencontainers.image.created` annotation.
- **Filter cosign attachment tags.** For `chainguard/python`, 998 of the first 1000 tags are `sha256-*.sig`, `.att`, and `.sbom`, so the two real tags were crowded out of a display that shows the first 10. The listing is flagged as partial when the registry pages it.
- **Allow underscores in the image-name check.** A name such as `sql_exporter` reported `Invalid image name` rather than what the registry says. This brings the name class into step with `extract_image_names`, which #3802 already fixed for the same reason.

An image published only to a private organization catalog now says so. Entitlement is enforced at the token endpoint, which answers 403, rather than at the manifest request.

### Before

```
# Image Check: python

- **Registry ref**: `cgr.dev/chainguard/python`
- **Live check**: Not performed
- **Note**: Registry returned HTTP 401
```

### After

```
# Image Check: python

- **Registry ref**: `cgr.dev/chainguard/python`
- **Live check**: Success
- **Current digest** of `latest`: `sha256:ecf07c37307575158ebde8169e03265260a1f92590c7ff3c2fbd850fa45a4ca4`
- **Built**: 2026-09-02T18:14:41Z (today)
- **Tags** (2): latest, latest-dev
- **Tag list**: partial. The registry paged the response, so more tags may exist beyond those listed.
```

## Testing

Verified against the live registry, with ground truth fetched independently through `urllib` so the check does not share a code path with the `httpx` calls under test:

- `python`: digest and build date match the independently fetched values; no `sha256-` tags survive filtering; `latest` and `latest-dev` both present.
- `static`: build date renders a non-zero age (3 days ago), and the real tags differ (`latest`, `latest-glibc`), so the filter is not special-casing one repository.
- `keycloak`: not in the public catalog, and the response explains that rather than surfacing a bare 404.
- `../../etc/passwd`: still rejected by name validation.
- Age arithmetic matches hand-computed values for a same-day image, a 3-day-old image, a 245-day-old timestamp, and returns `None` for a malformed one.
- `black` and `bandit` clean (two new bandit findings are B105 false positives on a dict key named `token`, both Low, below the hook's `-ll` threshold).

The tests are not in-tree: this repo has no Python test suite, and a live-registry call in CI would add a network dependency that can fail for reasons unrelated to the code.

## Docs

Updated the tool's description on the MCP server page and in the developer resources tool list. The example output on the MCP page also claimed tags `3.13, 3.13-dev` for `chainguard/python`, which the public catalog does not carry; it now shows the digest and build date instead.

## Note for review

The hosted server at `mcp.edu.chainguard.dev` picks this up on the next image build and Cloud Run deploy, so the fix is worth confirming against the hosted endpoint after merge rather than only in the container.

Refs DOCS-173. The image-count problem in the same Slack thread is separate and already tracked in DOCS-138 and DOCS-139.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) running Opus 5 on 2026-09-03.
