### PR TITLE
Override smol-toml to close CVE-2026-85730, and drop the stale DocSearch hold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,13 +79,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      # Hold DocSearch at v4. v5 adds an "Ask AI" feature (unused here) that
-      # pulls the Vercel AI SDK -> undici, reintroducing 13 alerts, and ships
-      # CSS Level 4 range media queries that Hugo's built-in LibSass can't
-      # parse, breaking the Sass build. Revisit only alongside a Dart Sass
-      # migration. See PR reverting #3773/#3775.
-      - dependency-name: "@docsearch/css"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@docsearch/js"
-        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7536,10 +7536,11 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },
@@ -11943,7 +11944,7 @@
         "markdownlint": "0.41.1",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8",
-        "smol-toml": "1.7.0"
+        "smol-toml": "^1.7.1"
       },
       "dependencies": {
         "js-yaml": {
@@ -13457,9 +13458,9 @@
       }
     },
     "smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true
     },
     "source-map-js": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "overrides": {
     "adm-zip": "^0.6.0",
-    "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41"
+    "@ai-sdk/provider-utils": ">=4.0.33 <4.0.41",
+    "smol-toml": "^1.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Type of change

Dependency and configuration maintenance. No content changes.

### What should this PR do?

Two independent changes to dependency configuration, kept together because both touch how we manage npm dependencies.

1. Close [Dependabot alert 162](https://github.com/chainguard-dev/edu/security/dependabot/162) (CVE-2026-85730, high) by overriding `smol-toml` to `^1.7.1`.
2. Remove the DocSearch major-version hold from `.github/dependabot.yml`, which no longer applies.

### Why are we making this change?

**smol-toml.** Versions through 1.7.0 never exit an internal loop when a value inside an array or inline table is followed by an unterminated comment. `parse('a=[1 #')` pins a CPU core and never returns.

`markdownlint-cli2` 0.23.2, the latest release, pins `smol-toml` to exactly 1.7.0, so no dependency bump clears the alert. `npm audit fix --force` offers only a downgrade to `markdownlint-cli2` 0.21.0. An `overrides` entry lifts the transitive dependency to 1.8.0 instead, matching how this repository already handles `adm-zip`.

The scope is development only, and the only TOML the linter reads is configuration already committed here, so the practical exposure is low. The fix costs two lines.

**DocSearch.** The `ignore` block held `@docsearch/css` and `@docsearch/js` below v5 for two reasons: v5's "Ask AI" feature pulled the Vercel AI SDK and undici, and v5 shipped CSS Level 4 range media queries that Hugo's built-in LibSass could not parse. Both reasons are gone.

- DocSearch already sits at 5.0.4, so the hold guards a major this repository passed weeks ago.
- `undici` does not appear anywhere in the dependency tree. The Vercel AI SDK does, but it arrives through `@scalar/api-reference`, not DocSearch, and the `@ai-sdk/provider-utils` override already bounds it.
- Every `css.Sass` call passes `transpiler dartsass`, backed by the `sass-embedded` dependency and the `link-dart-sass.js` postinstall.

Left alone, the entries would silently block a future v6.

### What are the acceptance criteria?

- `smol-toml` resolves to 1.8.0 or later in `package-lock.json`.
- Dependabot alert 162 closes.
- `npm run lint:markdown` and `npm run build` both pass.
- Dependabot can offer a DocSearch major-version update.

### How should this PR be tested?

No content changed, so there is nothing to proofread. Both changes were verified locally.

**smol-toml.** Confirm the override took effect, then confirm the advisory payload no longer hangs:

```
npm ci
npm ls smol-toml --all          # markdownlint-cli2@0.23.2 -> smol-toml@1.8.0

timeout 6 node --input-type=module -e \
  "import {parse} from './node_modules/smol-toml/dist/index.js'; \
   try { parse('a=[1 #'); console.log('NO THROW'); } \
   catch (e) { console.log('threw', e.constructor.name); }"
```

Before this change that command exits 124, having timed out. After it, it prints `threw TomlError` and exits 0.

End to end through the linter's real configuration path:

```
printf 'a=[1 #' > /tmp/bad.toml
timeout 20 npx markdownlint-cli2 --config /tmp/bad.toml README.md; echo "exit=$?"
```

Exit 2, a configuration error, rather than 124.

TOML configuration still parses correctly. Writing `MD013 = false` into a config file and passing it with `--config` suppresses the line-length rule; setting it to `true` brings the rule back. Full repository lint is clean:

```
npm run lint:markdown           # 0 issues in 429 files
npm audit                       # 4 vulnerabilities -> 2, both pre-existing adm-zip
```

**DocSearch.** `assets/scss/app.scss` imports `@docsearch/css/dist/style.scss` directly, and that file does carry the range media queries the removed comment warned about:

```
grep -o "@media[^{]*width[^{]*" node_modules/@docsearch/css/dist/style.css | head
```

A production build compiles them anyway:

```
npm run build                   # clean, 1687 pages
grep -o "DocSearch" public/main.*.css | wc -l    # 419
```

Dart Sass parses the range syntax and postcss downlevels it to `min-width` and `max-width`, so the DocSearch styles ship as expected, Ask AI screens included.

### Known limitation

The pre-commit hook keeps its own copy of `smol-toml` 1.7.0. `.pre-commit-config.yaml` builds `markdownlint-cli2` from the upstream repository in a pre-commit-managed environment, which honors that package's own pin rather than this override. Only an upstream release can change that, and this is the same split already documented for eslint. The exposure there is a repository-controlled TOML file read by a development-only linter, so I stopped short of working around it.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-10.
