### PR TITLE
Decouple the MCP index tests from live page titles

### DIFF
--- a/.github/workflows/mcp-image-smoke-test.yaml
+++ b/.github/workflows/mcp-image-smoke-test.yaml
@@ -10,14 +10,20 @@ on:
     paths:
       - scripts/**
       - .github/workflows/mcp-image-smoke-test.yaml
+      # The unit tests parse this bundle, and the nightly refresh PR is the
+      # only change that can break them on real compiler output. Without it
+      # here, a refresh regression stays hidden until some unrelated PR
+      # touches scripts/ and inherits the failure.
+      - static/downloads/chainguard-complete-docs.md
 
 permissions: {}
 
 jobs:
   # Unit tests for the document index (DOCS-181). The smoke test below proves
   # the server starts and answers; it cannot tell whether search returns the
-  # right page. These run against the bundle committed to the repo, so they
-  # catch a parser regression on the real document structure.
+  # right page. These parse the bundle committed to the repo, which the nightly
+  # job refreshes from live content, so they catch a parser regression against
+  # the real document structure.
   unit-test:
     if: github.repository == 'chainguard-dev/edu'
     runs-on: ubuntu-latest

--- a/scripts/test_mcp_server.py
+++ b/scripts/test_mcp_server.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
 """Tests for the AI Docs MCP server's document index.
 
-Regression coverage for the `search_docs` defects Jason Bishay reported in
-Slack (DOCS-181): an exact page title returned nothing, and the queries that
-did match landed on shell comments inside code blocks with empty bodies.
+Regression coverage for the `search_docs` defects reported in Slack
+(DOCS-181): an exact page title returned nothing, and the queries that did
+match landed on shell comments inside code blocks with empty bodies.
 
 Two layers:
 
-* A synthetic bundle that mirrors what `compile_docs.py` emits. Fast,
-  deterministic, and safe to run in CI.
-* The real bundle at `static/downloads/chainguard-complete-docs.md`, using
-  Jason's four verbatim queries. Skipped when the file is absent. A synthetic
-  fixture can only prove the parser handles the shape we think the compiler
-  writes; this layer proves it handles what the compiler actually wrote.
+* A synthetic bundle that mirrors what `compile_docs.py` emits. Deterministic,
+  so this is where every assertion about search behavior lives, including the
+  four verbatim queries from the report.
+* The real bundle at `static/downloads/chainguard-complete-docs.md`. Skipped
+  when the file is absent. A synthetic fixture can only prove the parser
+  handles the shape we think the compiler writes; this layer proves it handles
+  what the compiler actually wrote.
+
+The real-bundle layer asserts structure only, and derives whatever page
+identities it needs from the bundle at run time. That bundle is refreshed
+nightly from live content, so an assertion naming a specific page title or
+path is a time bomb: the Containers reorganization (#3926) retitled one page
+and turned every PR touching `scripts/` red two days later. Keep content
+identities out of this file.
 
 Run with:
     pytest scripts/test_mcp_server.py -v
@@ -27,8 +35,15 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REAL_BUNDLE = REPO_ROOT / "static" / "downloads" / "chainguard-complete-docs.md"
 
-# The page Jason could not retrieve. Ground truth confirmed against the bundle:
-# this title and path appear exactly once.
+# The page that could not be retrieved, as it was titled at the time. The
+# synthetic bundle below is built from these two values, so they are fixture
+# inputs, not ground truth: nothing here has to match a page in content/, and
+# nothing breaks when the real page is retitled or moved. Do not try to keep
+# them in sync — see the module docstring.
+#
+# The title's shape is load-bearing. 'Migrating' and 'Python' are not adjacent
+# in it, which is what makes test_reported_queries_find_the_python_guide a
+# real test of per-term scoring rather than phrase matching. Leave it alone.
 PYTHON_GUIDE_TITLE = "Migrating to Python Chainguard Containers"
 PYTHON_GUIDE_PATH = (
     "chainguard/containers/migration/migration-guides/migrating-python.md"
@@ -121,10 +136,15 @@ def index():
 
 
 @pytest.fixture(scope="module")
-def real_index():
+def real_bundle_text():
     if not REAL_BUNDLE.exists():
         pytest.skip(f"bundle not present at {REAL_BUNDLE}")
-    return mcp_server.ChaguardDocsIndex(REAL_BUNDLE.read_text(encoding="utf-8"))
+    return REAL_BUNDLE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def real_index(real_bundle_text):
+    return mcp_server.ChaguardDocsIndex(real_bundle_text)
 
 
 # --- Section parsing -------------------------------------------------------
@@ -136,7 +156,7 @@ def test_pages_are_keyed_by_their_title(index):
 
 
 def test_comments_inside_code_blocks_do_not_become_sections(index):
-    """The defect behind Jason's results: '# comment' in a fence started a section."""
+    """The defect behind the reported results: '# comment' in a fence started one."""
     assert "Install Composer and set up application" not in index.sections
     assert "Run the server" not in index.sections
 
@@ -177,23 +197,34 @@ def test_exact_page_title_returns_that_page(index):
 
 
 def test_every_result_has_a_body(index):
-    """Jason's hits were all empty, so a relevant match told the caller nothing."""
+    """The reported hits were all empty, so a relevant match told the caller nothing."""
     for query in ["python", PYTHON_GUIDE_TITLE, "multi-stage builds"]:
         for result in index.search(query):
             assert result["snippet"].strip(), f"empty body for query {query!r}"
 
 
-def test_terms_match_without_the_exact_phrase(index):
-    """'migrating python' must find "Migrating to Python …" — the words are never
-    adjacent in the corpus, so whole-phrase substring matching returns nothing."""
-    results = index.search("migrating python")
-    assert PYTHON_GUIDE_TITLE in [r["section"] for r in results]
+@pytest.mark.parametrize(
+    "query",
+    [
+        # The exact title. Returned nothing at all.
+        PYTHON_GUIDE_TITLE,
+        # Terms that are never adjacent in the page, so whole-phrase substring
+        # matching finds nothing.
+        "migrating python",
+        # MCP clients ask in sentences. The tool has to tolerate that.
+        "Give me the migration guide for python",
+        "python migration",
+    ],
+)
+def test_reported_queries_find_the_python_guide(index, query):
+    """The four queries from the Slack report (DOCS-181).
 
-
-def test_natural_language_query_finds_the_page(index):
-    """MCP clients ask in sentences. The tool has to tolerate that."""
-    results = index.search("Give me the migration guide for python")
-    assert PYTHON_GUIDE_TITLE in [r["section"] for r in results]
+    These ran against the real bundle until 2026-09-10. That coupled them to a
+    live page title, and a retitle broke CI on unrelated PRs. The synthetic
+    bundle tests the same search behavior and cannot rot.
+    """
+    sections = [r["section"] for r in index.search(query, max_results=5)]
+    assert PYTHON_GUIDE_TITLE in sections, f"got {sections}"
 
 
 def test_results_carry_the_page_url(index):
@@ -215,23 +246,26 @@ def test_image_results_have_no_url(index):
 @pytest.mark.parametrize(
     "source_path,expected",
     [
-        # Verified against the live site, 2026-09-08: all four return HTTP 200.
+        # These exercise page_url(), a pure function, so a moved page cannot
+        # fail the test — but pick paths that exist so the examples stay
+        # legible. All four verified HTTP 200 on the live site, 2026-09-10.
         (
-            "chainguard/containers/migration/migration-guides/migrating-python.md",
+            "chainguard/containers/migration/migration-guides/python.md",
             "https://edu.chainguard.dev/chainguard/containers/migration"
-            "/migration-guides/migrating-python/",
+            "/migration-guides/python/",
         ),
-        # Branch bundle: 32 pages in the bundle are named _index.md.
+        # Branch bundle: pages named _index.md serve at their directory.
         (
             "platform/administration/cloudevents/_index.md",
             "https://edu.chainguard.dev/platform/administration/cloudevents/",
         ),
-        # Leaf bundle: 76 pages are named index.md, and Hugo serves those at
-        # the directory too. Appending '/index/' 404s.
+        # Leaf bundle: pages named index.md serve at the directory too, so
+        # appending '/index/' 404s. Around one in eight pages is one of these.
         (
-            "chainguard/containers/how-to-use/retrieve-image-sboms/index.md",
-            "https://edu.chainguard.dev/chainguard/containers/how-to-use"
-            "/retrieve-image-sboms/",
+            "chainguard/containers/security-and-compliance"
+            "/retrieve-image-sboms/index.md",
+            "https://edu.chainguard.dev/chainguard/containers"
+            "/security-and-compliance/retrieve-image-sboms/",
         ),
         ("ai-docs-security.md", "https://edu.chainguard.dev/ai-docs-security/"),
         ("_index.md", "https://edu.chainguard.dev/"),
@@ -256,34 +290,116 @@ def test_title_match_outranks_an_incidental_body_mention(index):
 
 
 # --- The real bundle -------------------------------------------------------
+#
+# Structural assertions only. Every ground truth here is read out of the
+# bundle at run time, so nothing in this section names a page. See the module
+# docstring for why.
+
+# Exact-title retrieval is a rate, not a per-page guarantee. Twelve pages are
+# titled with a single common word — 'Cosign', 'Wolfi', 'chainctl', 'Rekor',
+# 'melange' — and lose to the hundreds of pages that mention the term. That is
+# a scoring nuance, not the DOCS-181 defect, and not worth gating a merge on.
+# Measured 2026-09-10 over all 592 distinct titles: 528 ranked first, 580 in
+# the top five, 12 missed.
+TITLE_SAMPLE_SIZE = 40
+MIN_TITLE_HIT_RATE = 0.9
 
 
-@pytest.mark.parametrize(
-    "query",
-    [
-        PYTHON_GUIDE_TITLE,
-        "migrating python",
-        "Give me the migration guide for python",
-        "python migration",
-    ],
-)
-def test_jasons_queries_find_the_python_guide(real_index, query):
-    """The four queries from the Slack report, run against the shipped bundle."""
-    sections = [r["section"] for r in real_index.search(query, max_results=5)]
-    assert PYTHON_GUIDE_TITLE in sections, f"got {sections}"
+def pages_declared_in(bundle_text):
+    """The page titles the compiler declared, read straight out of the raw text.
+
+    Ground truth has to come from somewhere other than the index, or these
+    assertions are tautologies: a mis-parsed bundle still contains whatever
+    junk keys it mis-parsed into, and searching for one of those keys happily
+    returns it. An earlier version of this section sampled titles from the
+    index itself, and the pre-fix parser passed every one of its assertions.
+
+    compile_docs.py writes every page as a '### <title>' line followed by a
+    '_Path: <path>_' line, and nothing else in the bundle carries that pair.
+    This deliberately plain line scan is a second implementation of that rule,
+    independent of ChaguardDocsIndex.
+    """
+    docs_region = bundle_text.split("\n## Container Images\n")[0]
+    lines = docs_region.split("\n")
+    return [
+        lines[i - 1].removeprefix("### ").strip()
+        for i, line in enumerate(lines)
+        if i and line.startswith("_Path: ") and lines[i - 1].startswith("### ")
+    ]
+
+
+def sampled(titles, count=TITLE_SAMPLE_SIZE):
+    """A deterministic sample spread across the bundle rather than the first N.
+
+    Searching every title takes about two minutes: each query scans an 11 MB
+    string. Striding keeps the sample representative without that cost.
+    """
+    stride = max(1, len(titles) // count)
+    return titles[::stride][:count]
+
+
+def test_real_bundle_declares_many_pages(real_bundle_text):
+    """Guards the ground truth itself, so the equality check cannot go vacuous.
+
+    The bundle declared 597 pages (592 distinct titles) on 2026-09-10 and only
+    grows. If the compiler's page signature ever changes, this fails here
+    rather than silently agreeing with an index that found nothing either.
+    """
+    assert len(pages_declared_in(real_bundle_text)) > 300
+
+
+def test_real_bundle_keys_are_the_declared_pages(real_index, real_bundle_text):
+    """Every indexed page is a declared page, and every declared page is indexed.
+
+    The DOCS-181 defect: the old parser started a section at any line
+    beginning '# ', so shell comments inside fenced blocks became keys. Run
+    against the 2026-09-10 bundle it yields 2,295 keys, exactly one of which
+    is a real page, and misses 591 of the 592 declared pages — which is why
+    whole guides were unfindable by their own title.
+
+    This replaced an assertion that no key starts with '#'. That one never
+    caught the defect: the old parser stripped the marker before using the
+    line as a key, so none of its 2,295 keys started with '#' either.
+    """
+    declared = set(pages_declared_in(real_bundle_text))
+    indexed = set(index_page_keys(real_index)) - {"Bundle Usage Guide"}
+
+    # A handful of titles repeat across languages ('Global configuration'
+    # exists for Java, JavaScript and Python), and the index qualifies those
+    # with their source path to keep them distinct.
+    indexed = {
+        name.split(" (")[0] if name.endswith(".md)") else name for name in indexed
+    }
+
+    assert indexed == declared, (
+        f"{len(indexed - declared)} indexed pages are not declared pages, "
+        f"{len(declared - indexed)} declared pages are missing from the index"
+    )
+
+
+def test_real_bundle_exact_titles_return_their_page(real_index, real_bundle_text):
+    """Searching a real page's exact title returns that page.
+
+    The headline reported symptom, measured against titles taken from the raw
+    bundle rather than from the index under test.
+    """
+    titles = sampled(pages_declared_in(real_bundle_text))
+    missed = [
+        title
+        for title in titles
+        if title not in [r["section"] for r in real_index.search(title, max_results=5)]
+    ]
+    hit_rate = 1 - len(missed) / len(titles)
+    assert hit_rate >= MIN_TITLE_HIT_RATE, (
+        f"{hit_rate:.0%} of {len(titles)} exact titles returned their page "
+        f"(want {MIN_TITLE_HIT_RATE:.0%}); missed {missed}"
+    )
 
 
 def test_real_bundle_results_are_never_empty(real_index):
     for query in ["python migration", "chainctl login", "FIPS"]:
         for result in real_index.search(query):
             assert result["snippet"].strip(), f"empty body for query {query!r}"
-
-
-def test_real_bundle_sections_are_document_headings(real_index):
-    """No section key should be a shell comment. 1,992 of them were."""
-    for name in index_page_keys(real_index):
-        assert not name.startswith("#"), f"{name!r} looks like a raw heading"
-    assert PYTHON_GUIDE_TITLE in real_index.sections
 
 
 def index_page_keys(idx):


### PR DESCRIPTION
## What broke

The DOCS-181 test suite asserted a hardcoded page title against
`static/downloads/chainguard-complete-docs.md`:

```python
PYTHON_GUIDE_TITLE = "Migrating to Python Chainguard Containers"
```

The Containers reorganization (#3926) retitled that page to "Migrate a Python
application to Chainguard Containers". The nightly job refreshed the bundle
(#3946), and five tests began failing on every PR touching `scripts/`. The
first one to hit it was an unrelated digestabot base-image bump (#3959) two
days later, which is how automated digest updates land.

Search was never broken. All four reported queries still return the guide —
first for three of them, third for `"python migration"`. Only the expected
string was stale.

## What changed

**The four reported queries move to the synthetic bundle.** It is deterministic, so
they cannot rot, and they test the same search behavior. No coverage is lost.

**The real-bundle layer is now structural only**, and reads its ground truth
out of the raw bundle at run time. Nothing in that section names a page.

**Ground truth comes from the compiler's own page signature.** This is the part
worth reviewing. My first attempt sampled page titles from the index under
test, which is circular — a mis-parsed bundle still contains whatever junk keys
it produced, and searching for one returns it. I reconstructed the pre-fix
parser to check, and it passed all three new assertions. Extracting the
declared `### <title>` + `_Path:` pairs with an independent line scan catches
it cold:

| Against the pre-fix parser | |
|---|---|
| Keys produced | 2,295 |
| Keys that are real pages | 1 |
| Declared pages missing | 591 of 592 |
| `keys_are_the_declared_pages` | fails |
| `exact_titles_return_their_page` | fails (0% vs 90% floor) |

**Retired the assertion that no section key starts with `#`.** It never caught
the defect it named: the old parser stripped the marker before using the line
as a key, so none of its 2,295 keys started with `#` either.

**Exact-title retrieval is asserted as a rate, not per page.** Twelve pages are
titled with a single common word — `Cosign`, `Wolfi`, `chainctl`, `Rekor`,
`melange` — and lose to the hundreds of pages mentioning the term. Measured
over all 592 distinct titles: 528 ranked first, 580 in the top five, 12 missed.
The test samples 40 titles and requires 90%; a parser or scorer regression
takes it to zero. A full sweep would add two minutes.

**Added the bundle to the workflow's `paths` filter.** The nightly refresh PR is
the only change that can break these tests against real compiler output, and it
was the one PR that did not run them. Note the tradeoff: `paths` is
workflow-level, so a structural break now blocks the refresh PR until fixed.
That is the behavior we want post-fix, but it does mean bundle freshness can
stall on a red test.

## Testing

- `pytest scripts/test_mcp_server.py -v` — 26 passed in 9.2s (was 5 failed, 21
  passed). Same test count.
- Falsified against a reconstruction of the pre-fix parser, as above.
- Refreshed the `page_url()` fixtures: the "verified HTTP 200" comment was wrong
  on two of four after the reorg (`migrating-python/` and
  `retrieve-image-sboms/` both 301 now). All four re-verified 200 today.

```release-note
NONE
```


---
Created in collaboration with Claude Code running Opus 5 on 2026-09-10.

