### PR TITLE
Align the pre-commit eslint hook with package.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,18 +125,24 @@ repos:
         files: ^content/.*\.md$
         exclude: ^content/platform/chainctl/chainctl-docs/
 
-  # Lint the theme's own JavaScript (assets/js, config). Uses ESLint 9 flat
-  # config (eslint.config.js). @eslint/js and globals are required by that
-  # config and installed into the hook's isolated environment.
+  # Lint the theme's own JavaScript (assets/js, config) against the flat config
+  # in eslint.config.js. @eslint/js and globals are required by that config and
+  # installed into the hook's isolated environment.
+  #
+  # These three versions MUST track package.json, or this hook and `npm run
+  # lint` disagree. @eslint/js decides it: the rule set in js.configs.recommended
+  # changes between majors, so a hook one major behind silently passes code that
+  # `npm run lint` rejects. `pre-commit autoupdate` bumps rev only and never
+  # touches additional_dependencies, so nothing keeps these in step for us.
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: 8ba198123f6fb414e19d879a1270d6d72116d89b  # frozen: v10.10.0
     hooks:
       - id: eslint
         files: ^(assets/js|config)/.*\.js$
         additional_dependencies:
-          - eslint@9.39.1
-          - "@eslint/js@^9.39.0"
-          - globals@^16.5.0
+          - eslint@10.9.1
+          - "@eslint/js@^10.0.1"
+          - globals@^17.11.0
 
   # Lint Markdown content against .markdownlint-cli2.jsonc.
   - repo: https://github.com/DavidAnson/markdownlint-cli2


### PR DESCRIPTION
CI lints with a different ESLint than `npm run lint` does, and the two have been disagreeing silently.

| | version | source |
| --- | --- | --- |
| pre-commit hook | `eslint@9.39.1`, `@eslint/js@^9.39.0`, `globals@^16.5.0` | `.pre-commit-config.yaml` `additional_dependencies` |
| `npm run lint` | `eslint ^10.9.1`, `@eslint/js ^10.0.1`, `globals ^17.11.0` | `package.json` |

`@eslint/js` is what makes this bite. The rule set in `js.configs.recommended` changes between majors, so a hook one major behind quietly passes code the project's own linter rejects.

## How it surfaced

`preserve-caught-error` is a builtin rule in **both** 9.39.1 and 10.x, but it only entered `js.configs.recommended` in 10. `assets/js/feedback-widget.js:323` violated it, which made `npm run lint` and `npm test` fail on a clean `main` while the `pre-commit` check stayed green.

Verified rather than assumed. ESLint 9.39.1, running this repo's own `eslint.config.js`, against the pre-fix `feedback-widget.js`:

```
exit: 0
```

ESLint 10.9.1 on that identical file reports the error. #3950 had that file in its diff, the hook ran on it, and it passed anyway — under ESLint 9, both before and after the fix in that PR.

## Why nothing caught the drift

`pre-commit-autoupdate.yaml` runs `pre-commit autoupdate --freeze` weekly, which updates `rev:` and never touches `additional_dependencies`. The `mirrors-eslint` rev has advanced to v10.10.0 while the explicit `eslint@9.39.1` pin held the actual linter at 9. The hook advertised v10 and ran v9, and no automation could have closed that gap.

The comment above the hook now says so, since the next person to read it needs to know these three versions are hand-maintained.

## Blast radius: none

Rebased onto `main` with #3950 merged, the aligned hook is clean across every JS file in the repo:

```
pre-commit run eslint --all-files
eslint...................................................................Passed
```

`npm run lint` also passes. The two linters now agree, which is the whole point of the change.

Before #3950 landed, this bump surfaced exactly one error — `feedback-widget.js:323`, the one #3950 fixed. There was no wider backlog behind it.

One pre-existing warning can surface separately: `assets/js/index.js` is in the flat config's `ignores`, and pre-commit passes it explicitly, so ESLint warns that it skipped it. It is a warning, not an error, and predates this change. Left alone rather than papered over with `--no-warn-ignored`, which would also hide genuine ignore mistakes.

## A note on what CI proves here

This PR changes no JavaScript, so the `--from-ref/--to-ref` ratchet skips the ESLint hook on it:

```
eslint...............................................(no files to check)Skipped
```

That is correct behavior, but it means the green check on this PR does not exercise the change. The `--all-files` run above is the evidence that matters.

## Testing

- `pre-commit run eslint --all-files` on top of merged `main`: passes.
- `npm run lint`: passes.
- Before #3950 merged, the same `--all-files` run caught `feedback-widget.js:323`, while the old pins passed it. That contrast is the bug this fixes.
- Confirmed `preserve-caught-error` is absent from `js.configs.recommended` in `@eslint/js` 9.x and present in 10.0.1, by loading both and inspecting the rule set.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-09.
