### PR TITLE
Let the MCP server reach cgr.dev: egress PRIVATE_RANGES_ONLY

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -101,7 +101,14 @@ resource "google_cloud_run_v2_service" "mcp-server" {
         network    = each.value.network
         subnetwork = each.value.subnet
       }
-      egress = "ALL_TRAFFIC"
+      // Unlike the Academy site service, the MCP server DOES egress: its
+      // check_image_freshness tool queries the cgr.dev registry. ALL_TRAFFIC
+      // routes that through the subnet, which has a default internet route but
+      // no Cloud NAT, so the instance has no public source address and every
+      // request to cgr.dev dies as a timeout. PRIVATE_RANGES_ONLY sends public
+      // traffic out through Cloud Run's managed egress instead. Google APIs are
+      // unaffected either way (Private Google Access). See DOCS-173.
+      egress = "PRIVATE_RANGES_ONLY"
     }
 
     service_account = google_service_account.chainguard-academy.email


### PR DESCRIPTION
## What this fixes

`check_image_freshness` on the hosted MCP server (`https://mcp.edu.chainguard.dev/mcp`) times out against `cgr.dev`, even though the identical code returns the digest, build date, and tags when run locally:

```
# Image Check: python
- **Live check**: Not performed
- **Note**: Live check failed: timed out
```

This is the second of two independent defects behind the same symptom. #3912 fixed the first — the tool never authenticated to the registry. This fixes the second: the service cannot reach the registry at all.

## Root cause

The `mcp-server` service sets its direct VPC egress to `ALL_TRAFFIC`, so every outbound packet leaves through the subnet from `chainguard-dev/common/infra//modules/networking`. That module creates a `0.0.0.0/0` route to the default internet gateway and enables Private Google Access, but provisions **no Cloud NAT** — and there is no NAT anywhere else in `iac/`. The instance therefore has only an internal address. Traffic to a public destination has a route but no source address to answer to, so it is dropped silently, surfacing as a timeout after the client's 10-second limit.

Google APIs kept working the whole time through Private Google Access, which is why GCS and Artifact Registry never showed a problem and this stayed invisible.

The setting was inherited from the Academy site service, which carries this comment directly above the same line:

```hcl
// Academy does not egress
egress = "ALL_TRAFFIC"
```

That is accurate for the site. The MCP server does egress — `check_image_freshness` is its one outbound call — and the setting was not revisited when the service was added.

## The change

`egress = "PRIVATE_RANGES_ONLY"` on the `mcp-server` service only. Public traffic goes out through Cloud Run's managed egress with a real source address; only RFC 1918 destinations stay on the VPC path. The MCP server needs nothing from private ranges, so nothing is lost, and no new infrastructure or cost is added.

The Academy site service is deliberately untouched.

This matches how Chainguard's other MCP servers are configured — see `skills-mcp/iac/main.tf` and `build/iac/mcp.tf` in `mono`, both of which use `PRIVATE_RANGES_ONLY`.

## Alternative considered

Adding Cloud NAT to the subnet would keep egress inside the VPC and make egress firewalling and flow logs possible for this service. It costs a gateway and changes the networking layer that both the site and the MCP server share, which is more blast radius than this fix needs. Worth revisiting if we ever want to restrict where this service can call out.

## Testing

`terraform validate` passes. `terraform fmt` reports only pre-existing misalignment elsewhere in the file, which I left alone rather than mixing unrelated churn into a one-line change; CI runs `init`/`plan`/`apply` and no `fmt -check`.

Before making this change I confirmed against the hosted endpoint that the #3912 code fix is live and correct — the endpoint advertises the updated tool description — and that the remaining failure is this timeout rather than authentication. I also ran the same check *before* that deploy landed, as a control: it already timed out under the old code, which is how I know this egress problem predates #3912 and is not a regression from it.

I cannot verify the end state myself, since `terraform apply` runs in CI and I have no GCP credentials for the project. After this merges and the `Deploy to Cloud Run` workflow applies it, `check_image_freshness` on the hosted endpoint should report `Live check: Success` with a digest and build date. I have a client-side harness ready to confirm that and will post the result on DOCS-173.

## Review note

This changes a production service's network egress path, so I would like a second pair of eyes from whoever owns Cloud Run networking, even though the file lives in this repo.

Refs DOCS-173, which carries the full diagnosis.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) running Opus 5 on 2026-09-03.
