### PR TITLE
Delay the changelog rotation handover by one week

### DIFF
--- a/.github/workflows/changelog-rotation.yaml
+++ b/.github/workflows/changelog-rotation.yaml
@@ -53,9 +53,9 @@ jobs:
 
           # Anchors the rotation. Must be a Monday, and may sit in the past:
           # backdating it starts the roster partway through a shift. This date is
-          # three weeks before the first scheduled run, so OWNERS[0] takes the
-          # single week of 2026-08-31 and the handover lands on 2026-09-07.
-          EPOCH = datetime.date(2026, 8, 10)
+          # two weeks before the first scheduled run, so OWNERS[0] takes the weeks
+          # of 2026-08-31 and 2026-09-07 and the handover lands on 2026-09-14.
+          EPOCH = datetime.date(2026, 8, 17)
 
           # Weeks each person owns before handing over.
           SHIFT_WEEKS = 4


### PR DESCRIPTION
The changelog rotation handed over on 2026-09-07, so `SharpRake` owned a
single week rather than a shift.

This moves `EPOCH` forward one Monday, from 2026-08-10 to 2026-08-17. The
first shift now covers the weeks of 2026-08-31 and 2026-09-07, and
`matthewhelmke` starts on 2026-09-14 with a full four weeks. Everyone after
that keeps four weeks each:

| Weeks | Owner |
|---|---|
| 08-31, 09-07 | SharpRake |
| 09-14 → 10-05 | matthewhelmke |
| 10-12 → 11-02 | s-stumbo |

I also retitled #3933 from the week of 2026-09-07 to the week of
2026-09-14, so it matches the shift it belongs to. The scheduled run on
2026-09-14 will find that title already open and skip, rather than filing a
duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)