### PR TITLE
Clear the zizmor 1.30.0 findings blocking the pre-commit check

### DIFF
--- a/.github/workflows/autodocs-platform.yaml
+++ b/.github/workflows/autodocs-platform.yaml
@@ -41,7 +41,10 @@ jobs:
         service_account: "github-chainguard-academy@chainguard-academy.iam.gserviceaccount.com"
         workload_identity_provider: "projects/456977358484/locations/global/workloadIdentityPools/chainguard-academy/providers/chainguard-edu"
 
-    - uses: ./.github/actions/integrate-platform-docs
+    # zizmor 1.30.0 wants GitHub's `$/` self-repository form here, but actionlint
+    # 1.7.12 rejects it as a malformed `uses:` (rhysd/actionlint#711). Switch to
+    # `$/.github/actions/integrate-platform-docs` once actionlint parses it.
+    - uses: ./.github/actions/integrate-platform-docs # zizmor: ignore[self-repository]
       with:
         project_id: "${{ secrets.PROJECT_ID }}"
         storage_bucket: "${{ secrets.STORAGE_BUCKET }}"

--- a/.github/workflows/templates/export-courses-docs-to-gcs.yaml
+++ b/.github/workflows/templates/export-courses-docs-to-gcs.yaml
@@ -96,10 +96,10 @@ jobs:
         # Create metadata file
         cat > "$EXPORT_DIR/metadata.json" << EOF
         {
-          "repository": "${{ github.repository }}",
+          "repository": "$GITHUB_REPOSITORY",
           "export_time": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-          "commit": "${{ github.sha }}",
-          "ref": "${{ github.ref }}",
+          "commit": "$GITHUB_SHA",
+          "ref": "$GITHUB_REF",
           "files_count": $(find "$EXPORT_DIR" -name "*.md" -type f | wc -l)
         }
         EOF

--- a/.github/workflows/templates/export-docs-to-gcs.yaml
+++ b/.github/workflows/templates/export-docs-to-gcs.yaml
@@ -10,10 +10,10 @@ on:
       - 'content/**'
       - 'docs/**'
       - '**.md'
-  
+
   schedule:
     - cron: '30 1 * * 0'  # Weekly on Sundays at 1:30 AM
-  
+
   workflow_dispatch:
 
 permissions:
@@ -23,7 +23,7 @@ permissions:
 jobs:
   export-docs:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -47,54 +47,54 @@ jobs:
     - name: Prepare documentation export
       run: |
         set -euo pipefail  # Exit on error, undefined variable, or pipe failure
-        
+
         # Use mktemp for secure temp directory
         EXPORT_DIR=$(mktemp -d)
         trap "rm -rf $EXPORT_DIR" EXIT  # Clean up on exit
-        
+
         # Copy all markdown content (adjust paths as needed for each repo)
         echo "Collecting documentation files..."
-        
+
         # For images-private repo
         if [[ "${{ github.repository }}" == *"images-private"* ]]; then
           echo "Collecting README.md files from image directories..."
-          
+
           # Create images directory structure
           mkdir -p "$EXPORT_DIR/images"
-          
+
           # Find all README.md files in images/*/README.md pattern
           # This captures only the main README for each image, not nested subdirectories
           find images -mindepth 2 -maxdepth 2 -name "README.md" -type f | while read file; do
             # Get the image directory name (e.g., adoptium-jdk-fips from images/adoptium-jdk-fips/README.md)
             image_dir=$(dirname "$file")
-            
+
             # Create the directory structure in export
             mkdir -p "$EXPORT_DIR/$image_dir"
-            
+
             # Copy and clean the README.md file
             # Remove HTML comments like <!--monopod:start-->, <!--getting:start-->, etc.
             sed -E 's/<!--[^>]*-->//g' "$file" | \
               sed '/^[[:space:]]*$/N;/\n[[:space:]]*$/d' > "$EXPORT_DIR/$file"
-            
+
             echo "  ✓ Processed $file"
           done
-          
+
           echo "Total image READMEs collected: $(find "$EXPORT_DIR/images" -name "README.md" | wc -l)"
         fi
-        
+
         # For courses repo
         if [[ "${{ github.repository }}" == *"courses"* ]]; then
           echo "Processing courses repository HTML content..."
-          
+
           # Install pandoc for HTML to Markdown conversion
           echo "Installing pandoc for HTML conversion..."
           sudo apt-get update && sudo apt-get install -y pandoc
-          
+
           # Find and process HTML files in course structure
           # Pattern: /CourseDirectory/lessons/*/content-*.html
           course_count=0
           lesson_count=0
-          
+
           # Look for course directories (they typically start with capital letters)
           for course_dir in [A-Z]*; do
             # Skip internal/private courses
@@ -102,34 +102,34 @@ jobs:
               echo "Skipping internal course: $course_dir"
               continue
             fi
-            
+
             if [ -d "$course_dir/lessons" ]; then
               echo "Processing course: $course_dir"
               course_count=$((course_count + 1))
-              
+
               # Create course directory in export
               mkdir -p "$EXPORT_DIR/$course_dir/lessons"
-              
+
               # Process each lesson directory
               for lesson_dir in "$course_dir/lessons"/*; do
                 if [ -d "$lesson_dir" ]; then
                   lesson_name=$(basename "$lesson_dir")
                   echo "  Processing lesson: $lesson_name"
-                  
+
                   # Create lesson directory
                   mkdir -p "$EXPORT_DIR/$course_dir/lessons/$lesson_name"
-                  
+
                   # Convert HTML files to markdown
                   for html_file in "$lesson_dir"/content-*.html; do
                     if [ -f "$html_file" ]; then
                       base_name=$(basename "$html_file" .html)
                       output_file="$EXPORT_DIR/$course_dir/lessons/$lesson_name/${base_name}.md"
-                      
+
                       # Convert HTML to Markdown using pandoc, then clean up
                       pandoc -f html -t markdown_strict "$html_file" | \
                         sed -E 's/<!--[^>]*-->//g' | \
                         sed '/^[[:space:]]*$/N;/\n[[:space:]]*$/d' > "$output_file"
-                      
+
                       lesson_count=$((lesson_count + 1))
                       echo "    ✓ Converted $(basename "$html_file")"
                     fi
@@ -138,29 +138,29 @@ jobs:
               done
             fi
           done
-          
+
           echo "Processed $course_count courses with $lesson_count lesson files"
         fi
-        
+
         # Create metadata file
         cat > "$EXPORT_DIR/metadata.json" << EOF
         {
-          "repository": "${{ github.repository }}",
+          "repository": "$GITHUB_REPOSITORY",
           "export_time": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-          "commit": "${{ github.sha }}",
-          "ref": "${{ github.ref }}",
+          "commit": "$GITHUB_SHA",
+          "ref": "$GITHUB_REF",
           "files_count": $(find "$EXPORT_DIR" \( -name "*.md" -o -name "*.html" \) -type f | wc -l)
         }
         EOF
-        
+
         # Validate JSON
         python3 -m json.tool "$EXPORT_DIR/metadata.json" > /dev/null
-        
+
         # Create tarball with restricted permissions
         cd "$(dirname "$EXPORT_DIR")"
         tar --owner=0 --group=0 --mode='u+rwX,go+rX,go-w' \
             -czf /tmp/docs-export.tar.gz "$(basename "$EXPORT_DIR")"
-        
+
         echo "Documentation export created:"
         ls -lh /tmp/docs-export.tar.gz
         echo "Files included: $(tar -tzf /tmp/docs-export.tar.gz | wc -l)"
@@ -168,7 +168,7 @@ jobs:
     - name: Upload to GCS
       run: |
         set -euo pipefail
-        
+
         # Determine repo name for path
         if [[ "${{ github.repository }}" == *"images-private"* ]]; then
           REPO_PATH="images-private"
@@ -177,28 +177,28 @@ jobs:
         else
           REPO_PATH=$(echo "${{ github.repository }}" | cut -d'/' -f2)
         fi
-        
+
         # Upload to GCS with specific content types
         echo "Uploading to gs://academy-all-docs/${REPO_PATH}/"
-        
+
         gcloud storage cp /tmp/docs-export.tar.gz \
           "gs://academy-all-docs/${REPO_PATH}/docs-export.tar.gz" \
           --project=chainguard-academy \
           --content-type="application/gzip" \
           --cache-control="no-cache"
-        
+
         # Extract for metadata upload
         EXPORT_DIR=$(mktemp -d)
         trap "rm -rf $EXPORT_DIR" EXIT
         tar -xzf /tmp/docs-export.tar.gz -C "$EXPORT_DIR" --strip-components=1
-        
+
         # Upload metadata
         gcloud storage cp "$EXPORT_DIR/metadata.json" \
           "gs://academy-all-docs/${REPO_PATH}/metadata.json" \
           --project=chainguard-academy \
           --content-type="application/json" \
           --cache-control="no-cache"
-        
+
         echo "Successfully uploaded documentation to GCS"
 
     - name: Trigger edu repo workflow

--- a/.github/workflows/templates/export-images-docs-to-gcs.yaml
+++ b/.github/workflows/templates/export-images-docs-to-gcs.yaml
@@ -66,10 +66,10 @@ jobs:
         # Create metadata file
         cat > "$EXPORT_DIR/metadata.json" << EOF
         {
-          "repository": "${{ github.repository }}",
+          "repository": "$GITHUB_REPOSITORY",
           "export_time": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-          "commit": "${{ github.sha }}",
-          "ref": "${{ github.ref }}",
+          "commit": "$GITHUB_SHA",
+          "ref": "$GITHUB_REF",
           "files_count": $(find "$EXPORT_DIR" -name "*.md" -type f | wc -l)
         }
         EOF


### PR DESCRIPTION
## Type of change

Repository maintenance — CI unblock plus one workflow hardening fix. No content changes.

### What should this PR do?

Clear both zizmor findings that the hook bump to zizmor 1.30.0 (#3873) introduced.

**1. `self-repository` on `autodocs-platform.yaml` — this is what blocks #3906**

zizmor 1.30.0 added the `self-repository` audit, which flags `uses: ./...` and wants GitHub's newer `$/...` form. Its auto-fix is unusable here. Verified locally against the pinned hooks:

| `.github/workflows/autodocs-platform.yaml:44` | zizmor 1.30.0 | actionlint 1.7.12 |
|---|---|---|
| `uses: ./.github/actions/...` (before) | **Failed** | Passed |
| `uses: $/.github/actions/...` (zizmor's fix) | Passed | **Failed** |

actionlint 1.7.12 is the latest release, and it rejects `$/` as a malformed `uses:` (`ref is missing`). Support is open at rhysd/actionlint#711. So this suppresses the finding inline and records the revert condition in a comment.

One detail worth knowing: the directive has to be a **trailing** comment on the `uses:` line. The finding's span starts there, so the style used elsewhere in this repo — the directive on its own line above the step, as in `digestabot.yaml` — does not suppress it.

**2. `template-injection` in the three GCS export templates**

`"ref": "${{ github.ref }}"` sits inside a `run:` block. Actions expands the expression into the script text before bash sees it, so a branch named `refs/heads/$(...)` runs code inside the job. These now read the runner's default environment variables, which the shell expands as data.

`github.repository` and `github.sha` in the same JSON literal are not attacker-controlled and zizmor does not flag them. They move too, so the block reads consistently.

### Why are we making this change?

`pre-commit` scopes its hooks with `--from-ref/--to-ref`, so it audits only the files a PR touches. #3906 bumps harden-runner and setup-gitsign inside `autodocs-platform.yaml`, which pulled that file into the audit set for the first time since the hook bump. `main` is green only because nothing had touched the file. Every future PR that touches it hits the same wall, and Dependabot cannot fix this one — the change it needs is not a version bump.

The template-injection findings are hardening, not an incident. Those templates trigger on `push` to `main`, where the ref is always `refs/heads/main`, and on `workflow_dispatch`, which already requires write access.

### What are the acceptance criteria?

- `pre-commit run zizmor --all-files` is clean, and `pre-commit run actionlint --all-files` still passes.
- #3906 goes green after a rebase onto this.

### How should this PR be tested?

No published content changes, so the standard procedure check does not apply. What I ran:

- `pre-commit run zizmor --all-files` — clean. Before: 3 high, 1 low.
- `pre-commit run actionlint --all-files` — passes.
- Simulated the metadata heredoc outside Actions with `GITHUB_REF='refs/heads/$(touch PWNED)x'`. The old form executes the command and silently records the wrong ref (`refs/heads/x`). The new form records the value verbatim and the JSON still validates.

Two notes for the reviewer:

- `export-docs-to-gcs.yaml` shows 32 whitespace-only lines. The `trailing-whitespace` hook rewrote the file when I staged it. `git diff -w` shows the three real lines.
- Nothing in this repo executes those templates, since GitHub runs workflows only from the top level of `.github/workflows`. This fixes the source of truth. The deployed copy in `chainguard-dev/courses` (`.github/workflows/export-docs-to-gcs.yaml:137`) still carries the pattern and does run; `images-private` is not visible to my token. I can open a follow-up there.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-03.
