### PR TITLE
Add a Libraries page for credentials in container builds

### DIFF
--- a/content/chainguard/libraries/introduction/access.md
+++ b/content/chainguard/libraries/introduction/access.md
@@ -4,7 +4,7 @@ linktitle: "Access"
 description: "Learn how to access Chainguard Libraries for enhanced security in Java and Python dependencies, including authentication and organization setup"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -298,6 +298,8 @@ password CHAINGUARD_PYTHON_TOKEN
 ```
 
 Note that the long string for the password value must use only one line.
+
+When you use this `.netrc` file in a container build, mount it as a build secret rather than copying it into an image layer. See [Container builds](/chainguard/libraries/policies-and-security/build-containers/).
 
 ### Verification
 

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Java on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries", "Java"]
 menu:
@@ -33,6 +33,7 @@ This guide outlines how to configure your build tool. If you are looking for som
 | Understand what Chainguard Libraries for Java is and how it works | [Java overview](/chainguard/libraries/java/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/java/global-configuration/) |
 | Migrate an existing project step by step | [Java migration guide](/chainguard/libraries/java/migration/) |
+| Install inside a container build without leaking credentials into the image | [Container builds](/chainguard/libraries/policies-and-security/build-containers/) |
 
 If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/troubleshooting/errors/) for more details.
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-31T14:23:56+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -39,6 +39,7 @@ This guide outlines how to configure your build tool. If you are looking for som
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/javascript/global-configuration/) |
 | Look up how to configure a specific build tool (npm, pnpm, Yarn, Bun) | This page |
 | Migrate an existing project step by step | [JavaScript migration guide](/chainguard/libraries/javascript/migration/) |
+| Install inside a container build without leaking credentials into the image | [Container builds](/chainguard/libraries/policies-and-security/build-containers/) |
 
 If a package or version is blocked by a policy or malware scan, your build tool returns an error. Refer to the [Error messages documentation](/chainguard/libraries/troubleshooting/errors/) for more details.
 

--- a/content/chainguard/libraries/policies-and-security/build-containers.md
+++ b/content/chainguard/libraries/policies-and-security/build-containers.md
@@ -1,0 +1,140 @@
+---
+title: "Configure Chainguard Libraries access in container builds"
+linktitle: "Container builds"
+description: "Authenticate to Chainguard Libraries during a container build without baking credentials into the final image."
+type: "article"
+date: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T00:00:00+00:00
+draft: false
+tags: ["Chainguard Libraries", "Integration"]
+menu:
+  docs:
+    parent: "policies-and-security"
+weight: 075
+toc: true
+aliases:
+  - /chainguard/libraries/build-containers/
+---
+
+When you build a container that installs from Chainguard Libraries, the build must authenticate to Chainguard Libraries — or to a repository manager that proxies it — without baking credentials into the final image.
+
+The package-manager configuration differs by language, but the container-build pattern is the same: pass the credentials into the build stage only for the install step that needs them. For the credentials file, target filename, and file format expected by each package manager, see the ecosystem-specific build configuration page:
+
+* [Java build configuration](/chainguard/libraries/java/build-configuration/)
+* [JavaScript build configuration](/chainguard/libraries/javascript/build-configuration/)
+* [Python build configuration](/chainguard/libraries/python/build-configuration/)
+    * Some Chainguard Libraries for Python packages currently lack macOS-compatible wheels. When the dependency you need is available only as a Chainguard Linux wheel, local installation and testing against the Chainguard-built package must happen in a container. A working build-time secret mount is therefore part of local development on macOS, not only a CI/CD concern.
+
+The repository can be Chainguard Libraries directly or a repository manager that proxies Chainguard Libraries. The secret-mount pattern is the same in either setup.
+
+## Do not bake credentials into image layers
+
+Avoid both of the following approaches:
+
+* Do not `COPY` a credentials file into the build stage. Deleting the file in a later `RUN` instruction does not remove it from the layer history; it can still be extracted with `docker history` or by inspecting the image layers.
+* Do not pass credentials through `ARG` or `ENV`. Build arguments and environment variables can be recorded in image metadata and exposed to anyone with access to the image.
+
+Also avoid printing the secret or copying it to another persistent path during the `RUN` instruction that consumes it. A secret mount protects the mounted file; it cannot protect a copy that your build writes into a layer.
+
+## Use BuildKit secret mounts
+
+Docker BuildKit's `--secret` flag mounts a file for a single `RUN` instruction. The file is available only while that instruction runs, is not written to an image layer, and does not appear in the image history.
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM cgr.dev/chainguard/python:latest-dev AS build
+
+RUN --mount=type=secret,id=netrc,target=/home/nonroot/.netrc,uid=65532,gid=65532 \
+    pip install -r requirements.txt
+```
+
+Supply the secret when you build the image:
+
+```bash
+docker build \
+  --secret id=netrc,src="$HOME/.netrc" \
+  -t myimage .
+```
+
+For a multi-stage build, consume the secret in the build stage and copy only the application artifacts into the final stage:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM cgr.dev/chainguard/python:latest-dev AS build
+WORKDIR /app
+
+COPY requirements.txt .
+RUN --mount=type=secret,id=netrc,target=/home/nonroot/.netrc,uid=65532,gid=65532 \
+    python -m venv /app/venv && \
+    /app/venv/bin/pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+FROM cgr.dev/chainguard/python:latest
+WORKDIR /app
+COPY --from=build /app /app
+ENV PATH="/app/venv/bin:$PATH"
+CMD ["python", "app.py"]
+```
+
+The final stage has no secret mount and does not copy the credentials file. Only the built application and its dependencies are copied from the build stage.
+
+The secret can come from a local file, a CI secret store, or another build-time secret source. Do not put it in the Dockerfile or the build context.
+
+The `id` value connects the command-line secret to the `RUN` instruction. The `target` value is the path where the package manager expects the credentials file. Both values are package-manager and image specific.
+
+## Account for the nonroot default user
+
+Chainguard `-dev` images run as a nonroot user by default. This differs from many Debian- and Alpine-based build images, which run as `root` unless you set another user.
+
+BuildKit secret mounts are read-only and are owned by `root` unless you set the mount ownership. If the `RUN` instruction executes as the default nonroot user, the package manager cannot read the file:
+
+```text
+cat: can't open '/home/nonroot/.netrc': Permission denied
+```
+
+For Chainguard's default nonroot user, set both `uid` and `gid` to `65532`:
+
+```dockerfile
+RUN --mount=type=secret,id=netrc,target=/home/nonroot/.netrc,uid=65532,gid=65532 \
+    pip install -r requirements.txt
+```
+
+The UID/GID is consistent across Chainguard `-dev` images, but the username and home directory are not. Use the target path for the specific image in your `FROM` instruction:
+
+| Image | Default user | Home directory | Example secret target |
+| --- | --- | --- | --- |
+| `python:latest-dev` | `nonroot` | `/home/nonroot` | `/home/nonroot/.netrc` |
+| `node:latest-dev` | `node` | `/home/node` | `/home/node/.npmrc` |
+| `jdk:latest-dev` | `java` | `/home/java` | `/home/java/.m2/settings.xml` |
+| `maven:latest-dev` | `nonroot` | `/home/nonroot` | `/home/nonroot/.m2/settings.xml` |
+
+If a stage switches to `USER root` before installing packages, the mount target and ownership must match the user active in the `RUN` instruction that reads the credentials. In that case, a root-owned mount should use a root-accessible target such as `/root/.netrc`, not the nonroot path and ownership from the table.
+
+## Package-manager reference
+
+The mount mechanics are shared across languages. Only the target filename and file format change:
+
+| Ecosystem | Typical credentials file | See |
+| --- | --- | --- |
+| Python | `.netrc` | [Python build configuration](/chainguard/libraries/python/build-configuration/) |
+| JavaScript | `.npmrc` | [JavaScript build configuration](/chainguard/libraries/javascript/build-configuration/) |
+| Java | Maven `settings.xml` or a Gradle init script | [Java build configuration](/chainguard/libraries/java/build-configuration/) |
+
+The ecosystem-specific page is also the source of truth for repository URLs, authentication fields, fallback behavior, lockfile handling, and package-manager-specific troubleshooting.
+
+## CI/CD
+
+Use the same `--secret` flag in CI/CD. Read the credential from the CI system's secret store and pass it to BuildKit as an environment-backed secret rather than writing it to the workspace.
+
+```yaml
+- name: Build image
+  run: |
+    docker build \
+      --secret id=netrc,env=NETRC_CONTENTS \
+      -t myimage .
+  env:
+    NETRC_CONTENTS: ${{ secrets.CHAINGUARD_PYTHON_NETRC }}
+```
+
+The same pattern applies to `.npmrc`, Maven `settings.xml`, and other package-manager configuration files: mount the file only for the install step that needs it, and keep it out of the final runtime stage.

--- a/content/chainguard/libraries/policies-and-security/overview.md
+++ b/content/chainguard/libraries/policies-and-security/overview.md
@@ -4,7 +4,7 @@ linktitle: "Policies overview"
 description: "Understand how Chainguard Libraries evaluates, verifies, and controls dependencies across supported ecosystems."
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries", "Policy", "Overview"]
 weight: 051
@@ -17,3 +17,4 @@ Learn how to verify Chainguard Library integrity, identify and remediate vulnera
 * [Verification](/chainguard/libraries/policies-and-security/verification/): Use `chainctl libraries verify` to confirm which dependencies were built by Chainguard and review their signed provenance and software bills of materials (SBOMs).
 * [CVE remediation](/chainguard/libraries/policies-and-security/cve-remediation/): Learn how Chainguard backports selected high- and critical-severity fixes to supported library versions and how to identify and use remediated releases.
 * [Vulnerability scanners](/chainguard/libraries/policies-and-security/scanners/): Learn how common vulnerability scanners work with Chainguard Libraries and how to interpret findings for Chainguard-built and remediated dependencies.
+* [Container builds](/chainguard/libraries/policies-and-security/build-containers/): Authenticate to Chainguard Libraries during a container build using BuildKit secret mounts, without baking credentials into the final image.

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-31T14:23:56+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -33,12 +33,13 @@ versions from PyPI under Chainguard security controls.
 
 This guide outlines how to configure your build tool. If you are looking for something else, refer to the following guides depending on your goals:
 
-| If you wnat to... | Use this page |
+| If you want to... | Use this page |
 | --- | --- |
 | Understand what Chainguard Libraries for Python is and how it works | [Python overview](/chainguard/libraries/python/overview/) |
 | Set up organization-wide access through a repository manager | [Global configuration](/chainguard/libraries/python/global-configuration/) |
 | Look up how to configure a specific build tool (pip, Poetry, uv) | This page |
 | Migrate an existing project step by step | [Python migration guide](/chainguard/libraries/python/migration/) |
+| Install inside a container build without leaking credentials into the image | [Container builds](/chainguard/libraries/policies-and-security/build-containers/) |
 
 Refer to the [minimal example projects](#minimal-example-projects) on this page for demonstrations using `uv` and `pip`.
 

--- a/content/chainguard/libraries/python/overview.md
+++ b/content/chainguard/libraries/python/overview.md
@@ -4,7 +4,7 @@ linktitle: "Python overview"
 description: "Learn about Chainguard Libraries for Python, providing enhanced security for PyPI packages through automated vulnerability patching and supply chain protection"
 type: "article"
 date: 2025-04-09T04:00:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:46:42+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python", "Overview"]
 menu:
@@ -358,6 +358,8 @@ Cached Docker image layers may reuse upstream dependencies even after reconfigur
 ```bash
 docker build --no-cache
 ```
+
+To authenticate to Chainguard Libraries during a container build without writing credentials into an image layer, see [Container builds](/chainguard/libraries/policies-and-security/build-containers/).
 
 ### Updating lockfile hashes
 


### PR DESCRIPTION
## Summary

Adds a cross-ecosystem Chainguard Libraries page on handling credentials during container builds, and cross-links it from related pages.

Build-time credential handling (BuildKit secret mounts, nonroot UID/GID, CI/CD) had been drafted onto the "Developer workflow" video-transcript page, which was the wrong home. This PR gives it a dedicated page under Policies and security and wires up discoverability.

This addresses https://linear.app/chainguard/issue/DOCS-37/docs-update-configure-chainguard-libraries-access-when-building-a

## Changes

- **New page** — `policies-and-security/build-containers.md`, "Configure Chainguard Libraries access in container builds" (weight 075). Covers BuildKit `--secret` mounts, single- and multi-stage examples, nonroot UID/GID (`65532`) guidance with a per-image target table, a package-manager reference, and CI/CD.
- **Cross-links to the new page** from:
  - the Python, JavaScript, and Java build-configuration intro tables
  - the Python overview's *Containerized builds* section
  - the access page's *.netrc for authentication* section
  - the Policies and security overview index
- **Typo fix** — "If you wnat to..." → "want" in the Python build-configuration intro table.

## Test plan

### Testing the content

I took the following steps to test this content:

1. Confirmed local environment — verified Docker Desktop (Mac) 4.55.0 / Engine 29.1.3 with BuildKit and buildx (v0.30.1-desktop.1) available, no setup needed.
2. Checked default user/home on each -dev image via `docker run --rm --entrypoint id <image>` and `... sh -c 'echo $HOME'`:
- python:latest-dev → nonroot / /home/nonroot
- node:latest-dev → node / /home/node
- jdk:latest-dev → java / /home/java
- maven:latest-dev → nonroot / /home/nonroot
- All four share UID/GID 65532, but usernames and home paths differ — this corrected the doc's original assumption that the nonroot behavior was opt-in via an explicit USER instruction, and added the per-image path table.
3. Ran broken/fixed Dockerfile pairs with a dummy .netrc (mounting a secret with cat, no real credentials) against three images:
- python:latest-dev — broken failed with Permission denied; fixed (uid=65532,gid=65532) succeeded.
- node:latest-dev — same pattern, broken failed, fixed succeeded.
- jdk:latest-dev — same pattern, broken failed, fixed succeeded.
- (maven:latest-dev wasn't build-tested this way — only its default user/home was checked in step 2.)
4. Ran a full real-world test on Python: minted a real pull token via `chainctl auth pull-token`, wrote a real .netrc, and ran `pip install --index-url https://libraries.cgr.dev/python/simple/ requests==2.31.0` inside a `RUN --mount=type=secret,...,uid=65532,gid=65532` build — succeeded end-to-end (exit 0), confirming the fix works for an actual package install, not just a file read.

### Testing the docs update

1. Install the pinned toolchain: `npm ci` (Hugo ≥0.164; a Homebrew Hugo breaks on `.Site.Language.Locale`).
2. Start the dev server (`npx hugo server`) and confirm a clean build with no errors or warnings.
3. Open `/chainguard/libraries/policies-and-security/build-containers/` and confirm:
   - the page renders and appears in the Policies and security nav at the expected position;
   - the table of contents lists every section;
   - code blocks show single `\` line continuations (no literal `\\`).
4. Confirm the alias `/chainguard/libraries/build-containers/` redirects to the page.
5. From each of the following, click through to the new page and confirm the link resolves (no 404):
   - Python / JavaScript / Java build-configuration (intro table row);
   - Python overview → *Containerized builds*;
   - Access → *.netrc for authentication*;
   - Policies and security overview.
6. Confirm `how-libraries-plug-into-workflow.md` renders as before (video transcript only, original title) — no leftover build-configuration content.
7. Optional functional check of the documented pattern:
   ```bash
   docker build --secret id=netrc,src="$HOME/.netrc" -t cg-secret-test .
   docker history --no-trunc cg-secret-test | grep -i netrc   # expect no match
   ```
   Confirm the credential file does not appear in any image layer.

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-09-09.
