### PR TITLE
Stop alias redirects from matching their own targets

### DIFF
--- a/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
@@ -8,14 +8,10 @@ aliases:
 - /chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/
 - /chainguard/containers/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/
 - /chainguard/containers/registry/pull-through-guides/artifactory/artifactory-images-pull-through/
-- /chainguard/chainguard-registry/pull-through-guides/artifactory/
-- /chainguard/chainguard-images/chainguard-registry/pull-through-guides/artifactory/
-- /chainguard/containers/chainguard-registry/pull-through-guides/artifactory/
-- /chainguard/containers/registry/pull-through-guides/artifactory/
 type: "article"
 description: "Tutorial outlining how to set up a remote Artifactory repository to pull images through Chainguard's container registry."
 date: 2024-02-13T15:56:52-07:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T13:00:03+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []

--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -1,7 +1,36 @@
+{{- /*
+Builds the nginx map that turns every Hugo alias into a 301. nginx.conf
+includes the result as /etc/nginx/aliases.
+
+The ([/?].*)? bound matches the alias itself, anything in its subtree, or a
+query string, but not a longer path segment that merely starts with the alias.
+An open-ended bound lets a rule feed itself: an alias of
+/pull-through-guides/artifactory on a page that now lives at
+/pull-through-guides/artifactory-containers-pull-through matches its own
+target and appends the suffix on every hop, so the URL never resolves
+(DOCS-186).
+
+"?" belongs in the character class because nginx matches this map against
+$request_uri, which carries the query string. Bounding on "/" alone would
+stop matching an aliased URL written without a trailing slash but with a
+query, such as /chainguard/fips?utm_source=x, and send it to a 404.
+
+nginx takes the first regex in a map that matches, so the rules are written
+longest alias first. An alias that is a prefix of another one would otherwise
+claim the subtree below it and hide the more specific rule, which is what
+sent /pull-through-guides/artifactory/artifactory-packages-pull-through to
+the wrong page.
+*/ -}}
+{{- $rules := slice -}}
 {{- range $p := .Site.Pages -}}
-{{- range .Aliases }}
-{{- if ne (strings.TrimSuffix "/" .) (strings.TrimSuffix "/" $p.RelPermalink) -}}
-"~^{{ strings.TrimSuffix "/" . }}(.+)?$" {{ strings.TrimSuffix "/" $p.RelPermalink }}$1;
-{{ end }}
+{{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}
+{{- range .Aliases -}}
+{{- $alias := strings.TrimSuffix "/" . -}}
+{{- if ne $alias $target -}}
+{{- $rules = $rules | append (dict "alias" $alias "target" $target "length" (len $alias)) -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
+{{- range sort $rules "length" "desc" -}}
+"~^{{ .alias }}([/?].*)?$" {{ .target }}$1;
+{{ end -}}

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,17 @@ http {
         # migration-guides/) and would also swallow /chainguard/migration-guides/.
         # Anchoring with /?$ matches only the roots themselves.
         "~^/chainguard/migration/?$" /chainguard/containers/migration/;
+        # The pull-through guides were flattened: the artifactory/ subsection is
+        # gone and its two guides now sit beside it as artifactory-containers-
+        # pull-through/ and artifactory-packages-pull-through/. Each guide keeps
+        # its own Hugo alias, but the section root has to be anchored here. As an
+        # alias it would be a prefix of the containers guide it points at, and the
+        # rule would match its own target and redirect forever (DOCS-186).
+        # The older /chainguard-registry/ and /chainguard-images/ spellings of
+        # this path need no rule: the section aliases above normalize them to
+        # /chainguard/containers/registry/ first, and they land here on the
+        # second hop.
+        "~^/chainguard/containers/registry/pull-through-guides/artifactory/?$" /chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/;
         "~^/software-security/secure-software-development/considerations-for-image-updates/(.+)?$" /chainguard/chainguard-images/recommended-practices/considerations-for-image-updates/;
         "~^/chainguard/chainguard-images/considerations-for-image-updates/(.+)?$" /chainguard/chainguard-images/recommended-practices/considerations-for-image-updates/;
         "~^/chainguard/chainguard-enforce/authentication/custom-idps/(.+)?$" /chainguard/administration/custom-idps/custom-idps/;


### PR DESCRIPTION
Both JFrog Artifactory pull-through guides were unreachable on edu.chainguard.dev. Requesting either one returned a 301 that appended `-containers-pull-through` to the path on every hop, until the browser stopped with a redirect-loop error. Denis Maligin reported it from the field; Artifactory is the path customers use to route Chainguard Containers through their existing artifact management, so anyone following our setup instructions got a browser error instead of the guide.

Fixes DOCS-186.

## What was wrong

`layouts/index.aliases` turns every Hugo alias into an nginx map rule:

```
"~^<alias>(.+)?$" <target>$1;
```

`(.+)?` matches any continuation, not just a path segment. The Containers reorganization (#3926) moved the containers guide to `artifactory-containers-pull-through/` but kept its alias for the old section root, `artifactory/`. The alias became a prefix of its own target, so the rule matched the URL it had just produced:

1. Request `.../pull-through-guides/artifactory-containers-pull-through/`
2. Matches `~^.../pull-through-guides/artifactory(.+)?$` with `$1 = "-containers-pull-through/"`
3. Redirects to `.../artifactory-containers-pull-through-containers-pull-through/`
4. Matches again

The template already skipped an alias equal to its own permalink. It did not skip an alias that is a prefix of it. `nginx.conf` documents this hazard twice (lines 65-69 and 83-89) and works around it by hand-anchoring individual rules; the generated rules never got the same treatment.

## What changed

- **`layouts/index.aliases`** — bound the generated rules with `([/?].*)?$`, so a rule matches the alias, its subtree, or a query string, but never a longer path segment that merely starts with the alias. `?` is in the character class because nginx matches this map against `$request_uri`; bounding on `/` alone would 404 an aliased URL written without a trailing slash but with a query.
- **`layouts/index.aliases`** — emit rules longest alias first. nginx takes the first match in a map, and a short alias was hiding the more specific rule below it, which is what sent `artifactory/artifactory-packages-pull-through` to the wrong page.
- **`nginx.conf`** — anchor the surviving `artifactory/` section root, matching how the other flattened section roots are handled.
- **Containers guide frontmatter** — drop the four section-root aliases the anchored rule replaces.

## Testing

Built the production image and replayed every legacy alias URL against it, following redirects, before and after.

| | Before | After |
| --- | ---: | ---: |
| Resolve (200) | 631 | **717** |
| 404 | 72 | 0 |
| Infinite loop | 14 | 0 |

717 of 717 now resolve, in at most two hops. No URL that worked before changed behavior. Also confirmed by hand: the two guides serve directly, the legacy deep links land on the correct guide, and the hand-written rules below the alias map (`chainctl`, `vulnerabilities`, `chainguard-images`) still fire.

One pre-existing quirk this does not touch: nginx re-appends the query string, so `?utm_source=x` arrives as `?utm_source=x?utm_source=x`. Identical before and after this change; filed separately.

### Note for reviewers: the deploy preview cannot show this bug

This redirect map only exists in `nginx.conf`, which serves production on Cloud Run. Netlify routes through `netlify.toml` and Hugo's own alias stubs instead, so the affected URL returns 200 on the preview *and* on the current unfixed `main`:

```
ornate-narwhal-088216.netlify.app/.../artifactory-containers-pull-through/   -> 200  (unfixed main)
edu.chainguard.dev/.../artifactory-containers-pull-through/                  -> 301  (loops)
```

To exercise the change, build the image and drive it locally:

```
docker build -t edu-test . && docker run -d --name edu-test -p 8080:8080 edu-test
curl -sSI http://localhost:8080/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/
```

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-09.

