### PR TITLE
Deploy the AI Docs MCP when its own source changes

### DIFF
--- a/.github/workflows/compile-ai-docs-from-gcs.yaml
+++ b/.github/workflows/compile-ai-docs-from-gcs.yaml
@@ -1,14 +1,28 @@
 name: Compile AI Documentation Bundle from GCS
 
 on:
-  # Nightly. The scheduled run is the only one that opens a bundle-refresh PR,
-  # so the served download stays at most a day behind. Dispatch-driven runs
-  # still rebuild GHCR, Artifact Registry, and Cloud Run on every source change.
+  # Every trigger rebuilds GHCR, Artifact Registry, and Cloud Run. Only the
+  # scheduled and manual runs go on to open the bundle-refresh pull request
+  # (see the publish-bundle job), so the served download stays at most a day
+  # behind while a source change still deploys immediately.
   schedule:
     - cron: '0 2 * * *'
 
   repository_dispatch:
     types: [ai-docs-source-updated]
+
+  # The server's own source. Content changes reach this workflow indirectly,
+  # via the dispatch that export-edu-docs-to-gcs.yaml sends, but nothing
+  # watched scripts/ — so merging a fix to the MCP server did not deploy it and
+  # the change waited for the nightly run (DOCS-183). Match on the whole
+  # directory rather than listing the files baked into the image, which is the
+  # same drift this trigger exists to prevent; mcp-image-smoke-test.yaml
+  # already scopes its PR gate the same way.
+  push:
+    branches: [ main ]
+    paths:
+      - scripts/**
+      - .github/workflows/compile-ai-docs-from-gcs.yaml
 
   workflow_dispatch:
 


### PR DESCRIPTION
Merging a change to the AI Docs MCP server's own source rebuilt and deployed nothing.

Found while verifying DOCS-181. That fix merged at 14:47 UTC; the hosted endpoint at `https://mcp.edu.chainguard.dev/mcp` was still serving the old code afterwards and only shipped once the deploy workflow was dispatched by hand. The risk isn't the delay — it's that a green merge looks like a shipped fix, so the next person tells a customer something is live when it isn't.

Closes DOCS-183.

## Why it happened

`compile-ai-docs-from-gcs.yaml` is the only workflow that rebuilds the image and deploys the Cloud Run service. It triggered on nightly cron, `workflow_dispatch`, and the `ai-docs-source-updated` repository dispatch sent by `export-edu-docs-to-gcs.yaml`, whose push paths are:

```yaml
- 'content/**'
- 'data/**'
- '**.md'
- 'scripts/generate_image_catalog.py'
- '.github/workflows/export-edu-docs-to-gcs.yaml'
```

`scripts/mcp-server.py` matches none of them. Neither does `Dockerfile.ai-docs`, `mcp-requirements.txt`, the `serve-mcp*.sh` entrypoints, or `compile_docs.py` — which determines the bundle structure the server parses.

So a typo fix in a content page shipped the server within minutes, while a fix to the server itself waited up to 24 hours. `scripts/**` was already covered for *testing* by `mcp-image-smoke-test.yaml`; only the deploy path had the gap.

## The change

A push trigger on the compile workflow itself, rather than widening the export workflow's paths. A server change needs a rebuild and a deploy; it does not need docs re-exported to GCS, which is what routing it through the export workflow would have caused.

```yaml
  push:
    branches: [ main ]
    paths:
      - scripts/**
      - .github/workflows/compile-ai-docs-from-gcs.yaml
```

Matching the whole directory is deliberate. Enumerating the files baked into the image is the same silent drift this trigger exists to prevent — it goes stale the first time a new file joins the image. `mcp-image-smoke-test.yaml` already scopes its PR gate the same way. The cost is an occasional redundant rebuild, for example on a test-only edit.

Nothing else needed changing. `publish-bundle` and the artifact upload feeding it are already gated to `schedule` and `workflow_dispatch`, so a push-triggered run rebuilds GHCR, Artifact Registry and Cloud Run **without** opening a bundle-refresh PR.

Also corrected the trigger comment. It claimed the scheduled run was the only one that opens the bundle-refresh PR; manual dispatch opens it too — that is where #3936 came from.

## Behavior worth knowing

A merge touching both `content/**` and `scripts/**` now starts two runs: the push trigger immediately, and the repository dispatch once the export finishes. The existing concurrency group (`compile-ai-docs-${{ github.ref }}`, `cancel-in-progress: false`) serializes them, so they queue rather than collide. That is redundant work in an uncommon case, and left as is on purpose — `cancel-in-progress: true` would risk killing a deploy mid-flight.

## Verification

The linters pass (actionlint, zizmor, yaml). Beyond that, this cannot be proven before it merges: GitHub reads `on.push.paths` from the workflow file on the default branch, so the trigger only exists once it lands.

The real check is the next merge that touches `scripts/**` — it should rebuild and deploy with no manual dispatch, and open no bundle PR. I'll confirm that on the following MCP change rather than call this done on the YAML alone.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
