### PR TITLE
Add mirroring guidance for bundle-signed Chainguard Containers

### DIFF
--- a/content/chainguard/containers/registry/mirroring-signed-images/index.md
+++ b/content/chainguard/containers/registry/mirroring-signed-images/index.md
@@ -1,0 +1,108 @@
+---
+title: "Mirroring Chainguard Containers with their signatures"
+linktitle: "Mirroring signed containers"
+type: "article"
+description: "Copy Chainguard Containers into your own registry or across an air gap without losing their Sigstore signatures and attestations"
+lead: "Signatures and attestations are separate artifacts. Copy tools that only follow the image tag leave them behind."
+date: 2026-09-09T00:00:00+00:00
+lastmod: 2026-09-09T00:00:00+00:00
+draft: false
+tags: ["Chainguard Containers", "Procedural"]
+images: []
+toc: true
+weight: 045
+---
+
+Chainguard publishes each container's signature and attestations (SBOMs, provenance, and build configuration) as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. A referrer is a separate manifest in the same repository that points at the image digest. Most image copy tools follow the tag you give them and copy the image alone, so a mirrored image arrives without anything to verify and `cosign verify` reports `no signatures found`.
+
+This guide shows how to copy a Chainguard Container together with its referrers, how to move it across an air gap, and which tools do and do not carry referrers. For the verification commands themselves, see [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/). For background on the format change, see [Migrating to Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/).
+
+## Prerequisites
+
+- [ORAS](https://oras.land/docs/installation) 1.2 or newer. The examples below were run with 1.3.1.
+- [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) 3.1.1 or newer, to confirm the copy.
+- Credentials for `cgr.dev` (`chainctl auth configure-docker`) and for your destination registry.
+
+## Copy an image and its referrers between registries
+
+`oras cp` with `-r` (`--recursive`) copies the image, every referrer attached to it, and the referrers attached to each per-platform manifest of a multi-architecture image:
+
+```shell
+oras cp -r cgr.dev/chainguard/go:latest registry.internal/chainguard/go:latest
+```
+
+Confirm the referrers arrived before relying on the mirror:
+
+```shell
+oras discover registry.internal/chainguard/go:latest
+```
+
+Then verify the mirrored image the same way you verify the original. The signature covers the image digest, not the registry it is served from, so the identity flags do not change:
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  registry.internal/chainguard/go:latest
+```
+
+Images from your organization's private registry use your `image-syncer` and `custom-image-builder` identities instead; see the [verification guide](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/#chainguards-signing-identities).
+
+## Move an image across an air gap
+
+Write the image and its referrers to an [OCI image layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md) on disk, move the directory, and push it into the registry on the other side:
+
+```shell
+# Connected side
+oras cp -r cgr.dev/chainguard/go:latest --to-oci-layout ./transfer:go
+tar -czf transfer.tgz transfer
+
+# Air-gapped side
+tar -xzf transfer.tgz
+oras cp -r --from-oci-layout ./transfer:go registry.internal/chainguard/go:latest
+oras discover registry.internal/chainguard/go:latest
+```
+
+Verify after loading into the registry. Cosign cannot verify an ORAS layout directory in place (`--local-image` expects a single image or index at the root of the layout), and verifying inside the air gap also needs the Sigstore trust root as a file. See [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/) for exporting the trust root and passing it with `--trusted-root`.
+
+## Registries without the Referrers API
+
+Referrers are served by the OCI 1.1 Referrers API (`GET /v2/<name>/referrers/<digest>`). If the destination registry does not implement it, ORAS can instead record the referrers under the fallback tag defined by the OCI distribution spec (`sha256-<digest>`), which Cosign and other referrer-aware clients also understand:
+
+```shell
+oras cp -r --to-distribution-spec v1.1-referrers-tag \
+  cgr.dev/chainguard/go:latest registry.internal/chainguard/go:latest
+```
+
+`cgr.dev` itself serves the Referrers API for every repository.
+
+## Tools compared
+
+Tested against a bundle-signed Chainguard Container with the versions shown. "Referrers" means the signature and attestation bundles arrived and `cosign verify` (3.1.3) succeeded on the copy.
+
+| Tool | Version | Referrers | Notes |
+|---|---|---|---|
+| `oras cp -r` | 1.3.1 | Yes | Recommended. Also handles per-platform referrers and OCI layouts. |
+| `crane copy` | 0.20.7 | No | Copies the tag only; `crane` has no referrer option. |
+| `skopeo copy` | 1.22.2 | No | Copies the tag only. |
+| `cosign copy` | 3.1.3 | Partial | Deprecated in Cosign 3.x. Copies legacy `.sig`/`.att` tags and only some bundles; do not rely on it. |
+| `cosign save` / `cosign load` | 3.1.3 | No | Carries legacy tags only; bundle referrers fail to load. Use the OCI layout procedure above. |
+| Registry replication features | varies | varies | Check the product's documentation for OCI referrers or "OCI artifact" support, then confirm with `oras discover` through the mirror. |
+
+## Pull-through caches
+
+A pull-through cache proxies requests to `cgr.dev`, so what it serves depends on whether it proxies the Referrers API as well as the manifest and blob endpoints. Check by listing referrers and verifying through the cache:
+
+```shell
+oras discover cache.internal/chainguard/go:latest
+cosign verify <identity flags> cache.internal/chainguard/go:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but not through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror with `oras cp -r` instead. Product-specific notes are in the [pull-through guides](/chainguard/containers/registry/pull-through-guides/).
+
+## Learn more
+
+- [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/security-and-compliance/verifying-chainguard-images-and-metadata-signatures-with-cosign/)
+- [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/)
+- [Migrating to Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/)
+- [ORAS: copying artifacts and referrers](https://oras.land/docs/commands/oras_cp)

--- a/content/chainguard/containers/registry/network-requirements.md
+++ b/content/chainguard/containers/registry/network-requirements.md
@@ -10,7 +10,7 @@ lead: "Using Chainguard Containers with firewalls, access control lists, and pro
 type: "article"
 description: "Using Chainguard Containers with firewalls, access control lists, and proxies."
 date: 2023-09-08T08:49:31+00:00
-lastmod: 2026-08-28T00:00:00+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers", "Reference"]
 images: []
@@ -58,9 +58,11 @@ This table lists the third-party DNS hostnames, associated ports, and protocols 
 |-----------------------------------------------------------|------|----------|---------|----------------------------------------------------------|
 | 9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com | 443  | HTTPS    | v4 & v6 | Blob storage for *.cgr.dev                               |
 | support.chainguard.dev                                    | 443  | HTTPS    | v4      | Support access for customers                             |
-| tuf-repo-cdn.sigstore.dev                                 | 443  | HTTPS    | v4      | Sigstore trust root for `chainctl` signature verification |
+| tuf-repo-cdn.sigstore.dev                                 | 443  | HTTPS    | v4      | Sigstore trust root for signature verification by `chainctl`, Cosign, Kyverno, and policy-controller |
 
 > Note that the `9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com` host is used to serve both image data and packages via `*.cgr.dev`.
+
+Verifying a Chainguard Container's signature needs only the registry and the Sigstore trust root. The signature carries its own transparency log entry and signed timestamp, so verifiers do not contact Rekor, Fulcio, or the timestamp authority. Environments that cannot reach `tuf-repo-cdn.sigstore.dev` can supply the trust root as a file; see [Verifying signatures in air-gapped environments](/open-source/sigstore/cosign/verifying-in-air-gapped-environments/).
 
 ## Ingress and egress
 

--- a/content/chainguard/containers/registry/pull-through-guides/artifact-registry-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/artifact-registry-pull-through/index.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Tutorial outlining how to set up a Google Artifact Registry repository to pull containers through from Chainguard's registry."
 date: 2024-07-08T15:56:52-07:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers", "Registry"]
 images: []
@@ -148,6 +148,20 @@ If you run into issues when trying to pull Containers from Chainguard's registry
 * When configuring a remote Google Artifact Registry repository, ensure that the **URL** field is set to `https://cgr.dev/`. This field **must not** contain additional components.
 * You can troubleshoot by running `docker login` from another node (using the Google Artifact Registry pull token credentials) and try pulling an image from `cgr.dev/chainguard/<image name>` or `cgr.dev/<company domain>/<image name>`.
 * It could be that your Google Artifact Registry repository was misconfigured. In this case, create and configure a new Google Artifact Registry repository to test with.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Google Artifact Registry proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
 
 ## Learn more
 

--- a/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
@@ -11,7 +11,7 @@ aliases:
 type: "article"
 description: "Tutorial outlining how to set up a remote Artifactory repository to pull images through Chainguard's container registry."
 date: 2024-02-13T15:56:52-07:00
-lastmod: 2026-09-09T13:00:03+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -212,6 +212,20 @@ If you run into issues when trying to pull images from Chainguard's container re
 * You can troubleshoot by running `docker login` from another node (using the Artifactory pull token credentials) and then trying to pull a Container from `cgr.dev/chainguard/<image name>` or `cgr.dev/<organization>/<image name>`.
 * It may help to [clear the Artifactory cache](https://jfrog.com/help/r/artifactory-cleanup-best-practices/clearing-an-oversized-cache).
 * Your Artifactory repository may be misconfigured. In this case, create and configure a new remote Artifactory repository to test with.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Artifactory proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
 
 ## Learn more
 

--- a/content/chainguard/containers/registry/pull-through-guides/cloudsmith-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/cloudsmith-pull-through/index.md
@@ -8,7 +8,7 @@ aliases:
 type: "article"
 description: "Tutorial outlining how to set up a Cloudsmith repository to pull containers through from Chainguard's registry."
 date: 2024-07-16T15:56:52-07:00
-lastmod: 2026-08-20T15:41:17+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -145,6 +145,20 @@ If you run into issues when trying to pull Containers from Chainguard's registry
 * When configuring a remote Cloudsmith repository, ensure that the **URL** field is set correctly. For Free container images, this should be `https://cgr.dev/chainguard`; for Production containers this should be `https://cgr.dev/`. This field **must not** contain any additional components.
 * You can troubleshoot by running `docker login` from another node (using the Cloudsmith pull token credentials) and try pulling an image from `cgr.dev/chainguard/<image name>` or `cgr.dev/<example.com>/<image name>`, using your own organization's registry name in place of `<example.com>`.
 * It could be that your Cloudsmith repository was misconfigured. In this case, create and configure a new Cloudsmith repository to test with.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Cloudsmith proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
 
 ## Learn more
 

--- a/content/chainguard/containers/registry/pull-through-guides/ecr-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/ecr-pull-through/index.md
@@ -4,7 +4,7 @@ linktitle: "Amazon ECR"
 type: "article"
 description: "Tutorial outlining how to set up an Amazon ECR pull through cache rule for pulling containers from Chainguard's registry."
 date: 2026-03-31T00:00:00+00:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers", "Registry"]
 images: []
@@ -156,6 +156,22 @@ If you run into issues when pulling Containers from Chainguard's registry throug
 * If you scoped the rule to a namespace, confirm your pull path omits that namespace. For a rule scoped to `example.com`, pull `cg-ecr/chainguard-base:latest`, not `cg-ecr/example.com/chainguard-base:latest`.
 * You can troubleshoot by running `docker login` from another machine (using the pull token credentials) and pulling directly from `cgr.dev/example.com/<image name>`, or from `cgr.dev/chainguard/<image name>` for Free Containers.
 * Refer to the AWS guide on [troubleshooting pull through cache issues](https://docs.aws.amazon.com/AmazonECR/latest/userguide/error-pullthroughcache.html) for common errors and their resolutions.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Amazon ECR proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
+
+AWS has announced that ECR pull through cache rules discover and sync OCI referrers from the upstream registry; cached referrers are refreshed on a schedule rather than on every pull, so a freshly rebuilt image can appear unsigned through the cache for a period after it is published upstream. ECR does not accept referrers pushed to it directly, so mirroring with `oras cp -r` into ECR is not an alternative.
 
 ## Learn more
 

--- a/content/chainguard/containers/registry/pull-through-guides/harbor/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/harbor/index.md
@@ -4,7 +4,7 @@ linktitle: "Harbor"
 type: "article"
 description: "Tutorial outlining how to sync images from Chainguard's registry to Harbor."
 date: 2025-08-19T12:00:00-00:00
-lastmod: 2026-09-04T16:13:45+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -133,6 +133,20 @@ docker pull $HARBOR_URL/cgr-mirror/$IMAGE:$TAG
 ```
 
 Again, be sure to replace this command's placeholder values as necessary.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Harbor proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
 
 ## Learn more
 

--- a/content/chainguard/containers/registry/pull-through-guides/nexus-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/nexus-pull-through/index.md
@@ -9,7 +9,7 @@ aliases:
 type: "article"
 description: "Tutorial outlining how to set up a Nexus repository to pull container images through from Chainguard's registry."
 date: 2024-03-28T15:56:52-07:00
-lastmod: 2026-08-20T15:41:17+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -111,6 +111,20 @@ If you run into issues when trying to pull Containers from Chainguard's Registry
 * When configuring a remote Nexus repository, ensure that the **URL** field is set to `https://cgr.dev/`. This field **must not** contain additional components.
 * You can troubleshoot by running `docker login` from another node (using the Nexus pull token credentials) and try pulling a container image from `cgr.dev/chainguard/<image name>` or `cgr.dev/<example.com>/<image name>`, using your own organization's registry name in place of `<example.com>`.
 * It could be that your Nexus repository was misconfigured. In this case, create and configure a new Nexus repository to test with.
+
+## Signatures and attestations
+
+Chainguard publishes each container's signature and attestations as [Sigstore bundles](https://docs.sigstore.dev/about/bundle/) attached to the image as OCI referrers. Whether they are available through the cache depends on whether Nexus proxies the OCI 1.1 Referrers API for the upstream repository. Check by listing the referrers and verifying the image through the cache:
+
+```shell
+oras discover <your-cache>/chainguard/nginx:latest
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
+  <your-cache>/chainguard/nginx:latest
+```
+
+If `oras discover` lists bundles against `cgr.dev` but returns nothing through the cache, the cache does not serve referrers. Verify against `cgr.dev` directly, or mirror the images with a tool that copies referrers; see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/).
 
 ## Learn more
 

--- a/content/open-source/sigstore/cosign/verifying-in-air-gapped-environments.md
+++ b/content/open-source/sigstore/cosign/verifying-in-air-gapped-environments.md
@@ -5,7 +5,7 @@ type: "article"
 description: "Use Cosign to verify container signatures and attestations without outbound network access"
 lead: "Cosign can verify signatures and attestations with no connection to the public Sigstore infrastructure"
 date: 2026-09-08T00:00:00+00:00
-lastmod: 2026-09-08T00:00:00+00:00
+lastmod: 2026-09-09T19:52:03+00:00
 draft: false
 tags: ["Cosign", "Procedural"]
 images: []
@@ -26,13 +26,14 @@ A keyless verification normally makes three kinds of network request. Only the f
 
 - **The Sigstore trust root**, fetched over [The Update Framework](https://theupdateframework.io/) (TUF) from `tuf-repo-cdn.sigstore.dev`. Cosign refreshes this metadata on every verification, so an air-gapped run fails unless you supply the trust root from a file.
 - **The registry**, to fetch the image and its signature. Inside the air gap, this is your internal registry or a directory on disk.
-- **The Rekor transparency log**, to confirm the signature was logged. Cosign doesn't need this. A Chainguard signature carries a signed entry timestamp alongside it, which proves the log entry exists and which Cosign checks offline.
+- **The Rekor transparency log**, to confirm the signature was logged. Cosign doesn't need this. A Chainguard signature carries its own transparency log entry and a signed timestamp, which Cosign checks offline.
 
 The last point matters: you keep transparency-log verification in an air-gapped environment. You don't need `--insecure-ignore-tlog`, and you shouldn't use it, because it discards a check that still works.
 
 ## Prerequisites
 
-- [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) v3.0.3 or later, installed on both a connected machine and inside the air-gapped environment. Cosign v3.0.3 fixed several problems with offline verification. Earlier releases need different flags, so upgrade rather than work around them.
+- [Cosign](/open-source/sigstore/cosign/how-to-install-cosign/) v3.1.1 or later, installed on both a connected machine and inside the air-gapped environment. Chainguard Containers require 3.1.1 to verify [Sigstore bundle signatures](/chainguard/containers/security-and-compliance/migrating-to-sigstore-bundles/), and v3.0.3 fixed several problems with offline verification. Earlier releases need different flags, so upgrade rather than work around them.
+- [ORAS](https://oras.land/docs/installation) 1.2 or later on the connected machine, to copy images together with their signatures.
 - A connected machine that can reach `cgr.dev` and the public Sigstore infrastructure.
 - An approved way to move files into the air-gapped environment.
 
@@ -58,7 +59,7 @@ Copying the whole `~/.sigstore` directory into the air-gapped environment doesn'
 
 ## Move the images and their signatures
 
-A Cosign signature is a separate artifact in the registry, stored under a tag derived from the image digest. Copying an image alone leaves the signature behind, and verification inside the air gap then fails with `no signatures found`.
+A Cosign signature is a separate artifact in the registry. Chainguard publishes signatures and attestations as Sigstore bundles attached to the image as OCI referrers, and, during the migration to that format, also under legacy tags derived from the image digest. Copying an image alone leaves both behind, and verification inside the air gap then fails with `no signatures found`.
 
 To see what's attached to an image, run `cosign tree` on the connected machine:
 
@@ -66,26 +67,26 @@ To see what's attached to an image, run `cosign tree` on the connected machine:
 cosign tree cgr.dev/chainguard/go:latest
 ```
 
-The output lists the signature and attestation tags attached to the image:
+The output lists the bundles attached to the image as OCI referrers, one per signature or attestation type. Images that still carry the legacy layout also show `Signatures for an image tag` and `Attestations for an image tag` entries:
 
 ```
 📦 Supply Chain Security Related artifacts for an image: cgr.dev/chainguard/go:latest
-└── 💾 Attestations for an image tag: cgr.dev/chainguard/go:sha256-6be282d9e6dc....att
-   ├── 🍒 sha256:475e95ecb3900fbf479c31b79527c8d1a8f85445dd44caaf21310fb8cd56fdad
-   ├── 🍒 sha256:ae3c33f8f466481133b4826e165f09cdd11bb76a93f6a6af3429e41c887b0109
-   └── 🍒 sha256:4f3c43079eed9885ebe77b787604e98ebf0f8020f61002efb70f5fda091ed27b
-└── 🔐 Signatures for an image tag: cgr.dev/chainguard/go:sha256-6be282d9e6dc....sig
-   └── 🍒 sha256:f0e210a4dfafc1188c7a9ab97b3e01082a7a9ebbbb98174292bedc8ddca71b61
+└── 🔗 https://sigstore.dev/cosign/sign/v1 artifacts via OCI referrer: cgr.dev/chainguard/go@sha256:a06a9b6d...
+   └── 🍒 sha256:14cf554baff036e5e1f75ef35cc988a099566268723b3fb934d5e482c08ebae9
+└── 🔗 https://spdx.dev/Document artifacts via OCI referrer: cgr.dev/chainguard/go@sha256:f1fc7521...
+   └── 🍒 sha256:f23ccc2edc59eac11ce753fc590a45cde72ea1d8fe63fb287f681ab0fe868ea0
+└── 🔗 https://slsa.dev/provenance/v1 artifacts via OCI referrer: cgr.dev/chainguard/go@sha256:bf5cb292...
+   └── 🍒 sha256:c6f25e5fbef68e24daefc36dc563e4b8cdc4e05bbb309be65975a23c1339da5f
 ```
 
 Choose one of the following two transports.
 
 ### Option 1: Copy into a mirrored registry
 
-Use `cosign copy`, which carries the image, its signatures, and its attestations together. For a multi-architecture image it also copies the per-platform signatures, which matters if the air-gapped environment pulls a single architecture:
+Use `oras cp -r`, which carries the image, its signatures, and its attestations together. For a multi-architecture image it also copies the referrers attached to each per-platform manifest, which matters if the air-gapped environment pulls a single architecture:
 
 ```sh
-cosign copy cgr.dev/chainguard/go:latest registry.internal/chainguard/go:latest
+oras cp -r cgr.dev/chainguard/go:latest registry.internal/chainguard/go:latest
 ```
 
 Confirm the signature arrived before you rely on the mirror:
@@ -95,18 +96,22 @@ cosign tree registry.internal/chainguard/go:latest
 ```
 
 {{< note >}}
-General-purpose copy tools don't carry Cosign signatures for Chainguard Containers. Chainguard stores signatures and attestations under `.sig` and `.att` tags rather than in the OCI referrers graph, so tools that walk referrers report success and copy the image bytes alone. Use `cosign copy`, or copy the `.sig` and `.att` tags explicitly.
+Tools that copy an image by tag do not carry its Sigstore bundles. `crane copy` and `skopeo copy` copy the image alone, `cosign copy` is deprecated in Cosign 3.x and copies only the legacy tags reliably, and `cosign save`/`cosign load` do not carry bundle referrers. See [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/) for the tested comparison.
 {{< /note >}}
 
 ### Option 2: Save to a directory
 
-If the air-gapped environment has no registry, `cosign save` writes the image and its attached artifacts to an OCI layout on disk:
+If the air-gapped environment has no registry on the connected side, write the image and its referrers to an OCI layout on disk with ORAS:
 
 ```sh
-cosign save cgr.dev/chainguard/go:latest --dir ./transfer
+oras cp -r cgr.dev/chainguard/go:latest --to-oci-layout ./transfer:go
 ```
 
-Move the `transfer` directory and `trusted_root.json` across the air gap together. On the other side you can verify the directory in place, or load it into a registry with `cosign load`.
+Move the `transfer` directory and `trusted_root.json` across the air gap together. On the other side, load the layout into your internal registry and verify it there:
+
+```sh
+oras cp -r --from-oci-layout ./transfer:go registry.internal/chainguard/go:latest
+```
 
 ## Verify inside the air-gapped environment
 
@@ -136,18 +141,9 @@ The following checks were performed on each of these signatures:
 The verified output still reports a `docker-reference` of `cgr.dev/chainguard/go`, even though you verified a mirrored copy. This is expected. The signature covers the image digest, not the registry it's served from.
 {{< /note >}}
 
-### Verify a saved directory
+### Verify a loaded layout
 
-Point Cosign at the directory with `--local-image`:
-
-```sh
-cosign verify \
-  --local-image \
-  --trusted-root ./trusted_root.json \
-  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
-  ./transfer
-```
+After loading a layout into the internal registry with `oras cp -r --from-oci-layout`, verify it exactly as a mirrored image. Cosign cannot verify an ORAS layout directory in place: `--local-image` expects a single image or index at the root of the layout, and an ORAS layout also holds the referrer manifests.
 
 ### Verify attestations
 
@@ -184,15 +180,9 @@ cosign verify \
 
 For more on these identities, see [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/).
 
-### Store signatures in a separate repository
+### Signatures in a separate repository
 
-Some registry layouts keep signatures apart from the images they sign. Set `COSIGN_REPOSITORY` to tell Cosign where to look:
-
-```sh
-export COSIGN_REPOSITORY=registry.internal/signatures
-```
-
-Without it, Cosign looks beside the image and reports `no signatures found`.
+Some registry layouts keep legacy `.sig` and `.att` tags apart from the images they sign, and `COSIGN_REPOSITORY` tells Cosign where to find them. That setting applies to the legacy layout only. Sigstore bundles are referrers of the image and must live in the image's own repository, so keep the referrers with the image when you mirror.
 
 ## Refresh the trust root
 
@@ -211,11 +201,11 @@ That's a decision about trust domains and key custody, not a technical requireme
 | Message | Cause |
 |---------|-------|
 | `tuf: failed to download 13.root.json` | Cosign tried to refresh TUF metadata over the network. Pass `--trusted-root`. |
-| `no signatures found` | The signature wasn't copied with the image, or it lives in another repository. Check with `cosign tree` and set `COSIGN_REPOSITORY` if needed. |
+| `no signatures found` | The signature wasn't copied with the image, usually because it was copied by tag with `crane copy`, `skopeo copy`, or a registry replication feature that ignores referrers. Check with `cosign tree` and re-copy with `oras cp -r`. |
 | `none of the expected identities matched what was in the certificate` | The `--certificate-identity` or `--certificate-oidc-issuer` value doesn't match the signer. The error lists the subject that was found. |
 | `Flag --offline has been deprecated` | Remove `--offline`. Supplying `--trusted-root` covers this case. |
 | `if any flags in the group [local-image new-bundle-format] are set none of the others can be` | Remove `--new-bundle-format`. Older guides pair it with `--local-image`, which Cosign v3.0.3 rejects. |
 
 ## Learn more
 
-For background on how Cosign verification works, read [An introduction to Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/). To verify Chainguard Containers in a connected environment, see [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/). For mirroring Chainguard Containers into an internal registry, see the [pull-through guides](/chainguard/containers/chainguard-registry/pull-through-guides/).
+For background on how Cosign verification works, read [An introduction to Cosign](/open-source/sigstore/cosign/an-introduction-to-cosign/). To verify Chainguard Containers in a connected environment, see [Verifying Chainguard Containers and metadata signatures with Cosign](/chainguard/containers/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/). For mirroring Chainguard Containers into an internal registry, see [Mirroring Chainguard Containers with their signatures](/chainguard/containers/registry/mirroring-signed-images/) and the [pull-through guides](/chainguard/containers/chainguard-registry/pull-through-guides/).


### PR DESCRIPTION
Part of the Sigstore bundle migration docs (CON-1109; see #3955 for the hub page). Chainguard is moving image signatures and attestations to Sigstore bundles attached as OCI referrers. Most copy tools follow the image tag and drop referrers, so a mirrored image arrives unsigned and nothing fails until `cosign verify` runs on the other side. The docs had no mirroring guidance at all, and the air-gapped verification guide merged last week asserts that Chainguard keeps signatures under `.sig`/`.att` tags rather than in the referrers graph, which inverts after the cutover.

Every command was run against the bundle-signed canary image, copying into a local `registry:3` with one repository per tool so referrers could not leak between tests; the tools table on the new page is the observed result. Links to the migration guide resolve once #3955 merges.

Key changes:
- **New page** `registry/mirroring-signed-images/`: `oras cp -r` registry-to-registry, the OCI-layout procedure for air gaps, the `--to-distribution-spec v1.1-referrers-tag` option for registries without the Referrers API, a tested tools comparison, and how to check a pull-through cache.
- **Air-gapped guide**: replaces `cosign copy`/`cosign save` with the oras equivalents (`cosign save`/`load` 3.1.3 fails to load bundle referrers; `cosign copy` is deprecated and carried only some bundles), inverts the storage-model note, updates the `cosign tree` example to show referrers, scopes `COSIGN_REPOSITORY` to the legacy layout, and raises the floor to 3.1.1.
- **Pull-through guides** (ECR, Harbor, Artifactory, Nexus, Cloudsmith, Artifact Registry): a "Signatures and attestations" section with the `oras discover`/`cosign verify` check through the cache; ECR additionally notes AWS's referrer sync and that ECR rejects referrer pushes.
- **Network requirements**: the TUF host row now covers Cosign, Kyverno and policy-controller, with a note that verification does not contact Rekor, Fulcio, or the timestamp authority.

Assisted by Claude Fable 5.1