### PR TITLE
Document Sigstore bundle signatures for Chainguard Containers

### DIFF
--- a/content/chainguard/containers/security-and-compliance/_index.md
+++ b/content/chainguard/containers/security-and-compliance/_index.md
@@ -9,7 +9,7 @@ aliases:
 description: "Scanning, SBOMs, verification, security advisories, policy enforcement, and the compliance evidence Chainguard Containers carry."
 type: "article"
 date: 2024-12-19T08:49:15+00:00
-lastmod: 2026-08-03T12:43:21+00:00
+lastmod: 2026-09-09T18:49:52+00:00
 draft: false
 images: []
 weight: 090
@@ -30,6 +30,11 @@ tutorials: [
     title: "Retrieve SBOMs",
     description: "Pull the build-time software bill of materials for any container",
     url: "/chainguard/containers/security-and-compliance/retrieve-image-sboms/"
+  },
+  {
+    title: "Sigstore bundle migration",
+    description: "What changes as signatures move to Sigstore bundles, and what to update",
+    url: "/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/"
   },
   {
     title: "Trivy",

--- a/content/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/index.md
+++ b/content/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/index.md
@@ -1,0 +1,89 @@
+---
+title: "Migrating to Sigstore bundle signatures for Chainguard Containers"
+linktitle: "Sigstore bundle migration"
+type: "article"
+description: "What changes when Chainguard Containers move from legacy Cosign signature tags to Sigstore bundles, which tools are affected, and what to do about it"
+date: 2026-09-08T00:00:00+00:00
+lastmod: 2026-09-08T00:00:00+00:00
+draft: false
+tags: ["Chainguard Containers", "Cosign", "Migration", "Overview"]
+images: []
+weight: 035
+toc: true
+---
+
+Chainguard is changing how container image signatures and attestations are published. Today they are stored as separate tags next to the image (`sha256-<digest>.sig` and `sha256-<digest>.att`) and logged to the Rekor v1 transparency log. They are moving to [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as [OCI referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) and logged to Rekor v2 with a signed timestamp.
+
+This page explains what changes, who is affected, and what to do. Dates are communicated through Chainguard's breaking-change notices; this page describes the change itself.
+
+## What changes
+
+The migration happens in two steps:
+
+1. **Dual publishing.** Every image gets both the legacy tags and the new bundle referrers. Nothing is removed. Most verification tooling keeps working unchanged, with one exception listed below.
+2. **Bundles only.** The legacy `.sig` and `.att` tags are no longer published for new builds. Tooling that only understands the legacy tags stops finding signatures.
+
+What does not change:
+
+- The identities Chainguard signs with. The public registry is still signed by the `chainguard-images/images` GitHub Actions workflow identity, and images in your private registry are still signed by your organization's `image-syncer` and `custom-image-builder` identities. Existing `--certificate-identity` and `--certificate-oidc-issuer` values stay valid.
+- The `cosign verify` and `cosign verify-attestation` commands in [Verifying Chainguard Containers with Cosign](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/). Cosign 3.1.1 and newer detects the format automatically.
+- The attestation types Chainguard publishes: SPDX and CycloneDX SBOMs, SLSA provenance, and the apko image configuration.
+
+## Am I affected?
+
+Check each of the following:
+
+- **Cosign version.** Run `cosign version`. You need **3.1.1 or newer**. See the compatibility table below for older releases.
+- **How you find signatures.** Anything that lists or pulls `sha256-<digest>.sig` or `.att` tags directly, including `cosign tree` from Cosign 2.x, stops working once bundles are the only format. Use `oras discover <image>` or Cosign 3.x to list the referrers instead.
+- **How you copy images.** Tools that copy an image by tag do not copy its referrers. If you mirror Chainguard Containers into your own registry or across an air gap, see [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/).
+- **Admission control.** If you enforce signatures with sigstore policy-controller or Kyverno, your policies need a configuration change before bundles become the only format. See the sections below.
+- **Attestation scripts.** Scripts that parse `cosign download attestation` output need a small change; see the [note on download output](#cosign-download-attestation-output).
+
+## Compatibility
+
+### Cosign
+
+| Cosign release | Legacy image | Dual-published image | Bundle-only image |
+|---|---|---|---|
+| 3.1.1 and newer | Verifies | Verifies | Verifies |
+| 2.6.3 to 2.6.5 | Verifies | Fails unless you pass `--use-signed-timestamps` | Fails unless you pass `--use-signed-timestamps` |
+| 2.6.2 and older | Verifies | Verifies (bundles are ignored) | Fails with `no signatures found` |
+
+Cosign 2.6.3 to 2.6.5 detect the bundle but do not, by default, accept the signed timestamp that Rekor v2 entries carry, so verification fails with `threshold not met for verified log entry integrated timestamps`. Upgrade to Cosign 3.1.1 or newer, or add `--use-signed-timestamps` to `cosign verify` and `cosign verify-attestation`.
+
+### sigstore policy-controller
+
+Existing `ClusterImagePolicy` resources keep working while images are dual published. Once bundles are the only format, policies that use the legacy signature path fail closed. The released policy-controller versions cannot verify bundle image signatures directly, but they can verify the signature bundle as an attestation. See [Using policy-controller to verify signed Chainguard Containers](/open-source/sigstore/policy-controller/policies/using-policy-controller-to-verify-signed-chainguard-images/).
+
+### Kyverno
+
+Existing `verifyImages` rules of type `Cosign` keep working while images are dual published and fail closed once bundles are the only format. Kyverno 1.19.0 and newer verifies bundles with `type: SigstoreBundle`. See [Enforcing Chainguard Container signatures with Kyverno](/chainguard/containers/security-and-compliance/enforcement/kyverno/).
+
+### chainctl
+
+Attestation commands in `chainctl images` require a chainctl release with bundle support. Update to the version named in the breaking-change notice.
+
+## `cosign download attestation` output
+
+For bundle attestations, `cosign download attestation` prints the whole Sigstore bundle as one JSON object per line instead of the bare DSSE envelope. The statement moves from `.payload` to `.dsseEnvelope.payload`. Use a `jq` expression that handles both:
+
+```shell
+cosign download attestation --predicate-type=https://spdx.dev/Document cgr.dev/chainguard/go \
+  | jq -r '.dsseEnvelope.payload // .payload' | base64 -d | jq .predicate
+```
+
+`cosign verify-attestation` output is unchanged and remains the recommended way to read attestations, because it also verifies them.
+
+## What to do
+
+1. Upgrade Cosign to 3.1.1 or newer everywhere you verify Chainguard Containers, including CI pipelines.
+2. If you mirror images, switch to a tool that copies referrers, such as `oras cp -r`, and confirm with `oras discover` that the signatures arrived.
+3. If you use policy-controller or Kyverno, apply the configuration described on their pages while images are still dual published, so the change is tested before the cutover.
+4. Fix any script that parses `cosign download attestation` output.
+
+## Learn more
+
+- [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/)
+- [How to retrieve attestations and SBOMs for Chainguard Containers](/chainguard/containers/security-and-compliance/retrieve-image-sboms/)
+- [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/)
+- [Sigstore bundle specification](https://docs.sigstore.dev/about/bundle/) and [Rekor v2](https://blog.sigstore.dev/rekor-v2-ga/)

--- a/content/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
+++ b/content/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/index.md
@@ -13,7 +13,7 @@ aliases:
 type: "article"
 description: "Learn how to verify Chainguard Container signatures and attestations with Cosign for supply chain security, ensuring image authenticity and integrity"
 date: 2024-03-18T08:59:52-07:00
-lastmod: 2026-09-08T13:28:24+00:00
+lastmod: 2026-09-09T18:49:52+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -27,7 +27,11 @@ This guide outlines how you can use Cosign to download and verify container imag
 
 ## Prerequisites
 
-The following examples require [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine to download and verify image attestations.
+The following examples require [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) **version 3.1.1 or newer** and [jq](https://stedolan.github.io/jq/) to be installed on your machine to download and verify image attestations. Run `cosign version` to check.
+
+{{< note >}}
+Chainguard is moving image signatures and attestations from legacy Cosign tags to [Sigstore bundles](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/). Cosign 3.1.1 and newer verifies both formats automatically, so the commands on this page do not change. Cosign 2.6.3 to 2.6.5 fail to verify bundled signatures unless you add `--use-signed-timestamps`, and Cosign 2.6.2 and older cannot verify them at all. See the migration guide for details.
+{{< /note >}}
 
 ## Registry and tags for Chainguard Containers
 
@@ -37,6 +41,18 @@ Attestations are provided per image build, so you'll need to specify the correct
 - `cgr.dev/YOUR-ORGANIZATION`: A private/dedicated registry contains your organization's **Production container images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
 
 The commands listed on this page default to the `:latest` tag, but you can specify a different tag to fetch attestations for.
+
+## How signatures and attestations are stored
+
+Signatures and attestations are separate artifacts stored in the same repository as the image. Chainguard publishes them as Sigstore bundles attached to the image as OCI referrers, and, during the migration, also as the legacy `sha256-<digest>.sig` and `sha256-<digest>.att` tags. Cosign finds either form on its own. To list the artifacts attached to an image, use `cosign tree`, which shows both the legacy tags and the bundle referrers in Cosign 3.x:
+
+```shell
+cosign tree cgr.dev/chainguard/go
+```
+
+[`oras discover`](https://oras.land/docs/commands/oras_discover) lists the bundle referrers alone.
+
+Each bundle carries the signature or attestation, the signing certificate, a Rekor transparency log entry, and a signed timestamp, so verification does not depend on reaching Rekor.
 
 ## Chainguard's signing identities
 
@@ -122,7 +138,7 @@ IMAGE=go
 cosign download attestation \
   --predicate-type=https://spdx.dev/Document \
   --platform=linux/amd64 \
-  cgr.dev/chainguard/${IMAGE} | jq -r .payload | base64 -d | jq .predicate
+  cgr.dev/chainguard/${IMAGE} | jq -r '.dsseEnvelope.payload // .payload' | base64 -d | jq .predicate
 ```
 
 ### Private/dedicated registry
@@ -132,8 +148,10 @@ IMAGE=go
 cosign download attestation \
   --predicate-type=https://spdx.dev/Document \
   --platform=linux/amd64 \
-  cgr.dev/${PARENT}/${IMAGE} | jq -r .payload | base64 -d | jq .predicate
+  cgr.dev/${PARENT}/${IMAGE} | jq -r '.dsseEnvelope.payload // .payload' | base64 -d | jq .predicate
 ```
+
+For attestations published as Sigstore bundles, `cosign download attestation` prints the whole bundle as one JSON object per line rather than the bare DSSE envelope, and the statement is under `.dsseEnvelope.payload`. The `jq` expression above handles both forms. `cosign verify-attestation`, shown in the next section, prints the same envelope for both forms and also verifies it, so prefer it where you can.
 
 ## Verifying container image attestations
 
@@ -181,7 +199,7 @@ cosign verify-attestation \
 
 ## Air-gapped and egress-restricted environments
 
-The commands in this guide reach the public Sigstore infrastructure to fetch the trust root Cosign verifies against. If that infrastructure is unreachable, you can export the trust root on a connected machine and pass it to Cosign as a file. Transparency-log verification still works, because the signature carries its own signed entry timestamp.
+The commands in this guide reach the public Sigstore infrastructure to fetch the trust root Cosign verifies against. If that infrastructure is unreachable, you can export the trust root on a connected machine and pass it to Cosign with `--trusted-root`. Transparency-log verification still works offline, because each signature carries its own log entry and signed timestamp. Cosign does not contact Rekor during verification, so `--rekor-url` is not needed.
 
 The signature is a separate artifact from the image, so mirroring the image alone leaves it behind. For the full procedure, including how to move signatures and attestations across an air gap, see [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/).
 
@@ -197,6 +215,8 @@ To avoid this problem, you could include either or both of the following `set` o
 - `set -o pipefail` ensures that status codes from Cosign aren't masked when piped to `jq`.
 
 ## Learn more
+
+To understand the move from legacy signature tags to Sigstore bundles, and what it means for your tooling, read [Migrating to Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/).
 
 To get up to speed with Sigstore, you can review the [Sigstore](/open-source/sigstore/) section of Chainguard Academy, visit the upstream [Sigstore Docs](https://docs.sigstore.dev/) site, and check out the [Sigstore organization on GitHub](https://github.com/sigstore). You can learn more about verifying software artifacts with Cosign by reading [How to verify file signatures with Cosign](/open-source/sigstore/cosign/how-to-verify-file-signatures-with-cosign/).
 

--- a/content/open-source/sbom/sboms-and-attestations.md
+++ b/content/open-source/sbom/sboms-and-attestations.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "An overview of the differences between attestations and SBOMs"
 date: 2023-03-19T15:56:52-07:00
-lastmod: 2026-07-27T15:39:06+00:00
+lastmod: 2026-09-09T18:49:52+00:00
 draft: false
 tags: ["Cosign", "SBOM", "Conceptual"]
 images: []
@@ -34,6 +34,10 @@ An *attestation* allows the end users or consumers of a software artifact (in th
 Put differently, an attestation is a written assurance of a software artifact's *provenance*, or the verifiable information about the artifact describing where, when, and how it was produced. You can think of an attestation as a proclamation that "software artifact X" was produced by "person Y" at "time Z". Because of this extra provenance information, attestations are generally seen as being more trustworthy than SBOMs since you can identify who signed them and when.
 
 Both `cosign attest` and `cosign attach` associate an artifact with an image and upload it to a registry. However, `cosign attest` generates an [in-toto attestation](https://in-toto.io/) while `cosign attach` does not. `cosign attest` then attaches it to the provided image and uploads it to a registry as an OCI artifact with a `.att` extension.
+
+{{< note >}}
+The `.att`, `.sig`, and `.sbom` tags described on this page are the layout Cosign 2.x produces. Cosign 3.x stores signatures and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers by default, discoverable with `oras discover` or `cosign tree`. Chainguard Containers are moving to that layout; see [Migrating to Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/).
+{{< /note >}}
 
 In the following example, `image.sbom` is an SBOM file that was previously created, `$IMAGE` is the image that will be attached to the SBOM, and `cosign.key` is the signer's private key.
 

--- a/content/open-source/sigstore/cosign/how-to-install-cosign.md
+++ b/content/open-source/sigstore/cosign/how-to-install-cosign.md
@@ -5,7 +5,7 @@ type: "article"
 lead: "Details for installing Cosign across operating systems to sign software artifacts"
 description: "Details for installing Cosign across operating systems"
 date: 2022-07-13T08:49:31+00:00
-lastmod: 2025-12-26T15:16:50+01:00
+lastmod: 2026-09-09T18:49:52+00:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -19,6 +19,10 @@ toc: true
 _An earlier version of this material was published in the [Cosign chapter](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/block-v1:LinuxFoundationX+LFS182x+2T2022+type@sequential+block@204b98f35bca48c194d1868e0356bef1/block-v1:LinuxFoundationX+LFS182x+2T2022+type@vertical+block@2f0ad9cb8f124a39ab555ac8bf1a114c) of the Linux Foundation [Sigstore course](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home)._
 
 Cosign supports software artifact signing, verification, and storage in an OCI (Open Container Initiative) registry. By signing software, you can authenticate that you are who you say you are, which can in turn enable a trust root so that developers and consumers who leverage your software can verify that you created the software artifact that you have said you’ve created. They can also ensure that that artifact was not tampered with by a third party. As someone who may use software libraries, containers, or other artifacts as part of your development lifecycle, a signed artifact can give you greater assurance that the code or container you are incorporating is from a trusted source.
+
+{{< note >}}
+To verify [Chainguard Containers](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/), install Cosign **3.1.1 or newer**. Chainguard publishes signatures as Sigstore bundles, which older releases cannot verify; see [Migrating to Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/).
+{{< /note >}}
 
 There are a few different ways to install Cosign to your local machine or remote server. The approach you choose should be based on the way you set up packages, the tooling that you use, or the way that your organization recommends. We will go through several options. Please refer to the [official Cosign installation documentation](https://docs.sigstore.dev/cosign/system_config/installation/) for additional context and updates.
 
@@ -120,13 +124,13 @@ The resulting binary from this installation will be placed at `$GOPATH/bin/cosig
 
 You can install Cosign with Go directly from the [Cosign GitHub releases page](https://github.com/sigstore/cosign/releases).
 
-At the time of writing, the newest release is [v3.0.2](https://github.com/sigstore/cosign/releases/tag/v3.0.2). You can download this version with the following command:
+For example, to install [v3.1.3](https://github.com/sigstore/cosign/releases/tag/v3.1.3):
 
 ```sh
-go install github.com/sigstore/cosign/v2/cmd/cosign@v3.0.2
+go install github.com/sigstore/cosign/v3/cmd/cosign@v3.1.3
 ```
 
-The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`. Check the [release page]([Cosign GitHub releases page](https://github.com/sigstore/cosign/releases) for additional releases.
+The resulting binary from this installation will be placed at `$GOPATH/bin/cosign`. Check the [Cosign GitHub releases page](https://github.com/sigstore/cosign/releases) for the current release.
 
 ## Installing Cosign with the Cosign binary
 


### PR DESCRIPTION
Chainguard is moving container image signatures and attestations from the legacy `sha256-<digest>.sig`/`.att` tags on Rekor v1 to Sigstore bundles attached as OCI referrers and logged to Rekor v2 (CON-1109). Customers need the Cosign version floor, a list of what is affected, and a heads-up on the one output-format change before the breaking-change notice goes out, and the notice should be able to link to tested guidance instead of restating it.

This PR adds a migration hub page and threads the version floor through the verification and install pages. The `cosign verify` and `verify-attestation` commands are unchanged; Cosign 3.1.1 and newer detects the format automatically. Every command was run against `cgr.dev/cosign-v3-testing/request-cosign-v3-canary` with cosign 3.1.3, 2.6.5 and 2.6.2, and the compatibility table on the hub page is the observed result.

Key changes:
- **New hub page** `security-and-compliance/migrating-to-sigstore-bundles/`: what changes, an "am I affected" checklist, the Cosign/policy-controller/Kyverno compatibility summary, and what to do; no commands live here so there is one canonical home per snippet.
- **Verify guide**: Cosign 3.1.1 floor with a note on 2.6.3–2.6.5 (`--use-signed-timestamps`), a short "how signatures are stored" section (`cosign tree` / `oras discover`), and a `--trusted-root` pointer for restricted networks since Rekor is not contacted during verification.
- **`download attestation` pipe**: `jq -r '.dsseEnvelope.payload // .payload'` so the same command works for bundle output (whole bundle per line) and the legacy envelope.
- **Install page**: 3.1.1 floor note; replaces the stale "newest release is v3.0.2" example, which also used the wrong `/v2` Go module path.
- **SBOMs vs attestations concept page**: notes that the `.att`/`.sig`/`.sbom` tag layout is Cosign 2.x behaviour and that 3.x stores bundles as referrers.
- **Section index**: lists the hub page under Security and compliance.

Assisted by Claude Fable 5.1