### PR TITLE
Move the bundle-refresh PR branch out of the tag namespace

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -473,7 +473,10 @@ jobs:
         # Only the served bundle. Everything else the compile job writes to
         # static/downloads is a build artifact that belongs in GHCR and GCS.
         add-paths: static/downloads/chainguard-complete-docs.md
-        branch: ai-docs-bundle
+        # Not "ai-docs-bundle": that is an existing release tag, and the action
+        # resolves the name to the tag, decides the branch already exists, then
+        # fails the push with "stale info" against a branch that never existed.
+        branch: ai-docs-bundle-refresh
         commit-message: Refresh the compiled AI documentation bundle
         title: "[AI Docs] Refresh the documentation bundle"
         body: |

--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -415,6 +415,10 @@ jobs:
     permissions:
       contents: read
       id-token: write # Federate a token via octo-sts
+    env:
+      # Single source of truth: the preflight check and the
+      # create-pull-request input must never drift apart.
+      PR_BRANCH: bot/docs-bundle-refresh
 
     steps:
     - name: Harden Runner
@@ -466,6 +470,24 @@ jobs:
           echo "Bundle content changed; opening a pull request."
         fi
 
+    - name: Fail early if a tag shadows the pull request branch
+      run: |
+        # create-pull-request fetches "$PR_BRANCH:refs/remotes/origin/$PR_BRANCH",
+        # and a bare ref name resolves against tags as well as heads. A tag of
+        # the same name therefore makes the action believe the branch already
+        # exists, and the push then fails with git's opaque "stale info" -- the
+        # DOCS-158 failure. Every tag in this repository starts with "ai-docs"
+        # and a "Block Tag Deletion" ruleset makes them permanent, so name the
+        # problem here rather than leaving the next person to decode it.
+        if git ls-remote --exit-code origin "refs/tags/$PR_BRANCH" > /dev/null 2>&1; then
+          echo "Error: a tag named '$PR_BRANCH' exists and shadows the branch"
+          echo "this job pushes to. Set PR_BRANCH to a name no tag uses, and"
+          echo "keep it outside the ai-docs* namespace."
+          exit 1
+        fi
+
+        echo "No tag shadows '$PR_BRANCH'."
+
     - name: Open a pull request for the refreshed bundle
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
@@ -473,10 +495,7 @@ jobs:
         # Only the served bundle. Everything else the compile job writes to
         # static/downloads is a build artifact that belongs in GHCR and GCS.
         add-paths: static/downloads/chainguard-complete-docs.md
-        # Not "ai-docs-bundle": that is an existing release tag, and the action
-        # resolves the name to the tag, decides the branch already exists, then
-        # fails the push with "stale info" against a branch that never existed.
-        branch: ai-docs-bundle-refresh
+        branch: ${{ env.PR_BRANCH }}
         commit-message: Refresh the compiled AI documentation bundle
         title: "[AI Docs] Refresh the documentation bundle"
         body: |


### PR DESCRIPTION
Follow-up to #3919. The nightly publish job failed on its first real run (manual trigger, [run 33877817558](https://github.com/chainguard-dev/edu/actions/runs/33877817558)).

## Cause

`ai-docs-bundle` is an existing **tag** — the archived GitHub release "Archived Bundle (superseded)", created 2026-04-07. `create-pull-request` fetches its target branch with `git fetch origin <branch>:refs/remotes/origin/<branch>`. A bare ref name resolves against tags as well as heads, so it picked up the tag:

```
* [new tag]         ai-docs-bundle -> origin/ai-docs-bundle
Pull request branch 'ai-docs-bundle' already exists as remote branch 'origin/ai-docs-bundle'
```

The action then treated the tag's history as the existing branch (11 commits ahead of `main`), reset it, and pushed with `--force-with-lease`. Git rejected that as `(stale info)`, because no branch of that name has ever existed. `gh api repos/chainguard-dev/edu/branches/ai-docs-bundle` returns 404 while `git/ref/tags/ai-docs-bundle` returns the tag, which is what made the failure look impossible.

## Why a simple rename was not enough

**Every tag in this repository begins with `ai-docs`** — all 17 of them:

```
ai-docs                      ai-docs-20260427-135041
ai-docs-bundle               ai-docs-20260428-120411
ai-docs-latest               ai-docs-20260428-132624
ai-docs-20260423-182027      ai-docs-20260429-133408
ai-docs-20260423-185744      ai-docs-20260429-134421
ai-docs-20260424-122346      ai-docs-20260429-150259
ai-docs-20260426-021819      ai-docs-20260430-121310
ai-docs-20260426-030135
ai-docs-20260427-122413
```

The timestamped ones came from the retired release process, which minted them automatically, and a **Block Tag Deletion** ruleset makes all of them permanent. Any branch named `ai-docs*` is one revived workflow away from the same failure.

## Fix

Three changes:

1. **`bot/docs-bundle-refresh`** — outside that namespace, matching the slash-prefixed convention already in use by `chore/`, `docs/`, and `dependabot/` branches. Verified free as both a tag and a branch.
2. **A preflight check** that runs `git ls-remote --exit-code origin "refs/tags/$PR_BRANCH"` before the pull request step and fails with a named error if a tag shadows the branch. A naming convention prevents the likely case; this prevents the confusing one. Git's `(stale info)` gives no hint that a tag is involved, and the branches API returning 404 actively misleads.
3. **A job-level `PR_BRANCH` variable** feeding both the check and the `create-pull-request` input, so they cannot drift apart.

Tested the check against the real remote in both directions: it exits 1 for `ai-docs-bundle` and passes for `bot/docs-bundle-refresh`.

## What already worked on the failing run

Everything except the push: the octo-sts token exchange against the new `ai-docs` trust policy, the artifact handoff between jobs, and the change gate, which correctly detected a real difference against the April copy and let it through. The `compile-docs` job succeeded, and the merge also confirmed the race fix — that push started one compile workflow where it previously started three, and `publish-bundle` correctly skipped on the dispatch-driven run.

## After this merges

Expect the next run to open the refresh pull request and then **fail the 14-day staleness guard**, because the served bundle is still dated 2026-04-03. That is the guard working, not a broken build, and it clears when the refresh pull request merges.

Refs [DOCS-158](https://linear.app/chainguard/issue/DOCS-158/the-ai-docs-bundle-has-never-been-republished-the-workflow-that).

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)