### PR TITLE
Add a task page for adding a package to a Chainguard Container

### DIFF
--- a/content/chainguard/containers/_index.md
+++ b/content/chainguard/containers/_index.md
@@ -9,7 +9,7 @@ aliases:
 description: "Chainguard provides the most secure container images with zero known CVEs, minimal attack surface, SBOMs, and daily updates — the enterprise choice for container security"
 type: "article"
 date: 2022-09-05T08:49:15+00:00
-lastmod: 2026-08-27T00:00:00+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 images: []
 weight: 020
@@ -23,6 +23,11 @@ banner: {
 }
 sectiontitle: "Most-read guides"
 tutorials: [
+  {
+    title: "Add a package",
+    description: "Compare the ways to add a package to a container, then add one",
+    url: "/chainguard/containers/building-and-modifying/adding-packages/"
+  },
   {
     title: "Custom Assembly",
     description: "Have Chainguard build a container with the extra packages you need",

--- a/content/chainguard/containers/building-and-modifying/_index.md
+++ b/content/chainguard/containers/building-and-modifying/_index.md
@@ -4,7 +4,7 @@ linktitle: "Building and modifying"
 description: "Adding packages to a Chainguard Container, working with Chainguard's package repositories, and building containers without a Dockerfile."
 type: "article"
 date: 2026-09-04T00:00:00+00:00
-lastmod: 2026-09-04T00:00:00+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 images: []
 weight: 060
@@ -18,6 +18,11 @@ banner: {
 }
 sectiontitle: "Extending and building containers"
 tutorials: [
+  {
+    title: "Add a package",
+    description: "Compare the ways to add a package, then add one and confirm it landed",
+    url: "/chainguard/containers/building-and-modifying/adding-packages/"
+  },
   {
     title: "Package repositories",
     description: "How Chainguard's package repositories are organized",

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -1,0 +1,253 @@
+---
+title: "Adding a package to a Chainguard Container"
+linktitle: "Add a package"
+description: "Choose how to add a package to a Chainguard Container, find the package name, apply the change, and confirm the package reached the finished image."
+type: "article"
+date: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T00:00:00+00:00
+draft: false
+tags: ["Chainguard Containers", "Custom Assembly", "Procedural"]
+images: []
+weight: 005
+toc: true
+---
+
+Chainguard Containers ship with only the packages their application needs, so sooner or later you'll want one that isn't there. [Custom Assembly](/chainguard/containers/custom-assembly/overview/) is the supported way to add it. You declare the package you want, Chainguard builds the image on its own infrastructure, and Chainguard rebuilds that image whenever the package is updated. You can drive Custom Assembly from the Chainguard Console, interactively with `chainctl`, or non-interactively with `chainctl` from a pipeline.
+
+This page helps you pick an approach, then covers the three steps that apply whichever one you pick: finding the package name, adding the package, and confirming that it reached the finished image.
+
+## Choose an approach
+
+The following table compares the available approaches:
+
+| Approach | Use it when | What you need |
+| --- | --- | --- |
+| [Custom Assembly in the Console](#add-the-package-in-the-console) | You want to browse the packages your organization can add and apply the change in a few clicks. | A Console account with a role that has the `repo.update` capability. |
+| [Custom Assembly with `chainctl`, interactively](#add-the-package-with-chainctl-interactively) | You work from a terminal and want to review a diff before it applies. | `chainctl`, installed and authenticated. |
+| [Custom Assembly with `chainctl`, non-interactively](#add-the-package-with-chainctl-non-interactively) | You keep image configuration in version control or apply it from CI/CD. | `chainctl` and a YAML build configuration file. |
+| [Custom Assembly with the Chainguard API](/chainguard/containers/custom-assembly/custom-assembly-api-demo/) | You're building your own tooling around Custom Assembly. | An API client and a Chainguard token. |
+| [`apk add` in a Dockerfile](/chainguard/containers/using-and-deploying/using-containers/#extending-chainguard-base-containers) | You build on a `-dev` variant or on `wolfi-base`, and you're prepared to pin package versions and image digests yourself. | A Dockerfile and a container image that includes `apk`. |
+| [`apk` with `chroot` in a multi-stage build](/chainguard/containers/building-and-modifying/install-apks-in-distroless-variants/) | You need a package in a distroless image and Custom Assembly doesn't fit your workflow. | A multi-stage Dockerfile. |
+
+Custom Assembly is the recommended approach because Chainguard's build pipeline resolves the packages you add against the packages already in the base image, then rebuilds the image when any of them change. Adding packages with `apk add` in your own Dockerfile moves that work to you: without pinned package versions and image digests, a package update can conflict with an older dependency in the base image and break your build until a new base image is released. For the longer version of this argument, see [Why use Custom Assembly for adding packages](/chainguard/containers/custom-assembly/overview/#why-use-custom-assembly-for-adding-packages).
+
+{{< note >}}
+Custom Assembly is available to organizations with access to [production Chainguard Containers](/chainguard/containers/concepts/container-categories/#production-containers). If you use Chainguard's free container images, take one of the Dockerfile approaches.
+{{< /note >}}
+
+## Before you begin
+
+The Custom Assembly approaches on this page share these prerequisites:
+
+* Access to production Chainguard Containers.
+* A role with the `repo.update` capability, to customize an existing image in place, or the `repo.create` capability, to save the result as a new image. Of Chainguard's three default roles — `viewer`, `editor`, and `owner` — only `owner` has both. For a custom role you can create instead, see [Custom Assembly permissions requirements](/chainguard/containers/custom-assembly/overview/#custom-assembly-permissions-requirements).
+* For the `chainctl` approaches, [`chainctl` installed](/platform/chainctl-usage/how-to-install-chainctl/) and [authenticated](/platform/chainctl-usage/authentication-options/).
+
+Custom Assembly adds packages to an image; it can't remove the packages the source image already contains. You can, however, remove packages you added in an earlier build.
+
+## Find the package name
+
+You can add only the packages your organization is entitled to, which are the packages that appear in the Chainguard Containers you already have access to. Package names often carry a version stream — `python-3.14` rather than `python` — so confirm the exact name before you add it.
+
+### Find a package in the Console
+
+Open the image in the [Chainguard Console](https://console.chainguard.dev), click **Customize image**, then use the **Filter packages** box. The list holds every package your organization can add. If the package you want isn't listed, open a Chainguard support ticket.
+
+### Find a package with apk
+
+Container images that include `apk` — a `-dev` variant does — can search the repository from inside a running container. For a free container image, no authentication is needed:
+
+```shell
+docker run --rm --entrypoint sh cgr.dev/chainguard/wolfi-base:latest \
+  -c 'apk update > /dev/null && apk search -e "mongo*"'
+```
+
+```output
+mongo-tools-100.18.0-r6
+mongodb-kubernetes-operator-0.13.0-r14
+mongodb-kubernetes-operator-compat-0.13.0-r14
+mongodb-kubernetes-operator-readinessprobe-0.13.0-r14
+```
+
+To search the packages your organization is entitled to, start a `-dev` variant of one of your organization's images with an `HTTP_AUTH` variable so that `apk` can reach your [private APK repository](/chainguard/containers/building-and-modifying/packages/private-apk-repos/):
+
+```shell
+docker run -it --rm --entrypoint /bin/sh --user root \
+  -e "HTTP_AUTH=basic:apk.cgr.dev:user:$(chainctl auth token --audience apk.cgr.dev)" \
+  cgr.dev/$ORGANIZATION/$CONTAINER:latest-dev
+```
+
+From the container's shell, run `apk update` and then `apk search`.
+
+## Add the package
+
+The three procedures that follow all produce the same result. Pick the one that matches how you work.
+
+### Add the package in the Console
+
+1. In the [Chainguard Console](https://console.chainguard.dev), open the image you want to customize.
+2. Click **Customize image**, then select the packages to add.
+3. Click **Continue**, then choose **Create a new image** or **Customize current image**.
+4. Click **Preview changes** and review the package list.
+5. Click **Apply changes**.
+
+For the full walkthrough, including how to edit or remove customizations later, see [Using the Chainguard Console to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-console/).
+
+### Add the package with chainctl interactively
+
+1. Open the image's build configuration:
+
+    ```shell
+    chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+    ```
+
+    Replace `$ORGANIZATION` with your organization's name and `$CONTAINER` with the name of the image. If you omit either flag, `chainctl` prompts you to choose.
+
+2. `chainctl` opens the configuration in your default text editor. Add the package under `contents.packages`:
+
+    ```yaml
+    contents:
+      packages:
+      - yarn
+      - wget
+      - bash
+    ```
+
+3. Save and close the file. `chainctl` prints a diff and asks you to confirm:
+
+    ```output
+    /tmp/3352123767.yaml (-deletion / +addition):
+
+     contents:
+       packages:
+       - yarn
+       - wget
+    +  - bash
+
+    Applying build config to $CONTAINER
+    Are you sure?
+    Do you want to continue? [y,N]:
+    ```
+
+4. Enter `y` to start the build.
+
+To save the result as a new image rather than changing the existing one, add `--save-as $NEW_NAME`. For the rest of what you can set in this file, including environment variables, annotations, and custom user accounts, see [Using chainctl to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-chainctl/).
+
+### Add the package with chainctl non-interactively
+
+Both `apply` and `edit` accept a configuration file, which skips the editor and the prompt. Use this form in CI/CD and anywhere you keep image configuration in version control.
+
+1. Write the build configuration to a file:
+
+    ```shell
+    cat > build.yaml <<EOF
+    contents:
+      packages:
+        - bash
+        - curl
+        - mysql
+    EOF
+    ```
+
+2. Preview what the file would change, without changing anything:
+
+    ```shell
+    chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --dry-run
+    ```
+
+    `--dry-run` prints the diff and exits with a non-zero status if there's anything to apply, which makes it usable as a drift check in a pipeline.
+
+3. Apply the configuration. `--yes` confirms the change without prompting:
+
+    ```shell
+    chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+    ```
+
+To save the result as a new image, add `--save-as $NEW_NAME`. This works when you target a single repository; it isn't available when you target several at once with repeated `--repo` flags or a wildcard.
+
+For a worked GitHub Actions pipeline built around these commands, see [Using GitOps to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-gitops/).
+
+## Confirm the package is in the image
+
+Custom Assembly builds run on Chainguard's infrastructure and normally finish in under 20 minutes, so your change won't reach the registry immediately.
+
+1. Check that the build succeeded:
+
+    ```shell
+    chainctl images repos build list --parent $ORGANIZATION --repo $CONTAINER
+    ```
+
+    ```output
+              START TIME           |        COMPLETION TIME        | RESULT  |             TAGS
+    -------------------------------|-------------------------------|---------|-------------------------------
+     Wed, 09 Sep 2026 12:46:56 CDT | Wed, 09 Sep 2026 12:47:13 CDT | Success | 26-full, 26.8-full, latest-full
+     Wed, 09 Sep 2026 12:45:22 CDT | Wed, 09 Sep 2026 12:46:13 CDT | Success | 26-dev, 26.8-dev, latest-dev
+    ```
+
+    The Console shows the same information on the image's **Builds** tab. Builds stay listed for 24 hours.
+
+2. Pull the image:
+
+    ```shell
+    docker pull cgr.dev/$ORGANIZATION/$CONTAINER:latest
+    ```
+
+3. Check for the package. If the image includes `apk`, query it directly. `apk info -e` prints the package name when the package is installed and exits with a non-zero status when it isn't:
+
+    ```shell
+    docker run --rm --entrypoint apk \
+      cgr.dev/$ORGANIZATION/$CONTAINER:latest-dev info -e bash
+    ```
+
+    ```output
+    bash
+    ```
+
+    Distroless images have no `apk`, so read the image's SBOM instead. This command lists the apk packages in the image:
+
+    ```shell
+    cosign download attestation \
+      --platform linux/amd64 \
+      --predicate-type https://spdx.dev/Document \
+      cgr.dev/$ORGANIZATION/$CONTAINER:latest \
+      | jq -r '.payload' | base64 -d \
+      | jq -r '.predicate.packages[]
+               | select(.externalRefs[]?.referenceLocator? // "" | startswith("pkg:apk/"))
+               | .name'
+    ```
+
+    ```output
+    ca-certificates-bundle
+    gdbm
+    glibc-2.44
+    ld-linux-2.44
+    python-3.14
+    ```
+
+    The Console shows the same list on the image's **SBOM** tab. For more ways to read this data, see [Retrieving Chainguard Container SBOMs](/chainguard/containers/security-and-compliance/retrieve-image-sboms/).
+
+## If the build fails
+
+A Custom Assembly build reports failure only after it finishes. Retrieve the logs for a build with the `logs` subcommand, which prompts you to pick a build report:
+
+```shell
+chainctl images repos build logs --parent $ORGANIZATION --repo $CONTAINER
+```
+
+In the Console, click a row on the image's **Builds** tab to open the same logs.
+
+Builds fail for a few recurring reasons:
+
+* Two packages install the same file, and Custom Assembly can't resolve the conflict.
+* A package is newer than the base image and was built against a newer version of `glibc`.
+* The build ran longer than an hour and timed out.
+* The package isn't one your organization is entitled to.
+
+For more on these cases, see [Custom Assembly troubleshooting](/chainguard/containers/custom-assembly/faq/#custom-assembly-troubleshooting). If you can't resolve a failure, [contact Chainguard support](https://www.chainguard.dev/contact?utm=docs).
+
+## Learn more
+
+* [Overview of Chainguard Custom Assembly](/chainguard/containers/custom-assembly/overview/) covers what Custom Assembly can change, its limitations, and how the CVE remediation SLA applies to customized images.
+* [Custom Assembly FAQs](/chainguard/containers/custom-assembly/faq/) answers questions about entitlements, FIPS, and support boundaries.
+* [Overview of Chainguard's package repositories](/chainguard/containers/building-and-modifying/packages/package-model/) explains where the packages you can add come from.
+* [Adding custom certificates with Custom Assembly](/chainguard/containers/custom-assembly/custom-assembly-certs/) covers embedding internal CA certificates in an image.

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -4,7 +4,7 @@ linktitle: "Add a package"
 description: "Choose how to add a package to a Chainguard Container, find the package name, apply the change, and confirm the package reached the finished image."
 type: "article"
 date: 2026-09-09T00:00:00+00:00
-lastmod: 2026-09-10T12:15:07+00:00
+lastmod: 2026-09-10T12:23:46+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly", "Procedural"]
 images: []
@@ -47,13 +47,17 @@ Custom Assembly adds packages to an image; it can't remove the packages the sour
 
 ## Find the package name
 
-You can add only the packages your organization is entitled to, which are the packages that appear in the Chainguard Containers you already have access to. Package names often carry a version stream — `python-3.14` rather than `python` — so confirm the exact name before you add it.
+You can add only the packages your organization is entitled to, which are the packages that appear in the Chainguard Containers you already have access to. Package names often carry a version stream — `python-3.14` rather than `python` — so confirm the exact name before you add it. Look it up in the Console, or with `apk` from inside a running container.
 
-### Find a package in the Console
+{{< tabs label="Ways to find a package name" >}}
+
+{{% tab title="Console" %}}
 
 Open the image in the [Chainguard Console](https://console.chainguard.dev), click **Customize image**, then use the **Filter packages** box. The list holds every package your organization can add. If the package you want isn't listed, [open a Chainguard support ticket](/get-started/get-support/).
 
-### Find a package with apk
+{{% /tab %}}
+
+{{% tab title="apk" %}}
 
 Container images that include `apk` — such as a `-dev` variant — can search the repository from inside a running container. For a free container image, no authentication is needed:
 
@@ -78,6 +82,10 @@ docker run -it --rm --entrypoint /bin/sh --user root \
 ```
 
 From the container's shell, run `apk update` and then `apk search`.
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## Add the package
 

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -4,7 +4,7 @@ linktitle: "Add a package"
 description: "Choose how to add a package to a Chainguard Container, find the package name, apply the change, and confirm the package reached the finished image."
 type: "article"
 date: 2026-09-09T00:00:00+00:00
-lastmod: 2026-09-10T12:11:42+00:00
+lastmod: 2026-09-10T12:15:07+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly", "Procedural"]
 images: []
@@ -22,9 +22,9 @@ The following table compares the available approaches:
 
 | Approach | Use it when | What you need |
 | --- | --- | --- |
-| [Custom Assembly in the Console](#add-the-package-in-the-console) | You want to browse the packages your organization can add and apply the change in a few clicks. | A Console account with a role that has the `repo.update` capability. |
-| [Custom Assembly with `chainctl`, interactively](#add-the-package-with-chainctl-interactively) | You work from a terminal and want to review a diff before it applies. | `chainctl`, installed and authenticated. |
-| [Custom Assembly with `chainctl`, non-interactively](#add-the-package-with-chainctl-non-interactively) | You keep image configuration in version control or apply it from CI/CD. | `chainctl` and a YAML build configuration file. |
+| [Custom Assembly in the Console](#add-the-package) | You want to browse the packages your organization can add and apply the change in a few clicks. | A Console account with a role that has the `repo.update` capability. |
+| [Custom Assembly with `chainctl`, interactively](#add-the-package) | You work from a terminal and want to review a diff before it applies. | `chainctl`, installed and authenticated. |
+| [Custom Assembly with `chainctl`, non-interactively](#add-the-package) | You keep image configuration in version control or apply it from CI/CD. | `chainctl` and a YAML build configuration file. |
 | [Custom Assembly with the Chainguard API](/chainguard/containers/custom-assembly/custom-assembly-api-demo/) | You're building your own tooling around Custom Assembly. | An API client and a Chainguard token. |
 | [`apk add` in a Dockerfile](/chainguard/containers/using-and-deploying/using-containers/#extending-chainguard-base-containers) | You build on a `-dev` variant or on `wolfi-base`, and you're prepared to pin package versions and image digests yourself. | A Dockerfile and a container image that includes `apk`. |
 | [`apk` with `chroot` in a multi-stage build](/chainguard/containers/building-and-modifying/install-apks-in-distroless-variants/) | You need a package in a distroless image and Custom Assembly doesn't fit your workflow. | A multi-stage Dockerfile. |
@@ -81,9 +81,11 @@ From the container's shell, run `apk update` and then `apk search`.
 
 ## Add the package
 
-The three procedures that follow all produce the same result. Pick the one that matches how you work.
+The three procedures below all produce the same result. Pick the tab that matches how you work.
 
-### Add the package in the Console
+{{< tabs label="Ways to add a package with Custom Assembly" >}}
+
+{{% tab title="Console" %}}
 
 1. In the [Chainguard Console](https://console.chainguard.dev), open the image you want to customize.
 2. Click **Customize image**, then select the packages to add.
@@ -93,7 +95,9 @@ The three procedures that follow all produce the same result. Pick the one that 
 
 For the full walkthrough, including how to edit or remove customizations later, see [Using the Chainguard Console to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-console/).
 
-### Add the package with chainctl interactively
+{{% /tab %}}
+
+{{% tab title="chainctl, interactively" %}}
 
 1. Open the image's build configuration:
 
@@ -133,7 +137,9 @@ For the full walkthrough, including how to edit or remove customizations later, 
 
 To save the result as a new image rather than changing the existing one, add `--save-as $NEW_NAME`. For the rest of what you can set in this file, including environment variables, annotations, and custom user accounts, see [Using chainctl to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-chainctl/).
 
-### Add the package with chainctl non-interactively
+{{% /tab %}}
+
+{{% tab title="chainctl, non-interactively" %}}
 
 Both `apply` and `edit` accept a configuration file, which skips the editor and the prompt. Use this form in CI/CD and anywhere you keep image configuration in version control.
 
@@ -166,6 +172,10 @@ Both `apply` and `edit` accept a configuration file, which skips the editor and 
 To save the result as a new image, add `--save-as $NEW_NAME`. This works when you target a single repository; it isn't available when you target several at once with repeated `--repo` flags or a wildcard.
 
 For a worked GitHub Actions pipeline built around these commands, see [Using GitOps to manage Custom Assembly resources](/chainguard/containers/custom-assembly/custom-assembly-gitops/).
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## Confirm the package is in the image
 

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -4,7 +4,7 @@ linktitle: "Add a package"
 description: "Choose how to add a package to a Chainguard Container, find the package name, apply the change, and confirm the package reached the finished image."
 type: "article"
 date: 2026-09-09T00:00:00+00:00
-lastmod: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T18:10:30+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly", "Procedural"]
 images: []
@@ -69,7 +69,7 @@ mongodb-kubernetes-operator-compat-0.13.0-r14
 mongodb-kubernetes-operator-readinessprobe-0.13.0-r14
 ```
 
-To search the packages your organization is entitled to, start a `-dev` variant of one of your organization's images with an `HTTP_AUTH` variable so that `apk` can reach your [private APK repository](/chainguard/containers/building-and-modifying/packages/private-apk-repos/):
+To search the packages your organization is entitled to, start a `-dev` variant of one of your organization's images with an `HTTP_AUTH` variable so that `apk` can reach your [Private APK Repository](/chainguard/containers/building-and-modifying/packages/private-apk-repos/):
 
 ```shell
 docker run -it --rm --entrypoint /bin/sh --user root \

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -4,7 +4,7 @@ linktitle: "Add a package"
 description: "Choose how to add a package to a Chainguard Container, find the package name, apply the change, and confirm the package reached the finished image."
 type: "article"
 date: 2026-09-09T00:00:00+00:00
-lastmod: 2026-09-09T18:10:30+00:00
+lastmod: 2026-09-10T12:11:42+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly", "Procedural"]
 images: []
@@ -51,11 +51,11 @@ You can add only the packages your organization is entitled to, which are the pa
 
 ### Find a package in the Console
 
-Open the image in the [Chainguard Console](https://console.chainguard.dev), click **Customize image**, then use the **Filter packages** box. The list holds every package your organization can add. If the package you want isn't listed, open a Chainguard support ticket.
+Open the image in the [Chainguard Console](https://console.chainguard.dev), click **Customize image**, then use the **Filter packages** box. The list holds every package your organization can add. If the package you want isn't listed, [open a Chainguard support ticket](/get-started/get-support/).
 
 ### Find a package with apk
 
-Container images that include `apk` — a `-dev` variant does — can search the repository from inside a running container. For a free container image, no authentication is needed:
+Container images that include `apk` — such as a `-dev` variant — can search the repository from inside a running container. For a free container image, no authentication is needed:
 
 ```shell
 docker run --rm --entrypoint sh cgr.dev/chainguard/wolfi-base:latest \

--- a/content/chainguard/containers/building-and-modifying/install-apks-in-distroless-variants.md
+++ b/content/chainguard/containers/building-and-modifying/install-apks-in-distroless-variants.md
@@ -4,7 +4,7 @@ linktitle: "Install APKs in distroless"
 description: "Learn how to install APK packages into Chainguard's distroless container images that do not include package managers"
 type: "article"
 date: 2026-04-21T00:00:01+00:00
-lastmod: 2026-04-21T00:00:01+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -18,6 +18,8 @@ aliases:
 This page documents workflows for installing APK packages in [distroless variants](/chainguard/containers/concepts/getting-started-distroless/) of Chainguard container images, such as most builds tagged `:latest`. We copy a filesystem from a distroless container image to a build image, install APKs to it using `chroot`, then copy the modified filesystem back to the distroless image in the final step.
 
 ## Overview: Installing packages in distroless containers
+
+> **Note**: The chroot workflow on this page is one of several ways to add a package to a Chainguard Container, and it's the most involved. For a comparison of all of them, see [Adding a package to a Chainguard Container](/chainguard/containers/building-and-modifying/adding-packages/).
 
 The distroless variants of Chainguard Containers do not contain shells or package managers by design. This reduces attack surface and exploitability for these images. In cases where additional packages are required, we typically recommend the following:
 

--- a/content/chainguard/containers/building-and-modifying/packages/package-model.md
+++ b/content/chainguard/containers/building-and-modifying/packages/package-model.md
@@ -5,7 +5,7 @@ lead: "Overview of Chainguard's package repositories, highlighting the different
 description: "Overview of Chainguard's package repositories, highlighting the different repositories and how to access them."
 type: "article"
 date: 2025-10-09T00:00:00Z
-lastmod: 2026-03-16T08:07:42+02:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview", "Product"]
 images: []
@@ -165,4 +165,4 @@ Similar to the [Chainguard shared responsibility model](https://edu.chainguard.d
 
 Chainguard’s package repositories provide trusted apk packages to support both standard and advanced containerized workloads. With the public Wolfi and Extra repositories alongside organization-specific private repositories, customers can reliably source the dependencies they need for production environments.
 
-We encourage you to learn more about Chainguard's private APK repositories by referring to our [documentation on the subject](/chainguard/containers/building-and-modifying/packages/private-apk-repos/). Additionally, if you're interested in customizing your Chainguard Containers by adding packages, we encourage you to check out our Chainguard's [Custom Assembly tool](/chainguard/containers/custom-assembly/overview/).
+We encourage you to learn more about Chainguard's private APK repositories by referring to our [documentation on the subject](/chainguard/containers/building-and-modifying/packages/private-apk-repos/). If you're ready to add a package to one of your container images, [Adding a package to a Chainguard Container](/chainguard/containers/building-and-modifying/adding-packages/) compares the available approaches and walks through the task.

--- a/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
@@ -4,7 +4,7 @@ linktitle: "Manage with chainctl"
 type: "article"
 description: "How to use chainctl to manage Custom Assembly resources."
 date: 2025-05-01T11:07:52+02:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
 images: []
@@ -26,10 +26,16 @@ You can use [`chainctl`, Chainguard's command-line interface tool](/platform/cha
 
 ## Adding packages to a customized container image
 
-To edit one of your organization's Custom Assembly container images, you can run the `chainctl image repo build edit` command:
+`chainctl` offers two ways to change the packages in a Custom Assembly container image. The `edit` subcommand opens the build configuration in your text editor, and the `apply` subcommand takes a configuration file you've already written. Both produce the same result, and both start a build once you confirm the change.
+
+For a shorter, task-first version of these procedures, along with how to find a package name and how to confirm the package reached the finished image, see [Adding a package to a Chainguard Container](/chainguard/containers/building-and-modifying/adding-packages/).
+
+### Editing packages interactively
+
+To edit one of your organization's Custom Assembly container images, you can run the `chainctl images repos build edit` command:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
 ```
 
 This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
@@ -65,6 +71,8 @@ Enter `y` to apply the changes.
 
 Following that, you'll be able to see the updated builds in the Chainguard Console, though it may take a few minutes for these changes to populate.
 
+### Applying packages non-interactively
+
 To edit a customized container image without any interactivity, you can use the `apply` subcommand. This method requires you to have a YAML file listing the desired packages, like the example created with this command:
 
 ```shell
@@ -80,7 +88,7 @@ EOF
 Then include this file in the `apply` command by adding the `-f` argument:
 
 ```shell
-chainctl image repo build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
 ```
 
 This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:
@@ -107,24 +115,36 @@ Do you want to continue? [y,N]:
 
 This approach is useful in cases where you would prefer to avoid any kind of interactivity, as in a CI/CD or other automation system.
 
+To see what a configuration file would change without changing anything, replace `--yes` with `--dry-run`. The command prints the same diff and then exits with a non-zero status if there's anything to apply, which makes it usable as a drift check in a pipeline:
+
+```shell
+chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --dry-run
+```
+
+The `edit` subcommand also accepts a configuration file through its own `-f` argument. Passing a file to `edit` skips the text editor but still prompts you to confirm the diff:
+
+```shell
+chainctl images repos build edit -f build.yaml --parent $ORGANIZATION --repo $CONTAINER
+```
+
 ### Using the `--save-as` option
 
 When customizing a Chainguard Container with Custom Assembly, you have the option to either customize the image itself or create a new image based on the original with your customizations applied to it.
 
-For example, say your organization has access to Chainguard's [`node` container image](https://images.chainguard.dev/directory/image/node/versions). If you use Custom Assembly to customize the `node` image without creating a new image, then the customizations applied to it will also apply to any users in your organization that are already consuming the image. Anyone who runs `docker pull cgr.dev/example.come/node` will download the customized image instead of the original, uncustomized one.
+For example, say your organization has access to Chainguard's [`node` container image](https://images.chainguard.dev/directory/image/node/versions). If you use Custom Assembly to customize the `node` image without creating a new image, then the customizations applied to it will also apply to any users in your organization that are already consuming the image. Anyone who runs `docker pull cgr.dev/example.com/node` will download the customized image instead of the original, uncustomized one.
 
 By creating a new image with Custom Assembly, you can customize the image without impacting any of the users or workflows already consuming it. You could also create multiple customized images based on the `node` container image to support specific functions.
 
 To use `chainctl` to create new customized container images with Custom Assembly, you must include the `--save-as` option, like this:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER --save-as $NEW_NAME
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER --save-as $NEW_NAME
 ```
 
 The following example command creates a new image named `custom-node` after applying the customizations:
 
 ```shell
-chainctl image repo build edit --parent example.com --repo node --save-as custom-node
+chainctl images repos build edit --parent example.com --repo node --save-as custom-node
 ```
 
 Once you run this example, the new container image would be accessible from the following URL:
@@ -133,7 +153,13 @@ Once you run this example, the new container image would be accessible from the 
 cgr.dev/example.com/custom-node
 ```
 
-Note that you **must** pass the new image's name when using the `--save-as` option; `chainctl` will return an error if you don't include a new name. Additionally, you can only use this option with the `edit` subcommand; you cannot create a new image declaratively using the `apply` subcommand.
+The `apply` subcommand accepts `--save-as` as well, so you can create a new image without any interactivity:
+
+```shell
+chainctl images repos build apply -f build.yaml --parent example.com --repo node --save-as custom-node --yes
+```
+
+Note that you **must** pass the new image's name when using the `--save-as` option; `chainctl` will return an error if you don't include a new name. Additionally, `--save-as` applies to a single source repository. It isn't available when you target several repositories at once, either by passing `--repo` more than once or by using a wildcard.
 
 ## Adding custom annotations and environment variables
 
@@ -146,7 +172,7 @@ Chainguard Containers include metadata in the form of *annotations*. These annot
 With Custom Assembly, you can add custom annotations to your Chainguard Containers using `chainctl`. The process is the same as the one outlined previously for adding packages. First run a command like the following:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
 ```
 
 In the text editor, add an `annotations` section to the bottom of the file like the following example:
@@ -173,10 +199,10 @@ Note that Custom Assembly blocks `org.opencontainers` and `dev.chainguard` annot
 
 Chainguard Containers often come with a set of predefined environment variables. These are useful for setting certain configuration details that are available to the container at runtime.
 
-You can follow the same procedure for adding custom annotations to add custom environment variables to your Custom Assembly container images. Start by running a `chainctl image repo build edit` command:
+You can follow the same procedure for adding custom annotations to add custom environment variables to your Custom Assembly container images. Start by running a `chainctl images repos build edit` command:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
 ```
 
 In the text editor, add an `environment` section like the following example:
@@ -206,10 +232,10 @@ Custom Assembly lets you replace the default APK repository URLs written to `/et
 
 > **Note**: This feature only affects which repository URLs are written into the image for runtime use. Build-time package resolution always uses Chainguard's `apk.cgr.dev` repositories. For more details on limitations and compatibility, refer to the [Custom runtime repositories overview](/chainguard/containers/custom-assembly/overview/#custom-runtime-repositories).
 
-To add custom runtime repositories, use `chainctl image repo build edit` as with other customizations:
+To add custom runtime repositories, use `chainctl images repos build edit` as with other customizations:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
 ```
 
 In the text editor, add a `runtime_repositories` field under `contents`:
@@ -248,7 +274,7 @@ EOF
 ```
 
 ```shell
-chainctl image repo build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
 ```
 
 To remove custom runtime repositories and revert to the default `virtualapk.cgr.dev` URLs, edit the configuration and remove the `runtime_repositories` field entirely.
@@ -274,7 +300,7 @@ Custom Assembly images trust only Chainguard's APK signing key by default. If yo
 To add a runtime key, pass the public key file to the `--with-runtime-keys` option:
 
 ```shell
-chainctl image repo build edit --parent $ORGANIZATION --repo $CONTAINER --with-runtime-keys=key-ee8fa0a3.rsa.pub
+chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER --with-runtime-keys=key-ee8fa0a3.rsa.pub
 ```
 
 Each file becomes a key in `/etc/apk/keys` named after the file's basename. The name must match the filename referenced by your repository's APKINDEX signature (`.SIGN.RSA256.<name>`), because `apk` looks up the key by that name during verification. `chainctl` uses filenames verbatim and returns an error if two files share the same basename.
@@ -315,7 +341,7 @@ Runtime keys are validated when the configuration is applied. The following rule
 You can also use the `list` subcommand to retrieve every one of a customized image's builds from the past 24 hours:
 
 ```shell
-chainctl image repo build list --parent $ORGANIZATION --repo $REPO
+chainctl images repos build list --parent $ORGANIZATION --repo $REPO
 ```
 
 This command is useful for quickly determining which builds were successful or failed:
@@ -333,7 +359,7 @@ This command is useful for quickly determining which builds were successful or f
 Lastly, you can also retrieve the logs for a given build with the `logs` subcommand:
 
 ```shell
-chainctl image repo build logs --parent $ORGANIZATION --repo $REPO
+chainctl images repos build logs --parent $ORGANIZATION --repo $REPO
 ```
 
 This command will prompt you to select the build report you want to view. These are organized in reverse chronological order by the time of each build:

--- a/content/chainguard/containers/custom-assembly/custom-assembly-console/index.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-console/index.md
@@ -4,7 +4,7 @@ linktitle: "Manage in the Console"
 type: "article"
 description: "How to use Chainguard's Custom Assembly tool in the Chainguard console."
 date: 2025-07-09T11:07:52+02:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly"]
 images: []
@@ -79,7 +79,7 @@ You can add more packages to the customized image by following the process outli
 
 To remove all of the container image's customizations, click the **More Actions** button at the top right then select **Remove customizations**. Removing all the added packages will return the image to its original state.
 
-Note that you can also edit the packages in a customized image [using the `chainctl image repo build edit` command](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#adding-packages-to-a-customized-container-image).
+Note that you can also edit the packages in a customized image [using the `chainctl images repos build edit` command](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#adding-packages-to-a-customized-container-image).
 
 If you elected to create a new container image with Custom Assembly, you can rename it by clicking the **Rename** button (next to the **Customize image** button) and entering a new name for the image. Note that after renaming the customized image, any references to the previous name will no longer work.
 

--- a/content/chainguard/containers/custom-assembly/custom-assembly-gitops.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-gitops.md
@@ -4,7 +4,7 @@ linktitle: "Manage with GitOps"
 type: "article"
 description: "How to use GitOps to manage Custom Assembly resources."
 date: 2026-01-29T11:07:52+02:00
-lastmod: 2026-09-01T16:34:19+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural", "Custom Assembly"]
 images: []
@@ -22,7 +22,7 @@ Chainguard's [Custom Assembly](/chainguard/containers/custom-assembly/overview/)
 
 This guide shows how to use Chainguard Custom Assembly as code from a CI/CD pipeline, storing your configuration in Git and using automation to apply changes and trigger builds. The examples in this guide focus on GitHub Actions, and are adapted from [Chainguard's custom-assembly-as-code demo repository](https://github.com/chainguard-demo/custom-assembly-as-code).
 
-> **NOTE**: `chainctl` is an API client that handles common tasks like authentication and applying configuration files. You can manage Custom Assembly [interactively using `chainctl`](/chainguard/containers/custom-assembly/custom-assembly-api-demo/). Running `chainctl` non-interactively is a common pattern for implementing GitOps workflows.
+> **NOTE**: `chainctl` is an API client that handles common tasks like authentication and applying configuration files. You can manage Custom Assembly [interactively using `chainctl`](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#editing-packages-interactively). Running `chainctl` non-interactively is a common pattern for implementing GitOps workflows.
 
 ## Prerequisites
 

--- a/content/chainguard/containers/custom-assembly/overview.md
+++ b/content/chainguard/containers/custom-assembly/overview.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "How to use Chainguard's Custom Assembly tool"
 date: 2025-02-19T11:07:52+02:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-09T18:05:27+00:00
 draft: false
 tags: ["Chainguard Containers", "Custom Assembly"]
 images: []
@@ -29,11 +29,19 @@ additional packages, environment variables, user accounts, and certificates,
 teams can reduce CVE exposure while maintaining the flexibility their workflows
 demand.
 
-This overview of Custom Assembly outlines how it works, its limitations, and how you can use container images customized with Custom Assembly. For a more hands-on tutorial on using Custom Assembly, Chainguard Academy currently has documentation for the following methods of managing the tool:
+This overview of Custom Assembly outlines how it works, its limitations, and how you can use container images customized with Custom Assembly.
 
-* [Using the Chainguard Console](/chainguard/containers/custom-assembly/custom-assembly-console/)
-* [Using `chainctl`, Chainguard's command-line interface tool](/chainguard/containers/custom-assembly/custom-assembly-chainctl/)
-* [Using Chainguard's API](/chainguard/containers/custom-assembly/custom-assembly-api-demo/)
+You can drive Custom Assembly through any of the following interfaces. They produce the same result, so pick the one that matches how you work:
+
+| Interface | Use it when |
+| --- | --- |
+| [The Chainguard Console](/chainguard/containers/custom-assembly/custom-assembly-console/) | You want to browse the packages your organization can add and apply the change in a few clicks. |
+| [`chainctl`, interactively](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#editing-packages-interactively) | You work from a terminal and want to review a diff before it applies. |
+| [`chainctl`, non-interactively](/chainguard/containers/custom-assembly/custom-assembly-chainctl/#applying-packages-non-interactively) | You keep image configuration in version control or apply it from CI/CD. |
+| [GitOps](/chainguard/containers/custom-assembly/custom-assembly-gitops/) | You want a pipeline that applies configuration changes as they merge. |
+| [Chainguard's API](/chainguard/containers/custom-assembly/custom-assembly-api-demo/) | You're building your own tooling around Custom Assembly. |
+
+If you're adding a package for the first time, [Adding a package to a Chainguard Container](/chainguard/containers/building-and-modifying/adding-packages/) walks the whole task end to end, from finding the package name to confirming it reached the finished image.
 
 With Custom Assembly, you can add the following to your container images:
 

--- a/content/chainguard/containers/overview.md
+++ b/content/chainguard/containers/overview.md
@@ -5,7 +5,7 @@ type: "article"
 description: "Learn about Chainguard Containers, distroless images, and how they provide enhanced security through minimal attack surface and comprehensive supply chain features."
 lead: "Chainguard Containers are security-hardened container images built with a distroless approach, containing only essential application components and runtime dependencies."
 date: 2022-09-01T08:49:31+00:00
-lastmod: 2025-07-23T16:52:56+00:00
+lastmod: 2026-09-09T18:07:04+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -36,9 +36,9 @@ All Chainguard Containers are built with a consistent set of security and supply
 
 Chainguard Containers include features that allow you to customize images, manage updates, and meet security and compliance requirements across the container lifecycle:
 
-- [Custom Assembly](/chainguard/containers/custom-assembly/overview/): Customize Chainguard images by adding packages, configuration files, and certificates using chainctl, without maintaining your own Dockerfiles.
+- [Custom Assembly](/chainguard/containers/custom-assembly/overview/): Customize Chainguard images by adding packages, configuration files, and certificates from the Chainguard Console, `chainctl`, or the Chainguard API, without maintaining your own Dockerfiles.
 - Custom certificates: Add trusted certificates [to existing containers via Custom Assembly](/chainguard/containers/custom-assembly/custom-assembly-certs/) (for organization-specific or environment-specific certificates) or by [using incert to build images with certificates embedded at build time](/chainguard/containers/custom-assembly/incert-custom-certs/).
-- [Packages](/chainguard/containers/building-and-modifying/packages/package-model/): Install and manage additional packages in Chainguard images while preserving Chainguard’s minimal, secure-by-default base images.
+- [Packages](/chainguard/containers/building-and-modifying/adding-packages/): Install and manage additional packages in Chainguard images while preserving Chainguard’s minimal, secure-by-default base images.
 - [EOL grace periods](/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/): Control how end-of-life packages are handled in images to balance security requirements with operational stability.
 - [STIGs](/chainguard/containers/security-and-compliance/stigs/): Use DISA STIG–aligned images to support compliance-driven environments.
 - [Unique tags](/chainguard/containers/reference/unique-tags/) and [tag history](/chainguard/containers/reference/using-the-tag-history-api/): Track image changes over time with immutable tags and access tag history via API.


### PR DESCRIPTION
Adds a task page for adding a package to a Chainguard Container, and fixes the pages it routes to.

Closes [DOCS-161](https://linear.app/chainguard/issue/DOCS-161/clarify-adding-package-to-a-chainguard-image).

While writing it I found that we tell customers a supported CI/CD capability doesn't exist: the `chainctl` guide states you cannot use `--save-as` with the `apply` subcommand, so anyone automating Custom Assembly reads that as "you can't create a new image from a pipeline." You can. Only batch mode excludes it. That correction is in this PR.

## Why

DOCS-161 came out of the Kapa mining pass (DOCS-145): a lot of questions about how to install additional packages in a Chainguard Container, where Kapa's own answer was easier to follow than ours because it plainly listed the ways to do it. Five of our pages answer some part of this question and none of them is the page a reader lands on.

Two steps existed nowhere in the docs: how to find out what a package is called before you add it, and how to confirm afterward that it actually reached the image.

## The new page

`content/chainguard/containers/building-and-modifying/adding-packages.md`, serving `/chainguard/containers/building-and-modifying/adding-packages/`. It routes rather than duplicates — the deep procedures stay where they are.

- A comparison table of all six routes: Custom Assembly through the Console, `chainctl` interactively, `chainctl` non-interactively, and the API; plus `apk add` in a Dockerfile and the chroot method for distroless.
- Custom Assembly prerequisites in one place: entitlement, `repo.update` versus `repo.create`, and `chainctl` login.
- **Find the package name** — new. Console filter, and `apk search` for both free and entitled images.
- Short procedures for the three Custom Assembly paths, each linking to the full guide.
- **Confirm the package is in the image** — new. Build status, then `apk info -e` for images with a package manager, and an SBOM query for distroless.
- What to do when a build fails.

## Corrections to existing pages

- **`custom-assembly-chainctl.md`**: `--save-as` does work with `apply`, verified against `chainctl` 0.2.347 and the generated reference, which carries an explicit example. The page said it doesn't. Corrected, and the non-interactive `--save-as` form is now shown.
- **`custom-assembly-gitops.md`**: "interactively using `chainctl`" linked to the API demo page.
- **`containers/overview.md`**: the "Install and manage additional packages" link went to the package-repository architecture page rather than to anything procedural. It also described Custom Assembly as `chainctl`-only, omitting the Console and the API.
- A `cgr.dev/example.come/node` typo.

## Structural changes

- Split the merged section in `custom-assembly-chainctl.md` into `Editing packages interactively` and `Applying packages non-interactively`. The `apply` path previously started mid-section under an `edit` heading, so it never appeared in the table of contents — which is the specific thing DOCS-161 asks us to fix.
- Documented `--dry-run` and `edit --file`.
- Normalized `chainctl image repo build` to `chainctl images repos build`. Both forms work, but the page used each in different places, which reads like two different commands.
- Turned the Custom Assembly overview's bulleted list of interfaces into a table that names both `chainctl` modes and GitOps, and says when to pick each.

## Testing

- `npm run build` clean, 1687 pages.
- Every internal link and `#fragment` on all ten changed pages resolves against the built site.
- Commands in the new page were run, and the sample outputs are captured rather than written by hand: `apk search -e` and `apk info -e` against `wolfi-base`, the SBOM `pkg:apk/` filter against `cgr.dev/chainguard/python:latest`, and `chainctl images repos build list` against a real customized repository.
- Not tested end to end: applying a Custom Assembly change, since that mutates a repository and starts a build. Everything run against the platform was read-only.

## Note for reviewers

The new page uses **Private APK Repository** per the brand style guide. The Word Usage Guide in this repo says `apk - never capitalized`, and the rest of `content/` uses the lowercase form roughly 66 times to 4, so the two guides conflict and the corpus follows neither consistently. I've kept this PR to the brand-guide form on new text only, rather than sweeping 70 occurrences into an unrelated diff. Happy to file that separately if we want a single answer.

---
Created in collaboration with Claude Code running Claude Opus 5 on 2026-09-09.
