### PR TITLE
Point the Artifactory link at its current path

### DIFF
--- a/content/chainguard/containers/migration/migrations-overview.md
+++ b/content/chainguard/containers/migration/migrations-overview.md
@@ -9,7 +9,7 @@ aliases:
 type: "article"
 description: "Key differences, a recommended rollout strategy, and troubleshooting guidance for moving existing container workloads to Chainguard Containers."
 date: 2024-07-22T12:56:52-00:00
-lastmod: 2026-08-27T00:00:00+00:00
+lastmod: 2026-09-09T13:12:18+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -53,7 +53,7 @@ Refer to our guide on [Chainguard's Container variants](/chainguard/containers/c
 
 Before you begin actively migrating to Chainguard Containers, review the images that your organization has access to and determine which teams and applications will be using each image. Notify the teams involved in the migration process so they can begin preparing. For teams that are new to Chainguard Containers, we recommend taking the online self-paced course, [Linky’s Guide to Chainguard Containers](https://courses.chainguard.dev/path/linkys-guide-to-chainguard-images).
 
-Next, determine which users and/or systems are going to need access to your Chainguard registry in order to begin preparing access. Most customers will need to copy images from their Chainguard registry into their organization's registry. An easy way to do this is by configuring the organization's registry as a pull-through mirror of the Chainguard registry. We have a guide on [how to configure Artifactory](/chainguard/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/) for this use case.
+Next, determine which users and/or systems are going to need access to your Chainguard registry in order to begin preparing access. Most customers will need to copy images from their Chainguard registry into their organization's registry. An easy way to do this is by configuring the organization's registry as a pull-through mirror of the Chainguard registry. We have a guide on [how to configure Artifactory](/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/) for this use case.
 
 ## Recommended rollout approach
 


### PR DESCRIPTION
The migration overview linked to the Artifactory containers guide by its pre-reorganization path:

```
/chainguard/chainguard-registry/pull-through-guides/artifactory/artifactory-images-pull-through/
```

That path still resolves, but only through two redirect hops. This points it at the guide directly.

Follow-up to [chainguard-dev/edu#3948](https://github.com/chainguard-dev/edu/pull/3948). Searching `content/` and `layouts/shortcodes/` for links to either Artifactory guide turned up this one stale reference; every other link already uses the current path. Confirmed against the build that the new target is a real page rather than another alias.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-09.
