### PR TITLE
Clear seven npm audit findings and drop the unused AI SDK from the bundle

### DIFF
--- a/assets/js/feedback-widget.js
+++ b/assets/js/feedback-widget.js
@@ -320,7 +320,7 @@ class FeedbackWidget {
       clearTimeout(timeoutId);
 
       if (error.name === "AbortError") {
-        throw new Error("Request timeout - please try again");
+        throw new Error("Request timeout - please try again", { cause: error });
       }
       throw error;
     }

--- a/assets/js/scalar-agent-chat-stub.js
+++ b/assets/js/scalar-agent-chat-stub.js
@@ -1,0 +1,16 @@
+// Build-time stub for @scalar/agent-chat.
+//
+// The API reference sets `agent: { disabled: true }` in scalar-api-reference.js,
+// so Scalar's AI chat drawer never mounts. Scalar lazy-loads the chat through a
+// dynamic import, but Hugo's js.Build emits a single bundle with no code
+// splitting, so esbuild inlines it regardless — pulling the whole Vercel AI SDK
+// into the script served on every API spec page.
+//
+// Shimming the package to this file drops that subtree from the bundle. If the
+// agent chat is ever enabled, delete this file and the matching `shims` entry in
+// layouts/shortcodes/openapi.html.
+
+export const Chat = {
+  name: "ScalarAgentChatDisabled",
+  render: () => null,
+};

--- a/layouts/shortcodes/openapi.html
+++ b/layouts/shortcodes/openapi.html
@@ -71,7 +71,9 @@
     margin: 0 48px 0 48px;
   }
 </style>
-{{ $js := resources.Get "js/scalar-api-reference.js" | js.Build (dict "minify" (not hugo.IsDevelopment)) -}}
+{{/* The agent chat is disabled at runtime; shim it out so its dependencies stay out of the bundle. */ -}}
+{{ $shims := dict "@scalar/agent-chat" "js/scalar-agent-chat-stub.js" -}}
+{{ $js := resources.Get "js/scalar-api-reference.js" | js.Build (dict "minify" (not hugo.IsDevelopment) "shims" $shims) -}}
 {{ if hugo.IsDevelopment -}}
   <script src="{{ $js.RelPermalink }}" defer></script>
 {{ else -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,35 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.2.tgz",
@@ -65,23 +94,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.5.tgz",
-      "integrity": "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.2",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/vue": {
@@ -99,6 +111,35 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2306,6 +2347,35 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2723,9 +2793,9 @@
       "license": "MIT"
     },
     "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8665,8 +8735,30 @@
       "integrity": "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==",
       "requires": {
         "@ai-sdk/provider": "3.0.2",
-        "@ai-sdk/provider-utils": "4.0.5",
+        "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41",
         "@vercel/oidc": "3.1.0"
+      },
+      "dependencies": {
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.40",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+          "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.14",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.8"
+          },
+          "dependencies": {
+            "@ai-sdk/provider": {
+              "version": "3.0.14",
+              "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+              "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+              "requires": {
+                "json-schema": "^0.4.0"
+              }
+            }
+          }
+        }
       }
     },
     "@ai-sdk/provider": {
@@ -8677,24 +8769,34 @@
         "json-schema": "^0.4.0"
       }
     },
-    "@ai-sdk/provider-utils": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.5.tgz",
-      "integrity": "sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==",
-      "requires": {
-        "@ai-sdk/provider": "3.0.2",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      }
-    },
     "@ai-sdk/vue": {
       "version": "3.0.33",
       "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.33.tgz",
       "integrity": "sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==",
       "requires": {
-        "@ai-sdk/provider-utils": "4.0.5",
+        "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41",
         "ai": "6.0.33",
         "swrv": "^1.0.4"
+      },
+      "dependencies": {
+        "@ai-sdk/provider": {
+          "version": "3.0.14",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+          "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+          "requires": {
+            "json-schema": "^0.4.0"
+          }
+        },
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.40",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+          "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.14",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.8"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -10136,8 +10238,30 @@
       "requires": {
         "@ai-sdk/gateway": "3.0.13",
         "@ai-sdk/provider": "3.0.2",
-        "@ai-sdk/provider-utils": "4.0.5",
+        "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41",
         "@opentelemetry/api": "1.9.0"
+      },
+      "dependencies": {
+        "@ai-sdk/provider-utils": {
+          "version": "4.0.40",
+          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+          "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+          "requires": {
+            "@ai-sdk/provider": "3.0.14",
+            "@standard-schema/spec": "^1.1.0",
+            "eventsource-parser": "^3.0.8"
+          },
+          "dependencies": {
+            "@ai-sdk/provider": {
+              "version": "3.0.14",
+              "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+              "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+              "requires": {
+                "json-schema": "^0.4.0"
+              }
+            }
+          }
+        }
       }
     },
     "ajv": {
@@ -10382,9 +10506,9 @@
       "dev": true
     },
     "colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "dev": true
     },
     "colorjs.io": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "postinstall": "node scripts/link-dart-sass.js"
   },
   "overrides": {
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Dependabot filed two alerts on 2026-09-08 and auto-dismissed a third. Working through them turned up a larger problem: the API reference has been shipping an AI SDK it never runs.

## The bundle

`assets/js/scalar-api-reference.js` sets `agent: { disabled: true }`, so Scalar's AI chat drawer never mounts. That flag governs runtime, not the build. Scalar lazy-loads the drawer through `defineAsyncComponent(async () => import(...))`, but Hugo's `js.Build` emits one bundle with no code splitting, so esbuild inlines the dynamic import. The whole Vercel AI SDK has been riding along in the ~4 MB script served on all three API spec pages.

Shimming `@scalar/agent-chat` to a stub removes it.

| | before | after |
| --- | --- | --- |
| built script | 4,153,066 B | 3,922,099 B |
| `AI_APICallError` | 1 | 0 |
| `AI_TypeValidationError` | 1 | 0 |
| `AI_JSONParseError` | 1 | 0 |
| `AI_RetryError` | 1 | 0 |
| `AI_NoObjectGeneratedError` | 1 | 0 |
| `ai-sdk`, `swrv` | 2, 1 | 0, 0 |

231 KB smaller, and the code is gone rather than merely idle. `Chat` is the only symbol Scalar imports from that package, so the stub exports only `Chat`.

## The advisories

**`@ai-sdk/provider-utils`** ([GHSA-866g-f22w-33x8](https://github.com/advisories/GHSA-866g-f22w-33x8)) resolved to 4.0.5. Every package in the chain — `ai@6.0.33`, `@ai-sdk/vue@3.0.33`, `@ai-sdk/gateway@3.0.13` — pins that exact version, so an override is the only route to a patched release. Bumping `@scalar/api-reference` does not help: 1.68.0 ships `@scalar/agent-chat@0.12.30`, which carries identical pins.

The override range stops below 4.0.41 because that is where `provider-utils` starts depending on `undici`. Nothing else in the tree needs undici, and this subtree no longer reaches the browser, so the override's only remaining job is closing the alert. It should not add a package to do that. The cost is five extra lockfile entries, because npm nests three copies of `provider-utils` rather than hoisting one.

**`colord`** ([GHSA-2wm5-q62r-hmrv](https://github.com/advisories/GHSA-2wm5-q62r-hmrv)) moves 2.9.3 to 2.10.0, inside stylelint's existing `^2.9.3` range. Lockfile only. Dependabot auto-dismissed this one under the dev-scope rule, but `npm audit` still counted it.

`npm audit` falls from 9 findings to 2.

## Also here

`npm run lint` fails on a clean `main`: eslint 10's `preserve-caught-error` flags `feedback-widget.js:323`, where the timeout branch discarded the `AbortError` it was reacting to. Attaching it as `cause` fixes the rule and keeps the original error for anyone debugging a timeout. Folded in here because it otherwise blocks `npm test` for everyone.

## Not fixed

The remaining two `npm audit` findings are both [GHSA-vwc7-r8mq-g2x9](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9) against `adm-zip`, counted once directly and once through `hugo-extended`. The affected range is `>= 0.5.9, <= 0.6.0` and there is no patched release: 0.6.0 is the newest on npm. The existing `adm-zip` override stays, because dropping it resolves to 0.5.18, which is vulnerable to this advisory *and* the earlier one the override was added for.

`npm audit` proposes `hugo-extended@0.152.2`, which does drop `adm-zip` entirely. That is a twelve-minor Hugo downgrade and breaks the build. Not viable.

Reachability: `hugo-extended` is the only consumer and calls `adm-zip` at `dist/lib/install.mjs:169`, on the Windows `.zip` branch alone. macOS 0.153.0+ uses `.pkg`, Linux and BSD use `tar.gz`. On CI, Netlify, and Linux workstations the package installs and never executes. Windows contributors are on the live path, since the call passes `overwrite: true`, which is this advisory's precondition — though exploiting it needs an attacker-planted symlink under `node_modules/hugo-extended/bin`, and the archive is SHA-256 verified against Hugo's release.

DOCS-151 tracks the override; its exit criteria predate this advisory and need updating.

## Testing

- `npm run build` — exit 0, 1687 pages, matching the pre-change baseline.
- `npm run lint` — exit 0. Red on `main` before this branch.
- All three spec pages (`spec`, `spec-api-v1`, `spec-api-v2`) render operations, query parameters, response schemas, and the server block. Verified in a browser against `npm start`, not just checked for HTTP 200.
- Console compared with the shim stashed and restored. No new errors; the CSP noise from Amplitude, Qualified, and ZoomInfo is identical either way.
- Dev mode confirmed separately, since `hugo server` builds unminified: the served script also contains no ai-sdk markers.
- The changed `feedback-widget.js` branch was exercised directly against a real `AbortError`: the message is preserved, `cause` is attached, and non-abort errors still pass through untouched.
- `node_modules` was stale against the lockfile when this started, so every measurement above was retaken after `npm ci`.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-09.
