### PR TITLE
docs(chainctl): explain pull token output formats and credential naming (DOCS-148)

### DIFF
--- a/content/chainguard/containers/chainguard-registry/authenticating/index.md
+++ b/content/chainguard/containers/chainguard-registry/authenticating/index.md
@@ -96,6 +96,11 @@ Pulls authenticated in this way are associated with a Chainguard identity, which
 You can also export the pull token details into environment variables for
 [authentication in automated
 systems](/chainguard/containers/features/packages/private-apk-repos/#pull-token-automation).
+Running `chainctl auth pull-token create --output=env` sets
+`CHAINGUARD_IDENTITY_ID` to the username and `CHAINGUARD_TOKEN` to the password.
+Refer to [pull token output formats and credential
+names](/platform/chainctl-usage/pull-token-output/) for the other formats and
+for the variable names each library ecosystem uses.
 
 ### Using a pull token with Podman, Helm, and other tools
 
@@ -110,13 +115,13 @@ docker login "cgr.dev" \
 Save that pair and pass it to any tool that logs in to an OCI registry. For example, Podman:
 
 ```sh
-podman login cgr.dev --username "$CHAINGUARD_IDENTITY" --password "$CHAINGUARD_TOKEN"
+podman login cgr.dev --username "$CHAINGUARD_IDENTITY_ID" --password "$CHAINGUARD_TOKEN"
 ```
 
 Or Helm:
 
 ```sh
-helm registry login cgr.dev --username "$CHAINGUARD_IDENTITY" --password "$CHAINGUARD_TOKEN"
+helm registry login cgr.dev --username "$CHAINGUARD_IDENTITY_ID" --password "$CHAINGUARD_TOKEN"
 ```
 
 The same username and password work with registry mirroring tools such as Artifactory. Refer to the [pull-through guides](/chainguard/containers/chainguard-registry/pull-through-guides/) for tool-specific instructions.

--- a/content/chainguard/containers/features/packages/private-apk-repos/index.md
+++ b/content/chainguard/containers/features/packages/private-apk-repos/index.md
@@ -350,7 +350,11 @@ repository of the parent organization.
   365 days), valid unit strings range from nanoseconds to hours and are `ns`,
   `us`, `ms`, `s`, `m`, and `h`.
 * `--output=env`: set the command output to use export commands for environment
-  variables.
+  variables. `apk` and `oci` pull tokens use the unqualified
+  `CHAINGUARD_IDENTITY_ID` and `CHAINGUARD_TOKEN` names; library ecosystems use
+  names such as `CHAINGUARD_JAVA_IDENTITY_ID`. Refer to [pull token output
+  formats and credential
+  names](/platform/chainctl-usage/pull-token-output/) for the full mapping.
 * `--parent=ORGANIZATION`: specify the parent organization for your account as
   provided when requesting access and replace `ORGANIZATION`.
 

--- a/content/chainguard/libraries/introduction/access.md
+++ b/content/chainguard/libraries/introduction/access.md
@@ -160,6 +160,13 @@ Chainguard console:
 
 ## Pull token characteristics and use
 
+The username is the identity ID of the pull token identity that `chainctl` just
+created, and the password is the token itself. `chainctl` labels the same two
+values `identity_id` and `token` with `--output=json`, and
+`CHAINGUARD_JAVA_IDENTITY_ID` and `CHAINGUARD_JAVA_TOKEN` with `--output=env`.
+Refer to [pull token output formats and credential
+names](/platform/chainctl-usage/pull-token-output/) for the full mapping.
+
 The returned username and password combination is a new credential set in the
 organization that is independent of the account used to create and retrieve the
 credential set. It is therefore suitable for use in any service application,

--- a/content/platform/chainctl-usage/authentication-options.md
+++ b/content/platform/chainctl-usage/authentication-options.md
@@ -67,3 +67,5 @@ Assumable identities let automation tools like GitHub Actions or AWS Lambda conn
 ## Pull tokens
 
 Pull tokens are ideal for pulling images and libraries and can be long-lived. You can create them in the Chainguard Console or with `chainctl`. See [authenticating to the Chainguard registry](/chainguard/containers/chainguard-registry/authenticating/#authenticating-with-a-pull-token).
+
+A pull token is a pair of values that most tools consume as a username and a password. `chainctl` labels that pair differently in each output format, so refer to [pull token output formats and credential names](/platform/chainctl-usage/pull-token-output/) to map the labels to each other.

--- a/content/platform/chainctl-usage/pull-token-output.md
+++ b/content/platform/chainctl-usage/pull-token-output.md
@@ -1,0 +1,174 @@
+---
+title: "Pull token output formats and credential names"
+linktitle: "Pull token output"
+aliases:
+- /chainguard/chainctl-usage/pull-token-output/
+type: "article"
+description: "A reference for the output formats chainctl auth pull-token create supports and the names each format gives to the identity ID and token."
+lead: "Every pull token is a pair of values — an identity ID and a token — and each output format labels that pair differently. This page maps the labels to each other."
+date: 2026-09-03T00:00:00+00:00
+lastmod: 2026-09-03T00:00:00+00:00
+draft: false
+tags: ["chainctl", "Reference"]
+images: []
+menu:
+  docs:
+    parent: "chainctl-usage"
+toc: true
+weight: 025
+---
+
+`chainctl auth pull-token create` returns two values:
+
+* An **identity ID**, the identifier of the pull token identity that `chainctl` just created. It takes the form `ORGANIZATION_ID/TOKEN_ID`, where both parts are hexadecimal strings.
+* A **token**, a JSON Web Token that authenticates as that identity until the token's time to live expires.
+
+Every tool that consumes a pull token takes that pair as a username and a password for [HTTP basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication#basic_authentication_scheme): the identity ID is the username, and the token is the password. What changes between output formats is only the label.
+
+## Terminology mapping
+
+| Value | Default output | `--output=json` | `--output=env` |
+| --- | --- | --- | --- |
+| Identity ID | `Username` | `identity_id` | `CHAINGUARD_IDENTITY_ID` or `CHAINGUARD_<ECOSYSTEM>_IDENTITY_ID` |
+| Token | `Password` | `token` | `CHAINGUARD_TOKEN` or `CHAINGUARD_<ECOSYSTEM>_TOKEN` |
+
+The Chainguard Console labels the same two values **Username** and **Password** when it displays a new access token.
+
+`chainctl auth pull-token` without a subcommand is equivalent to `chainctl auth pull-token create`, so the formats described here apply to both.
+
+`chainctl auth pull-token create` supports two output formats, `env` and `json`, plus the default output you get when you pass no `--output` flag at all.
+
+## Default output
+
+With no `--output` flag, `chainctl` prints instructions for the repository type you asked for.
+
+For `--repository=oci`, the default, it prints a ready-to-run `docker login` command:
+
+```sh
+chainctl auth pull-token create
+```
+
+```output
+To use this pull token in another environment, run this command:
+
+    docker login "cgr.dev" --username "45a.....764595/095.....68679" --password "eyJhbGciO..........WF0IjoxN"
+```
+
+The `--username` value is the identity ID and the `--password` value is the token. Both work with any tool that logs in to an OCI registry, including Podman, Helm, and registry mirroring tools. Refer to [Authenticate to Chainguard's Registry](/chainguard/containers/chainguard-registry/authenticating/#using-a-pull-token-with-podman-helm-and-other-tools) for examples.
+
+For every other repository type, `chainctl` prints the pair as a username and a password:
+
+```sh
+chainctl auth pull-token create --repository=java
+```
+
+```output
+To use this pull token in another environment, supply the following for Basic authorization:
+
+Username: 45a.....764595/095.....68679
+
+Password: eyJhbGciO..........WF0IjoxN
+```
+
+## JSON output
+
+`--output=json` prints one compact object with an `identity_id` field and a `token` field:
+
+```sh
+chainctl auth pull-token create --repository=java --output=json
+```
+
+```output
+{"identity_id":"45a.....764595/095.....68679","token":"eyJhbGciO..........WF0IjoxN"}
+```
+
+The field names stay the same for every repository type. Pipe the object to `jq` or another JSON processor to extract either value:
+
+```sh
+TOKEN_JSON=$(chainctl auth pull-token create --repository=java --output=json)
+USERNAME=$(echo "$TOKEN_JSON" | jq -r '.identity_id')
+PASSWORD=$(echo "$TOKEN_JSON" | jq -r '.token')
+```
+
+## Environment output
+
+`--output=env` prints two `export` statements, one per value:
+
+```sh
+chainctl auth pull-token create --repository=java --output=env
+```
+
+```output
+export CHAINGUARD_JAVA_IDENTITY_ID=45a.....764595/095.....68679
+export CHAINGUARD_JAVA_TOKEN=eyJhbGciO..........WF0IjoxN
+```
+
+Wrap the command in `eval` to run those `export` statements, which sets both variables in your current session:
+
+```sh
+eval $(chainctl auth pull-token create --repository=java --output=env)
+```
+
+The variable names depend on the repository type. For a library ecosystem, `chainctl` uppercases the `--repository` value and inserts it into the name; for `oci` and `apk` it uses the unqualified names.
+
+| `--repository` | Identity ID variable | Token variable |
+| --- | --- | --- |
+| `oci` (default) | `CHAINGUARD_IDENTITY_ID` | `CHAINGUARD_TOKEN` |
+| `apk` | `CHAINGUARD_IDENTITY_ID` | `CHAINGUARD_TOKEN` |
+| `java` | `CHAINGUARD_JAVA_IDENTITY_ID` | `CHAINGUARD_JAVA_TOKEN` |
+| `javascript` | `CHAINGUARD_JAVASCRIPT_IDENTITY_ID` | `CHAINGUARD_JAVASCRIPT_TOKEN` |
+| `python` | `CHAINGUARD_PYTHON_IDENTITY_ID` | `CHAINGUARD_PYTHON_TOKEN` |
+
+Because the ecosystem name is part of the variable, credentials for two ecosystems can coexist in one shell session or one secrets file:
+
+```sh
+eval $(chainctl auth pull-token create --repository=java --output=env)
+eval $(chainctl auth pull-token create --repository=python --output=env)
+```
+
+Each invocation creates a new pull token identity. Write the `export` statements to a file or a secrets manager rather than rerunning the command whenever you need the values again, because `chainctl` displays the token only once.
+
+### Chainguard and tool-specific variables
+
+`chainctl` emits variables starting with `CHAINGUARD_`. However, build tools that read credentials from the environment typically use their own names, and don't read the `CHAINGUARD_*` variables directly. In such cases, you must map one to the other explicitly.
+
+For example, `uv` reads index-scoped credentials from `UV_INDEX_<NAME>_USERNAME` and `UV_INDEX_<NAME>_PASSWORD`, where `<NAME>` is the index name in uppercase, with underscores replacing hyphens. For an index named `chainguard`:
+
+```sh
+export UV_INDEX_CHAINGUARD_USERNAME="${CHAINGUARD_PYTHON_IDENTITY_ID}"
+export UV_INDEX_CHAINGUARD_PASSWORD="${CHAINGUARD_PYTHON_TOKEN}"
+```
+
+The same pattern applies wherever a tool defines its own variable, such as the `HTTP_AUTH` variable used for [private APK repositories](/chainguard/containers/features/packages/private-apk-repos/#pull-token-automation):
+
+```sh
+export HTTP_AUTH="basic::${CHAINGUARD_IDENTITY_ID}:${CHAINGUARD_TOKEN}"
+```
+
+Names you choose yourself, such as GitHub Actions secrets, are also independent of the `CHAINGUARD_*` convention. Whatever you call them, the identity ID is the username and the token is the password.
+
+## Why the `--output` help text lists more formats
+
+If you pass any other value, `chainctl` prints a warning to standard error, then falls back to default output. Requesting `csv`, for example, produces a warning along these lines:
+
+```output
+"csv" is not a supported output. Supported: [ env json]. Using print to command line
+```
+
+Even when a command returns this warning, it still creates the pull token. It refuses only the formatting request, so a script that expects machine-readable output on standard output receives prose instead. This matters most for `eval`: `eval $(chainctl auth pull-token --output=csv)` creates a token, sends the warning to your terminal, and then tries to run the human-readable text as shell commands.
+
+The `--output` flag is global, so `chainctl --help` and every reference page describe it the same way:
+
+```output
+  -o, --output string      Output format. One of: [csv, env, go-template, id, json, markdown, none, table, terse, tree, wide]
+```
+
+That list is the union of every format any `chainctl` command supports, not a list of formats that all commands support. Each command declares its own subset. Table-shaped commands such as `chainctl iam identities list` accept `csv` and `markdown`; `pull-token create` returns a single credential pair and accepts only `env` and `json`.
+
+## Related pages
+
+* [Authenticate to Chainguard's Registry](/chainguard/containers/chainguard-registry/authenticating/#authenticating-with-a-pull-token) for container pull tokens
+* [Chainguard Libraries access](/chainguard/libraries/introduction/access/#pull-token) for library pull tokens
+* [Private APK repositories](/chainguard/containers/features/packages/private-apk-repos/#pull-token-automation) for APK pull tokens
+* [chainctl auth pull-token create](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_create/) for the generated flag reference
+* [Automating with chainctl](/platform/chainctl-usage/automating-chainctl/) for other scripting patterns


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update / New Content**
- Adds a `chainctl` usage page mapping pull token credentials across the default, `json`, and `env` output formats
- Documents that `pull-token create` supports only `env` and `json`, and that the global `--output` list spans all of `chainctl`
- Corrects `$CHAINGUARD_IDENTITY` to `$CHAINGUARD_IDENTITY_ID` in the registry authentication examples
- Cross-links the new page from the container, APK, and libraries pull token guides

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-148/clarify-chainctl-auth-pull-token-output-formats-and-credential-naming

Explains that a pull token's Username/Password, `identity_id`/`token`, and `CHAINGUARD_*` variables are three labels for the same identity ID and token.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
A customer reported confusion because `--output env` emits `CHAINGUARD_*_IDENTITY_ID` and `CHAINGUARD_*_TOKEN` while the default output labels the same values Username and Password. Nothing in the docs connected the two, and the generated `--output` reference line lists formats such as `csv` and `markdown` that this command silently ignores. The generated reference page is synced from mono with `rsync --delete`, so the explanation needs a hand-authored home.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- The terminology mapping is correct: Username = identity ID = `identity_id` = `CHAINGUARD_IDENTITY_ID`, and Password = pull token = `token` = `CHAINGUARD_TOKEN`
- The docs state that `apk` and `oci` use unqualified variable names while library ecosystems get an ecosystem infix
- The docs distinguish `chainctl`'s `CHAINGUARD_*` variables from tool-specific ones such as `UV_INDEX_*` and `HTTP_AUTH`
- Readers understand that the global `--output` help lists formats across `chainctl`, not per command

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Confirm `/platform/chainctl-usage/pull-token-output/` renders and appears in the chainctl usage sidebar
3. Run `chainctl auth pull-token create --repository=java --output=env` and `--output=json` and compare against the documented output; try `--output=csv` to confirm the warning and text fallback
4. Verify the inbound links from Authentication options, Authenticate to Chainguard's Registry, Chainguard Libraries access, and Private APK repositories
