### PR TITLE
Remove unsourced CVE comparisons across the Containers docs

### DIFF
--- a/content/chainguard/containers/getting-started/ai-and-data/pytorch/index.md
+++ b/content/chainguard/containers/getting-started/ai-and-data/pytorch/index.md
@@ -11,7 +11,7 @@ aliases:
 - /chainguard/containers/getting-started/pytorch/
 description: "Learn how to use Chainguard's PyTorch container image for deep learning with enhanced security, minimal CVEs, and GPU acceleration support"
 date: 2024-04-25T08:00:00+02:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers", "AI"]
 draft: false
 images: []
@@ -22,7 +22,7 @@ weight: 020
 toc: true
 ---
 
-Chainguard's [PyTorch container image](https://images.chainguard.dev/directory/image/pytorch/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-pytorch) provides a security-hardened foundation for deep learning workloads with significantly fewer vulnerabilities than traditional PyTorch containers. Built with [PyTorch](https://pytorch.org/) and [CUDA](https://developer.nvidia.com/about-cuda) support for GPU acceleration, this minimal image maintains full deep learning capabilities while dramatically reducing attack surface. This guide demonstrates fine-tuning models, secure inference deployment, and compares the enhanced security posture to official PyTorch images.
+Chainguard's [PyTorch container image](https://images.chainguard.dev/directory/image/pytorch/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-pytorch) provides a security-hardened foundation for deep learning workloads. Built with [PyTorch](https://pytorch.org/) and [CUDA](https://developer.nvidia.com/about-cuda) support for GPU acceleration, this minimal image maintains full deep learning capabilities while reducing attack surface. This guide demonstrates fine-tuning models and secure inference deployment.
 
 {{< details "What is Deep Learning?" >}}
 {{< blurb/deep-learning >}}

--- a/content/chainguard/containers/getting-started/languages-and-runtimes/go.md
+++ b/content/chainguard/containers/getting-started/languages-and-runtimes/go.md
@@ -15,7 +15,7 @@ aliases:
 - /chainguard/containers/migration/migration-guides/migrating_go/
 description: "Learn how to build more secure Go applications with Chainguard's Go container images, featuring minimal attack surface and multi-stage build patterns for optimized runtime"
 date: 2023-02-28T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -26,7 +26,7 @@ weight: 020
 toc: true
 ---
 
-Chainguard's [Go container image](https://images.chainguard.dev/directory/image/go/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-go) provides a secure foundation for building Go applications with significantly fewer vulnerabilities than traditional Go images. The distroless `latest` variant contains only the Go compiler and runtime, while the `latest-dev` variant includes additional build tools and package management capabilities for development workflows.
+Chainguard's [Go container image](https://images.chainguard.dev/directory/image/go/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-go) provides a secure foundation for building Go applications. The distroless `latest` variant contains only the Go compiler and runtime, while the `latest-dev` variant includes additional build tools and package management capabilities for development workflows.
 
 In this guide, we'll demonstrate how to build and execute Go applications using Chainguard Containers, using three examples from our [demos repository](https://github.com/chainguard-dev/edu-images-demos). In the first example, we'll build a CLI application using a Docker multi-stage build. In the second example, we'll build an application that's accessible by HTTP server, also using a Docker multi-stage build to obtain an optimized runtime. The third example shows how to build an image using [ko](https://ko.build/), a tool that enables you to build container images from Go programs and push them to container registries without requiring a Dockerfile.
 

--- a/content/chainguard/containers/getting-started/languages-and-runtimes/node.md
+++ b/content/chainguard/containers/getting-started/languages-and-runtimes/node.md
@@ -9,7 +9,7 @@ aliases:
 - /chainguard/containers/getting-started/node/
 description: "Learn how to use Chainguard's Node.js container images for secure JavaScript applications with minimal vulnerabilities, distroless design, and built-in npm support"
 date: 2023-02-01T11:07:52+02:00
-lastmod: 2025-08-01T15:09:59+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -20,7 +20,7 @@ weight: 040
 toc: true
 ---
 
-Chainguard's [Node container image](https://images.chainguard.dev/directory/image/node/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-node) provides a secure runtime for Node.js applications with significantly fewer vulnerabilities than traditional Node images. This distroless image includes Node.js and npm while maintaining a minimal attack surface for production deployments.
+Chainguard's [Node container image](https://images.chainguard.dev/directory/image/node/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-node) provides a secure runtime for Node.js applications. This distroless image includes Node.js and npm while maintaining a minimal attack surface for production deployments.
 
 In this guide, we'll set up a demo application and create a Dockerfile to build and execute the demo using the Node Chainguard Containers as base.
 

--- a/content/chainguard/containers/getting-started/platform-and-infrastructure/gitlab/index.md
+++ b/content/chainguard/containers/getting-started/platform-and-infrastructure/gitlab/index.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "GitLab"
 description: "Learn how to deploy GitLab using Chainguard's security-hardened container images with reduced vulnerabilities, verifiable provenance, and daily security updates"
 date: 2026-06-24T00:00:00+00:00
-lastmod: 2026-08-21T16:30:07+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -18,7 +18,7 @@ aliases:
 - /chainguard/containers/getting-started/gitlab/
 ---
 
-Chainguard's GitLab container images provide a security-hardened foundation for deploying GitLab's DevOps platform with significantly fewer vulnerabilities than the standard upstream images. Built on Wolfi, these images are rebuilt daily with the latest security patches and include verifiable Sigstore signatures and SBOMs for every component.
+Chainguard's GitLab container images provide a security-hardened foundation for deploying GitLab's DevOps platform. Built on Wolfi, these images are rebuilt daily with the latest security patches and include verifiable Sigstore signatures and SBOMs for every component.
 
 The Chainguard GitLab offering spans fifteen components that align with the official GitLab Helm chart architecture: `gitlab-base`, `gitlab-certificates`, `gitaly`, `gitlab-agent`, `gitlab-kas`, `gitlab-shell`, `gitlab-exporter`, `gitlab-pages`, `gitlab-container-registry`, `gitlab-runner`, `gitlab-runner-helper`, and the Community Edition services `gitlab-sidekiq-ce`, `gitlab-toolbox-ce`, `gitlab-webservice-ce`, and `gitlab-workhorse-ce`. A FIPS-validated variant is also available for FedRAMP compliance.
 

--- a/content/chainguard/containers/getting-started/web-and-data-services/mariadb/index.md
+++ b/content/chainguard/containers/getting-started/web-and-data-services/mariadb/index.md
@@ -9,7 +9,7 @@ aliases:
 - /chainguard/containers/getting-started/mariadb/
 description: "Learn how to deploy MariaDB databases using Chainguard's security-hardened container image with minimal vulnerabilities and distroless design"
 date: 2023-07-28T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -20,7 +20,7 @@ weight: 010
 toc: true
 ---
 
-Chainguard's MariaDB container image provides a security-hardened foundation for database workloads with significantly fewer vulnerabilities than traditional MariaDB images. Built on Wolfi with a distroless design, this container removes unnecessary components while maintaining full MariaDB functionality.
+Chainguard's MariaDB container image provides a security-hardened foundation for database workloads. Built on Wolfi with a distroless design, it removes unnecessary components while maintaining full MariaDB functionality. For current CVE data on each image and tag, see the [MariaDB entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/mariadb/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-mariadb).
 
 Through daily rebuilds with the latest patches and minimal dependencies, Chainguard's MariaDB image dramatically reduces your database's attack surface. This enables you to run production MariaDB databases with enhanced security posture and a smaller container footprint.
 

--- a/content/chainguard/containers/getting-started/web-and-data-services/nginx/index.md
+++ b/content/chainguard/containers/getting-started/web-and-data-services/nginx/index.md
@@ -7,7 +7,7 @@ aliases:
 - /chainguard/containers/getting-started/nginx
 description: "Learn how to deploy nginx web server using Chainguard's security-hardened container image with minimal vulnerabilities and distroless runtime"
 date: 2023-01-09T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -18,7 +18,7 @@ weight: 030
 toc: true
 ---
 
-Chainguard's nginx container images provide a security-hardened foundation for web server deployments with significantly fewer vulnerabilities than traditional nginx images. Available in both development (`:latest-dev`) and production (`:latest`) variants, these containers maintain full nginx functionality while dramatically reducing attack surface. The production variant uses a distroless approach, removing shells and package managers to enhance security for production workloads.
+Chainguard's nginx container images provide a security-hardened foundation for web server deployments. Available in both development (`:latest-dev`) and production (`:latest`) variants, these images maintain full nginx functionality while reducing attack surface. The production variant uses a distroless approach, removing shells and package managers to enhance security for production workloads. For current CVE data on each image and tag, see the [nginx entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/nginx/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-nginx).
 
 In this tutorial, we will create a local demo website using nginx to serve static HTML content to a local port on your machine. Then we will use the nginx Chainguard Container to build and execute the demo in a lightweight containerized environment.
 

--- a/content/chainguard/containers/getting-started/web-and-data-services/postgres/index.md
+++ b/content/chainguard/containers/getting-started/web-and-data-services/postgres/index.md
@@ -9,7 +9,7 @@ aliases:
 - /chainguard/containers/getting-started/postgres/
 description: "Learn how to deploy PostgreSQL databases using Chainguard's security-hardened container image with minimal vulnerabilities and distroless design"
 date: 2023-08-10T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -20,7 +20,7 @@ weight: 040
 toc: true
 ---
 
-Chainguard's PostgreSQL container image provides a security-hardened foundation for running Postgres databases with significantly fewer vulnerabilities than traditional PostgreSQL images. Built on Wolfi with a distroless design, this container maintains full PostgreSQL functionality while dramatically reducing attack surface.
+Chainguard's PostgreSQL container image provides a security-hardened foundation for running Postgres databases. Built on Wolfi with a distroless design, it includes only the packages the database needs, maintaining full PostgreSQL functionality while reducing attack surface. For current CVE data on each image and tag, see the [PostgreSQL entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/postgres/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-postgres).
 
 Through daily rebuilds with the latest patches and minimal dependencies, Chainguard's PostgreSQL image enhances database security posture. This enables you to run production Postgres workloads in containerized environments with both a smaller footprint and improved protection against supply chain attacks.
 

--- a/content/chainguard/containers/getting-started/web-and-data-services/wordpress.md
+++ b/content/chainguard/containers/getting-started/web-and-data-services/wordpress.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "WordPress"
 description: "Learn how to deploy WordPress using Chainguard's security-hardened container image with reduced vulnerabilities and distroless runtime options"
 date: 2024-07-19T11:07:52+02:00
-lastmod: 2026-09-03T15:24:53+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 tags: ["Chainguard Containers"]
 draft: false
 images: []
@@ -18,7 +18,7 @@ aliases:
 - /chainguard/containers/getting-started/wordpress/
 ---
 
-Chainguard's [WordPress container image](https://images.chainguard.dev/directory/image/wordpress/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-wordpress) is a drop-in replacement for the official [WordPress FPM-Alpine image](https://hub.docker.com/_/wordpress), with significantly fewer vulnerabilities than the standard image. It includes a [distroless](/chainguard/containers/getting-started-distroless/) variant for production use that removes shells, package managers, and other unnecessary components. The image ships with the latest PHP and WordPress versions and all required PHP extensions.
+Chainguard's [WordPress container image](https://images.chainguard.dev/directory/image/wordpress/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-chainguard-images-getting-started-wordpress) is a drop-in replacement for the official [WordPress FPM-Alpine image](https://hub.docker.com/_/wordpress). It includes a [distroless](/chainguard/containers/getting-started-distroless/) variant for production use that removes shells, package managers, and other unnecessary components. The image ships with the latest PHP and WordPress versions and all required PHP extensions.
 
 This guide covers three ways to use the WordPress Chainguard Container to build and run WordPress projects.
 

--- a/content/chainguard/containers/migration/migration-guides/node.md
+++ b/content/chainguard/containers/migration/migration-guides/node.md
@@ -16,7 +16,7 @@ aliases:
 type: "article"
 description: "Learn how to migrate Node.js applications to Chainguard Containers for reduced vulnerabilities, smaller image sizes, and automated security patching"
 date: 2024-05-09T15:56:52-07:00
-lastmod: 2025-07-23T16:52:56+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 draft: false
 tags: ["Chainguard Containers", "Migration"]
 images: []
@@ -24,7 +24,7 @@ weight: 030
 toc: true
 ---
 
-Chainguard's Node.js containers offer a streamlined migration path for applications seeking enhanced security posture through minimal, distroless design. Built on [Wolfi](/open-source/wolfi/), these containers significantly reduce attack surface compared to traditional Node.js images, resulting in fewer vulnerabilities and smaller image sizes. Daily automated builds ensure your applications always have the latest security patches without manual intervention.
+Chainguard's Node.js container images offer a streamlined migration path for applications seeking enhanced security posture through minimal, distroless design. Built on [Wolfi](/open-source/wolfi/), they include only the packages your application needs, which keeps both the attack surface and the image size small. Daily automated builds ensure your applications always have the latest security patches without manual intervention. For current CVE data on each image and tag, see the [Node entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/node/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-node).
 
 {{< details "What is Distroless?" >}}
 {{< blurb/distroless >}}

--- a/content/chainguard/containers/migration/migration-guides/php.md
+++ b/content/chainguard/containers/migration/migration-guides/php.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "Learn how to migrate PHP applications to Chainguard Containers for enhanced security, reduced CVEs, and support for both FPM and CLI workloads"
 date: 2024-04-04T15:56:52-07:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-08T17:40:54+00:00
 draft: false
 tags: ["Chainguard Containers", "Migration"]
 images: []
@@ -18,7 +18,7 @@ weight: 040
 toc: true
 ---
 
-Chainguard's PHP containers provide enhanced security for PHP applications through minimal, purpose-built images that significantly reduce attack surface. Built on [Wolfi](/open-source/wolfi/), these containers achieve dramatically fewer vulnerabilities compared to traditional PHP images while maintaining full compatibility with PHP workloads. Daily automated builds ensure applications receive the latest security patches without manual intervention.
+Chainguard's PHP container images provide enhanced security for PHP applications through minimal, purpose-built images that reduce attack surface. Built on [Wolfi](/open-source/wolfi/), they include only the packages your application needs, while maintaining full compatibility with PHP workloads. Daily automated builds deliver the latest security patches without manual intervention. For current CVE data on each PHP image and tag, see the [PHP entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/php/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-php).
 
 This article will assist you in the process of migrating your existing PHP Dockerfiles to leverage the benefits of Chainguard Containers, including a smaller attack surface and a more secure application footprint.
 

--- a/content/chainguard/containers/migration/migration-guides/php.md
+++ b/content/chainguard/containers/migration/migration-guides/php.md
@@ -18,7 +18,7 @@ weight: 040
 toc: true
 ---
 
-Chainguard's PHP container images provide enhanced security for PHP applications through minimal, purpose-built images that reduce attack surface. Built on [Wolfi](/open-source/wolfi/), they include only the packages your application needs, while maintaining full compatibility with PHP workloads. Daily automated builds deliver the latest security patches without manual intervention. For current CVE data on each PHP image and tag, see the [PHP entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/php/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-php).
+Chainguard's PHP container images provide enhanced security for PHP applications through minimal, purpose-built images that reduce attack surface. Based on [Wolfi](/open-source/wolfi/), they include only the packages your application needs, while maintaining full compatibility with PHP workloads. Daily automated builds deliver the latest security patches without manual intervention. For current CVE data on each PHP image and tag, see the [PHP entry in the Chainguard Containers directory](https://images.chainguard.dev/directory/image/php/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-php).
 
 This article will assist you in the process of migrating your existing PHP Dockerfiles to leverage the benefits of Chainguard Containers, including a smaller attack surface and a more secure application footprint.
 

--- a/content/chainguard/containers/migration/migration-guides/python.md
+++ b/content/chainguard/containers/migration/migration-guides/python.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "Learn how to migrate Python applications to Chainguard Containers for enhanced security posture, reduced CVEs, and streamlined dependency management"
 date: 2024-05-02T15:06:00-07:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-08T17:57:46+00:00
 draft: false
 tags: ["Chainguard Containers", "Migration"]
 images: []
@@ -99,7 +99,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 
 ## Serving an application with nginx and Docker Compose
 
-We provide an [nginx Chainguard Container](https://images.chainguard.dev/directory/image/nginx/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-python), also with low to no CVEs, that can be used as a secure and performant reverse proxy to serve your application. You can view an [example orchestration of a Flask application and nginx using Chainguard Containers](https://github.com/chainguard-dev/cg-images-python-migration/tree/compose-flask-nginx) at the linked repository. The `compose.yml` file is provided as a reference below.
+We provide an [nginx Chainguard Container](https://images.chainguard.dev/directory/image/nginx/overview?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement&utm_content=edu-content-chainguard-migration-migrating-python), also built on Wolfi and rebuilt daily, that can be used as a secure and performant reverse proxy to serve your application. You can view an [example orchestration of a Flask application and nginx using Chainguard Containers](https://github.com/chainguard-dev/cg-images-python-migration/tree/compose-flask-nginx) at the linked repository. The `compose.yml` file is provided as a reference below.
 
 ```Dockerfile
 services:


### PR DESCRIPTION
Removes unsourced comparative CVE claims across the Chainguard Containers docs and points readers at evidence that still exists.

Addresses the unblocked half of DOCS-184. Started as a one-sentence fix to the PHP migration guide; `check-related-pages` showed the same defect on ten more pages, so this cleans up the set.

## What started it

PR #3768 deleted the vulnerability-comparison pages and stripped the link out of one sentence in the PHP guide, leaving the claim behind:

```diff
-these containers achieve [dramatically fewer vulnerabilities](/chainguard/containers/vuln-comparison/php/) compared to traditional PHP images
+these containers achieve dramatically fewer vulnerabilities compared to traditional PHP images
```

That was the only sentence #3768 orphaned. But the same shape — "significantly fewer vulnerabilities than traditional X images" — turned out to exist on ten other pages that never had a citation to begin with.

A link to the Chainguard Containers directory doesn't substantiate one either: the directory reports our own CVE data, not upstream's. So a claim about being *lower than* something else is unsupported whether or not a directory link sits beside it.

These pages feed the AI docs bundle, which exists to be read by machines, so an unsupported comparative propagates further than it would on a page a human skims.

## Changes by group

**Claim replaced with mechanism plus a live source** (no evidence link previously):

- `getting-started/web-and-data-services/postgres/index.md`
- `getting-started/web-and-data-services/mariadb/index.md`
- `getting-started/web-and-data-services/nginx/index.md`
- `migration/migration-guides/php.md`
- `migration/migration-guides/node.md`

Each now describes what the image actually does — ships only the packages the application needs — and links to the directory for current per-tag CVE data. That link can't rot the way a hand-maintained comparison page did.

**Claim removed, existing evidence left to stand:**

- `getting-started/platform-and-infrastructure/gitlab/index.md` — GitLab has no single directory image (it's fifteen components), so no link fits. The daily rebuilds, Sigstore signatures, and SBOMs already on the page are concrete and verifiable.
- `getting-started/languages-and-runtimes/go.md`, `web-and-data-services/wordpress.md`, `languages-and-runtimes/node.md`, `ai-and-data/pytorch/index.md` — these already linked to the directory, so the claim is simply dropped.

**Wording and accuracy:**

- `migration/migration-guides/python.md` used `low to no CVEs`. The word list rules that out by name; the official adjective is "zero CVEs." Restated as the mechanism instead.
- `pytorch/index.md` promised the guide "compares the enhanced security posture to official PyTorch images." It contains no such comparison, so the promise is gone.
- Dropped `dramatically` where it survived, and corrected `Chainguard's PHP containers` and `Chainguard's Node.js containers` to `container images` per the naming rules.

## Deliberately unchanged

`migration/migration-guides/dotnet.md` keeps its comparative claim. That guide builds the same application two ways, shows the scan output, and carries a note that the numbers were accurate at the time of writing. Its claim is sourced by the page itself — it's the one page in the set that earned it.

## Verification

- All five directory links verified HTTP 200 before commit
- `pre-commit` clean across all ten files
- A repo-wide grep for `significantly fewer vulnerabilities`, `dramatically fewer`, `low to no CVE`, and `fewer vulnerabilities compared` now returns only dotnet.md

## Not in this PR

The other half of DOCS-184 — 11 stale `vuln-comparison` links in container image READMEs — is blocked by CON-1961. Those READMEs reach the bundle through the image-docs → GCS export and can't be fixed from this repo.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
