### PR TITLE
Fix search_docs: index real pages and score per term

### DIFF
--- a/.github/workflows/mcp-image-smoke-test.yaml
+++ b/.github/workflows/mcp-image-smoke-test.yaml
@@ -14,6 +14,41 @@ on:
 permissions: {}
 
 jobs:
+  # Unit tests for the document index (DOCS-181). The smoke test below proves
+  # the server starts and answers; it cannot tell whether search returns the
+  # right page. These run against the bundle committed to the repo, so they
+  # catch a parser regression on the real document structure.
+  unit-test:
+    if: github.repository == 'chainguard-dev/edu'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          files.pythonhosted.org:443
+          github.com:443
+          pypi.org:443
+
+    - name: Checkout edu repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: pip install -r scripts/mcp-requirements.txt pytest
+
+    - name: Run tests
+      run: pytest scripts/test_mcp_server.py -v
+
   smoke-test:
     if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest

--- a/scripts/mcp-server.py
+++ b/scripts/mcp-server.py
@@ -73,6 +73,84 @@ MANIFEST_ACCEPT = ", ".join(
 # roughly 500 to 1. They are filtered out of tag listings.
 COSIGN_ATTACHMENT_PREFIX = "sha256-"
 
+# compile_docs.py writes every documentation page as
+#     ### <title>
+#     _Path: <source path>_
+#     <page content>
+# so the title line plus the path line is a page boundary. Nothing else in the
+# bundle carries that pair: page bodies keep their own '##' and '###' headings,
+# which is why heading level alone cannot mark where a page starts (DOCS-181).
+PAGE_HEADING = re.compile(
+    r"^### (?P<title>.+)\n_Path: (?P<path>.+?)_\s*$", re.MULTILINE
+)
+
+# Everything from this marker on is container-image READMEs, delimited by
+# IMAGE_SEPARATOR rather than by the page signature above.
+IMAGES_MARKER = re.compile(r"^## Container Images\n", re.MULTILINE)
+
+# Search scoring (DOCS-181). The previous scorer counted the whole query as one
+# literal substring, so 'migrating python' scored zero everywhere — those two
+# words are never adjacent in the corpus, even on the page titled "Migrating to
+# Python Chainguard Containers". Score per term instead, and weight the title,
+# because callers search for what a page is about rather than for a phrase it
+# happens to contain.
+SEARCH_TERM = re.compile(r"[a-z0-9][a-z0-9._/-]*")
+
+# Words that appear in nearly every section, plus the ones an MCP client tends
+# to wrap a question in ("give me the guide for ...").
+SEARCH_STOPWORDS = frozenset(
+    """a an and are as at be by can do does for from get give had has have how
+    i in into is it me my of on or please show that the their them then there
+    these this to use used using want was what when where which who why will
+    with you your""".split()
+)
+
+# Suffixes stripped to a common stem so 'migration' and 'migrating' match. This
+# is deliberately cruder than a real stemmer: the stem is then counted as a
+# substring of the section text, so over-matching costs recall noise rather
+# than a miss, and it needs no dependency and no pass over the 14 MB bundle.
+STEM_SUFFIXES = (
+    "ations",
+    "ation",
+    "ings",
+    "ing",
+    "ments",
+    "ment",
+    "ions",
+    "ion",
+    "es",
+    "s",
+)
+MIN_STEM_LEN = 4
+
+TITLE_TERM_WEIGHT = 40  # a term in the page title
+TERM_COVERAGE_WEIGHT = 10  # each distinct query term the section matches
+EXACT_PHRASE_BONUS = 60  # the whole query, verbatim
+BODY_HIT_CAP = 20  # ceiling on raw frequency, so long pages cannot dominate
+
+# Where the bundled pages are published, so a search result can link to the
+# page rather than only naming it.
+EDU_BASE_URL = "https://edu.chainguard.dev"
+
+
+def page_url(source_path: str) -> str:
+    """Map a bundle '_Path:' value to the published page URL.
+
+    compile_docs.py records the path relative to content/, and Hugo serves
+    'chainguard/libraries/python/overview.md' at
+    '<base>/chainguard/libraries/python/overview/'.
+
+    Both bundle forms are served at the directory rather than below it: a
+    branch bundle (_index.md, 32 pages) and a leaf bundle (index.md, 76
+    pages). Keeping the filename would 404 on 13% of the corpus. Verified
+    against the live site (DOCS-181).
+    """
+    slug = source_path.removesuffix(".md")
+    slug = slug.removesuffix("/_index").removesuffix("/index")
+    if slug in ("_index", "index"):
+        return f"{EDU_BASE_URL}/"
+    return f"{EDU_BASE_URL}/{slug}/"
+
 
 def extract_image_names(container_section: str) -> List[str]:
     """Return image names from the compiled '## Container Images' section text.
@@ -104,56 +182,80 @@ class ChaguardDocsIndex:
 
     def __init__(self, docs_content: str):
         self.content = docs_content
-        self.sections = self._parse_sections()
+        self.sections, self.page_paths = self._parse_sections()
         self.images = self._extract_images()
 
-    def _parse_sections(self) -> Dict[str, str]:
-        """Parse markdown into logical sections."""
+    def _parse_sections(self) -> tuple[Dict[str, str], Dict[str, str]]:
+        """Split the bundle into one section per documentation page or image.
+
+        Returns the sections keyed by page title (or 'image:<name>'), and the
+        source path of each page.
+
+        The previous parser started a new section at any line beginning with
+        '# '. compile_docs.py never emits that as structure, so every such line
+        was content — a shell comment inside a fenced block, or an H1 in an
+        image README. Page text ended up filed under keys like 'Install
+        Composer and set up application', and whole guides became unfindable
+        (DOCS-181). Key on what the compiler actually writes instead.
+        """
         sections = {}
-        current_section = None
-        current_content = []
+        page_paths = {}
 
-        for line in self.content.split("\n"):
-            # Top-level headers indicate new sections
-            if line.startswith("# "):
-                if current_section:
-                    sections[current_section] = "\n".join(current_content)
-                current_section = line[2:].strip()
-                current_content = [line]
-            elif current_content:
-                current_content.append(line)
-
-        # Add last section
-        if current_section:
-            sections[current_section] = "\n".join(current_content)
-
-        # Also parse individual container images as separate sections
-        # Find the Container Images section and extract individual image docs
-        container_images_match = re.search(
-            r"^## Container Images\n", self.content, re.MULTILINE
+        images_marker = IMAGES_MARKER.search(self.content)
+        docs_region = (
+            self.content[: images_marker.start()] if images_marker else self.content
         )
-        if container_images_match:
-            start_pos = container_images_match.end()
-            section_content = self.content[start_pos:]
 
-            # Use regex to find all image sections (### header followed by content until next separator or end)
-            # Pattern: ### image-name followed by content until <!-- IMAGE_SEPARATOR --> or end of string.
-            # Name class allows underscores to match images like sql_exporter (DOCS-138).
-            image_pattern = (
-                r"### ([a-z0-9][a-z0-9_-]*)\n(.*?)(?=\n<!-- IMAGE_SEPARATOR -->|\Z)"
+        headings = list(PAGE_HEADING.finditer(docs_region))
+
+        # Whatever precedes the first page is the bundle's own front matter:
+        # the usage guide that tells an AI client how to query this file.
+        preamble = docs_region[: headings[0].start()] if headings else docs_region
+        if preamble.strip():
+            sections["Bundle Usage Guide"] = preamble.strip()
+
+        for i, heading in enumerate(headings):
+            end = headings[i + 1].start() if i + 1 < len(headings) else len(docs_region)
+            title = heading.group("title").strip()
+            path = heading.group("path").strip()
+
+            # A handful of titles repeat across languages ('Global
+            # configuration' exists for Java, JavaScript and Python). Qualify
+            # the duplicates so one does not overwrite the others.
+            key = title if title not in sections else f"{title} ({path})"
+
+            sections[key] = docs_region[heading.start() : end].strip()
+            page_paths[key] = path
+
+        sections.update(self._parse_image_sections(images_marker))
+        return sections, page_paths
+
+    def _parse_image_sections(self, images_marker) -> Dict[str, str]:
+        """Parse the container-image READMEs into 'image:<name>' sections.
+
+        Pattern: ### image-name followed by content until <!-- IMAGE_SEPARATOR -->
+        or end of string. Name class allows underscores to match images like
+        sql_exporter (DOCS-138).
+
+        Anything after the last separator is dropped. The bundle currently ends
+        there; if the DFC mappings section returns (DOCS-174), index it here.
+        """
+        if not images_marker:
+            return {}
+
+        image_pattern = (
+            r"### ([a-z0-9][a-z0-9_-]*)\n(.*?)(?=\n<!-- IMAGE_SEPARATOR -->|\Z)"
+        )
+        return {
+            f"image:{match.group(1)}": f"### {match.group(1)}\n{match.group(2).strip()}"
+            for match in re.finditer(
+                image_pattern, self.content[images_marker.end() :], re.DOTALL
             )
-            for match in re.finditer(image_pattern, section_content, re.DOTALL):
-                image_name = match.group(1)
-                image_content = f"### {image_name}\n{match.group(2).strip()}"
-                sections[f"image:{image_name}"] = image_content
-
-        return sections
+        }
 
     def _extract_images(self) -> List[str]:
         """Extract list of container image names from docs."""
-        container_images_match = re.search(
-            r"^## Container Images\n", self.content, re.MULTILINE
-        )
+        container_images_match = IMAGES_MARKER.search(self.content)
         if container_images_match:
             names = extract_image_names(self.content[container_images_match.end() :])
             if names:
@@ -167,29 +269,28 @@ class ChaguardDocsIndex:
 
     def search(self, query: str, max_results: int = 5) -> List[Dict[str, str]]:
         """Search documentation for relevant content."""
-        query_lower = query.lower()
+        stems = self._query_stems(query)
+        if not stems:
+            return []
+
+        query_lower = query.lower().strip()
         results = []
 
         for section_name, section_content in self.sections.items():
-            # Simple relevance scoring based on query term frequency
-            content_lower = section_content.lower()
-            score = content_lower.count(query_lower)
+            score = self._score_section(
+                section_name, section_content, stems, query_lower
+            )
 
             if score > 0:
-                # Extract a relevant snippet
-                lines = section_content.split("\n")
-                snippet_lines = []
-                for line in lines[:50]:  # First 50 lines of section
-                    if query_lower in line.lower():
-                        snippet_lines.append(line)
-                        if len(snippet_lines) >= 5:
-                            break
-
+                source_path = self.page_paths.get(section_name)
                 results.append(
                     {
                         "section": section_name,
                         "score": score,
-                        "snippet": "\n".join(snippet_lines[:5]),
+                        # Image READMEs are not published pages, so they have
+                        # no path and no URL to offer.
+                        "url": page_url(source_path) if source_path else "",
+                        "snippet": self._build_snippet(section_content, stems),
                         "full_content": section_content[:2000],  # First 2000 chars
                     }
                 )
@@ -197,6 +298,87 @@ class ChaguardDocsIndex:
         # Sort by relevance and return top results
         results.sort(key=lambda x: x["score"], reverse=True)
         return results[:max_results]
+
+    @staticmethod
+    def _stem(word: str) -> str:
+        """Strip one common suffix, leaving at least MIN_STEM_LEN characters."""
+        for suffix in STEM_SUFFIXES:
+            if word.endswith(suffix) and len(word) - len(suffix) >= MIN_STEM_LEN:
+                return word[: -len(suffix)]
+        return word
+
+    @classmethod
+    def _query_stems(cls, query: str) -> List[str]:
+        """Reduce a query to the distinct stems worth searching for.
+
+        'Give me the migration guide for python' becomes ['migrat', 'guide',
+        'python']. Returns them in query order, deduplicated.
+        """
+        stems = []
+        for word in SEARCH_TERM.findall(query.lower()):
+            if word in SEARCH_STOPWORDS:
+                continue
+            stem = cls._stem(word)
+            if len(stem) >= MIN_STEM_LEN and stem not in stems:
+                stems.append(stem)
+        return stems
+
+    @staticmethod
+    def _score_section(
+        section_name: str, section_content: str, stems: List[str], query_lower: str
+    ) -> int:
+        """Rank one section against the query stems.
+
+        Reward breadth first — a section matching every term beats one matching
+        a single term many times — then the title, then raw frequency.
+        """
+        title_lower = section_name.lower()
+        content_lower = section_content.lower()
+
+        matched = 0
+        score = 0
+        for stem in stems:
+            hits = content_lower.count(stem)
+            if hits:
+                matched += 1
+                score += min(hits, BODY_HIT_CAP)
+            if stem in title_lower:
+                score += TITLE_TERM_WEIGHT
+
+        if not matched:
+            return 0
+
+        score += matched * TERM_COVERAGE_WEIGHT
+        if query_lower in content_lower:
+            score += EXACT_PHRASE_BONUS
+        return score
+
+    @staticmethod
+    def _build_snippet(section_content: str, stems: List[str], limit: int = 5) -> str:
+        """Return up to `limit` lines of the section worth showing the caller.
+
+        Prefer lines mentioning the most query terms. The old version only
+        looked at the first 50 lines of the section, so a match further down
+        produced a result with an empty body — every hit in the DOCS-181 report
+        read that way. Fall back to the opening prose so a result always says
+        something.
+        """
+        lines = [line for line in section_content.split("\n") if line.strip()]
+
+        scored = []
+        for position, line in enumerate(lines):
+            lowered = line.lower()
+            hits = sum(1 for stem in stems if stem in lowered)
+            if hits:
+                scored.append((-hits, position, line))
+
+        if scored:
+            scored.sort()
+            best = sorted(scored[:limit], key=lambda item: item[1])
+            return "\n".join(line for _, _, line in best)
+
+        opening = [line for line in lines if not line.startswith("_")]
+        return "\n".join(opening[:limit])
 
     def get_image_docs(self, image_name: str) -> Optional[str]:
         """Get documentation for a specific container image."""
@@ -597,6 +779,8 @@ def search_docs(
     response = f"# Search Results for: {query}\n\n"
     for i, result in enumerate(results, 1):
         response += f"## Result {i}: {result['section']}\n\n"
+        if result["url"]:
+            response += f"{result['url']}\n\n"
         response += f"{result['snippet']}\n\n"
         response += "---\n\n"
     return response

--- a/scripts/test_mcp_server.py
+++ b/scripts/test_mcp_server.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Tests for the AI Docs MCP server's document index.
+
+Regression coverage for the `search_docs` defects Jason Bishay reported in
+Slack (DOCS-181): an exact page title returned nothing, and the queries that
+did match landed on shell comments inside code blocks with empty bodies.
+
+Two layers:
+
+* A synthetic bundle that mirrors what `compile_docs.py` emits. Fast,
+  deterministic, and safe to run in CI.
+* The real bundle at `static/downloads/chainguard-complete-docs.md`, using
+  Jason's four verbatim queries. Skipped when the file is absent. A synthetic
+  fixture can only prove the parser handles the shape we think the compiler
+  writes; this layer proves it handles what the compiler actually wrote.
+
+Run with:
+    pytest scripts/test_mcp_server.py -v
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REAL_BUNDLE = REPO_ROOT / "static" / "downloads" / "chainguard-complete-docs.md"
+
+# The page Jason could not retrieve. Ground truth confirmed against the bundle:
+# this title and path appear exactly once.
+PYTHON_GUIDE_TITLE = "Migrating to Python Chainguard Containers"
+PYTHON_GUIDE_PATH = (
+    "chainguard/containers/migration/migration-guides/migrating-python.md"
+)
+
+
+def load_server_module():
+    """Import scripts/mcp-server.py, whose filename is not a valid module name.
+
+    The module indexes DOCS_PATH at import time. Point it at paths that do not
+    exist so the import stays cheap and the tests supply their own content.
+    """
+    os.environ["DOCS_PATH"] = "/nonexistent/docs.md"
+    os.environ["CATALOG_PATH"] = "/nonexistent/catalog.json"
+
+    spec = importlib.util.spec_from_file_location(
+        "mcp_server_under_test", Path(__file__).parent / "mcp-server.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mcp_server = load_server_module()
+
+
+def build_page(title, path, body_lines):
+    """Emit one documentation page exactly as compile_docs.py writes it."""
+    body = "\n".join(body_lines)
+    return f"### {title}\n_Path: {path}_\n\n{body}\n\n---\n"
+
+
+# A page long enough that the term under test sits past the 50-line window the
+# old snippet builder used, which is why every result came back with an empty
+# body. The fenced block carries the same shape of shell comment that the old
+# parser mistook for a top-level heading.
+PYTHON_GUIDE_BODY = (
+    [
+        "## Overview",
+        "",
+        "This guide covers moving an application onto a Chainguard Python container.",
+        "",
+        "```bash",
+        "# Install Composer and set up application",
+        "composer install",
+        "# Run the server",
+        "./serve.sh",
+        "```",
+        "",
+    ]
+    + ["Filler line about container migration steps." for _ in range(60)]
+    + [
+        "",
+        "## Multi-stage builds",
+        "",
+        "Use the -dev variant at build time and the runtime image to ship.",
+    ]
+)
+
+SYNTHETIC_BUNDLE = (
+    "# Chainguard Documentation Bundle\n\n"
+    "## Usage Guide\n\n"
+    "Ask about container images, migration, and security.\n\n"
+    "## Table of Contents\n\n"
+    "1. [Usage Guide](#usage-guide)\n"
+    "2. [Documentation Content](#documentation-content)\n\n"
+    "---\n\n"
+    "## Documentation Content\n\n"
+    + build_page(PYTHON_GUIDE_TITLE, PYTHON_GUIDE_PATH, PYTHON_GUIDE_BODY)
+    + build_page(
+        "Getting Started with Chainguard Containers",
+        "chainguard/containers/getting-started.md",
+        ["## Prerequisites", "", "You need a cgr.dev account."],
+    )
+    + "\n---\n\n"
+    "## Container Images\n\n"
+    "_This section contains documentation for Chainguard container images._\n\n"
+    "### python\n"
+    "A minimal Python container image.\n"
+    "\n<!-- IMAGE_SEPARATOR -->\n"
+    "### nginx\n"
+    "A minimal nginx container image.\n"
+    "\n<!-- IMAGE_SEPARATOR -->\n"
+)
+
+
+@pytest.fixture(scope="module")
+def index():
+    return mcp_server.ChaguardDocsIndex(SYNTHETIC_BUNDLE)
+
+
+@pytest.fixture(scope="module")
+def real_index():
+    if not REAL_BUNDLE.exists():
+        pytest.skip(f"bundle not present at {REAL_BUNDLE}")
+    return mcp_server.ChaguardDocsIndex(REAL_BUNDLE.read_text(encoding="utf-8"))
+
+
+# --- Section parsing -------------------------------------------------------
+
+
+def test_pages_are_keyed_by_their_title(index):
+    """A reader searching for a page should get the page, named as the page."""
+    assert PYTHON_GUIDE_TITLE in index.sections
+
+
+def test_comments_inside_code_blocks_do_not_become_sections(index):
+    """The defect behind Jason's results: '# comment' in a fence started a section."""
+    assert "Install Composer and set up application" not in index.sections
+    assert "Run the server" not in index.sections
+
+
+def test_headings_inside_a_page_do_not_split_it(index):
+    """A page's own '##' headings belong to the page, not to sections of their own."""
+    assert "Overview" not in index.sections
+    assert "Multi-stage builds" not in index.sections
+    assert "Multi-stage builds" in index.sections[PYTHON_GUIDE_TITLE]
+
+
+def test_page_content_is_not_truncated(index):
+    """The whole page is indexed, so terms late in a long page stay findable."""
+    page = index.sections[PYTHON_GUIDE_TITLE]
+    assert "Use the -dev variant at build time" in page
+
+
+def test_image_sections_still_parse(index):
+    """Images keep their existing 'image:' keys; this path already worked."""
+    assert "image:python" in index.sections
+    assert "image:nginx" in index.sections
+    assert index.images == ["nginx", "python"]
+
+
+def test_no_content_is_dropped(index):
+    """Every section of the bundle lands somewhere in the index."""
+    indexed = "\n".join(index.sections.values())
+    assert "Ask about container images, migration, and security." in indexed
+
+
+# --- Search results --------------------------------------------------------
+
+
+def test_exact_page_title_returns_that_page(index):
+    results = index.search(PYTHON_GUIDE_TITLE)
+    assert results, "an exact page title must return the page"
+    assert results[0]["section"] == PYTHON_GUIDE_TITLE
+
+
+def test_every_result_has_a_body(index):
+    """Jason's hits were all empty, so a relevant match told the caller nothing."""
+    for query in ["python", PYTHON_GUIDE_TITLE, "multi-stage builds"]:
+        for result in index.search(query):
+            assert result["snippet"].strip(), f"empty body for query {query!r}"
+
+
+def test_terms_match_without_the_exact_phrase(index):
+    """'migrating python' must find "Migrating to Python …" — the words are never
+    adjacent in the corpus, so whole-phrase substring matching returns nothing."""
+    results = index.search("migrating python")
+    assert PYTHON_GUIDE_TITLE in [r["section"] for r in results]
+
+
+def test_natural_language_query_finds_the_page(index):
+    """MCP clients ask in sentences. The tool has to tolerate that."""
+    results = index.search("Give me the migration guide for python")
+    assert PYTHON_GUIDE_TITLE in [r["section"] for r in results]
+
+
+def test_results_carry_the_page_url(index):
+    """A caller asking for a guide should get a link they can open."""
+    result = index.search(PYTHON_GUIDE_TITLE)[0]
+    assert result["url"] == (
+        "https://edu.chainguard.dev/chainguard/containers/migration"
+        "/migration-guides/migrating-python/"
+    )
+
+
+def test_image_results_have_no_url(index):
+    """Image READMEs are not published pages, so there is nothing to link to."""
+    for result in index.search("nginx container image"):
+        if result["section"].startswith("image:"):
+            assert result["url"] == ""
+
+
+@pytest.mark.parametrize(
+    "source_path,expected",
+    [
+        # Verified against the live site, 2026-09-08: all four return HTTP 200.
+        (
+            "chainguard/containers/migration/migration-guides/migrating-python.md",
+            "https://edu.chainguard.dev/chainguard/containers/migration"
+            "/migration-guides/migrating-python/",
+        ),
+        # Branch bundle: 32 pages in the bundle are named _index.md.
+        (
+            "platform/administration/cloudevents/_index.md",
+            "https://edu.chainguard.dev/platform/administration/cloudevents/",
+        ),
+        # Leaf bundle: 76 pages are named index.md, and Hugo serves those at
+        # the directory too. Appending '/index/' 404s.
+        (
+            "chainguard/containers/how-to-use/retrieve-image-sboms/index.md",
+            "https://edu.chainguard.dev/chainguard/containers/how-to-use"
+            "/retrieve-image-sboms/",
+        ),
+        ("ai-docs-security.md", "https://edu.chainguard.dev/ai-docs-security/"),
+        ("_index.md", "https://edu.chainguard.dev/"),
+        ("index.md", "https://edu.chainguard.dev/"),
+    ],
+)
+def test_page_url_mapping(source_path, expected):
+    assert mcp_server.page_url(source_path) == expected
+
+
+def test_search_docs_output_shows_the_url(monkeypatch, index):
+    """The rendered tool response, not just the internal result dict."""
+    monkeypatch.setattr(mcp_server, "docs_index", index)
+    output = mcp_server.search_docs(PYTHON_GUIDE_TITLE, max_results=1)
+    assert "https://edu.chainguard.dev/chainguard/containers/migration" in output
+
+
+def test_title_match_outranks_an_incidental_body_mention(index):
+    """A page about the topic should beat a page that merely mentions the word."""
+    results = index.search(PYTHON_GUIDE_TITLE)
+    assert results[0]["section"] == PYTHON_GUIDE_TITLE
+
+
+# --- The real bundle -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        PYTHON_GUIDE_TITLE,
+        "migrating python",
+        "Give me the migration guide for python",
+        "python migration",
+    ],
+)
+def test_jasons_queries_find_the_python_guide(real_index, query):
+    """The four queries from the Slack report, run against the shipped bundle."""
+    sections = [r["section"] for r in real_index.search(query, max_results=5)]
+    assert PYTHON_GUIDE_TITLE in sections, f"got {sections}"
+
+
+def test_real_bundle_results_are_never_empty(real_index):
+    for query in ["python migration", "chainctl login", "FIPS"]:
+        for result in real_index.search(query):
+            assert result["snippet"].strip(), f"empty body for query {query!r}"
+
+
+def test_real_bundle_sections_are_document_headings(real_index):
+    """No section key should be a shell comment. 1,992 of them were."""
+    for name in index_page_keys(real_index):
+        assert not name.startswith("#"), f"{name!r} looks like a raw heading"
+    assert PYTHON_GUIDE_TITLE in real_index.sections
+
+
+def index_page_keys(idx):
+    return [name for name in idx.sections if not name.startswith("image:")]


### PR DESCRIPTION
Fixes the AI Docs MCP server's `search_docs`, which could not return a documentation page by its title.

Jason Bishay reported this in Slack. His customer cannot use Guardener because of policy restrictions and is running their container migrations through this MCP server instead, so `search_docs` is that customer's path to the migration guides. Asking for the Python migration guide returned nothing.

Closes DOCS-181.

## The defects

Reproduced against the served bundle by running the shipped `ChaguardDocsIndex` verbatim. Jason's four queries, before:

| Query | Result |
| -- | -- |
| `Migrating to Python Chainguard Containers` (exact page title) | 1 hit, empty body |
| `migrating python` | nothing |
| `Give me the migration guide for python` | nothing |
| `python migration` | 3 hits — a `.rego` snippet heading, a `uv` comment, "set default registry as a string". All empty bodies. |

Four causes, all in one code path:

1. **Sections split on code-block comments.** `_parse_sections()` started a new section at any line beginning with `# `. `compile_docs.py` never emits that as structure — every such line is content, a shell comment inside a fenced block or an H1 in an image README. The Python guide's title sat at line 1,878 of a 1,921-line "section" named `Install Composer and set up application`.
2. **Whole-query substring scoring.** `content.count(query)` requires the exact phrase. `migrating python` scored zero everywhere, because those two words are never adjacent — not even on the page titled "Migrating to Python Chainguard Containers".
3. **Result labels were those bogus section keys**, so hits were named after shell comments.
4. **Snippets scanned only the first 50 lines** of a section. 46% of sections were longer, so a match further down produced an empty body.

## The changes

- **Parse what the compiler writes.** `compile_docs.py` emits each page as `### <title>` followed by `_Path: <source path>_`. That pair is unambiguous — page bodies keep their own `##` and `###` headings, so heading level alone cannot mark a page boundary. Section count drops from 3,851 to 2,155 (603 pages + 1,551 images + the usage guide), and no key is a shell comment. Duplicate titles (`Global configuration` exists for Java, JavaScript and Python) are qualified by path instead of overwriting each other.
- **Score per term.** Stopwords removed, crude suffix stemming so `migrating` and `migration` share a stem, title terms weighted, breadth of match rewarded over raw frequency, and a bonus for the exact phrase. No new dependencies.
- **Build snippets from the whole section**, ranked by term density, with a prose fallback so a result is never empty.
- **Return the published URL** with each result, derived from the recorded path, so a caller gets a link to open rather than only a page name.

## Verification

`scripts/test_mcp_server.py` — 26 tests over a synthetic bundle mirroring the compiler's output, plus the real committed bundle using Jason's four verbatim queries. Written before the fix: against unmodified code it failed 15 of 17, and the two that passed were the image-parsing guardrails.

Checked by hand against the live bundle:

- All four of Jason's queries now return the Python guide. The one exception is `python migration`, where the Libraries Python overview ranks first and the containers guide is in the top 5; that query is genuinely ambiguous between the two.
- A 12-query sweep (auth, FIPS, pull tokens, SBOMs, assumable identity, distroless debugging) returns sensible top-3 pages with zero empty bodies. Slowest query 204 ms.
- 40 generated URLs sampled across the corpus, covering both bundle forms, all return HTTP 200. An earlier draft appended `/index/` to leaf bundles and 404'd on 76 pages; the probe caught it.
- `get_image_docs`, `get_tool_docs` and `get_security_content` read the same sections and improve as a side effect — `get_tool_docs('chainctl')` used to match a shell comment and now returns a real chainctl page.

Known limitation: `migrating to nginx` returns the PHP and Python guides. There is no nginx migration guide in the bundle, so that is the closest available answer rather than a defect.

## CI

Adds a `unit-test` job to `mcp-image-smoke-test.yaml`, which already triggers on `scripts/**`. The existing smoke test proves the server starts and answers; it cannot tell whether search returns the right page.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
