### PR TITLE
Add a registry authentication error reference for Chainguard Containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public
 resources
 .netlify
 .hugo_build.lock
+assets/jsconfig.json
 .DS_Store
 .bash_history
 

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -4,7 +4,7 @@ linktitle: "Skills Registry"
 description: "Enable the Chainguard Skills Registry, then push, install, and run an agent skill scoped to your organization."
 type: "article"
 date: 2026-06-05T08:48:45+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Agent Skills", "Overview"]
 images: []
@@ -105,7 +105,7 @@ The directory name (`hello-world/`) must match the `name` field in the frontmatt
 
 This section outlines some of the `chainctl` commands you can use to manage skills in your organization's private Skills Registry. The following commands use the `hello-world` skill as an example, but you can use any other skills you've created in its place.
 
-Refer to the [`chainctl skills` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_skills/) for more information.
+Refer to the [`chainctl skills` reference documentation](/platform/chainctl/chainctl-docs/chainctl_skills/) for more information.
 
 ### Validate the skill
 
@@ -247,7 +247,7 @@ Uninstalled skill "hello-world".
 
 By default, `uninstall` removes the skill from every agent directory where it's installed. Use the `--agent` flag to remove it from specific agents only, or the `--global` flag to remove it from global directories instead of the current project. Add the `-y` flag to skip the confirmation prompt.
 
-`uninstall` operates only on the local files on your machine. It doesn't modify your organization's registry. To remove a published skill from the registry, use [`chainctl skills delete`](/chainguard/chainctl/chainctl-docs/chainctl_skills_delete/) instead.
+`uninstall` operates only on the local files on your machine. It doesn't modify your organization's registry. To remove a published skill from the registry, use [`chainctl skills delete`](/platform/chainctl/chainctl-docs/chainctl_skills_delete/) instead.
 
 ### Delete a skill from the registry
 

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -4,7 +4,7 @@ linktitle: "Skills Registry"
 description: "Enable the Chainguard Skills Registry, then push, install, and run an agent skill scoped to your organization."
 type: "article"
 date: 2026-06-05T08:48:45+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Agent Skills", "Overview"]
 images: []
@@ -25,7 +25,7 @@ This guide walks through the full workflow, including how to enable the registry
 
 To follow this guide, you need:
 
-* `chainctl` **v0.2.275** or later, installed and authenticated. Refer to [How to install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
+* `chainctl` **v0.2.275** or later, installed and authenticated. Refer to [How to install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/) if you don't have it yet.
 * An active Chainguard organization.
 * Owner access on the organization.
 

--- a/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -372,7 +372,7 @@ chainctl image repo list --repo=python -o json | jq -r '.items[].activeTags'
 
 You can list the version information for packages that have multiple release
 tracks with `chainctl package versions list`, which uses the [List Repos
-API](/chainguard/api/spec/#/operations/Registry_ListRepos/).
+API](/platform/api/spec/#/operations/Registry_ListRepos/).
 
 The following `chainctl` command lists the active release tracks for the `python`
 package:

--- a/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Understanding Chainguard's approach to container image versions."
 date: 2024-01-08T08:49:31+00:00
-lastmod: 2026-09-02T13:31:42+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -396,7 +396,7 @@ well as the date after which it will no longer be covered by the EOL grace
 period.
 
 Refer to the [`chainctl`
-documentation](/chainguard/chainctl/chainctl-docs/chainctl_packages_versions_list/)
+documentation](/platform/chainctl/chainctl-docs/chainctl_packages_versions_list/)
 for the full list of options that can be passed to the command.
 
 ### EOL grace period API

--- a/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
@@ -4,7 +4,7 @@ linktitle: "Manage with chainctl"
 type: "article"
 description: "How to use chainctl to manage Custom Assembly resources."
 date: 2025-05-01T11:07:52+02:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
 images: []
@@ -20,7 +20,7 @@ aliases:
 
 Chainguard's [Custom Assembly](/chainguard/containers/custom-assembly/overview/) is a tool that allows customers to create customized containers with extra packages and annotations added. This enables customers to reduce their risk exposure by creating container images that are tailored to their internal organization and application requirements while still having few-to-zero CVEs.
 
-You can use [`chainctl`, Chainguard's command-line interface tool](/chainguard/chainctl/), to further customize your Custom Assembly builds and retrieve information about them. This guide provides an overview of the relevant `chainctl` commands and outlines how you can edit the configuration of Custom Assembly containers, as well as retrieve a list of a customized image's builds and its build logs.
+You can use [`chainctl`, Chainguard's command-line interface tool](/platform/chainctl/), to further customize your Custom Assembly builds and retrieve information about them. This guide provides an overview of the relevant `chainctl` commands and outlines how you can edit the configuration of Custom Assembly containers, as well as retrieve a list of a customized image's builds and its build logs.
 
 > **Note**: This tutorial highlights using `chainctl` to interact with Custom Assembly resources. However, you can also interact with Custom Assembly using [the Chainguard Console](/chainguard/containers/custom-assembly/custom-assembly-console/), as well as [the Chainguard API](/chainguard/containers/custom-assembly/custom-assembly-api-demo/).
 
@@ -386,7 +386,7 @@ You can use `chainctl images repos build apply` to do things like:
 * Use wildcards: `--repo="python-*"` or `--repo="*"` (all repos under the parent)
 * Combine with `--dry-run` to see which repos would change (drift detection) without actually updating anything.
 
-For more information, refer to [chainctl images repos build apply](/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/).
+For more information, refer to [chainctl images repos build apply](/platform/chainctl/chainctl-docs/chainctl_images_repos_build_apply/).
 
 ## Learn more
 

--- a/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
@@ -4,7 +4,7 @@ linktitle: "Manage with chainctl"
 type: "article"
 description: "How to use chainctl to manage Custom Assembly resources."
 date: 2025-05-01T11:07:52+02:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
 images: []
@@ -392,4 +392,4 @@ For more information, refer to [chainctl images repos build apply](/platform/cha
 
 You can also use `chainctl` to add custom certificates to your Custom Assembly images. Refer to our guide on [Adding custom certificates with Custom Assembly](/chainguard/containers/custom-assembly/custom-assembly-certs/#using-chainctl-to-add-custom-certificates-using-custom-assembly) for more information.
 
-Additionally, you can interact with Custom Assembly with the [Chainguard API](/chainguard/api/spec/). Our tutorial on [Using the Chainguard API to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-api-demo/) outlines how to run a demo application that updates the configuration of a Custom Assembly container through the Chainguard API.
+Additionally, you can interact with Custom Assembly with the [Chainguard API](/platform/api/spec/). Our tutorial on [Using the Chainguard API to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-api-demo/) outlines how to run a demo application that updates the configuration of a Custom Assembly container through the Chainguard API.

--- a/content/chainguard/containers/custom-assembly/overview.md
+++ b/content/chainguard/containers/custom-assembly/overview.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "How to use Chainguard's Custom Assembly tool"
 date: 2025-02-19T11:07:52+02:00
-lastmod: 2026-03-16T08:07:42+02:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly"]
 images: []
@@ -41,7 +41,7 @@ With Custom Assembly, you can add the following to your container images:
 * [Custom certificates](/chainguard/containers/custom-assembly/custom-assembly-certs/) — Embed PEM-encoded x509v3 certificates (such as internal CA certificates) directly into the image's truststore. These are merged with the default certificate bundle at /etc/ssl/certs/ca-certificates.crt and the Java truststore.
 * [Chainguard-managed certificate bundles](/chainguard/containers/custom-assembly/custom-assembly-certs/#chainguard-managed-certificate-bundles) — Pre-packaged certificate bundles for regulated environments, such as commercial AWS or AWS GovCloud.
 * [Environment variables and annotations](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#adding-custom-annotations-and-environment-variables) — Set custom runtime environment variables and custom metadata annotations.
-* [Custom user accounts and groups](/chainguard/chainctl/chainctl-docs/chainctl_images_repos_build_apply/) — Use `chainctl images repos build apply` or `chainctl images repos build edit` to define custom users with specific UIDs/GIDs, home directories, group memberships, and specify which user the image runs as.
+* [Custom user accounts and groups](/platform/chainctl/chainctl-docs/chainctl_images_repos_build_apply/) — Use `chainctl images repos build apply` or `chainctl images repos build edit` to define custom users with specific UIDs/GIDs, home directories, group memberships, and specify which user the image runs as.
 * [Custom runtime repositories](#custom-runtime-repositories) — Replace the default APK repository URLs in the assembled image with your own internal mirror URLs, so that runtime `apk add` commands resolve against your infrastructure instead of Chainguard's default endpoints.
 * [Custom runtime keys](#custom-runtime-keys) — Embed your mirror's APK signing public keys in the assembled image, so that runtime `apk add` commands can verify packages from mirrors that re-sign them.
 

--- a/content/chainguard/containers/custom-assembly/overview.md
+++ b/content/chainguard/containers/custom-assembly/overview.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "How to use Chainguard's Custom Assembly tool"
 date: 2025-02-19T11:07:52+02:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly"]
 images: []
@@ -85,7 +85,7 @@ To create such a custom role, you can use the `chainctl iam roles create` comman
 chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_report.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
 ```
 
-After creating this custom role, you would need to bind it to any identities in your organization that you want to be able to manage Custom Assembly resources. Check out our [Overview of roles and role-bindings in Chainguard](/chainguard/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to learn more.
+After creating this custom role, you would need to bind it to any identities in your organization that you want to be able to manage Custom Assembly resources. Check out our [Overview of roles and role-bindings in Chainguard](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to learn more.
 
 ## Using customized containers
 

--- a/content/chainguard/containers/registry/authenticating/index.md
+++ b/content/chainguard/containers/registry/authenticating/index.md
@@ -4,7 +4,7 @@ linktitle: "Authenticate"
 type: "article"
 description: "A guide on authenticating to Chainguard's registry to get container images"
 date: 2023-03-21T15:10:16+00:00
-lastmod: 2026-09-04T16:00:38+00:00
+lastmod: 2026-09-09T15:50:32+00:00
 tags: ["Chainguard Containers", "Registry"]
 draft: false
 images: []
@@ -49,7 +49,9 @@ Before you start, [sign up for a Chainguard account](#signing-up) and [install `
     docker pull cgr.dev/$ORGANIZATION/python:latest
     ```
 
-To see which repositories your organization can pull, run `chainctl images repos list`. To browse the full catalog, visit the [Chainguard Containers Directory](https://images.chainguard.dev/).
+To see which repositories your organization can pull, run `chainctl images repos list`. To browse the full catalog, visit the [Chainguard Containers Directory](https://images.chainguard.dev/). Your organization's registry holds a subset of what the Directory lists, so browsing a container there doesn't mean you can pull it; refer to [Onboard your teams](/get-started/onboard-your-teams/#what-your-organization-can-pull) for how your subscription determines what's available.
+
+If the pull fails, refer to [Troubleshoot registry authentication errors](/chainguard/containers/troubleshooting/registry-errors/), which maps each error `cgr.dev` returns to its cause.
 
 ## Signing up
 
@@ -157,6 +159,8 @@ This table shows the name of each pull token, their descriptions, the date they 
 You can create a new pull token by clicking the **Create pull token** button at the top of the page. A new pane will appear where you can enter a name for the new pull token, add an optional description, and select when the pull token will expire. The **Expiration** drop-down menu has options for 30, 60, and 90 days, as well as a **Custom** expiration option. This will cause a **Custom Expiration** window to appear, allowing you to select the date when you'd like the token to expire.
 
 After entering these details, click the **Create token** button and your new pull token will appear in the list with the rest of your organization's tokens.
+
+If the Console won't let you create a pull token, your role is missing a capability rather than the registry rejecting you. Creating a pull token creates a Chainguard identity and a role-binding for it, so it needs a role with the `identity (create)` and `role_bindings (create)` capabilities. `registry.pull_token_creator` is the least privileged built-in role with both. Refer to [Overview of roles and role-bindings](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to bind it, and to the [capabilities reference](/platform/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for what each built-in role carries.
 
 ## Authenticating with GitHub Actions
 

--- a/content/chainguard/containers/registry/overview.md
+++ b/content/chainguard/containers/registry/overview.md
@@ -3,7 +3,7 @@ title: "Registry overview"
 type: "article"
 description: "Learn about Chainguard's container registry, including public access to free images, authenticated access for production images, and network requirements"
 date: 2023-03-21T16:36:47+00:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-09T15:50:32+00:00
 draft: false
 images: []
 tags: ["Chainguard Containers", "Registry"]
@@ -23,6 +23,14 @@ Chainguard Registry hosts more secure container images with two access tiers: pu
 While all public Chainguard Containers are freely available, logging in with a Chainguard account and authenticating when pulling from the registry provides a mechanism for Chainguard to contact you if there are any current or known upcoming issues with images you are pulling.
 
 If you would like to learn more about **Chainguard Containers**, you can review our [documentation](/chainguard/containers/overview/), and you can request further information through our [inquiry form](https://www.chainguard.dev/contact?utm_source=cg-academy&utm_medium=referral&utm_campaign=dev-enablement).
+
+## What your organization can pull
+
+Your organization's registry at `cgr.dev/$ORGANIZATION/` holds only the containers your organization has access to, which is a subset of what the public [Chainguard Containers Directory](https://images.chainguard.dev/) lists. Browsing a container in the Directory doesn't mean you can pull it. Refer to [Onboard your teams](/get-started/onboard-your-teams/#what-your-organization-can-pull) for how your subscription determines what's available, and to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/) when a container you expected is missing.
+
+## Troubleshooting authentication errors
+
+If a login or pull returns a `401`, `403`, or `404`, refer to [Troubleshoot registry authentication errors](/chainguard/containers/troubleshooting/registry-errors/), which maps each error to its cause.
 
 ## Status
 

--- a/content/chainguard/containers/security-and-compliance/security-advisories/how-to-use/index.md
+++ b/content/chainguard/containers/security-and-compliance/security-advisories/how-to-use/index.md
@@ -15,7 +15,7 @@ aliases:
 type: "article"
 description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Container Directory."
 date: 2023-12-27T11:07:52+02:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers", "CVE"]
 images: []
@@ -40,7 +40,7 @@ You don't need any special access or software to explore Chainguard's Security A
 To follow along with these examples, you'll need the following tools installed.
 
 * A security scanner like [Trivy](https://trivy.dev/docs/latest/getting-started/installation/), [Grype](https://github.com/anchore/grype#installation), or [Docker Scout](https://docs.docker.com/get-docker/) — This guide's examples use Grype to scan container images and identify vulnerabilities. However, you should be able to follow along with any container vulnerability scanning tool.
-* [`chainctl`](/platform/chainctl/) — Chainguard's command-line interface tool. To install `chainctl`, follow our [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
+* [`chainctl`](/platform/chainctl/) — Chainguard's command-line interface tool. To install `chainctl`, follow our [installation guide](/platform/chainctl-usage/how-to-install-chainctl/).
 * [`jq`](https://jqlang.github.io/jq/) — `jq` is a command-line JSON processor that allows you to filter and manipulate streaming JSON data. Although it isn’t strictly necessary for the purposes of this guide, this tutorial includes commands that use `jq` to filter command output that would otherwise be difficult to read. You can install `jq` by following the instructions on [the project’s Download jq page](https://jqlang.github.io/jq/download/).
 
 Lastly, note that this guide includes examples involving a sample organization with a private registry provided by Chainguard and named `example.com`. If you would like to follow along with your own private Chainguard Containers, be sure to change this where relevant to reflect your own setup. If you don't have access to a private registry, you can also follow along using Chainguard's public [Free containers](/chainguard/containers/concepts/container-categories/#free-containers), but be aware that these are limited to only the `latest` or `latest-dev` tags. You can download Free Containers from the `cgr.dev/chainguard` registry, as in `cgr.dev/chainguard/go:latest`.

--- a/content/chainguard/containers/security-and-compliance/security-advisories/how-to-use/index.md
+++ b/content/chainguard/containers/security-and-compliance/security-advisories/how-to-use/index.md
@@ -15,7 +15,7 @@ aliases:
 type: "article"
 description: "Article outlining how one can explore and use the Security Advisories found on the Chainguard Container Directory."
 date: 2023-12-27T11:07:52+02:00
-lastmod: 2026-08-31T15:18:48+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers", "CVE"]
 images: []
@@ -40,7 +40,7 @@ You don't need any special access or software to explore Chainguard's Security A
 To follow along with these examples, you'll need the following tools installed.
 
 * A security scanner like [Trivy](https://trivy.dev/docs/latest/getting-started/installation/), [Grype](https://github.com/anchore/grype#installation), or [Docker Scout](https://docs.docker.com/get-docker/) — This guide's examples use Grype to scan container images and identify vulnerabilities. However, you should be able to follow along with any container vulnerability scanning tool.
-* [`chainctl`](/chainguard/chainctl/) — Chainguard's command-line interface tool. To install `chainctl`, follow our [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
+* [`chainctl`](/platform/chainctl/) — Chainguard's command-line interface tool. To install `chainctl`, follow our [installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/).
 * [`jq`](https://jqlang.github.io/jq/) — `jq` is a command-line JSON processor that allows you to filter and manipulate streaming JSON data. Although it isn’t strictly necessary for the purposes of this guide, this tutorial includes commands that use `jq` to filter command output that would otherwise be difficult to read. You can install `jq` by following the instructions on [the project’s Download jq page](https://jqlang.github.io/jq/download/).
 
 Lastly, note that this guide includes examples involving a sample organization with a private registry provided by Chainguard and named `example.com`. If you would like to follow along with your own private Chainguard Containers, be sure to change this where relevant to reflect your own setup. If you don't have access to a private registry, you can also follow along using Chainguard's public [Free containers](/chainguard/containers/concepts/container-categories/#free-containers), but be aware that these are limited to only the `latest` or `latest-dev` tags. You can download Free Containers from the `cgr.dev/chainguard` registry, as in `cgr.dev/chainguard/go:latest`.

--- a/content/chainguard/containers/troubleshooting/registry-errors.md
+++ b/content/chainguard/containers/troubleshooting/registry-errors.md
@@ -4,7 +4,7 @@ linktitle: "Registry errors"
 description: "Map the errors cgr.dev returns during login and pull to their causes, including why the same HTTP status code means different things at the token endpoint and the registry API."
 type: "article"
 date: 2026-09-09T00:00:00+00:00
-lastmod: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T17:21:21+00:00
 draft: false
 tags: ["Chainguard Containers", "Registry"]
 images: []
@@ -33,16 +33,14 @@ The two steps reuse the same HTTP status codes for unrelated problems. A `403` f
 | `FORBIDDEN`, "caller does not have the required capabilities" | Registry API | You're authenticated, but you aren't authorized for this repository. |
 | `NAME_UNKNOWN`, "repository does not exist" | Registry API | The repository name doesn't exist in that organization. |
 
-A bare "Forbidden" body doesn't tell you which of those two it is. Chainguard's registry returns the same `403` to a caller that sent no credentials, a caller whose credentials it can't use, and a caller naming a repository it won't grant a token for. Treat it as a prompt to work through the possible causes in order rather than as a single diagnosis, and in particular don't read it as confirmation that your credentials were accepted.
+A bare `Forbidden` message doesn't tell you which of those two it is. Chainguard's registry returns the same `403` to a caller that sent no credentials, a caller whose credentials it can't use, and a caller naming a repository it won't grant a token for. Treat it as a prompt to work through the possible causes in order rather than as a single diagnosis, and in particular don't read it as confirmation that your credentials were accepted.
 
 ## Authentication required from the token endpoint
 
 You'll see a `401` like the following when a build or pull runs with no credentials configured:
 
 ```output
-failed to fetch anonymous token: unexpected status from GET request to
-https://cgr.dev/token?scope=repository%3A$ORGANIZATION%2Fpython%3Apull&service=cgr.dev:
-401 Unauthorized
+failed to fetch anonymous token: unexpected status from GET request to https://cgr.dev/token?scope=repository%3A$ORGANIZATION%2Fpython%3Apull&service=cgr.dev: 401 Unauthorized
 ```
 
 The word "anonymous" is the signal. Your tool found no credentials for `cgr.dev`, so it asked for a public token, and the repository you named isn't public. Containers in the `cgr.dev/chainguard/` namespace are public and need no authentication. Everything in your organization's own namespace at `cgr.dev/$ORGANIZATION/` requires credentials.
@@ -62,8 +60,7 @@ If the failure happens inside `docker build` rather than `docker pull`, check th
 A `403` from the token endpoint looks like this, often from `helm registry login` or another tool that logs in without naming a repository:
 
 ```output
-Error: authenticating to "cgr.dev": GET "https://cgr.dev/token?service=cgr.dev":
-response status code 403: forbidden
+Error: authenticating to "cgr.dev": GET "https://cgr.dev/token?service=cgr.dev": response status code 403: forbidden
 ```
 
 This response means the token endpoint rejected the request outright. It doesn't tell you which part of the request it objected to, so check these in order:
@@ -77,8 +74,7 @@ This response means the token endpoint rejected the request outright. It doesn't
 A `400` means the organization portion of the image reference didn't match any Chainguard organization:
 
 ```output
-{"errors":[{"code":"BAD_REQUEST","message":"rpc error: code = InvalidArgument
-desc = unable to resolve ..."}]}
+{"errors":[{"code":"BAD_REQUEST","message":"rpc error: code = InvalidArgument desc = unable to resolve ..."}]}
 ```
 
 Unlike the other errors on this page, this one has nothing to do with your credentials. The organization name is wrong. List the organizations you belong to and compare:
@@ -87,22 +83,20 @@ Unlike the other errors on this page, this one has nothing to do with your crede
 chainctl iam organizations list
 ```
 
-Organization names are usually domain names, such as `example.com`, and the full image reference is `cgr.dev/$ORGANIZATION/$IMAGE:$TAG`. Omitting the organization, or using your organization's display name instead of its registry name, produces this error.
+Organization names are usually domain names, such as `example.com`, and the full image reference is `cgr.dev/$ORGANIZATION/$IMAGE:$TAG`. Omitting the organization, or using your organization's display name instead of its registry name, can produce this error.
 
 ## Missing capabilities from the registry API
 
 This `403` is the one that means your login worked and your authorization didn't:
 
 ```output
-{"errors":[{"code":"FORBIDDEN","message":"caller does not have the required
-capabilities at \"...\""}]}
+{"errors":[{"code":"FORBIDDEN","message":"caller does not have the required capabilities at \"...\""}]}
 ```
 
 It also surfaces through the tool you're running. A Helm install that logged in successfully and then failed reports it against the API path:
 
 ```output
-Error: INSTALLATION FAILED: ... /$ORGANIZATION/postgresql/tags/list ...
-response status code 403
+Error: INSTALLATION FAILED: ... /$ORGANIZATION/postgresql/tags/list ... response status code 403
 ```
 
 Two different problems produce this error, and the fix differs:
@@ -126,7 +120,7 @@ Once you hold a valid token, a name that isn't in the organization returns a `40
 {"errors":[{"code":"NAME_UNKNOWN","message":"repository does not exist \"...\""}]}
 ```
 
-Check the spelling against `chainctl images repos list`, then against the [Chainguard Containers Directory](https://images.chainguard.dev/). If the Directory doesn't list the container either, Chainguard doesn't build it yet and you can ask for it. Refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
+Check the spelling against `chainctl images repos list`, then against the [Chainguard Containers Directory](https://images.chainguard.dev/). If the Directory doesn't list the container either, Chainguard doesn't build it yet and you can ask for it through [Requesting new Chainguard resources](/chainguard/containers/reference/request-resources/). To work out which of those situations you're in, refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
 
 ## Check your credential format
 
@@ -155,8 +149,7 @@ Helm and Podman need `chainctl` installed only to create the token. Once you hav
 A registry mirror reports Chainguard's errors in its own wording, which can obscure which of the preceding cases you're in. Artifactory, for example, reports a rejected credential as a configuration problem:
 
 ```output
-Invalid username/password configured for Remote Docker repository:
-$REPOSITORY_NAME ... Can't fetch token for repo ... realm: https://cgr.dev/token
+Invalid username/password configured for Remote Docker repository: $REPOSITORY_NAME ... Can't fetch token for repo ... realm: https://cgr.dev/token
 ```
 
 The `realm: https://cgr.dev/token` fragment tells you the failure happened during credential exchange, so work through [Forbidden from the token endpoint](#forbidden-from-the-token-endpoint) and [Check your credential format](#check-your-credential-format). Mirrors are a common place for the username to be wrong, because their configuration forms label the field "username" and invite an email address.

--- a/content/chainguard/containers/troubleshooting/registry-errors.md
+++ b/content/chainguard/containers/troubleshooting/registry-errors.md
@@ -1,0 +1,191 @@
+---
+title: "Troubleshoot registry authentication errors"
+linktitle: "Registry errors"
+description: "Map the errors cgr.dev returns during login and pull to their causes, including why the same HTTP status code means different things at the token endpoint and the registry API."
+type: "article"
+date: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T00:00:00+00:00
+draft: false
+tags: ["Chainguard Containers", "Registry"]
+images: []
+weight: 015
+toc: true
+---
+
+A login or pull against `cgr.dev` failed and you have an error string. This page maps the errors Chainguard's registry returns to their causes and tells you what to check for each one.
+
+If your pull fails for a container you can see in the [Chainguard Containers Directory](https://images.chainguard.dev/), the container most likely hasn't been added to your organization yet. That case has its own guide: refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
+
+## Where registry errors come from
+
+Pulling a container from `cgr.dev` takes two separate requests, and each one fails differently:
+
+1. **Credential exchange.** Your tool sends your credentials to the token endpoint at `https://cgr.dev/token` and gets back a bearer token scoped to the repository you asked for. `docker login`, `helm registry login`, `podman login`, and `chainctl auth configure-docker` all exercise this step.
+1. **The pull.** Your tool presents that bearer token to the registry API at `https://cgr.dev/v2/` and requests the tags, manifest, and layers.
+
+The two steps reuse the same HTTP status codes for unrelated problems. A `403` from the token endpoint means something different from a `403` from the registry API, so read the error code and message in the response body rather than the status number on its own:
+
+| Response body | Returned by | Meaning |
+| -- | -- | -- |
+| `UNAUTHORIZED`, "Authentication required" | Token endpoint | The repository requires credentials and you presented none that worked. |
+| `FORBIDDEN`, "Forbidden" | Token endpoint | The endpoint won't issue a token for the repository you named, or it couldn't use the credentials you sent. |
+| `BAD_REQUEST`, "InvalidArgument" | Token endpoint | The organization in the image reference didn't resolve. |
+| `FORBIDDEN`, "caller does not have the required capabilities" | Registry API | You're authenticated, but you aren't authorized for this repository. |
+| `NAME_UNKNOWN`, "repository does not exist" | Registry API | The repository name doesn't exist in that organization. |
+
+A bare "Forbidden" body doesn't tell you which of those two it is. Chainguard's registry returns the same `403` to a caller that sent no credentials, a caller whose credentials it can't use, and a caller naming a repository it won't grant a token for. Treat it as a prompt to work through the possible causes in order rather than as a single diagnosis, and in particular don't read it as confirmation that your credentials were accepted.
+
+## Authentication required from the token endpoint
+
+You'll see a `401` like the following when a build or pull runs with no credentials configured:
+
+```output
+failed to fetch anonymous token: unexpected status from GET request to
+https://cgr.dev/token?scope=repository%3A$ORGANIZATION%2Fpython%3Apull&service=cgr.dev:
+401 Unauthorized
+```
+
+The word "anonymous" is the signal. Your tool found no credentials for `cgr.dev`, so it asked for a public token, and the repository you named isn't public. Containers in the `cgr.dev/chainguard/` namespace are public and need no authentication. Everything in your organization's own namespace at `cgr.dev/$ORGANIZATION/` requires credentials.
+
+Configure the credential helper, then retry:
+
+```shell
+chainctl auth configure-docker
+```
+
+You don't need to run `chainctl auth login` first. For headless machines, CI systems, and other login flows, refer to [Authenticate to Chainguard's Registry](/chainguard/containers/registry/authenticating/) and [Authentication options for `chainctl`](/platform/chainctl-usage/authentication-options/).
+
+If the failure happens inside `docker build` rather than `docker pull`, check that the builder can see your Docker configuration. A `FROM` line pointing at your organization's namespace needs the same credentials a direct pull does.
+
+## Forbidden from the token endpoint
+
+A `403` from the token endpoint looks like this, often from `helm registry login` or another tool that logs in without naming a repository:
+
+```output
+Error: authenticating to "cgr.dev": GET "https://cgr.dev/token?service=cgr.dev":
+response status code 403: forbidden
+```
+
+This response means the token endpoint rejected the request outright. It doesn't tell you which part of the request it objected to, so check these in order:
+
+1. **The credential format.** The username for a pull token is the Chainguard identity ID that owns the token, not your email address. Refer to [Check your credential format](#check-your-credential-format).
+1. **The credential's age.** Pull tokens expire 30 days after creation by default. Create a replacement with `chainctl auth configure-docker --pull-token`.
+1. **The repository name.** A scope the endpoint won't grant returns this `403` rather than a `404`, whether the repository doesn't exist or isn't in your organization's catalog. Confirm the name against `chainctl images repos list`.
+
+## The organization didn't resolve
+
+A `400` means the organization portion of the image reference didn't match any Chainguard organization:
+
+```output
+{"errors":[{"code":"BAD_REQUEST","message":"rpc error: code = InvalidArgument
+desc = unable to resolve ..."}]}
+```
+
+Unlike the other errors on this page, this one has nothing to do with your credentials. The organization name is wrong. List the organizations you belong to and compare:
+
+```shell
+chainctl iam organizations list
+```
+
+Organization names are usually domain names, such as `example.com`, and the full image reference is `cgr.dev/$ORGANIZATION/$IMAGE:$TAG`. Omitting the organization, or using your organization's display name instead of its registry name, produces this error.
+
+## Missing capabilities from the registry API
+
+This `403` is the one that means your login worked and your authorization didn't:
+
+```output
+{"errors":[{"code":"FORBIDDEN","message":"caller does not have the required
+capabilities at \"...\""}]}
+```
+
+It also surfaces through the tool you're running. A Helm install that logged in successfully and then failed reports it against the API path:
+
+```output
+Error: INSTALLATION FAILED: ... /$ORGANIZATION/postgresql/tags/list ...
+response status code 403
+```
+
+Two different problems produce this error, and the fix differs:
+
+- **The repository isn't in your organization's catalog.** This is the more common cause. Your credentials are valid, but the container hasn't been added to your organization. Refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/) for how to add it or request it, along with the roles that each path requires.
+- **Your identity lacks a role that grants pull access.** Check which capabilities your current credentials carry:
+
+    ```shell
+    chainctl auth status
+    ```
+
+    Read the `Capabilities` field in the output. Pulling containers needs a role with the `manifest (list)` capability; `registry.pull` is the least privileged built-in role that has it. To grant it, refer to [Overview of roles and role-bindings](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/). Pulling APK packages needs `apk (list)` instead, which [Private APK repositories](/chainguard/containers/building-and-modifying/packages/private-apk-repos/#troubleshooting) covers.
+
+An identity federated from a CI system carries only the role you assigned when you created it. An identity created with `--role=registry.pull` can pull containers and do nothing else, which is intentional, but it means the same credentials fail if your workflow later tries to list repositories or read entitlements.
+
+## Repository does not exist
+
+Once you hold a valid token, a name that isn't in the organization returns a `404` rather than a `403`:
+
+```output
+{"errors":[{"code":"NAME_UNKNOWN","message":"repository does not exist \"...\""}]}
+```
+
+Check the spelling against `chainctl images repos list`, then against the [Chainguard Containers Directory](https://images.chainguard.dev/). If the Directory doesn't list the container either, Chainguard doesn't build it yet and you can ask for it. Refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
+
+## Check your credential format
+
+When you authenticate with a pull token, the username is the Chainguard identity ID associated with that token, and the password is the token itself:
+
+```shell
+docker login "cgr.dev" \
+  --username "<identity-id>" \
+  --password "<pull-token>"
+```
+
+The email address you use to sign in to the Chainguard Console is not a valid registry username. Neither is your organization name. `chainctl auth configure-docker --pull-token` prints the correct pair, and `chainctl auth pull-token create --output=env` writes them to `CHAINGUARD_IDENTITY_ID` and `CHAINGUARD_TOKEN` for use in scripts.
+
+The same pair works with any tool that logs in to an OCI registry:
+
+```shell
+helm registry login cgr.dev \
+  --username "$CHAINGUARD_IDENTITY_ID" \
+  --password "$CHAINGUARD_TOKEN"
+```
+
+Helm and Podman need `chainctl` installed only to create the token. Once you have the identity ID and token, the login itself doesn't call `chainctl`, so you can run it on a machine that doesn't have `chainctl` at all. Refer to [pull token output formats and credential names](/platform/chainctl-usage/pull-token-output/) for the other output formats.
+
+## Errors from a pull-through cache or mirror
+
+A registry mirror reports Chainguard's errors in its own wording, which can obscure which of the preceding cases you're in. Artifactory, for example, reports a rejected credential as a configuration problem:
+
+```output
+Invalid username/password configured for Remote Docker repository:
+$REPOSITORY_NAME ... Can't fetch token for repo ... realm: https://cgr.dev/token
+```
+
+The `realm: https://cgr.dev/token` fragment tells you the failure happened during credential exchange, so work through [Forbidden from the token endpoint](#forbidden-from-the-token-endpoint) and [Check your credential format](#check-your-credential-format). Mirrors are a common place for the username to be wrong, because their configuration forms label the field "username" and invite an email address.
+
+Pull tokens expire, so a mirror that worked for a month and then stopped is likely holding an expired token. For the tool-specific settings each platform needs, refer to the [pull-through guides](/chainguard/containers/registry/pull-through-guides/).
+
+## Isolate the failing step
+
+To find out which of the two requests is failing, ask the token endpoint directly. This returns the HTTP status for a credential exchange with no credentials attached:
+
+```shell
+curl -s -o /dev/null -w '%{http_code}\n' \
+  "https://cgr.dev/token?scope=repository%3A$ORGANIZATION%2F$IMAGE%3Apull&service=cgr.dev"
+```
+
+A `401` means the reference resolved and the endpoint wants credentials, so your tool's configuration is the problem rather than the name you used. Drop the `-o /dev/null` to read the error code and message in the response body.
+
+To check the second request, compare `chainctl auth status` against the capabilities listed in [Missing capabilities from the registry API](#missing-capabilities-from-the-registry-api).
+
+## Can't create a pull token
+
+If the Console won't let you create a pull token, or `chainctl auth pull-token create` fails, the problem is your role rather than the registry. Creating a pull token creates a Chainguard identity and a role-binding for it, so it needs a role carrying the `identity (create)` and `role_bindings (create)` capabilities.
+
+`registry.pull_token_creator` is the least privileged built-in role with both. Ask an administrator in your organization to bind it to your account, or refer to [Overview of roles and role-bindings](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to do it yourself. The [capabilities reference](/platform/administration/iam-organizations/roles-role-bindings/capabilities-reference/) lists every capability each built-in role carries.
+
+## Learn more
+
+- [Authenticate to Chainguard's Registry](/chainguard/containers/registry/authenticating/)
+- [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/)
+- [Onboard your teams](/get-started/onboard-your-teams/#what-your-organization-can-pull)
+- [Network requirements](/chainguard/containers/registry/network-requirements/)
+- [Get support](/get-started/get-support/)

--- a/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-09-09T15:50:32+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "Product"]
 images: []
@@ -302,13 +302,13 @@ helm install grafana oci://cgr.dev/$ORGANIZATION/charts/grafana \
 
 Many customers choose to handle container images by overriding the Chainguard repository and registry and using their own internal mirror. How you set this up depends on your chosen solution, but it does affect these Helm charts. You will need to override values in the Helm chart with the appropriate new values for your mirror.
 
-One way you can do this is with the `chainctl image helm values` command, which generates minimal Helm value overrides that modify image references in a Chainguard Helm chart to refer to a different registry and/or organization that you specify. Refer to [[chainctl images helm values](/chainguard/chainctl/chainctl-docs/chainctl_images_helm_values/)] for specifics along with:
+One way you can do this is with the `chainctl image helm values` command, which generates minimal Helm value overrides that modify image references in a Chainguard Helm chart to refer to a different registry and/or organization that you specify. Refer to [[chainctl images helm values](/platform/chainctl/chainctl-docs/chainctl_images_helm_values/)] for specifics along with:
 
 ```sh
 chainctl images helm values --help
 ```
 
-This command is a subcommand of [chainctl images helm](/chainguard/chainctl/chainctl-docs/chainctl_images_helm/), which groups Helm chart related commands.
+This command is a subcommand of [chainctl images helm](/platform/chainctl/chainctl-docs/chainctl_images_helm/), which groups Helm chart related commands.
 
 ## Troubleshooting
 

--- a/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-helm-charts/index.md
+++ b/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-provided upstream Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-09-04T16:00:38+00:00
+lastmod: 2026-09-09T15:50:32+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "Product"]
 images: []
@@ -325,5 +325,7 @@ To get the `values.yaml` so you can examine it, run:
 ```sh
 helm show values oci://cgr.dev/$ORGANIZATION/charts/grafana
 ```
+
+If `helm registry login` fails, or if the login succeeds and the install then returns a `403`, refer to [Troubleshoot registry authentication errors](/chainguard/containers/troubleshooting/registry-errors/). Those two failures have different causes, and that page tells them apart.
 
 Refer to the [Helm commands documentation](https://helm.sh/docs/helm/) for more information.

--- a/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-iamguarded-helm-charts/index.md
+++ b/content/chainguard/containers/using-and-deploying/helm-charts/use-chainguard-iamguarded-helm-charts/index.md
@@ -8,7 +8,7 @@ type: "article"
 description: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 lead: "A primer on how to use Chainguard-produced iamguarded Helm charts to deploy Chainguard container images"
 date: 2025-07-11T08:49:31+00:00
-lastmod: 2026-09-04T16:00:38+00:00
+lastmod: 2026-09-09T15:50:32+00:00
 draft: false
 tags: ["Chainguard Containers", "Helm charts", "iamguarded", "Product"]
 images: []
@@ -285,5 +285,7 @@ To get the `values.yaml` so you can examine it, run:
 ```sh
 helm show values oci://cgr.dev/chainguard-private/iamguarded-charts/rabbitmq
 ```
+
+If `helm registry login` fails, or if the login succeeds and the install then returns a `403`, refer to [Troubleshoot registry authentication errors](/chainguard/containers/troubleshooting/registry-errors/). Those two failures have different causes, and that page tells them apart.
 
 Refer to the [Helm commands documentation](https://helm.sh/docs/helm/) for more information.

--- a/content/chainguard/guardener/github/actions-security.md
+++ b/content/chainguard/guardener/github/actions-security.md
@@ -4,7 +4,7 @@ linktitle: "Hardened Actions"
 description: "Configure Chainguard Guardener to recommend and migrate your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents."
 type: "article"
 date: 2026-07-08T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["GitHub", "Automation"]
 images: []
@@ -56,7 +56,7 @@ An on-demand run performs exactly the same migration as the scheduled flow: it o
 Before you start, make sure that:
 
 - The Guardener GitHub App is installed and your Chainguard organization is linked to your GitHub organization, as described in [Getting started](/chainguard/guardener/github/getting-started/). The migration must be requested through the Chainguard organization that owns the GitHub App installation.
-- You hold the `guardener.actions.migrate` capability on that Chainguard organization. Organization owners have it, and it is included in the built-in `guardener.user` and `guardener.admin` roles. Refer to the [Built-in roles and capabilities reference](/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for more information on roles.
+- You hold the `guardener.actions.migrate` capability on that Chainguard organization. Organization owners have it, and it is included in the built-in `guardener.user` and `guardener.admin` roles. Refer to the [Built-in roles and capabilities reference](/platform/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for more information on roles.
 
 Run `chainctl guardener github migrate create` with the repository to migrate:
 

--- a/content/chainguard/guardener/github/actions-security.md
+++ b/content/chainguard/guardener/github/actions-security.md
@@ -4,7 +4,7 @@ linktitle: "Hardened Actions"
 description: "Configure Chainguard Guardener to recommend and migrate your GitHub Actions to Chainguard's hardened, SHA-pinned equivalents."
 type: "article"
 date: 2026-07-08T00:00:00+00:00
-lastmod: 2026-08-10T00:00:00+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["GitHub", "Automation"]
 images: []
@@ -92,9 +92,9 @@ The owning organization is derived from the operation name, so no `--parent` is 
 
 For the complete set of flags and options, refer to the `chainctl` reference:
 
-- [`chainctl guardener github migrate`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate/)
-- [`chainctl guardener github migrate create`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate_create/)
-- [`chainctl guardener github migrate get`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_migrate_get/)
+- [`chainctl guardener github migrate`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_migrate/)
+- [`chainctl guardener github migrate create`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_migrate_create/)
+- [`chainctl guardener github migrate get`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_migrate_get/)
 
 ## Exclude files and actions
 

--- a/content/chainguard/guardener/github/app-connections.md
+++ b/content/chainguard/guardener/github/app-connections.md
@@ -4,7 +4,7 @@ linktitle: "App connections"
 description: "Set up, inspect, and remove the connections between your Chainguard organization and your GitHub organizations for Chainguard Guardener."
 type: "article"
 date: 2026-08-03T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["GitHub", "Configuration"]
 images: []
@@ -47,7 +47,7 @@ The `chainctl guardener github` commands check permissions on both sides of the 
 | List connections (`status`) | The `guardener.association.list` capability on the Chainguard organization. |
 | Unlink (`unlink`) | **Either**: the `guardener.association.manage` capability on the Chainguard organization, **or** ownership of the GitHub organization (refer to [Removing a connection](#removing-a-connection)). |
 
-Refer to the [Built-in roles and capabilities reference](/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for how capabilities map to roles.
+Refer to the [Built-in roles and capabilities reference](/platform/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for how capabilities map to roles.
 
 Commands that prove GitHub organization ownership (`link`, and the fallback path of `unlink`) open a browser window to authorize with GitHub. Listing connections with `status` is read-only and never involves a browser.
 

--- a/content/chainguard/guardener/github/app-connections.md
+++ b/content/chainguard/guardener/github/app-connections.md
@@ -4,7 +4,7 @@ linktitle: "App connections"
 description: "Set up, inspect, and remove the connections between your Chainguard organization and your GitHub organizations for Chainguard Guardener."
 type: "article"
 date: 2026-08-03T00:00:00+00:00
-lastmod: 2026-08-03T00:00:00+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["GitHub", "Configuration"]
 images: []
@@ -183,10 +183,10 @@ A connection alone changes nothing. Check that the repository is covered by the 
 
 For the complete set of flags and options, refer to the `chainctl` reference:
 
-- [`chainctl guardener`](/chainguard/chainctl/chainctl-docs/chainctl_guardener/)
-- [`chainctl guardener github`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github/)
-- [`chainctl guardener github link`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_link/)
-- [`chainctl guardener github unlink`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_unlink/)
+- [`chainctl guardener`](/platform/chainctl/chainctl-docs/chainctl_guardener/)
+- [`chainctl guardener github`](/platform/chainctl/chainctl-docs/chainctl_guardener_github/)
+- [`chainctl guardener github link`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_link/)
+- [`chainctl guardener github unlink`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_unlink/)
 
 ## Next steps
 

--- a/content/chainguard/guardener/github/getting-started.md
+++ b/content/chainguard/guardener/github/getting-started.md
@@ -4,7 +4,7 @@ linktitle: "Getting started"
 description: "Install the Chainguard Guardener GitHub App and link your Chainguard organization to your GitHub organization to start using the Guardener."
 type: "article"
 date: 2026-07-08T00:00:00+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["GitHub", "Getting Started"]
 images: []
@@ -103,10 +103,10 @@ Unlinking stops the Guardener's Chainguard-connected features, such as private r
 
 For the complete set of flags and options, refer to the `chainctl` reference:
 
-- [`chainctl guardener`](/chainguard/chainctl/chainctl-docs/chainctl_guardener/)
-- [`chainctl guardener github`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github/)
-- [`chainctl guardener github link`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_link/)
-- [`chainctl guardener github unlink`](/chainguard/chainctl/chainctl-docs/chainctl_guardener_github_unlink/)
+- [`chainctl guardener`](/platform/chainctl/chainctl-docs/chainctl_guardener/)
+- [`chainctl guardener github`](/platform/chainctl/chainctl-docs/chainctl_guardener_github/)
+- [`chainctl guardener github link`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_link/)
+- [`chainctl guardener github unlink`](/platform/chainctl/chainctl-docs/chainctl_guardener_github_unlink/)
 
 ## Next steps
 

--- a/content/chainguard/guardener/github/getting-started.md
+++ b/content/chainguard/guardener/github/getting-started.md
@@ -4,7 +4,7 @@ linktitle: "Getting started"
 description: "Install the Chainguard Guardener GitHub App and link your Chainguard organization to your GitHub organization to start using the Guardener."
 type: "article"
 date: 2026-07-08T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["GitHub", "Getting Started"]
 images: []
@@ -29,8 +29,8 @@ Once the app is installed, the Guardener can respond on your public repositories
 
 Before you begin, make sure you have the following:
 
-- **`chainctl` installed and authenticated.** If you haven't installed it yet, follow the [chainctl installation guide](/chainguard/chainctl-usage/how-to-install-chainctl/), then run `chainctl auth login`.
-- **A Chainguard organization** where you are an owner, or where you otherwise hold the `guardener.association.manage` capability. This capability is required to link a GitHub organization to your Chainguard group. Refer to the [Built-in roles and capabilities reference](/chainguard/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for more information on roles.
+- **`chainctl` installed and authenticated.** If you haven't installed it yet, follow the [chainctl installation guide](/platform/chainctl-usage/how-to-install-chainctl/), then run `chainctl auth login`.
+- **A Chainguard organization** where you are an owner, or where you otherwise hold the `guardener.association.manage` capability. This capability is required to link a GitHub organization to your Chainguard group. Refer to the [Built-in roles and capabilities reference](/platform/administration/iam-organizations/roles-role-bindings/capabilities-reference/) for more information on roles.
 - **Owner (admin) access to the GitHub organization** you want to link. Installing the app and authorizing the link both require GitHub organization ownership.
 
 The `chainctl guardener` commands identify your Chainguard organization by its group name — you don't need to look up a group ID. Pass the name with `--group`, or omit the flag entirely and `chainctl` will prompt you to select from the organizations you have access to.

--- a/content/chainguard/libraries/introduction/access.md
+++ b/content/chainguard/libraries/introduction/access.md
@@ -4,7 +4,7 @@ linktitle: "Access"
 description: "Learn how to access Chainguard Libraries for enhanced security in Java and Python dependencies, including authentication and organization setup"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -59,7 +59,7 @@ preferred method where your environment supports it.
 
 Once your user account is created and access is confirmed, [install the
 Chainguard Control `chainctl` command line
-tool](/chainguard/chainctl-usage/how-to-install-chainctl/) and log in to your
+tool](/platform/chainctl-usage/how-to-install-chainctl/) and log in to your
 account:
 
 ```shell
@@ -324,7 +324,7 @@ Python users can leverage an alternative to pull tokens. The [Chainguard keyring
 implementation](https://github.com/chainguard-dev/keyrings-chainguard-libraries)
 provides short-lived credentials from supported environments, such as local
 development and CI/CD platforms that can use [assumable
-identities](/chainguard/administration/assumable-ids/assumable-ids/).
+identities](/platform/administration/assumable-ids/assumable-ids/).
 
 Where possible, Chainguard recommends using short-lived credentials to access
 Chainguard Libraries.

--- a/content/chainguard/libraries/introduction/access.md
+++ b/content/chainguard/libraries/introduction/access.md
@@ -4,7 +4,7 @@ linktitle: "Access"
 description: "Learn how to access Chainguard Libraries for enhanced security in Java and Python dependencies, including authentication and organization setup"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-09-09T15:46:42+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -98,7 +98,7 @@ for the ecosystem and the `libraries.java.pull_token_creator`,
 ### Creating pull tokens with chainctl
 
 Create a new pull token for the Chainguard Libraries for Java with the [chainctl
-auth pull-token](/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/)
+auth pull-token](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token/)
 command:
 
 ```shell
@@ -422,8 +422,8 @@ Use the action to remove a pull token:
 - Confirm the deletion in the dialog by pressing **Delete pull token**.
 
 Alternatively use chainctl with the [auth
-pull-token](/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/) and
-[iam identities](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities/)
+pull-token](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token/) and
+[iam identities](/platform/chainctl/chainctl-docs/chainctl_iam_identities/)
 commands for various inspection and management tasks.
 
 List all pull tokens with the `list` command:
@@ -459,7 +459,7 @@ chainctl auth pull-token list --repository=python --expired=true
 ```
 
 Use the [delete command for IAM
-identities](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_delete/)
+identities](/platform/chainctl/chainctl-docs/chainctl_iam_identities_delete/)
 to delete a specific pull token using its ID `45a0c61ea6fd97...`:
 
 ```shell
@@ -477,11 +477,11 @@ chainctl iam ids rm --expired --parent=example
 
 ## Manage library entitlements
 
-You can create, list, and remove entitlements using [`chainctl libraries entitlements`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements/).
+You can create, list, and remove entitlements using [`chainctl libraries entitlements`](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements/).
 
 ### Create entitlements
 
-As administrator you can use [`chainctl libraries entitlements create`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for one or more ecosystems:
+As administrator you can use [`chainctl libraries entitlements create`](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for one or more ecosystems:
 
 ```shell
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT,JAVA,PYTHON
@@ -497,7 +497,7 @@ To update the upstream fallback policy on an existing entitlement, rerun the `cr
 
 ### Remove entitlements
 
-You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/):
+You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/):
 
 ```shell
 chainctl libraries entitlements delete --ecosystem=JAVASCRIPT --parent=example
@@ -527,6 +527,6 @@ Ecosystem Library Entitlements for example (45a0...p7q)
 
 ## Manage library policies
 
-Users with the Owner role can create, enable, disable, and list library policies using [`chainctl libraries policy`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_policy/) commands. These policies apply to all packages pulled through Chainguard Repository. The [upstream fallback](/chainguard/libraries/introduction/overview/#upstream-fallback-and-controls) must be enabled for an ecosystem in order to use policies.
+Users with the Owner role can create, enable, disable, and list library policies using [`chainctl libraries policy`](/platform/chainctl/chainctl-docs/chainctl_libraries_policy/) commands. These policies apply to all packages pulled through Chainguard Repository. The [upstream fallback](/chainguard/libraries/introduction/overview/#upstream-fallback-and-controls) must be enabled for an ecosystem in order to use policies.
 
 Learn about how to manage policies in the [Libraries policies page](/chainguard/chainguard-repository/library-policies/).

--- a/content/chainguard/libraries/introduction/overview.md
+++ b/content/chainguard/libraries/introduction/overview.md
@@ -6,7 +6,7 @@ description: "Learn about Chainguard Libraries, providing enhanced security for
     comprehensive supply chain protection."
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-20T19:51:12+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries", "Overview"]
 menu:
@@ -173,7 +173,7 @@ subject to additional security controls before being served.
 
 To enable or change upstream fallback configuration, use the [`chainctl
 libraries entitlements`
-command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/).
+command](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/).
 
 For example, the following command creates or updates an entitlement to Chainguard Libraries
 for JavaScript, and adds the npm upstream fallback policy. Enabling upstream fallback includes a 7-day cooldown by default, which can also be configured:

--- a/content/chainguard/libraries/introduction/quickstart.md
+++ b/content/chainguard/libraries/introduction/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quickstart"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-08-21T16:30:07+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -59,7 +59,7 @@ Before getting started:
 * Entitle access for yourself to Chainguard Libraries.
     * Chainguard Libraries are available to Catalog Starter and Free tier users,
       and trial users.
-    * Run the following [chainctl libraries](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements/) command to create an entitlement for libraries:
+    * Run the following [chainctl libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements/) command to create an entitlement for libraries:
 
 ```bash
 chainctl libraries entitlements create --ecosystems=JAVASCRIPT

--- a/content/chainguard/libraries/introduction/quickstart.md
+++ b/content/chainguard/libraries/introduction/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quickstart"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -47,7 +47,7 @@ Before getting started:
 
 * If you're not yet a Chainguard user, you must [create an
       account](https://console.chainguard.dev/auth/login).
-* [Install `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) and
+* [Install `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/) and
   log in:
 
    ```bash

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -30,7 +30,7 @@ For a reference of the configuration options for each supported build tool, chec
 Before you begin, you need:
 
 - An existing Java project
-- [`chainctl` installed and authenticated](/chainguard/chainctl-usage/how-to-install-chainctl/)
+- [`chainctl` installed and authenticated](/platform/chainctl-usage/how-to-install-chainctl/)
 
 ### Create an entitlement
 

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -34,7 +34,7 @@ Before you begin, you need:
 
 ### Create an entitlement
 
-You must have an [entitlement to Chainguard Libraries](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for Java with [upstream fallback](/chainguard/libraries/introduction/overview/#upstream-fallback-and-controls) enabled.
+You must have an [entitlement to Chainguard Libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for Java with [upstream fallback](/chainguard/libraries/introduction/overview/#upstream-fallback-and-controls) enabled.
 
 To create an entitlement to Chainguard Libraries for Java and enable upstream fallback, which includes a default 7-day cooldown, run the following command:
 
@@ -105,7 +105,7 @@ eval $(chainctl auth pull-token --parent=example.org --repository=java --name=my
 
 This results in values for the `CHAINGUARD_JAVA_IDENTITY_ID` and `CHAINGUARD_JAVA_TOKEN` variables. The token is named `my-java-token`, with a default expiration of 30 days. To configure the expiration, use the `--ttl` flag.
 
-Learn more about command options in the [chainctl documentation](/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/).
+Learn more about command options in the [chainctl documentation](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token/).
 
 When configuring direct access, note that environment variables do not persist between terminal sessions. You must re-export them each time you open a new terminal, or add them to your shell profile. Learn more about pull tokens in the [Access documentation](https://edu.chainguard.dev/chainguard/libraries/introduction/access/).
 

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -287,7 +287,7 @@ and all other packages should resolve to `libraries.cgr.dev/javascript`.
 ### Minimal example project
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/introduction/access/#env).
+detailed in the [access documentation](/chainguard/libraries/introduction/access/#use-environment-variables-for-pull-token-credentials).
 
 **1. Create a JavaScript project**
 
@@ -312,7 +312,7 @@ directory:
 chainctl auth configure-npm
 ```
 
-[This command](/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/) writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+[This command](/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/) writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/platform/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
 Alternatively, you can configure the `.npmrc` file manually:
 
@@ -584,7 +584,7 @@ pnpm init
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/introduction/access/#env).
+detailed in the [access documentation](/chainguard/libraries/introduction/access/#use-environment-variables-for-pull-token-credentials).
 
 To create pull token credentials and set them as environment variables, run:
 
@@ -821,7 +821,7 @@ yarn init
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/introduction/access/#env). Once
+detailed in the [access documentation](/chainguard/libraries/introduction/access/#use-environment-variables-for-pull-token-credentials). Once
 the environment variables are set, the following steps configure registry
 access with authentication in the `.yarnrc.yml` file in the current project
 directory:
@@ -986,7 +986,7 @@ yarn init -y
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/introduction/access/#env). Once
+detailed in the [access documentation](/chainguard/libraries/introduction/access/#use-environment-variables-for-pull-token-credentials). Once
 the environment variables are set, the following steps configure registry access
 with authentication in the `.npmrc` file directory:
 
@@ -1127,7 +1127,7 @@ bun init -y
 ```
 
 For testing purposes, you can use direct access and environment variables as
-detailed in the [access documentation](/chainguard/libraries/introduction/access/#env). Once
+detailed in the [access documentation](/chainguard/libraries/introduction/access/#use-environment-variables-for-pull-token-credentials). Once
 the environment variables are set, the following steps configure registry
 access with authentication in the `bunfig.toml` file in the current project
 directory:

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for JavaScript on your workstation"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-09-09T15:46:42+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
@@ -89,7 +89,7 @@ distributing upstream artifacts directly, the resulting checksums differ even
 for identical package versions. These hashes must be updated before your package
 manager will accept packages from Chainguard.
 
-Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile) and in the [`chainctl libraries update-hashes` command docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+Learn more in the [JavaScript migration guide](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile) and in the [`chainctl libraries update-hashes` command docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
 <a id="update-hashes-auth"></a>
 
@@ -312,7 +312,7 @@ directory:
 chainctl auth configure-npm
 ```
 
-[This command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+[This command](/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/) writes a project-level `.npmrc` with the registry URL and base64-encoded credentials. It also prints the equivalent `npm config set` commands for use in CI or other environments where you need to configure `.npmrc` manually. If this command returns an error, ensure that you are using the [latest version of `chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
 Alternatively, you can configure the `.npmrc` file manually:
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -69,7 +69,7 @@ this page follow this pattern.
 
 ### Updating lockfile hashes
 
-If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
+If you are migrating an existing JavaScript project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from npm or through your repository manager. The [`chainctl libraries update-hashes` command](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
 for all supported JavaScript lockfile formats.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
@@ -84,7 +84,7 @@ chainctl libraries update-hashes \
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
-Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
 <a name="cloudsmith"></a>
 

--- a/content/chainguard/libraries/javascript/global-configuration.md
+++ b/content/chainguard/libraries/javascript/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for JavaScript in your organization"
 type: "article"
 date: 2025-06-05T09:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries", "JavaScript"]
 images: []
@@ -84,7 +84,7 @@ chainctl libraries update-hashes \
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
-Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+Learn more in the [Build configuration page](/chainguard/libraries/javascript/build-configuration/#updating-lockfile-hashes) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
 <a name="cloudsmith"></a>
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -40,7 +40,7 @@ Before you begin, you'll need:
 
 - An existing JavaScript project with a `package.json` and a lockfile
   (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, or `bun.lock`)
-- [`chainctl` installed and authenticated](/chainguard/chainctl-usage/how-to-install-chainctl/)
+- [`chainctl` installed and authenticated](/platform/chainctl-usage/how-to-install-chainctl/)
 - An [entitlement to Chainguard Libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/)
   for JavaScript
 
@@ -186,7 +186,7 @@ Because [this
 command](/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/) uses a
 session-backed bearer token, you will need to re-run it when the token expires.
 If the command returns an error, ensure you are using the [latest version of
-chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
+chainctl](/platform/chainctl-usage/how-to-install-chainctl/#updating-chainctl).
 
 For pnpm and Yarn, [configure the .npmrc
 manually](#manual-registry-configuration). `chainctl auth configure-npm`
@@ -197,7 +197,7 @@ Chainguard has not yet rebuilt.
 #### CI/CD and automated environments
 
 For CI/CD environments, [assumable
-identities](/chainguard/administration/assumable-ids/assumable-ids/) are the
+identities](/platform/administration/assumable-ids/assumable-ids/) are the
 recommended approach. Rather than managing a static token, an assumable identity
 lets your CI/CD workload authenticate directly with Chainguard using its own
 platform identity; no long-lived credentials to rotate or accidentally expose.

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -41,7 +41,7 @@ Before you begin, you'll need:
 - An existing JavaScript project with a `package.json` and a lockfile
   (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, or `bun.lock`)
 - [`chainctl` installed and authenticated](/chainguard/chainctl-usage/how-to-install-chainctl/)
-- An [entitlement to Chainguard Libraries](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/)
+- An [entitlement to Chainguard Libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/)
   for JavaScript
 
 ### Create an entitlement
@@ -77,7 +77,7 @@ You can [create a pull token in the Chainguard Console](/chainguard/libraries/in
 chainctl auth pull-token --repository=javascript --name=my-js-token
 ```
 
-This outputs an identity ID and token named `my-js-token`, with a default expiration of 30 days. To configure the expiration, use the `--ttl` flag. Learn more about command options in the [chainctl documentation](/chainguard/chainctl/chainctl-docs/chainctl_auth_pull-token/).
+This outputs an identity ID and token named `my-js-token`, with a default expiration of 30 days. To configure the expiration, use the `--ttl` flag. Learn more about command options in the [chainctl documentation](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token/).
 
 Set the identity ID and token as environment variables:
 
@@ -183,7 +183,7 @@ chainctl auth configure-npm
 ```
 
 Because [this
-command](/chainguard/chainctl/chainctl-docs/chainctl_auth_configure-npm/) uses a
+command](/platform/chainctl/chainctl-docs/chainctl_auth_configure-npm/) uses a
 session-backed bearer token, you will need to re-run it when the token expires.
 If the command returns an error, ensure you are using the [latest version of
 chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl).

--- a/content/chainguard/libraries/policies-and-security/verification.md
+++ b/content/chainguard/libraries/policies-and-security/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-08-27T19:36:12+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -19,7 +19,7 @@ aliases:
 ---
 
 Chainguard's `chainctl` tool with the command [`libraries
-verify`](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/) verifies
+verify`](/platform/chainctl/chainctl-docs/chainctl_libraries_verify/) verifies
 which of your language ecosystem dependencies were built by Chainguard,
 providing critical visibility into your software supply chain security. By
 verifying binary artifacts across your projects and repositories, you can confirm which dependencies came from Chainguard's hardened build environment, identify opportunities to
@@ -44,7 +44,7 @@ installed and available on your path:
 - [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) —
   Chainguard-maintained tool that includes the `libraries verify` command,
   details also in the [reference
-  documentation](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/).
+  documentation](/platform/chainctl/chainctl-docs/chainctl_libraries_verify/).
 
 `chainctl libraries verify` checks signatures in-process. To fetch the Sigstore
 trust root, the command needs network access to `tuf-repo-cdn.sigstore.dev`.
@@ -483,6 +483,6 @@ A 0% coverage result is expected when verifying a fat JAR, uber JAR, or shaded J
 
 - [Chainguard Libraries overview](/chainguard/libraries/introduction/overview/)
 - [Chainguard Libraries authentication](/chainguard/libraries/introduction/access/)
-- [`chainctl libraries verify` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl_libraries_verify/)
+- [`chainctl libraries verify` reference documentation](/platform/chainctl/chainctl-docs/chainctl_libraries_verify/)
 - [{{<icon "play-circle-fill">}} Learning Lab: Chainguard Libraries for Java](/software-security/learning-labs/ll202505/)
 - [{{<icon "play-circle-fill">}} Learning Lab: Chainguard Libraries for Python](/software-security/learning-labs/ll202506/)

--- a/content/chainguard/libraries/policies-and-security/verification.md
+++ b/content/chainguard/libraries/policies-and-security/verification.md
@@ -6,7 +6,7 @@ description:
   Libraries using the chainctl tool for enhanced supply chain security"
 type: "article"
 date: 2025-07-03T12:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -41,7 +41,7 @@ Command characteristics:
 Before using `chainctl` to verify libraries, ensure you have the following
 installed and available on your path:
 
-- [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/) —
+- [`chainctl`](/platform/chainctl-usage/how-to-install-chainctl/) —
   Chainguard-maintained tool that includes the `libraries verify` command,
   details also in the [reference
   documentation](/platform/chainctl/chainctl-docs/chainctl_libraries_verify/).
@@ -421,7 +421,7 @@ therefore conclude that the `example.jar` file originates from Chainguard, was
 built in the Chainguard Factory from source, and is available at
 `https://libraries.cgr.dev/java/junit/junit/4.13.2/junit-4.13.2.jar`. You can
 [manually download the file to
-compare](/chainguard/libraries/java/overview/#manual-access/), if desired.
+compare](/chainguard/libraries/java/overview/#manual-access), if desired.
 
 ## Container analysis
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Configure build tools"
 description: "Configuring Chainguard Libraries for Python on your workstation"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-09-09T15:46:42+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 menu:
@@ -165,7 +165,7 @@ authentication](/chainguard/libraries/introduction/access/#netrc).
 
 If you are migrating an existing Python project to Chainguard Libraries, your lockfile likely contains integrity hashes generated against packages previously downloaded from the PyPI registry or through your repository manager. Because Chainguard rebuilds packages from verified source, the checksums for those packages differ from the ones already recorded in your lockfile. These hashes must be updated before reinstalling.
 
-The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates for all supported Python lockfile formats. Rather than manually regenerating lock files with each tool, you can run the command directly against your existing lockfile to update hashes to Chainguard checksums while preserving your locked dependency versions, without re-resolving your dependency graph.
+The [`chainctl libraries update-hashes` command](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates for all supported Python lockfile formats. Rather than manually regenerating lock files with each tool, you can run the command directly against your existing lockfile to update hashes to Chainguard checksums while preserving your locked dependency versions, without re-resolving your dependency graph.
 
 Supported formats include `requirements.txt` (pip-tools `--hash` style), `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, and `pylock.toml`.
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-08-28T16:31:04+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -68,7 +68,7 @@ However, if you intentionally want to manage fallback ordering yourself, you can
 
 ### Updating lockfile hashes
 
-If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
+If you are migrating an existing Python project to Chainguard Libraries through a repository manager, your lockfile likely contains integrity hashes generated against packages previously downloaded from PyPI or through your repository manager. The [`chainctl libraries update-hashes` command](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/) automates lockfile hash updates
 for all supported Python lockfile formats.
 
 When you are using a repository manager, pass the full repository manager URL with `--registry-url` and authenticate with one of the supported methods: `--username` and `--password`, `--token`, or a `.netrc` entry for the registry host. For example:
@@ -83,7 +83,7 @@ chainctl libraries update-hashes \
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
-Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/chainguard/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
 <a id="cloudsmith"></a>
 

--- a/content/chainguard/libraries/python/global-configuration.md
+++ b/content/chainguard/libraries/python/global-configuration.md
@@ -4,7 +4,7 @@ linktitle: "Global configuration"
 description: "Configuring Chainguard Libraries for Python in your organization"
 type: "article"
 date: 2025-03-25T08:04:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Libraries", "Python"]
 images: []
@@ -83,7 +83,7 @@ chainctl libraries update-hashes \
 
 After updating the lockfile, keep your repository manager configuration in place and reinstall through the same repository manager endpoint to apply the updated hashes.
 
-Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes/) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
+Learn more in the [Build configuration page](/chainguard/libraries/python/build-configuration/#updating-lockfile-hashes) and in the [chainctl docs](/platform/chainctl/chainctl-docs/chainctl_libraries_update-hashes/).
 
 <a id="cloudsmith"></a>
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -30,7 +30,7 @@ For a reference of the configuration options for each supported build tool, chec
 Before you begin, you need:
 
 * An existing, working Python project with a `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, or `pylock.toml`
-* [chainctl installed and authenticated](/chainguard/chainctl-usage/how-to-install-chainctl/)
+* [chainctl installed and authenticated](/platform/chainctl-usage/how-to-install-chainctl/)
 * An [entitlement to Chainguard Libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for Python.
 
 If you do not have an entitlement to Chainguard Libraries for Python yet, run the following command to create an entitlement and enable upstream fallback:
@@ -352,7 +352,7 @@ Regenerating the lockfile is another valid approach, and many teams use the migr
 
 * Pinning versions is a security best practice. Regenerating re-resolves your dependencies and can change versions, so you lose your existing pins unless you re-pin afterward.
 * Resolvers pick the newest version that satisfies each constraint. Whether Chainguard has that version available depends on the [cooldown
-period you've configured](/chainguard/libraries/overview/#cooldown-period): a release still inside your cooldown window isn't available yet and returns a 404 error.
+period you've configured](/chainguard/libraries/introduction/overview/#cooldown-period): a release still inside your cooldown window isn't available yet and returns a 404 error.
 
 To regenerate — for example, to intentionally refresh your dependency versions — use the following commands.
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-08-31T14:57:37+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -31,7 +31,7 @@ Before you begin, you need:
 
 * An existing, working Python project with a `requirements.txt`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Pipfile.lock`, or `pylock.toml`
 * [chainctl installed and authenticated](/chainguard/chainctl-usage/how-to-install-chainctl/)
-* An [entitlement to Chainguard Libraries](/chainguard/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for Python.
+* An [entitlement to Chainguard Libraries](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/) for Python.
 
 If you do not have an entitlement to Chainguard Libraries for Python yet, run the following command to create an entitlement and enable upstream fallback:
 

--- a/content/get-started/getting-started-with-chainctl.md
+++ b/content/get-started/getting-started-with-chainctl.md
@@ -6,14 +6,14 @@ lead: "Chainguard's chainctl CLI enables more secure management of container ima
 description: "Get started with chainctl basics including authentication, organization management, and essential commands for Chainguard's container security platform"
 type: "article"
 date: 2025-03-03T08:49:15+00:00
-lastmod: 2026-08-25T13:40:33+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl", "Getting Started"]
 images: []
 weight: 030
 ---
 
-Chainguard's `chainctl` provides command-line access to manage container images, identity resources, and security configurations across your organization. This guide covers essential commands to begin using `chainctl` effectively in your security and DevOps workflows. For comprehensive command documentation, refer to the [chainctl reference](/chainguard/chainctl/).
+Chainguard's `chainctl` provides command-line access to manage container images, identity resources, and security configurations across your organization. This guide covers essential commands to begin using `chainctl` effectively in your security and DevOps workflows. For comprehensive command documentation, refer to the [chainctl reference](/platform/chainctl/).
 
 ## Authenticate and check auth status
 

--- a/content/get-started/getting-started-with-chainctl.md
+++ b/content/get-started/getting-started-with-chainctl.md
@@ -6,7 +6,7 @@ lead: "Chainguard's chainctl CLI enables more secure management of container ima
 description: "Get started with chainctl basics including authentication, organization management, and essential commands for Chainguard's container security platform"
 type: "article"
 date: 2025-03-03T08:49:15+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["chainctl", "Getting Started"]
 images: []
@@ -65,7 +65,7 @@ To update your `chainctl` installation, use:
 chainctl update
 ```
 
-Because this replaces the installed binary, you need write access to the directory where `chainctl` lives. On Linux and macOS, updating a system-wide install such as `/usr/local/bin` requires administrative privileges (for example, with `sudo`). The command also verifies the downloaded binary's signature in-process before installing it; refer to [Updating chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/#updating-chainctl) for details.
+Because this replaces the installed binary, you need write access to the directory where `chainctl` lives. On Linux and macOS, updating a system-wide install such as `/usr/local/bin` requires administrative privileges (for example, with `sudo`). The command also verifies the downloaded binary's signature in-process before installing it; refer to [Updating chainctl](/platform/chainctl-usage/how-to-install-chainctl/#updating-chainctl) for details.
 
 ## Configure chainctl
 
@@ -81,7 +81,7 @@ If you make a mistake and can't recall the original settings, reset the configur
 chainctl config reset
 ```
 
-Learn more at [How to manage chainctl configuration](/chainguard/chainctl-usage/manage-chainctl-config/).
+Learn more at [How to manage chainctl configuration](/platform/chainctl-usage/manage-chainctl-config/).
 
 ## List available images
 

--- a/content/open-source/build-tools/apko/bazel-rules.md
+++ b/content/open-source/build-tools/apko/bazel-rules.md
@@ -7,7 +7,7 @@ type: "article"
 lead: "Build secure, minimal Wolfi-based container images using Bazel"
 description: "Build secure, minimal Wolfi-based container images using Bazel"
 date: 2023-10-23T08:49:31+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["apko", "Procedural",]
 images: []
@@ -48,7 +48,7 @@ Before you begin, ensure you have the following:
   `dev.chainguard.package.main` label on your image is `bazel-9`.
 - **`chainctl`** installed and authenticated. `chainctl` is the Chainguard
   command line tool. See the
-  [chainctl documentation](/chainguard/chainctl/) for
+  [chainctl documentation](/platform/chainctl/) for
   installation instructions.
 - **`rules_apko` version `1.5.37`** available in the
   [Bazel Central Registry](https://registry.bazel.build/modules/rules_apko).

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2026-08-21T16:30:07+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -23,7 +23,7 @@ Once an administrator has [configured an identity provider](#setup-and-administr
 
 ### Authenticate with `chainctl`
 
-[`chainctl`, the Chainguard command line interface (CLI)](/chainguard/chainctl/), supports SSO authentication by supplying the identity provider organization name as a flag or by setting it as a default in configuration. To use a flag to authenticate using SSO, pass the `--identity-provider` flag to `chainctl auth login`.
+[`chainctl`, the Chainguard command line interface (CLI)](/platform/chainctl/), supports SSO authentication by supplying the identity provider organization name as a flag or by setting it as a default in configuration. To use a flag to authenticate using SSO, pass the `--identity-provider` flag to `chainctl auth login`.
 
 ```sh
 export IDP_ID=<idp_id>
@@ -241,7 +241,7 @@ Lastly, to delete an identity provider, run the `delete` subcommand.
 chainctl iam identity-provider delete
 ```
 
-For more details, check out the [`chainctl` documentation for these commands](/chainguard/chainctl/chainctl-docs/chainctl_iam_identity-providers/).
+For more details, check out the [`chainctl` documentation for these commands](/platform/chainctl/chainctl-docs/chainctl_iam_identity-providers/).
 
 ## IAM and security
 

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -75,7 +75,7 @@ Once set, the configured identity provider will be used automatically any time y
 
 ### Authenticate with `chainctl` using a verified organization
 
-If your organization is [verified](/chainguard/administration/iam-organizations/verified-orgs/), you can use your organization name instead of the ID of your identity provider to authenticate.
+If your organization is [verified](/platform/administration/iam-organizations/verified-orgs/), you can use your organization name instead of the ID of your identity provider to authenticate.
 
 ```sh
 chainctl auth login --org-name example.com
@@ -88,7 +88,7 @@ defaults:
   org-name: example.com
 ```
 
-To learn more about working with your `chainctl` config, you can read our doc on [How to manage `chainctl` configuration](/chainguard/chainctl-usage/manage-chainctl-config/).
+To learn more about working with your `chainctl` config, you can read our doc on [How to manage `chainctl` configuration](/platform/chainctl-usage/manage-chainctl-config/).
 
 ### Authenticate with the Chainguard Console
 
@@ -133,7 +133,7 @@ Identity providers usually tie this classification to the application *type* you
 
 ### Integration guides for supported identity providers
 
-We have [published guides for multiple platforms](/chainguard/administration/custom-idps/), including Okta and Ping Identity. If you aren’t using one of these identity providers, you can complete the following Generic Integration Guide to configure your provider to work with Chainguard. However, be aware that Chainguard does not actively support identity providers other than the ones listed previously. If you are using an alternate identity provider, we encourage you to contact us to learn more.
+We have [published guides for multiple platforms](/platform/administration/custom-idps/), including Okta and Ping Identity. If you aren’t using one of these identity providers, you can complete the following Generic Integration Guide to configure your provider to work with Chainguard. However, be aware that Chainguard does not actively support identity providers other than the ones listed previously. If you are using an alternate identity provider, we encourage you to contact us to learn more.
 
 ### Generic integration guide
 
@@ -165,7 +165,7 @@ Next, use `chainctl` to log in to Chainguard with an OIDC provider (such as Goog
 chainctl auth login
 ```
 
-The bootstrap account can use any supported IdP -- for example you may choose to temporarily use a personal Google account. You can leave this account active as a [backup account](/chainguard/administration/custom-idps/custom-idps/#backup-accounts) or, if you prefer, you can delete the account by removing the role-binding after configuring the custom IdP.
+The bootstrap account can use any supported IdP -- for example you may choose to temporarily use a personal Google account. You can leave this account active as a [backup account](/platform/administration/custom-idps/custom-idps/#backup-accounts) or, if you prefer, you can delete the account by removing the role-binding after configuring the custom IdP.
 
 Create a new identity provider using the details you noted from your OIDC application. Replace `<application_client_id>`, `<client_secret>`, and `<issuer_url>` with the values from your own application, and `<organization_id>` with the UIDP of the organization where you want to install the identity provider.
 
@@ -261,4 +261,4 @@ In the case of an outage or misconfiguration of your identity provider, it can b
 
 As an OIDC login account needs to be set up to bootstrap the SSO identity provider initially, it’s possible to keep this account as a backup account in case you need it for recovery. However, the nature of these OIDC provider accounts is such that it is difficult to share them as a backup resource since they’re often tied to a single user.
 
-Instead of relying on an account with an OIDC login provider, you can alternatively set up an assumable identity to use as a backup account. Refer to our [conceptual guide on assumable identities](/chainguard/administration/iam-organizations/assumable-ids/) to learn more.
+Instead of relying on an account with an OIDC login provider, you can alternatively set up an assumable identity to use as a backup account. Refer to our [conceptual guide on assumable identities](/platform/administration/assumable-ids/assumable-ids/) to learn more.

--- a/content/platform/api/authentication.md
+++ b/content/platform/api/authentication.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "Tutorial with examples showing how you can authenticate with the Chainguard SDK's auth and auth/ggcr packages."
 date: 2025-06-04T08:49:31+00:00
-lastmod: 2026-09-04T16:00:38+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Console", "Procedural"]
 images: []
@@ -15,7 +15,7 @@ toc: true
 weight: 065
 ---
 
-There are several ways for users to interact with the Chainguard platform, with [`chainctl`](/chainguard/chainctl/) (Chainguard's command-line tool) and the [Chainguard Console](https://console.chainguard.dev/overview) (Chainguard's web interface) being the two most commonly-used methods. However, both of these require a human user to authenticate, and aren't useful for working with Chainguard resources programmatically.
+There are several ways for users to interact with the Chainguard platform, with [`chainctl`](/platform/chainctl/) (Chainguard's command-line tool) and the [Chainguard Console](https://console.chainguard.dev/overview) (Chainguard's web interface) being the two most commonly-used methods. However, both of these require a human user to authenticate, and aren't useful for working with Chainguard resources programmatically.
 
 The [Chainguard SDK](https://github.com/chainguard-dev/sdk) serves to ease programmatic integration with the Chainguard platform. This guide highlights two examples from the SDK repository that show how to authenticate to the [Chainguard registry](/chainguard/chainguard-registry/overview/) using the `chainguard.dev/sdk/auth` and `chainguard.dev/sdk/auth/ggcr` packages. The first has you authenticate as a local user, while the second has you authenticate as an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/).
 
@@ -229,7 +229,7 @@ Again, this example doesn't really reflect a real-world use case. Users will gen
 
 You can experiment with updating this example to authenticate by assuming an identity you created and retrieve the digest of a container image from your organization's private repository within the Chainguard registry.
 
-To do so, you will need an appropriately-configured assumable identity. You can create an assumable identity with the [`chainctl iam identities create` command](/chainguard/chainctl/chainctl-docs/chainctl_iam_identities_create/).
+To do so, you will need an appropriately-configured assumable identity. You can create an assumable identity with the [`chainctl iam identities create` command](/platform/chainctl/chainctl-docs/chainctl_iam_identities_create/).
 
 ### Example 2 using curl
 

--- a/content/platform/api/authentication.md
+++ b/content/platform/api/authentication.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "Tutorial with examples showing how you can authenticate with the Chainguard SDK's auth and auth/ggcr packages."
 date: 2025-06-04T08:49:31+00:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Console", "Procedural"]
 images: []
@@ -17,7 +17,7 @@ weight: 065
 
 There are several ways for users to interact with the Chainguard platform, with [`chainctl`](/platform/chainctl/) (Chainguard's command-line tool) and the [Chainguard Console](https://console.chainguard.dev/overview) (Chainguard's web interface) being the two most commonly-used methods. However, both of these require a human user to authenticate, and aren't useful for working with Chainguard resources programmatically.
 
-The [Chainguard SDK](https://github.com/chainguard-dev/sdk) serves to ease programmatic integration with the Chainguard platform. This guide highlights two examples from the SDK repository that show how to authenticate to the [Chainguard registry](/chainguard/chainguard-registry/overview/) using the `chainguard.dev/sdk/auth` and `chainguard.dev/sdk/auth/ggcr` packages. The first has you authenticate as a local user, while the second has you authenticate as an [assumed identity](/chainguard/administration/assumable-ids/assumable-ids/).
+The [Chainguard SDK](https://github.com/chainguard-dev/sdk) serves to ease programmatic integration with the Chainguard platform. This guide highlights two examples from the SDK repository that show how to authenticate to the [Chainguard registry](/chainguard/chainguard-registry/overview/) using the `chainguard.dev/sdk/auth` and `chainguard.dev/sdk/auth/ggcr` packages. The first has you authenticate as a local user, while the second has you authenticate as an [assumed identity](/platform/administration/assumable-ids/assumable-ids/).
 
 This page gives examples in Golang as well as using `curl`. For more information about the Golang examples, refer to the [`examples` folder](https://github.com/chainguard-dev/sdk/tree/main/examples/registry) in the SDK repository.
 
@@ -233,7 +233,7 @@ To do so, you will need an appropriately-configured assumable identity. You can 
 
 ### Example 2 using curl
 
-First, login with chainctl using an OIDC token. Where the token comes from will differ by platform. Refer to our [Identity provider samples](/chainguard/administration/custom-idps/idp-providers/) for some examples.
+First, login with chainctl using an OIDC token. Where the token comes from will differ by platform. Refer to our [Identity provider samples](/platform/administration/custom-idps/idp-providers/) for some examples.
 
 ```shell
 chainctl auth login --identity "<identity-id>" --identity-token /var/run/chainguard/oidc/oidc-token
@@ -272,7 +272,7 @@ In our example, [we requested a list of groups the account belongs to](https://e
 }
 ```
 
-Using environment variables is helpful when working with assumable identities through the API and API tokens. Here's a high-level example of what you might do. Refer to your identity provider's documentation and [Assumable identities](/chainguard/administration/assumable-ids/assumable-ids/) to learn more.
+Using environment variables is helpful when working with assumable identities through the API and API tokens. Here's a high-level example of what you might do. Refer to your identity provider's documentation and [Assumable identities](/platform/administration/assumable-ids/assumable-ids/) to learn more.
 
 Here are some sample environment variables:
 
@@ -294,7 +294,7 @@ API_TOKEN=$(curl -sSf \
 curl -H "Authorization: Bearer ${API_TOKEN}" https://console-api.enforce.dev/registry/v1/repos
 ```
 
-Refer to the [Assumable identities documentation](/chainguard/administration/assumable-ids/assumable-ids/#using-the-chainguard-api) for another example of authentication using an assumed identity.
+Refer to the [Assumable identities documentation](/platform/administration/assumable-ids/assumable-ids/#using-the-chainguard-api) for another example of authentication using an assumed identity.
 
 ## Learn more
 
@@ -302,6 +302,6 @@ The Chainguard SDK is a powerful tool for interacting with the Chainguard platfo
 
 To learn more, you may be interested in the following resources:
 
-* [Overview of assumable identities in Chainguard](/chainguard/administration/assumable-ids/assumable-ids/)
+* [Overview of assumable identities in Chainguard](/platform/administration/assumable-ids/assumable-ids/)
 * [Authenticate to Chainguard's registry](/chainguard/chainguard-registry/authenticating/)
-* [Chainguard OpenAPI specification](/chainguard/api/spec/)
+* [Chainguard OpenAPI specification](/platform/api/spec/)

--- a/content/platform/chainctl-usage/chainctl-iam.md
+++ b/content/platform/chainctl-usage/chainctl-iam.md
@@ -6,7 +6,7 @@ lead: "Chainguard's chainctl iam commands provide enterprise-grade identity and 
 description: "Learn how to use chainctl iam commands to manage identity, access controls, and role-based permissions for Chainguard's container security platform"
 type: "article"
 date: 2025-03-06T08:49:15+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl", "iam"]
 images: []
@@ -17,7 +17,7 @@ Chainguard's identity and access management (IAM) system provides fine-grained c
 
 For the following, assume that returned information only includes that which your account has permissions to view. Also, actions such as `create` and `delete` are similarly limited.
 
-This page is intended as an introductory overview of IAM with chainctl. For a full reference of all commands with details and switches, refer to [chainctl reference](/chainguard/chainctl/).
+This page is intended as an introductory overview of IAM with chainctl. For a full reference of all commands with details and switches, refer to [chainctl reference](/platform/chainctl/).
 
 ## List folders
 

--- a/content/platform/chainctl-usage/chainctl-images.md
+++ b/content/platform/chainctl-usage/chainctl-images.md
@@ -7,7 +7,7 @@ lead: "Chainguard's chainctl images commands enable discovery, analysis, and com
 description: "Learn how to use chainctl images commands to discover, examine version history, and compare Chainguard's security-hardened container images in your registry"
 type: "article"
 date: 2025-03-06T08:49:15+00:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -16,7 +16,7 @@ weight: 070
 
 Chainguard's `chainctl images` commands provide comprehensive tools for managing security-hardened container images in your organization's registry. These commands enable you to discover available images, analyze version histories, examine security metadata, and compare different image versions to make informed deployment decisions.
 
-For a full reference of all commands with details and switches, refer to [chainctl reference](/chainguard/chainctl/).
+For a full reference of all commands with details and switches, refer to [chainctl reference](/platform/chainctl/).
 
 ## List available Chainguard container images
 

--- a/content/platform/chainctl-usage/chainctl-version-update.md
+++ b/content/platform/chainctl-usage/chainctl-version-update.md
@@ -6,7 +6,7 @@ lead: "Keep your chainctl CLI updated to access the latest Chainguard security f
 description: "Learn how to check your chainctl version and update to the latest release for enhanced security features and improved container management capabilities"
 type: "article"
 date: 2025-03-06T08:49:15+00:00
-lastmod: 2026-08-25T13:24:30+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -15,7 +15,7 @@ weight: 040
 
 Chainguard regularly releases updates to `chainctl` with new security features, performance improvements, and expanded capabilities for container management. This guide explains how to check your current version and update to the latest release.
 
-For a full reference of all commands with details and switches, refer to [chainctl reference](/chainguard/chainctl/).
+For a full reference of all commands with details and switches, refer to [chainctl reference](/platform/chainctl/).
 
 ## View your chainctl version
 

--- a/content/platform/chainctl-usage/comparing-images.md
+++ b/content/platform/chainctl-usage/comparing-images.md
@@ -18,7 +18,7 @@ aliases:
 type: "article"
 description: "Learn how to use chainctl images diff to compare Chainguard container versions, analyze security improvements, and track package changes between builds"
 date: 2023-08-30T11:07:52+02:00
-lastmod: 2025-07-23T15:09:59+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -31,7 +31,7 @@ toc: true
 
 Chainguard's `chainctl images diff` command provides detailed comparisons between container image versions, enabling you to track security improvements, package updates, and vulnerability changes across builds. This powerful feature helps you understand exactly what changes between image versions, whether comparing daily builds, analyzing CVE remediation, or evaluating custom image updates.
 
-The [`chainctl`](/chainguard/chainctl/) diff functionality supports informed deployment decisions by revealing package-level differences, security posture changes, and build variations between any two Chainguard container images.
+The [`chainctl`](/platform/chainctl/) diff functionality supports informed deployment decisions by revealing package-level differences, security posture changes, and build variations between any two Chainguard container images.
 
 ## Prerequisites
 
@@ -153,4 +153,4 @@ Another potential use could be in cases where you're interested in knowing the d
 ## Learn more
 
 To learn more about the `chainctl image` subcommands, we encourage you to check out our
-[`chainctl` command resources](/chainguard/chainctl/chainctl-docs/chainctl_images/). You can also explore the rest of our [Chainguard Containers resources](/chainguard/containers/) to learn more about how images can help you keep your software secure by default.
+[`chainctl` command resources](/platform/chainctl/chainctl-docs/chainctl_images/). You can also explore the rest of our [Chainguard Containers resources](/chainguard/containers/) to learn more about how images can help you keep your software secure by default.

--- a/content/platform/chainctl-usage/comparing-images.md
+++ b/content/platform/chainctl-usage/comparing-images.md
@@ -18,7 +18,7 @@ aliases:
 type: "article"
 description: "Learn how to use chainctl images diff to compare Chainguard container versions, analyze security improvements, and track package changes between builds"
 date: 2023-08-30T11:07:52+02:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -37,7 +37,7 @@ The [`chainctl`](/platform/chainctl/) diff functionality supports informed deplo
 
 In order to use the `chainctl images diff` subcommand, you'll need to have a few tools installed.
 
-* You'll need `chainctl` installed on your local machine. Follow our guide on [How to install chainctl](/chainguard/chainctl-usage/how-to-install-chainctl/) to set this up. If you already have `chainctl` installed, be sure to update it to the latest version with `chainctl update`.
+* You'll need `chainctl` installed on your local machine. Follow our guide on [How to install chainctl](/platform/chainctl-usage/how-to-install-chainctl/) to set this up. If you already have `chainctl` installed, be sure to update it to the latest version with `chainctl update`.
 * Next, ensure you have Cosign installed. Our guide on [How to install Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) outlines several methods for installing Cosign.
 * You'll also need Grype installed on your local machine, as `chainctl` uses this to scan the images when performing the diff. Follow the installation instructions for your operating system on the [Grype project GitHub repository](https://github.com/anchore/grype#installation).
 * Lastly, an example command in this guide uses `jq` — a command-line JSON processor — to make the command's output more readable. You don't strictly need to have `jq` installed in order to use the `diff` subcommand, but if you'd like you can install it by following [the official documentation](https://jqlang.github.io/jq/download/).

--- a/content/platform/chainctl-usage/how-to-install-chainctl.md
+++ b/content/platform/chainctl-usage/how-to-install-chainctl.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Learn how to install chainctl, Chainguard's command-line interface for managing container images, IAM resources, and security configurations across platforms"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2026-09-09T15:53:21+00:00
+lastmod: 2026-09-09T17:33:40+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -60,7 +60,7 @@ You are now ready to use the `chainctl` command. You can verify that it works co
 
 ## Install with `curl`
 
-A platform-agnostic approach to installing `chainctl` is through using `curl`. We have [specific instructions for Windows users](/chainguard/chainctl-usage/how-to-install-chainctl/#installing-with-curl-in-windows-powershell) on installing `chainctl` with `curl`, but all others can run the following command:
+A platform-agnostic approach to installing `chainctl` is through using `curl`. We have [specific instructions for Windows users](/platform/chainctl-usage/how-to-install-chainctl/#installing-with-curl-in-windows-powershell) on installing `chainctl` with `curl`, but all others can run the following command:
 
 ```bash
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')"

--- a/content/platform/chainctl-usage/how-to-install-chainctl.md
+++ b/content/platform/chainctl-usage/how-to-install-chainctl.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Learn how to install chainctl, Chainguard's command-line interface for managing container images, IAM resources, and security configurations across platforms"
 date: 2022-09-22T15:56:52-07:00
-lastmod: 2026-09-01T13:37:32+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -97,7 +97,7 @@ Following that you can use `chainctl`. Be aware that Windows PowerShell does not
 .\chainctl auth login
 ```
 
-Also, please note that while [`chainctl` commands](/chainguard/chainctl/) will generally work, some are not as thoroughly tested on Windows and may not behave as expected.
+Also, please note that while [`chainctl` commands](/platform/chainctl/) will generally work, some are not as thoroughly tested on Windows and may not behave as expected.
 
 ## Install with Scoop in Windows
 

--- a/content/platform/chainctl-usage/manage-chainctl-config.md
+++ b/content/platform/chainctl-usage/manage-chainctl-config.md
@@ -7,7 +7,7 @@ aliases:
 - /chainguard/administration/manage-chainctl-config
 type: "article"
 date: 2023-07-07T05:56:52-07:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-09T15:53:21+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -60,7 +60,7 @@ Global Flags:
 Use "chainctl config [command] --help" for more information about a command.
 ```
 
-Each command is covered below. The full command reference is available on the [`chainctl config` reference page](/chainguard/chainctl/chainctl-docs/chainctl_config/).
+Each command is covered below. The full command reference is available on the [`chainctl config` reference page](/platform/chainctl/chainctl-docs/chainctl_config/).
 
 ## View your current configuration
 
@@ -231,7 +231,7 @@ To return a property to its default, use `unset`:
 chainctl config unset output.color.pass
 ```
 
-Both `set` and `unset` write to the configuration file immediately. Refer to the [`chainctl config set` reference page](/chainguard/chainctl/chainctl-docs/chainctl_config_set/) for more detail.
+Both `set` and `unset` write to the configuration file immediately. Refer to the [`chainctl config set` reference page](/platform/chainctl/chainctl-docs/chainctl_config_set/) for more detail.
 
 ## Save a configuration file
 
@@ -261,4 +261,4 @@ If you run into issues with your configuration, reset it to the default state:
 chainctl config reset
 ```
 
-This deletes the configuration files chainctl manages in the default locations and restores default values. Files you passed explicitly with `--config` are not deleted. You can review all available commands in the [`chainctl` reference documentation](/chainguard/chainctl/chainctl-docs/chainctl/).
+This deletes the configuration files chainctl manages in the default locations and restores default values. Files you passed explicitly with `--config` are not deleted. You can review all available commands in the [`chainctl` reference documentation](/platform/chainctl/chainctl-docs/chainctl/).


### PR DESCRIPTION
Adds an error reference for registry authentication and authorization failures, and cross-links it from the pages where those failures happen.

Users arrive holding an exact `cgr.dev` error string and want it decoded, and we had no page that mapped one to the other. In the July 2026 Kapa export (DOCS-157) this cluster ran 11 threads from 9 unique users; Kapa hedged or deflected to support in 7 of 11 and cited no edu page in 4, leaning on a Zendesk registry authentication article 28 times within the cluster instead. This gives those threads a page to land on.

## The reference page

New page at `content/chainguard/containers/troubleshooting/registry-errors.md`, serving `/chainguard/containers/troubleshooting/registry-errors/`. It parallels [Chainguard Libraries error messages](https://edu.chainguard.dev/chainguard/libraries/troubleshooting/errors/) in structure and naming.

It's organized around the two requests a pull actually makes — the credential exchange at `cgr.dev/token`, then the pull itself against `cgr.dev/v2` — because those two layers reuse the same status codes for unrelated problems. Each section is keyed to the verbatim strings users report, so searching the page for a pasted error lands in the right place.

## Please read this part: the issue specified the wrong diagnosis

DOCS-157 asked us to distinguish "a credential failure (401, login rejected) versus an entitlement failure (403, login succeeded but the resource is not in your organization)." I probed `cgr.dev` before drafting, and **neither half holds**. Built as specced, the page would have misdiagnosed the single most-cited error string in the cluster.

At `/token`, unauthenticated:

| Scope | Status | Code |
| -- | -- | -- |
| `chainguard/python` (in the free catalog) | `200` | token issued |
| `chainguard/keycloak` (real product, not free) | `403` | `FORBIDDEN` "Forbidden" |
| `chainguard/nope-not-real-xyz` (nonexistent) | `403` | `FORBIDDEN` "Forbidden" |
| `<private-org>/python` (org has it) | `401` | `UNAUTHORIZED` "Authentication required" |
| `<private-org>/nope-not-real-xyz` | `403` | `FORBIDDEN` "Forbidden" |
| `<nonexistent-org>/python` | `400` | `BAD_REQUEST` `InvalidArgument` |

The real rule is that **`403` means the endpoint won't grant you that scope**, and **`401` means the scope is grantable once you authenticate**. So `401` is the closer thing to an entitlement signal and `403` is not one at all — the reverse of the spec.

The genuine authorization failure lives one layer up, at `/v2/<org>/<repo>/tags/list` with a valid token, and it announces itself in the message text: `403 FORBIDDEN "caller does not have the required capabilities at ..."`, distinct from layer 1's bare `"Forbidden"`. That string was already documented in `private-apk-repos`, and the probe matches it. Absence at that layer surfaces as `404 NAME_UNKNOWN`, not `403`.

So the page's organizing claim is that **the message text, not the status number, is the discriminator.** Two different `403`s mean unrelated things.

Two smaller corrections that follow:

- The issue attributed the `helm registry login` `403` to using an email address as the username. The scopeless `/token?service=cgr.dev` returns that same `403` with no credentials at all, and again with garbage credentials, so it can't support that diagnosis. The remedy is still right — the username must be the identity ID from a pull token — so the page lists it first among things to check rather than presenting it as the cause.
- `400 BAD_REQUEST` on an org name that doesn't resolve is documented nowhere. It's a clean signal for a mistyped or omitted organization, which users don't distinguish from a `403`.

Full measurements are in a comment on DOCS-157 so this doesn't have to be re-derived.

## Cross-links

The existing explanation of what an organization can pull was unreachable from where the error occurs, which was the reachability problem the issue identified:

- **Registry overview** — new sections for what your organization can pull and for troubleshooting authentication errors.
- **Registry authentication** — the error page after the quickstart, plus a pointer from the Console pull-token section to `registry.pull_token_creator`, so "I can't create a pull token" reaches the capability that grants it.
- **Both Helm chart guides** — not in the original plan. The `iamguarded-charts` chart-install `403` in the source data came from exactly that path, and neither Troubleshooting section mentioned authentication at all.

The genuine entitlement case routes to the availability guide from #3890 rather than restating it.

## Scope notes

- DOCS-157 proposed `content/chainguard/containers/errors.md`. #3926 reorganized the section after the issue was filed, so this goes under `troubleshooting/` where the Libraries page now lives and where the sibling troubleshooting pages are.
- The four `chainctl` custom-IdP threads folded into the issue are deferred. They fail at a different service with an unrelated fix, and would read as an intrusion on a page built around the two `cgr.dev` layers. `content/platform/administration/custom-idps/` has no troubleshooting content at all, which is worth its own issue.

## Second and third commits

Separate from the docs change, and reviewable on their own:

- **`chore: ignore the Hugo-generated assets/jsconfig.json`** — Hugo writes this during a build for editor import resolution. It showed up untracked after every build.
- **`chore: update stale pre-rename chainctl link paths`** — 61 links across 30 files still used `/chainguard/chainctl/`. Not broken for readers; production 301s the old prefix, so this removes the redirect hop and stops the stale prefix spreading by copy-paste. All 61 are markdown link targets, so the rewrite is scoped to the `](` form and touches no prose.

## Verification

- `npm run build` clean, 1683 pages.
- `markdownlint-cli2` clean on every changed file.
- Every internal link and anchor on all changed pages resolved against the built site, fragments included. Anchors were checked post-build against `public/`, since heading IDs are generated and a source-only check can't see them.
- Each of the 29 distinct rewritten `chainctl` targets verified against the local build, which has no redirect layer and so fails on a path that is wrong rather than merely stale.
- Error semantics verified by direct probe against `cgr.dev` rather than taken from the reported strings.

Closes DOCS-157

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
