### PR TITLE
Add accessibility labels to tabs shortcodes

### DIFF
--- a/content/chainguard/libraries/introduction/quickstart.md
+++ b/content/chainguard/libraries/introduction/quickstart.md
@@ -4,7 +4,7 @@ linktitle: "Quickstart"
 description: "Learn how to get started with Chainguard Libraries"
 type: "article"
 date: 2025-03-25T00:08:04+00:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-10T12:58:57+00:00
 draft: false
 tags: ["Chainguard Libraries"]
 menu:
@@ -102,7 +102,7 @@ Learn how to set up direct access in the build configuration documentation for
 [Pull tokens](/chainguard/libraries/introduction/access/#creating-pull-tokens-for-libraries)
 are required for authentication. You can [create one using `chainctl`](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token_create/):
 
-{{< tabs >}}
+{{< tabs label="Language ecosystem for creating a pull token" >}}
 
 {{% tab title="Java" %}}
 
@@ -154,7 +154,7 @@ If you [configure upstream fallback](/chainguard/libraries/introduction/overview
 
 Upstream packages served through the Chainguard Repository are subject to configurable policy controls such as cooldown and malware protection. It is strongly recommended that you follow this approach.
 
-{{< tabs >}}
+{{< tabs label="Language ecosystem for build tool configuration" >}}
 
 {{% tab title="Java" %}}
 

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Java project to pull dependencies from Chainguard Libraries"
 date: 2026-07-02T00:00:00+00:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-10T12:58:57+00:00
 tags: ["Chainguard Libraries", "Java"]
 menu:
   docs:
@@ -59,7 +59,7 @@ It can take up to 30 minutes for the fallback and cooldown policies to take effe
 
 Before making any changes, confirm your project builds cleanly against Maven Central.
 
-{{< tabs >}}
+{{< tabs label="Build tool for confirming your baseline build" >}}
 
 {{% tab title="Maven" %}}
 
@@ -132,7 +132,7 @@ The `https://libraries.cgr.dev/java/` endpoint is also the [Chainguard Repositor
 
 ### Direct access
 
-{{< tabs >}}
+{{< tabs label="Build tool for direct access configuration" >}}
 
 {{% tab title="Maven" %}}
 
@@ -286,7 +286,7 @@ If your organization uses a repository manager, configure it to use Chainguard L
 
 Once configured, point your build tool at your repository manager URL. In this setup, the credentials your build tool uses are your repository manager credentials — not a Chainguard pull token.
 
-{{< tabs >}}
+{{< tabs label="Build tool for repository manager configuration" >}}
 
 {{% tab title="Maven" %}}
 
@@ -414,7 +414,7 @@ Replace `https://repo.example.com/java-all/` with your repo manager's virtual re
 
 To force re-resolution from Chainguard, you can clear local caches or clear only relevant artifacts.
 
-{{< tabs >}}
+{{< tabs label="Build tool for refreshing dependencies" >}}
 
 {{% tab title="Maven" %}}
 
@@ -461,7 +461,7 @@ bazel clean --expunge
 
 Run a full build and capture the output.
 
-{{< tabs >}}
+{{< tabs label="Build tool for building the project" >}}
 
 {{% tab title="Maven" %}}
 
@@ -511,7 +511,7 @@ To check whether a specific artifact was built by Chainguard, use `chainctl libr
 
 When upstream fallback is enabled, [packages that aren't built by Chainguard] are subject to Chainguard's security controls.
 
-{{< tabs >}}
+{{< tabs label="Build tool for verifying artifacts" >}}
 
 {{% tab title="Maven" %}}
 

--- a/content/chainguard/libraries/javascript/migration.md
+++ b/content/chainguard/libraries/javascript/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing JavaScript project to pull dependencies from Chainguard Libraries"
 date: 2026-06-01T00:00:00+00:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-10T12:58:57+00:00
 tags: ["Chainguard Libraries", "JavaScript"]
 menu:
   docs:
@@ -104,7 +104,7 @@ one place.
 
 To see all currently active npm configuration and where each value comes from:
 
-{{< tabs >}}
+{{< tabs label="Package manager for auditing registry configuration" >}}
 
 {{% tab title="npm" %}}
 
@@ -315,7 +315,7 @@ Once configured, point your build tool at your repository manager URL. In this
 setup, the credentials your build tool uses are your repository manager
 credentials — not a Chainguard pull token.
 
-{{< tabs >}}
+{{< tabs label="Package manager for repository manager configuration" >}}
 
 {{% tab title="npm or Yarn Classic" %}}
 
@@ -406,7 +406,7 @@ You can update your lockfile in one of two ways. Update the checksums in place t
 keep your existing pinned versions, or regenerate the lockfile if you also want to
 refresh your dependency versions.
 
-{{< tabs >}}
+{{< tabs label="Lockfile update approach" >}}
 
 {{% tab title="Update in place" %}}
 
@@ -478,7 +478,7 @@ Libraries](#packages-not-available-in-chainguard-libraries) for next steps.
 
 ## Step 4: Delete node_modules and clear caches
 
-{{< tabs >}}
+{{< tabs label="Package manager for clearing caches" >}}
 
 {{% tab title="npm" %}}
 
@@ -573,7 +573,7 @@ your repository manager host, not `registry.npmjs.org`.
 
 > Note: When using the `update-hashes` command, some package managers and tool versions default to appending the hash rather than replacing it. In some cases, the resulting dual-hash format fails on install. If you encounter integrity errors, [run the command again](#step-3-update-your-lockfile) and include the `--replace` flag.
 
-{{< tabs >}}
+{{< tabs label="Package manager for reinstalling dependencies" >}}
 
 {{% tab title="npm" %}}
 
@@ -652,7 +652,7 @@ their directory structure.
 
 When upstream fallback is enabled, [packages that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
 
-{{< tabs >}}
+{{< tabs label="Package manager for verifying libraries" >}}
 
 {{% tab title="npm" %}}
 

--- a/content/chainguard/libraries/policies-and-security/build-pinning.md
+++ b/content/chainguard/libraries/policies-and-security/build-pinning.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Build pinning"
 description: "Use build pinning to keep library artifacts stable across rebuilds."
 date: 2026-08-19T08:04:00+00:00
-lastmod: 2026-08-21T15:16:45+00:00
+lastmod: 2026-09-10T12:58:57+00:00
 draft: false
 tags: ["Chainguard Libraries", "Build pinning"]
 menu:
@@ -102,7 +102,7 @@ To move a package from an upstream-sourced artifact to a Chainguard-built one, y
 
 First, force a fresh install:
 
-{{< tabs >}}
+{{< tabs label="Language ecosystem for adopting a Chainguard build" >}}
 
 {{% tab title="Java" %}}
 

--- a/content/chainguard/libraries/python/migration.md
+++ b/content/chainguard/libraries/python/migration.md
@@ -4,7 +4,7 @@ type: "article"
 linktitle: "Migrate to Chainguard"
 description: "How to migrate an existing Python project to pull dependencies from Chainguard Libraries"
 date: 2026-07-14T00:00:00+00:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-10T12:58:57+00:00
 tags: ["Chainguard Libraries", "Python"]
 menu:
   docs:
@@ -45,7 +45,7 @@ It can take up to 30 minutes for fallback policy changes to take effect.
 
 For authentication, you need a pull token or the Python keyring provider.
 
-{{< tabs >}}
+{{< tabs label="Authentication method" >}}
 
 {{% tab title="Pull token" %}}
 
@@ -99,7 +99,7 @@ First, configure authentication using a pull token or the Python keyring provide
 
 Setting pull token credentials in `.netrc` is a common approach for individual work stations. Setting authentication in `pip.conf` is preferred for CI/CD, where you need credentials isolated per project or per pipeline rather than a single shared home-directory file.
 
-{{< tabs >}}
+{{< tabs label="Direct access authentication method" >}}
 
 {{% tab title="Pull token in .netrc" %}}
 
@@ -187,7 +187,7 @@ Next, point your build tool at the Chainguard index.
 
 Note that Chainguard publishes both standard and [remediated Python indexes](/chainguard/libraries/policies-and-security/cve-remediation/). Remediated versions use a `+cgr.N` local-version suffix, and Python package managers treat those as compatible higher-precedence replacements for the base version. In addition, CUDA-enabled Python libraries use separate CUDA-specific indexes such as `https://libraries.cgr.dev/cu128/simple/`, and they are not dependency-complete for NVIDIA toolkit components.  
 
-{{< tabs >}}
+{{< tabs label="Package manager for build tool configuration" >}}
 
 {{% tab title="pip" %}}
 
@@ -253,7 +253,7 @@ If your organization uses a repository manager, configure Chainguard Libraries a
 
 Once configured, point your build tool at your repository manager URL instead of `libraries.cgr.dev` directly. In this setup, the credentials are your repository manager credentials — not a Chainguard pull token.
 
-{{< tabs >}}
+{{< tabs label="Package manager for repository manager setup" >}}
 
 {{% tab title="pip" %}}
 
@@ -314,7 +314,7 @@ Your existing lockfile or hash-pinned `requirements.txt` contains checksums gene
 
 You can update your lockfile in one of two ways. Update the checksums in place to keep your existing pinned versions, or regenerate the lockfile if you also want to refresh your dependency versions.
 
-{{< tabs >}}
+{{< tabs label="Lockfile update approach" >}}
 
 {{% tab title="Update in place" %}}
 
@@ -390,7 +390,7 @@ poetry lock
 Reinstalling after switching indexes can silently reuse a cached artifact
 from your previous index, with no error indicating this happened. To avoid this, clear caches.
 
-{{< tabs >}}
+{{< tabs label="Package manager for clearing caches" >}}
 
 {{% tab title="pip" %}}
 
@@ -428,7 +428,7 @@ docker build --no-cache .
 
 Reinstall dependencies and confirm that the lockfile reflects Chainguard as the source.
 
-{{< tabs >}}
+{{< tabs label="Package manager for reinstalling dependencies" >}}
 
 {{% tab title="pip" %}}
 
@@ -461,7 +461,7 @@ poetry install
 
 After reinstalling, you can use `chainctl` to verify which dependencies are built by Chainguard. When upstream fallback is enabled, [libraries that aren't built by Chainguard](#packages-not-available-in-chainguard-libraries) are subject to Chainguard's security controls.
 
-{{< tabs >}}
+{{< tabs label="Package manager for verifying libraries" >}}
 
 {{% tab title="pip and uv" %}}
 


### PR DESCRIPTION
## What this changes

Adds a descriptive `label` to every `{{< tabs >}}` shortcode across the Libraries docs — 23 tab groups in 6 files. The `tabs` shortcode already renders `label` as an `aria-label` on the `role="tablist"` element (`layouts/shortcodes/tabs.html`); until now none of the tab groups set it, so screen-reader users heard no context for each tab set.

Labels are **task-specific**, not generic, so that repeated tab sets on a single page (for example, the pip/uv/Poetry groups that recur throughout the Python migration guide) are distinguishable rather than identical.

### Files touched

- `content/chainguard/libraries/python/migration.md` (8 groups)
- `content/chainguard/libraries/javascript/migration.md` (6 groups)
- `content/chainguard/libraries/java/migration.md` (6 groups)
- `content/chainguard/libraries/introduction/quickstart.md` (2 groups)
- `content/chainguard/libraries/policies-and-security/build-pinning.md` (1 group)

Content only — no shortcode logic changed.

## Test plan

The change is not visible in a rendered preview (`aria-label` doesn't display on screen); verify it in the DOM or with an accessibility tool.

1. Build and serve the site locally with the pinned Hugo:
   ```
   npm ci
   npm run dev   # or: hugo server
   ```
2. Open an affected page, e.g. `/chainguard/libraries/python/migration/`.
3. Open browser DevTools and inspect each set of tabs. Confirm the wrapper renders as:
   ```html
   <div role="tablist" aria-label="Package manager for reinstalling dependencies">
   ```
   with a label that matches the surrounding task.
4. Confirm repeated tab sets on the same page (pip/uv/Poetry in the Python guide; Maven/Gradle/Bazel in the Java guide) each have a **distinct** `aria-label`.
5. Optional: run an axe / Lighthouse accessibility scan and confirm no "tablist has no accessible name" findings.
6. Confirm no bare tabs remain:
   ```
   grep -rn '{{< tabs >}}' content/    # expect 0 results
   ```

---
Created in collaboration with Claude Code running Claude Opus 4.8 (1M context) on 2026-09-10.
