### PR TITLE
Remove unnecessary --parent flags from chainctl examples (DOCS-25)

### DIFF
--- a/content/chainguard/actions/overview.md
+++ b/content/chainguard/actions/overview.md
@@ -37,12 +37,6 @@ To follow this guide, you need:
 - An active Chainguard organization.
 - Owner access on the organization.
 
-The examples in this guide use an `$ORGANIZATION` environment variable to refer to your organization. Set it to the name of your organization before you begin:
-
-```shell
-export ORGANIZATION=<your-organization>
-```
-
 ## Preliminary steps
 
 Before using Chainguard Actions, log in to Chainguard and enable the Chainguard Actions entitlement for your organization.
@@ -56,7 +50,7 @@ chainctl auth login
 Create the Chainguard Actions entitlement to enable access to the hardened actions hosted at `github.com/chainguard-actions`:
 
 ```shell
-chainctl actions entitlements create --parent $ORGANIZATION
+chainctl actions entitlements create
 ```
 
 The output confirms the entitlement:
@@ -68,7 +62,7 @@ Enabled Actions product for org chainguard.edu ($ENTITLEMENT_ID) [entitlement id
 Confirm your entitlement:
 
 ```shell
-chainctl actions entitlements list --parent $ORGANIZATION
+chainctl actions entitlements list
 ```
 
 ```output

--- a/content/chainguard/agent-skills/skills-registry.md
+++ b/content/chainguard/agent-skills/skills-registry.md
@@ -42,7 +42,7 @@ Before your org can push or install skills, create a skills entitlement.
 > **Note**: You must have the `owner` role in your organization to create a skills entitlement and accept the Skills Registry terms of service.
 
 ```shell
-chainctl skills entitlements create --parent $ORG
+chainctl skills entitlements create
 ```
 
 ```output
@@ -274,7 +274,7 @@ Unlike `uninstall`, `delete` removes the skill from the registry for your whole 
 
 | Action | Command |
 | ----- | ----- |
-| Enable the entitlement | `chainctl skills entitlements create --parent $ORG` |
+| Enable the entitlement | `chainctl skills entitlements create` |
 | Accept the registry terms | `chainctl skills accept-terms --group $ORG` |
 | Validate a skill | `chainctl skills validate <name>` |
 | Push a skill | `chainctl skills push <name> --group $ORG --tag <version>` |

--- a/content/chainguard/chainguard-repository/container-policies.md
+++ b/content/chainguard/chainguard-repository/container-policies.md
@@ -67,7 +67,7 @@ Chainguard ships a set of system policies that are available to every organizati
 The `no-eol` policy denies any image whose primary package has reached its end-of-life (EOL) date. An image is allowed when it has no recorded EOL date, or when that date is still in the future. This policy takes no parameters.
 
 ```shell
-chainctl policies enable --policy=no-eol --mode=DRY_RUN --parent=$ORGANIZATION
+chainctl policies enable --policy=no-eol --mode=DRY_RUN
 ```
 
 ### cooldown
@@ -77,7 +77,7 @@ The `cooldown` policy denies images that are newer than a minimum age, measured 
 It accepts one parameter, `days`, an integer number of days an image must exist before it is allowed. The default is `7`, and accepted values range from `1` to `365`.
 
 ```shell
-chainctl policies enable --policy=cooldown --mode=DRY_RUN --param=days=14 --parent=$ORGANIZATION
+chainctl policies enable --policy=cooldown --mode=DRY_RUN --param=days=14
 ```
 
 ### support-window
@@ -87,7 +87,7 @@ The `support-window` policy requires an image's primary package to have a minimu
 It accepts one parameter, `months`, an integer minimum number of months of support. The default is `6`, and accepted values range from `1` to `24`.
 
 ```shell
-chainctl policies enable --policy=support-window --mode=DRY_RUN --param=months=12 --parent=$ORGANIZATION
+chainctl policies enable --policy=support-window --mode=DRY_RUN --param=months=12
 ```
 
 ## Usage
@@ -97,43 +97,43 @@ Policies are managed using `chainctl`. System policies are shipped with the plat
 See which policies are available to your organization:
 
 ```shell
-chainctl policies list --parent=$ORGANIZATION
+chainctl policies list
 ```
 
 Inspect a policy to see its full definition and configurable parameters before enabling it:
 
 ```shell
-chainctl policies describe --policy=$POLICY --parent=$ORGANIZATION
+chainctl policies describe --policy=$POLICY
 ```
 
 See which policies are currently active:
 
 ```shell
-chainctl policies binding list --parent=$ORGANIZATION
+chainctl policies binding list
 ```
 
 Activate a policy in `DRY_RUN` mode. This example activates the "no end-of-life" artifacts policy. Chainguard recommends that you roll out policies using `DRY_RUN` mode first and track for a time to be certain it has the impact you intend before moving to `ENFORCE`.
 
 ```shell
-chainctl policies enable --policy=no-eol --mode=DRY_RUN --parent=$ORGANIZATION
+chainctl policies enable --policy=no-eol --mode=DRY_RUN
 ```
 
 Some policies accept parameters. Use `--param=KEY=VALUE` to supply them:
 
 ```shell
-chainctl policies enable --policy=cooldown --mode=DRY_RUN --param=days=7 --parent=$ORGANIZATION
+chainctl policies enable --policy=cooldown --mode=DRY_RUN --param=days=7
 ```
 
 Promote a policy to `ENFORCE`:
 
 ```shell
-chainctl policies enable --policy=no-eol --mode=ENFORCE --parent=$ORGANIZATION
+chainctl policies enable --policy=no-eol --mode=ENFORCE
 ```
 
 Disable a policy:
 
 ```shell
-chainctl policies disable --policy=no-eol --parent=$ORGANIZATION
+chainctl policies disable --policy=no-eol
 ```
 
 ## Checking whether an image is allowed
@@ -178,7 +178,7 @@ This is distinct from `chainctl policies check`, which evaluates one image again
 List the decisions recorded for your organization:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION
+chainctl policies decision list
 ```
 
 ```output
@@ -192,14 +192,14 @@ chainctl policies decision list --parent=$ORGANIZATION
 Narrow the results with filters. To see only the pulls a policy denied, filter by outcome:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --result=DENIED
+chainctl policies decision list --result=DENIED
 ```
 
 You can also restrict to a single policy, a single mode (`ENFORCE` or `DRY_RUN`), a time window, or a single image, and request JSON for further processing. The `--since` flag takes a number of days with a `d` suffix (for example `7d`), and `--repo` accepts an image as `REPO` or `REPO:TAG`:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --policy=no-eol --mode=ENFORCE --since=30d -o json
-chainctl policies decision list --parent=$ORGANIZATION --repo=nginx:latest
+chainctl policies decision list --policy=no-eol --mode=ENFORCE --since=30d -o json
+chainctl policies decision list --repo=nginx:latest
 ```
 
 Decisions are deduplicated per day, so repeated pulls of the same digest under the same policy and outcome appear once for that day rather than once per pull.
@@ -207,7 +207,7 @@ Decisions are deduplicated per day, so repeated pulls of the same digest under t
 Decisions are listed newest first. The command returns at most 20 decisions by default; use `--limit` to change the page size, which accepts a value from `1` to `100`:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --limit=50
+chainctl policies decision list --limit=50
 ```
 
 ## Example: staging a policy with dry run
@@ -217,19 +217,19 @@ chainctl policies decision list --parent=$ORGANIZATION --limit=50
 First, enable the policy in `DRY_RUN` mode:
 
 ```shell
-chainctl policies enable --policy=no-eol --mode=DRY_RUN --parent=$ORGANIZATION
+chainctl policies enable --policy=no-eol --mode=DRY_RUN
 ```
 
 Let your normal pull traffic flow for a representative period. Then review what the policy denied while in dry run. Use `--since` to limit the review to a recent window, here the last seven days:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --policy=no-eol --mode=DRY_RUN --result=DENIED --since=7d
+chainctl policies decision list --policy=no-eol --mode=DRY_RUN --result=DENIED --since=7d
 ```
 
 Each `DENIED` row is a pull that would have been blocked under `ENFORCE`. Inspect the digests to confirm the policy is catching what you intend and nothing critical to your workloads. If the results look wrong, adjust the policy's parameters or disable it; if they look right, promote the binding to enforcement:
 
 ```shell
-chainctl policies enable --policy=no-eol --mode=ENFORCE --parent=$ORGANIZATION
+chainctl policies enable --policy=no-eol --mode=ENFORCE
 ```
 
 After promoting, keep reviewing decisions to confirm enforcement behaves as expected. The same command now returns `ENFORCE`-mode rows for the pulls the policy is actively blocking.
@@ -248,8 +248,7 @@ Waive a policy for a specific image, identified by digest, with a reason:
 chainctl policies override create \
   --policy=no-eol \
   --artifact_id=sha256:abc123... \
-  --reason="approved exception, ticket OPS-42" \
-  --parent=$ORGANIZATION
+  --reason="approved exception, ticket OPS-42"
 ```
 
 The `--artifact_id` value must be a manifest digest rather than a tag, so the waiver targets one exact artifact. A given policy and image can carry at most one override; to change an existing one, delete it and create it again. For `chainctl` versions 0.2.337 and earlier, use the `--digest` tag instead of `--artifact_id`.
@@ -257,7 +256,7 @@ The `--artifact_id` value must be a manifest digest rather than a tag, so the wa
 Review the active overrides for an organization to see what has been waived, by whom, and why:
 
 ```shell
-chainctl policies override list --parent=$ORGANIZATION
+chainctl policies override list
 ```
 
 ```output
@@ -539,7 +538,7 @@ line 12:5: rego_type_error: undefined ref: input.parameters.day
 **From a manifest.** This is the primary path, and the only one that supports parameters:
 
 ```shell
-chainctl policies custom create --file policy.yaml --parent=$ORGANIZATION
+chainctl policies custom create --file policy.yaml
 ```
 
 **From a raw Rego file.** A shortcut for parameterless policies, where writing a manifest for two fields is more ceremony than it is worth. `--name` and `--resource-type` are both required in this mode; `--description` is optional:
@@ -549,8 +548,7 @@ chainctl policies custom create \
   --expression lts-only.rego \
   --name lts-only \
   --resource-type Repo \
-  --description "Allow only LTS versions of the main package" \
-  --parent=$ORGANIZATION
+  --description "Allow only LTS versions of the main package"
 ```
 
 If a policy declares parameters, it must be created from a manifest — there is no flag equivalent for a parameter schema. In `--file` mode the manifest is authoritative.
@@ -573,14 +571,14 @@ Names are validated on create and update. A name must:
 **Full replacement from a manifest.** The manifest supplants the entire definition — the resulting policy is exactly what the manifest declares, and any field the manifest omits is cleared:
 
 ```shell
-chainctl policies custom update --policy lts-only --file policy.yaml --parent=$ORGANIZATION
+chainctl policies custom update --policy lts-only --file policy.yaml
 ```
 
 **Partial update from flags.** Only the fields you pass are changed; everything else is preserved:
 
 ```shell
 # Rename
-chainctl policies custom update --policy lts-only --name lts-strict --parent=$ORGANIZATION
+chainctl policies custom update --policy lts-only --name lts-strict
 
 # Change just the description
 chainctl policies custom update --policy lts-only --description "Allow only LTS main packages"
@@ -616,7 +614,7 @@ Note: parameter_schemas changed. Existing bindings were not re-validated against
 `chainctl policies custom delete` permanently removes a custom policy:
 
 ```shell
-chainctl policies custom delete --policy lts-only --parent=$ORGANIZATION
+chainctl policies custom delete --policy lts-only
 ```
 
 Only custom policies can be deleted; system policies are managed by Chainguard and are rejected with an error.
@@ -639,7 +637,7 @@ chainctl policies custom delete --policy 720a...c81 --force
 As with `update`, pass `--resource-type` when a name is shared across resource types:
 
 ```shell
-chainctl policies custom delete --policy minimum-version --resource-type Python --parent=$ORGANIZATION
+chainctl policies custom delete --policy minimum-version --resource-type Python
 ```
 
 ### A full custom policy lifecycle
@@ -655,19 +653,19 @@ chainctl policies custom validate --file lts-only.yaml
 Create the policy. This defines it but does not activate it — a policy with no binding has no effect:
 
 ```shell
-chainctl policies custom create --file lts-only.yaml --parent=$ORGANIZATION
+chainctl policies custom create --file lts-only.yaml
 ```
 
 Confirm it is there. Custom policies appear alongside system policies, distinguished by the type column:
 
 ```shell
-chainctl policies list --parent=$ORGANIZATION
+chainctl policies list
 ```
 
 Activate it in `DRY_RUN` mode, which records outcomes without blocking any pulls:
 
 ```shell
-chainctl policies enable --policy=lts-only --mode=DRY_RUN --parent=$ORGANIZATION
+chainctl policies enable --policy=lts-only --mode=DRY_RUN
 ```
 
 Check a specific image against your active policies without waiting for a pull:
@@ -679,26 +677,26 @@ chainctl policies check cgr.dev/$ORGANIZATION/python:latest
 Let your normal pull traffic run for a representative period, then review what the policy would have denied:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --policy=lts-only --result=DENIED --since=7d
+chainctl policies decision list --policy=lts-only --result=DENIED --since=7d
 ```
 
 Each `DENIED` row is a pull that would have been blocked under `ENFORCE`. If the results are as
 expected, promote the binding:
 
 ```shell
-chainctl policies enable --policy=lts-only --mode=ENFORCE --parent=$ORGANIZATION
+chainctl policies enable --policy=lts-only --mode=ENFORCE
 ```
 
 To stop enforcing without deleting the policy, disable the binding. The definition stays in place and can be re-enabled later:
 
 ```shell
-chainctl policies disable --policy=lts-only --parent=$ORGANIZATION
+chainctl policies disable --policy=lts-only
 ```
 
 To remove the policy entirely, along with its bindings and overrides:
 
 ```shell
-chainctl policies custom delete --policy lts-only --parent=$ORGANIZATION
+chainctl policies custom delete --policy lts-only
 ```
 
 ## Custom policies FAQ
@@ -734,7 +732,7 @@ Once you know which policy is responsible, work through the usual causes in this
 To see what a policy has actually decided against real pull traffic, use the decision log rather than `check`:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --policy=lts-only --result=DENIED --since=7d
+chainctl policies decision list --policy=lts-only --result=DENIED --since=7d
 ```
 
 Note that `check` evaluates against your current configuration on demand, while decisions are the historical record of evaluations that already happened during real pulls.
@@ -757,7 +755,7 @@ The [input document reference](#the-input-document) has the full table with type
 To see the shape of the input against a real policy, inspect a system policy, which reads the same document:
 
 ```shell
-chainctl policies describe --policy=no-eol --parent=$ORGANIZATION -o json
+chainctl policies describe --policy=no-eol -o json
 ```
 
 ### Why was my Rego rejected at write time?
@@ -807,8 +805,8 @@ This is the authoritative check. A manifest that validates cleanly will not be r
 The most realistic check is the platform itself. Create the policy and enable it in `DRY_RUN` mode, which records outcomes without blocking any pulls:
 
 ```shell
-chainctl policies custom create --file policy.yaml --parent=$ORGANIZATION
-chainctl policies enable --policy=lts-only --mode=DRY_RUN --parent=$ORGANIZATION
+chainctl policies custom create --file policy.yaml
+chainctl policies enable --policy=lts-only --mode=DRY_RUN
 ```
 
 Check a specific image immediately:
@@ -820,7 +818,7 @@ chainctl policies check cgr.dev/$ORGANIZATION/python:latest
 Then let normal pull traffic run for a representative period and review what the policy would have blocked:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --policy=lts-only --result=DENIED --since=7d
+chainctl policies decision list --policy=lts-only --result=DENIED --since=7d
 ```
 
 Every `DENIED` row is a pull that would have failed under `ENFORCE`. Promote the binding only once those results match your expectations.
@@ -844,7 +842,7 @@ Policy names are unique per resource type, not per organization, so a `Repo` pol
 When a name is ambiguous, `chainctl policies custom update` and `delete` accept `--resource-type` to disambiguate:
 
 ```shell
-chainctl policies custom delete --policy minimum-version --resource-type Python --parent=$ORGANIZATION
+chainctl policies custom delete --policy minimum-version --resource-type Python
 ```
 
 The flag is ignored when `--policy` is given as a UIDP, which already identifies a single policy.
@@ -856,7 +854,7 @@ Updating a policy from a manifest is a full replacement, so a policy can gain, l
 `chainctl` warns you when an update changes the parameter schema. Review your bindings afterwards:
 
 ```shell
-chainctl policies binding list --parent=$ORGANIZATION
+chainctl policies binding list
 ```
 
 Re-enable any binding whose parameters no longer match the policy's schema, supplying the current parameters with `--param=KEY=VALUE`.
@@ -878,7 +876,7 @@ Pulling an image with a client such as Docker involves two separate requests: a 
 To work around this, create an override for each denied digest. First attempt the pull so both decisions are recorded, then use [policy decisions](#policy-decisions) to find the digests that were blocked:
 
 ```shell
-chainctl policies decision list --parent=$ORGANIZATION --result=DENIED
+chainctl policies decision list --result=DENIED
 ```
 
 ```output
@@ -894,14 +892,12 @@ Create an override for each of the denied digests:
 chainctl policies override create \
   --policy=cooldown \
   --artifact_id=sha256:609aeb... \
-  --reason="approved exception, ticket OPS-42" \
-  --parent=$ORGANIZATION
+  --reason="approved exception, ticket OPS-42"
 
 chainctl policies override create \
   --policy=cooldown \
   --artifact_id=sha256:db532b... \
-  --reason="approved exception, ticket OPS-42" \
-  --parent=$ORGANIZATION
+  --reason="approved exception, ticket OPS-42"
 ```
 
 With both digests waived, the pull is allowed. Remember that the override is subject to the cache refresh described above, so allow a short delay before retrying the pull.

--- a/content/chainguard/containers/building-and-modifying/adding-packages.md
+++ b/content/chainguard/containers/building-and-modifying/adding-packages.md
@@ -110,10 +110,10 @@ For the full walkthrough, including how to edit or remove customizations later, 
 1. Open the image's build configuration:
 
     ```shell
-    chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+    chainctl images repos build edit --repo $CONTAINER
     ```
 
-    Replace `$ORGANIZATION` with your organization's name and `$CONTAINER` with the name of the image. If you omit either flag, `chainctl` prompts you to choose.
+    Replace `$CONTAINER` with the name of the image. If you omit it, `chainctl` prompts you to choose. It also prompts for the organization when you have access to more than one; pass `--parent=<organization>` to skip that prompt.
 
 2. `chainctl` opens the configuration in your default text editor. Add the package under `contents.packages`:
 
@@ -166,7 +166,7 @@ Both `apply` and `edit` accept a configuration file, which skips the editor and 
 2. Preview what the file would change, without changing anything:
 
     ```shell
-    chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --dry-run
+    chainctl images repos build apply -f build.yaml --repo $CONTAINER --dry-run
     ```
 
     `--dry-run` prints the diff and exits with a non-zero status if there's anything to apply, which makes it usable as a drift check in a pipeline.
@@ -174,7 +174,7 @@ Both `apply` and `edit` accept a configuration file, which skips the editor and 
 3. Apply the configuration. `--yes` confirms the change without prompting:
 
     ```shell
-    chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+    chainctl images repos build apply -f build.yaml --repo $CONTAINER --yes
     ```
 
 To save the result as a new image, add `--save-as $NEW_NAME`. This works when you target a single repository; it isn't available when you target several at once with repeated `--repo` flags or a wildcard.
@@ -192,7 +192,7 @@ Custom Assembly builds run on Chainguard's infrastructure and normally finish in
 1. Check that the build succeeded:
 
     ```shell
-    chainctl images repos build list --parent $ORGANIZATION --repo $CONTAINER
+    chainctl images repos build list --repo $CONTAINER
     ```
 
     ```output
@@ -249,7 +249,7 @@ Custom Assembly builds run on Chainguard's infrastructure and normally finish in
 A Custom Assembly build reports failure only after it finishes. Retrieve the logs for a build with the `logs` subcommand, which prompts you to pick a build report:
 
 ```shell
-chainctl images repos build logs --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build logs --repo $CONTAINER
 ```
 
 In the Console, click a row on the image's **Builds** tab to open the same logs.

--- a/content/chainguard/containers/building-and-modifying/packages/private-apk-repos/index.md
+++ b/content/chainguard/containers/building-and-modifying/packages/private-apk-repos/index.md
@@ -334,7 +334,7 @@ commands to set environment variables `CHAINGUARD_IDENTITY_ID` for username and
 `CHAINGUARD_TOKEN` for password values and basic authentication use.
 
 ```shell
-chainctl auth pull-token --repository=apk --ttl=2190h --output=env --parent=ORGANIZATION
+chainctl auth pull-token --repository=apk --ttl=2190h --output=env
 ```
 
 ```output
@@ -355,18 +355,17 @@ repository of the parent organization.
   names such as `CHAINGUARD_JAVA_IDENTITY_ID`. Refer to [pull token output
   formats and credential
   names](/platform/chainctl-usage/pull-token-output/) for the full mapping.
-* `--parent=ORGANIZATION`: specify the parent organization for your account as
-  provided when requesting access and replace `ORGANIZATION`.
 
 Each invocation of the command creates a new identity with access rights as a
-pull token.
+pull token. `chainctl` uses your organization automatically when you belong to
+only one; if you have access to more than one, add `--parent=ORGANIZATION`.
 
 Combine the call with `eval` to populate the environment variables directly by
 calling `chainctl`. The following example uses the default TTL value of 30 days,
 which is suitable for regular CI runs:
 
 ```shell
-eval $(chainctl auth pull-token --repository=apk --output env --parent=ORGANIZATION)
+eval $(chainctl auth pull-token --repository=apk --output env)
 ```
 
 The generated pull token can be provided in the `HTTP_AUTH` environment variable

--- a/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
@@ -95,12 +95,10 @@ The API endpoint you can reach for EOL data is [`Registry_ListEolTags`](/platfor
 To follow along, you'll need to know the unique ID path (UIDP) of the container image repository you'd like to retrieve end-of-life data for. You can find this with the following `chainctl` command:
 
 ```shell
-chainctl images repos list --parent $ORGANIZATION -o wide
+chainctl images repos list -o wide
 ```
 
-Replace `$ORGANIZATION` with the name of your organization.
-
-This command will return a table showing the UIDPs of every Chainguard Container the specified organization has access to:
+This command will return a table showing the UIDPs of every Chainguard Container your organization has access to:
 
 ```output
                 ID                 |      REGISTRY       |   REPO   |        BUNDLES        |    TIER

--- a/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/versions.md
@@ -408,7 +408,7 @@ provides lifecycle information about a Chainguard container image's tags.
 For instance, the following snippet retrieves EOL data for the `python` image:
 
 ```sh
-REPO_ID=$(chainctl images repos list --repo=python --parent=${ORGANIZATION} -o json | jq -r '.items[0].id')
+REPO_ID=$(chainctl images repos list --repo=python -o json | jq -r '.items[0].id')
 
 curl -H "Authorization: Bearer $(chainctl auth token)" \
     "https://console-api.enforce.dev/registry/v1/eoltags?uidp.childrenOf=${REPO_ID}" \

--- a/content/chainguard/containers/custom-assembly/custom-assembly-certs.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-certs.md
@@ -49,10 +49,10 @@ With Custom Assembly, you can add custom certificates to your Chainguard Contain
 You can add certificates interactively by running a command like the following:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --repo $CONTAINER
 ```
 
-This will open your default text editor with the current configuration. This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
+This will open your default text editor with the current configuration. This example includes the `--repo` argument, which points to the name of the image you want to customize. If you omit it, `chainctl` prompts you to select a container image interactively. It also prompts for the organization when you have access to more than one; pass `--parent=<organization>` to skip that prompt.
 
 In the editor, add one or more `certificates` sections with your custom certificates. Note that each entry must contain exactly one PEM block (`BEGIN CERTIFICATE` to `END CERTIFICATE`):
 
@@ -95,7 +95,7 @@ This adds (concatenates) the provided inline certificates to the default trustst
 Alternatively, you can use the `--with-certificates` flag to pre-populate the `certificates.additional` section from a selected `.pem` file. Here is an example invocation that uses a `.pem` file named `certificates.pem`:
 
 ```shell
-chainctl images repos build edit --with-certificates certificate.pem --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --with-certificates certificate.pem --repo $CONTAINER
 ```
 
 As with the previous example, this will open up the configuration in your default editor. After saving and closing the editor, `chainctl` will prompt you to confirm the changes before applying them.
@@ -119,7 +119,7 @@ EOF
 Then include this file in the `apply` command by adding the `-f` argument:
 
 ```shell
-chainctl image repos build apply --parent $ORGANIZATION --repo $CONTAINER -f cert.yaml --yes
+chainctl image repos build apply --repo $CONTAINER -f cert.yaml --yes
 ```
 
 This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:

--- a/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-chainctl.md
@@ -35,10 +35,10 @@ For a shorter, task-first version of these procedures, along with how to find a 
 To edit one of your organization's Custom Assembly container images, you can run the `chainctl images repos build edit` command:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --repo $CONTAINER
 ```
 
-This example includes the `--parent` flag, which points to the name of your organization, and the `--repo` argument, which points to the name of the image you want to customize. If you omit these arguments, `chainctl` will prompt you to select your organization and container image interactively.
+This example includes the `--repo` argument, which points to the name of the image you want to customize. If you omit it, `chainctl` prompts you to select a container image interactively. It also prompts for the organization when you have access to more than one; pass `--parent=<organization>` to skip that prompt.
 
 This command will open up a file with your machine's default text editor. This file will contain a structure like the following:
 
@@ -88,7 +88,7 @@ EOF
 Then include this file in the `apply` command by adding the `-f` argument:
 
 ```shell
-chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+chainctl images repos build apply -f build.yaml --repo $CONTAINER --yes
 ```
 
 This command will again ask you to confirm that you want to apply the new configuration. To make this example completely declarative, this example includes `--yes` to automatically confirm the changes:
@@ -118,13 +118,13 @@ This approach is useful in cases where you would prefer to avoid any kind of int
 To see what a configuration file would change without changing anything, replace `--yes` with `--dry-run`. The command prints the same diff and then exits with a non-zero status if there's anything to apply, which makes it usable as a drift check in a pipeline:
 
 ```shell
-chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --dry-run
+chainctl images repos build apply -f build.yaml --repo $CONTAINER --dry-run
 ```
 
 The `edit` subcommand also accepts a configuration file through its own `-f` argument. Passing a file to `edit` skips the text editor but still prompts you to confirm the diff:
 
 ```shell
-chainctl images repos build edit -f build.yaml --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit -f build.yaml --repo $CONTAINER
 ```
 
 ### Using the `--save-as` option
@@ -138,13 +138,13 @@ By creating a new image with Custom Assembly, you can customize the image withou
 To use `chainctl` to create new customized container images with Custom Assembly, you must include the `--save-as` option, like this:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER --save-as $NEW_NAME
+chainctl images repos build edit --repo $CONTAINER --save-as $NEW_NAME
 ```
 
 The following example command creates a new image named `custom-node` after applying the customizations:
 
 ```shell
-chainctl images repos build edit --parent example.com --repo node --save-as custom-node
+chainctl images repos build edit --repo node --save-as custom-node
 ```
 
 Once you run this example, the new container image would be accessible from the following URL:
@@ -156,7 +156,7 @@ cgr.dev/example.com/custom-node
 The `apply` subcommand accepts `--save-as` as well, so you can create a new image without any interactivity:
 
 ```shell
-chainctl images repos build apply -f build.yaml --parent example.com --repo node --save-as custom-node --yes
+chainctl images repos build apply -f build.yaml --repo node --save-as custom-node --yes
 ```
 
 Note that you **must** pass the new image's name when using the `--save-as` option; `chainctl` will return an error if you don't include a new name. Additionally, `--save-as` applies to a single source repository. It isn't available when you target several repositories at once, either by passing `--repo` more than once or by using a wildcard.
@@ -172,7 +172,7 @@ Chainguard Containers include metadata in the form of *annotations*. These annot
 With Custom Assembly, you can add custom annotations to your Chainguard Containers using `chainctl`. The process is the same as the one outlined previously for adding packages. First run a command like the following:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --repo $CONTAINER
 ```
 
 In the text editor, add an `annotations` section to the bottom of the file like the following example:
@@ -202,7 +202,7 @@ Chainguard Containers often come with a set of predefined environment variables.
 You can follow the same procedure for adding custom annotations to add custom environment variables to your Custom Assembly container images. Start by running a `chainctl images repos build edit` command:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --repo $CONTAINER
 ```
 
 In the text editor, add an `environment` section like the following example:
@@ -235,7 +235,7 @@ Custom Assembly lets you replace the default APK repository URLs written to `/et
 To add custom runtime repositories, use `chainctl images repos build edit` as with other customizations:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER
+chainctl images repos build edit --repo $CONTAINER
 ```
 
 In the text editor, add a `runtime_repositories` field under `contents`:
@@ -274,7 +274,7 @@ EOF
 ```
 
 ```shell
-chainctl images repos build apply -f build.yaml --parent $ORGANIZATION --repo $CONTAINER --yes
+chainctl images repos build apply -f build.yaml --repo $CONTAINER --yes
 ```
 
 To remove custom runtime repositories and revert to the default `virtualapk.cgr.dev` URLs, edit the configuration and remove the `runtime_repositories` field entirely.
@@ -300,7 +300,7 @@ Custom Assembly images trust only Chainguard's APK signing key by default. If yo
 To add a runtime key, pass the public key file to the `--with-runtime-keys` option:
 
 ```shell
-chainctl images repos build edit --parent $ORGANIZATION --repo $CONTAINER --with-runtime-keys=key-ee8fa0a3.rsa.pub
+chainctl images repos build edit --repo $CONTAINER --with-runtime-keys=key-ee8fa0a3.rsa.pub
 ```
 
 Each file becomes a key in `/etc/apk/keys` named after the file's basename. The name must match the filename referenced by your repository's APKINDEX signature (`.SIGN.RSA256.<name>`), because `apk` looks up the key by that name during verification. `chainctl` uses filenames verbatim and returns an error if two files share the same basename.
@@ -341,7 +341,7 @@ Runtime keys are validated when the configuration is applied. The following rule
 You can also use the `list` subcommand to retrieve every one of a customized image's builds from the past 24 hours:
 
 ```shell
-chainctl images repos build list --parent $ORGANIZATION --repo $REPO
+chainctl images repos build list --repo $REPO
 ```
 
 This command is useful for quickly determining which builds were successful or failed:
@@ -359,7 +359,7 @@ This command is useful for quickly determining which builds were successful or f
 Lastly, you can also retrieve the logs for a given build with the `logs` subcommand:
 
 ```shell
-chainctl images repos build logs --parent $ORGANIZATION --repo $REPO
+chainctl images repos build logs --repo $REPO
 ```
 
 This command will prompt you to select the build report you want to view. These are organized in reverse chronological order by the time of each build:
@@ -401,7 +401,6 @@ For example, if you wanted to apply custom certs at scale across every repo you 
 
 ```shell
 chainctl images repos build apply \
-  --parent=$ORGANIZATION \
   --repo="kubernetes-*" \
   --with-certificates=ca.pem
 ```

--- a/content/chainguard/containers/custom-assembly/custom-assembly-gitops.md
+++ b/content/chainguard/containers/custom-assembly/custom-assembly-gitops.md
@@ -132,11 +132,10 @@ Then use this variable to create a role binding that grants the custom role to t
 ```shell
 chainctl iam role-bindings create \
   --identity=$IDENTITY_ID \
-  --role=<custom-role> \
-  --parent=<chainguard-org>
+  --role=<custom-role>
 ```
 
-Be sure to replace `<custom-role>` with the name of the custom role you created and `<chainguard-org>` with the name of your Chainguard organization.
+Be sure to replace `<custom-role>` with the name of the custom role you created. If you have access to more than one organization, add `--parent <chainguard-org>` to choose where the role binding is created.
 
 ## Step 3: Note your identity ID
 

--- a/content/chainguard/containers/custom-assembly/overview.md
+++ b/content/chainguard/containers/custom-assembly/overview.md
@@ -90,7 +90,7 @@ This means that in order to use Custom Assembly (including `--save-as`), your ac
 To create such a custom role, you can use the `chainctl iam roles create` command. The following example creates a custom role named `ca-role` with all the same capabilities as the `viewer` role, but with the added `repo.update` and `repo.create` capabilities:
 
 ```shell
-chainctl iam roles create ca-role --parent=$ORGANIZATION --capabilities=repo.create,repo.update,build_report.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
+chainctl iam roles create ca-role --capabilities=repo.create,repo.update,build_report.list,account_associations.list,apk.list,group_invites.list,groups.list,identity.list,identity_providers.list,libraries.artifacts.list,libraries.entitlements.list,manifest.list,manifest.metadata.list,record_signatures.list,registry.entitlements.list,repo.list,roles.list,sboms.list,subscriptions.list,tag.list,version.list,vuln_report.list,vuln_reports.list
 ```
 
 After creating this custom role, you would need to bind it to any identities in your organization that you want to be able to manage Custom Assembly resources. Check out our [Overview of roles and role-bindings in Chainguard](/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings/) to learn more.

--- a/content/chainguard/containers/getting-started/platform-and-infrastructure/gitlab/index.md
+++ b/content/chainguard/containers/getting-started/platform-and-infrastructure/gitlab/index.md
@@ -118,7 +118,6 @@ Create a long-lived pull token for your Chainguard organization:
 
 ```shell
 chainctl auth pull-token create \
-  --parent $ORGANIZATION \
   --name gitlab-pull-token \
   --ttl 8760h
 ```

--- a/content/chainguard/containers/reference/pricing/index.md
+++ b/content/chainguard/containers/reference/pricing/index.md
@@ -65,10 +65,10 @@ Click **Delete** and enter the name of the container image to confirm that you w
 
 You can also use [`chainctl`](/chainguard/chainctl-usage/how-to-install-chainctl/), Chainguard's command-line interface, to change the name of a container image that has already been added to your organization.
 
-To begin, run a command like the following to check whether the container image you want to add is already in your organization. This example checks whether the `php` container image is included in the `example.com` organization:
+To begin, run a command like the following to check whether the container image you want to add is already in your organization. This example checks whether the `php` container image is included:
 
 ```shell
-chainctl images repos list --parent=example.com --repo=php -o json | jq -r '.items[0].id'
+chainctl images repos list --repo=php -o json | jq -r '.items[0].id'
 ```
 
 ```Output
@@ -80,7 +80,7 @@ Note that this example uses [`jq`](https://jqlang.org/), a lightweight command-l
 Knowing that the image is included in the organization, you can rename it. This example renames the `php` container image to `php-new`:
 
 ```shell
-chainctl images repo update php --parent=example.com --name=php-new
+chainctl images repo update php --name=php-new
 ```
 
 ```Output
@@ -94,7 +94,7 @@ After making this change, references to the previous name will no longer work fo
 If you happen to rename an image in error, you can change it back using the same command, swapping the old name and new name:
 
 ```shell
-chainctl images repo update php-new --parent=example.com --name=php
+chainctl images repo update php-new --name=php
 ```
 
 ## Learn more

--- a/content/chainguard/containers/registry/authenticating/index.md
+++ b/content/chainguard/containers/registry/authenticating/index.md
@@ -217,7 +217,6 @@ chainctl iam identities create circleci-identity
 --identity-issuer="https://oidc.circleci.com/org/1234"
 --subject-pattern="org/1234/project/.+$"
 --role=registry.pull
---parent=$ORGANIZATION
 ```
 
 Use the identity created in the above command, shown here in the third `run` section as `5678`, to configure your workflow to install `chainctl` and assume this identity when the workflow runs:
@@ -283,8 +282,7 @@ Next, use `chainctl` to create an [assumed identity](/platform/administration/as
 chainctl iam identities create entraid-identity \
   --identity-issuer="https://login.microsoftonline.com/{tenant}/v2.0" \
   --subject-pattern="^.+$" \ # matches all users from this issuer, adjust to restrict access
-  --role=registry.pull \
-  --parent="$ORGANIZATION"
+  --role=registry.pull
 ```
 
 Use the identity created in the above command, shown here in the third `run` section as `entraid-identity`, to configure your workflow to install `chainctl` and assume this identity when the workflow runs:

--- a/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/artifactory-containers-pull-through/index.md
@@ -93,10 +93,10 @@ To get started, create [a pull token](/chainguard/chainguard-registry/authentica
 To create a pull token with `chainctl`, run the following command:
 
 ```sh
-chainctl auth configure-docker --pull-token --parent <organization>
+chainctl auth configure-docker --pull-token
 ```
 
-Be sure to replace `<organization>` with your organization's name or ID.
+`chainctl` uses your organization automatically when you belong to only one. If you have access to more than one, add `--parent <organization>`, replacing `<organization>` with the name or ID you want to use.
 
 > **Note**: You can find your Chainguard organization's name or ID by running `chainctl iam organizations list -o table`.
 

--- a/content/chainguard/containers/registry/pull-through-guides/artifactory-packages-pull-through/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/artifactory-packages-pull-through/index.md
@@ -34,16 +34,10 @@ In order to complete this tutorial, you need the following:
 
 When configuring an Artifactory remote repository to function as a pull-through cache for packages from a Chainguard private APK repository, the remote repository must authenticate to Chainguard. This section outlines the steps necessary to create a Chainguard pull token and configure the required permissions to access your Chainguard organization's private APK repository:
 
-Set your Chainguard organization identifier as an environment variable. Replace the `example.org` placeholder with your organization's name as it appears in the Chainguard Console:
+Generate a pull token:
 
 ```shell
-export CHAINGUARD_ORG=example.org
-```
-
-Next, generate a pull token:
-
-```shell
-chainctl auth pull-token --repository=apk --parent=${CHAINGUARD_ORG} -o env
+chainctl auth pull-token --repository=apk -o env
 ```
 
 This `chainctl` command's `--repository=apk` flag creates a role binding to bind the pull token identity the `apk.pull` role, enabling the identity to download packages from the private APK repository of the parent organization.
@@ -78,7 +72,7 @@ To set up the remote repository:
 This takes you to a **Basic** configuration tab where you can enter the following details for the remote repository:
 
 * **Repository Key** — This is a name used to identify your remote repository, for example `cg-private`.
-* **URL** — This must be set to `https://apk.cgr.dev/${CHAINGUARD_ORG}`, but with your organization's actual name in place of `${CHAINGUARD_ORG}`. For example, if your organization is named `example` use `https://apk.cgr.dev/example`.
+* **URL** — This must be set to `https://apk.cgr.dev/<organization>`, replacing `<organization>` with your organization's name as it appears in the Chainguard Console. For example, if your organization is named `example` use `https://apk.cgr.dev/example`.
 * **User Name** — This is used by Artifactory to authenticate to Chainguard and access your private APK repository. Use the pull token `Username` value you generated with `chainctl` in the previous step.
 * **Password / Access Token** — This is used along with the user name to authenticate to Chainguard. Here, enter the `Password` value returned by the `chainctl auth pull-token` command in the previous section.
 

--- a/content/chainguard/containers/registry/pull-through-guides/harbor/index.md
+++ b/content/chainguard/containers/registry/pull-through-guides/harbor/index.md
@@ -40,7 +40,7 @@ Before configuring a proxy cache or replication rule, you must create a registry
 If you don't already have one, generate a pull token in your organization:
 
 ```shell
-chainctl auth configure-docker --parent <org-name> --pull-token
+chainctl auth configure-docker --pull-token
 ```
 
 This returns username and password credentials:

--- a/content/chainguard/containers/using-and-deploying/helm-charts/proxy-and-cache/index.md
+++ b/content/chainguard/containers/using-and-deploying/helm-charts/proxy-and-cache/index.md
@@ -25,11 +25,10 @@ In Artifactory's **Administration** module, select **Repositories**, then **Crea
 To determine values for the `User Name` and `Password / Access Token` fields, run the following command:
 
 ```bash
-$ORGANIZATION=YOUR-ORGANIZATION
-chainctl auth configure-docker --pull-token --save --parent $ORGANIZATION
+chainctl auth configure-docker --pull-token --save
 ```
 
-Set $ORGANIZATION to be the organization name you're pulling Helm Charts from. Output will look like this:
+Output will look like this:
 
 ```bash
 To use this pull token in another environment, run this command:
@@ -62,7 +61,7 @@ Finally, we'll create a Kubernetes Secret that will be used to pull the `kafka-i
 ```bash
 JFROG_USERNAME= # Your username, i.e. username@chainguard.dev
 JFROG_TOKEN= # Your token
-ORGANIZATION= # Your organization, i.e. YOUR-ORGANIZATION - you may already have this set from a previous example
+ORGANIZATION= # Your organization, i.e. YOUR-ORGANIZATION
 kubectl create secret docker-registry chainguard-pull-secret \
     --docker-server=chainguard.jfrog.io \
     --docker-username=$JFROG_USERNAME \

--- a/content/chainguard/guardener/dockerfile-migration/_index.md
+++ b/content/chainguard/guardener/dockerfile-migration/_index.md
@@ -35,13 +35,15 @@ You also need the following:
 - Your Dockerfile and build context (source code and other inputs) present on the same machine where you run the migration.
 - A user with permission to accept the Guardener legal terms must accept them for your organization before anyone can run a session. Refer to [IAM access](#iam-access) below for the roles involved.
 
-If you encounter permission errors, check your available groups and verify role bindings:
+If you encounter permission errors, check your available organizations and verify role bindings:
 
 ```shell
 chainctl iam organizations list -o table
 
-chainctl iam role-bindings create --parent <group-id> --identity <identity> --role <role-with-repo.create>
+chainctl iam role-bindings create --identity <identity> --role <role-with-repo.create>
 ```
+
+If you have access to more than one organization or folder, add `--parent <organization>` to the second command to choose where the role binding is created.
 
 ## How it works
 

--- a/content/chainguard/guardener/github/actions-security.md
+++ b/content/chainguard/guardener/github/actions-security.md
@@ -61,11 +61,10 @@ Before you start, make sure that:
 Run `chainctl guardener github migrate create` with the repository to migrate:
 
 ```shell
-chainctl guardener github migrate create <owner>/<repo> \
-  --parent <group-name>
+chainctl guardener github migrate create <owner>/<repo>
 ```
 
-The repository can be given as `owner/repo` shorthand or as a full URL (`https://github.com/owner/repo`); only github.com repositories are supported today. `--parent` is the Chainguard organization that owns the GitHub App installation — if you omit it, `chainctl` prompts you to select one.
+The repository can be given as `owner/repo` shorthand or as a full URL (`https://github.com/owner/repo`); only github.com repositories are supported today. The migration runs under the Chainguard organization that owns the GitHub App installation. `chainctl` selects that organization automatically when only one is available and prompts you when there are several; pass `--parent <group-name>` to name it explicitly.
 
 By default the command waits for the migration to finish (up to 10 minutes, adjustable with `--timeout`) and prints the result:
 

--- a/content/chainguard/libraries/introduction/access.md
+++ b/content/chainguard/libraries/introduction/access.md
@@ -27,8 +27,9 @@ system. This guide explains how to access (download) Chainguard library artifact
 - Ensure you have access to Chainguard Libraries.
     - If you are not a Chainguard user yet, a new Chainguard account must be
 created and you must [add an entitlement to Chainguard Libraries](/chainguard/libraries/introduction/access/#manage-library-entitlements).
-- Confirm the name of your organization so you can use it with the `--parent`
-parameter to specify your organization when running commands with `chainctl`.
+- If you have access to more than one Chainguard organization, confirm the name
+of the one you want to use. You can then pass it to `chainctl` commands with the
+`--parent` parameter.
 
 ### Direct access vs. artifact manager
 
@@ -102,7 +103,7 @@ auth pull-token](/platform/chainctl/chainctl-docs/chainctl_auth_pull-token/)
 command:
 
 ```shell
-chainctl auth pull-token --repository=java --parent=example --ttl=8670h
+chainctl auth pull-token --repository=java --ttl=8670h
 ```
 
 - `--repository=java`: retrieve the token for use with [Chainguard Libraries for
@@ -110,8 +111,6 @@ chainctl auth pull-token --repository=java --parent=example --ttl=8670h
   [Chainguard Libraries for Python](/chainguard/libraries/python/overview/) and
   `javascript` for a token to use [Chainguard Libraries for
   JavaScript](/chainguard/libraries/javascript/overview/).
-- `--parent=example`: specify the parent organization for your account as
-  provided when requesting access to Chainguard Libraries and replace `example`.
 - `--ttl=8670h`: set the duration for the validity of the token, defaults to
   `720h` (equivalent to 30 days), maximum valid value is `8760h` (equivalent to
   365 days), valid unit strings range from nanoseconds to hours and are `ns`,
@@ -120,11 +119,11 @@ chainctl auth pull-token --repository=java --parent=example --ttl=8670h
 Use the optional `--name` flag to supply a meaningful and short name for the
 token, to be able to locate it easier at a later stage.
 
-When omitting the parent parameter, potentially a list of organizations is
-displayed. Use the arrow keys to navigate the selection displayed after the
-question “With which location is the pull token associated?” and select the
-organization that has the entitlement to access Chainguard Libraries for Java.
-Press `/` to filter the list.
+If you belong to a single organization, `chainctl` selects it automatically. If
+you have access to more than one, it asks “With which location is the pull token
+associated?” Use the arrow keys to select the organization that has the
+entitlement to access Chainguard Libraries for Java, and press `/` to filter the
+list. Pass `--parent=<organization>` to skip the prompt.
 
 `chainctl` returns a username and password suitable for basic authentication in
 the response:
@@ -206,7 +205,7 @@ Use the `env` environment output option to create a snippet for a new token
 suitable for integration in a script.
 
 ```shell
-$ chainctl auth pull-token --output env --repository=java --parent=example
+$ chainctl auth pull-token --output env --repository=java
 export CHAINGUARD_JAVA_IDENTITY_ID=<identity-id>
 export CHAINGUARD_JAVA_TOKEN=<pull-token>
 ```
@@ -215,7 +214,7 @@ Combine the call with `eval` to populate the environment variables directly by
 calling `chainctl`:
 
 ```shell
-eval $(chainctl auth pull-token --output env --repository=java --parent=example)
+eval $(chainctl auth pull-token --output env --repository=java)
 ```
 
 Equivalent commands for Python and JavaScript are supported and result in values
@@ -470,7 +469,7 @@ Use the identifier or name of your organization `example` and the `--expired`
 flag to remove all expired pull tokens:
 
 ```shell
-chainctl iam ids rm --expired --parent=example
+chainctl iam ids rm --expired
 ```
 
 <a id="entitlement"></a>
@@ -500,7 +499,7 @@ To update the upstream fallback policy on an existing entitlement, rerun the `cr
 You can delete an ecosystem library entitlement for a specific ecosystem from your organization with [`chainctl libraries entitlements delete`](/platform/chainctl/chainctl-docs/chainctl_libraries_entitlements_create/):
 
 ```shell
-chainctl libraries entitlements delete --ecosystem=JAVASCRIPT --parent=example
+chainctl libraries entitlements delete --ecosystem=JAVASCRIPT
 ```
 
 ### List entitlements

--- a/content/chainguard/libraries/java/build-configuration.md
+++ b/content/chainguard/libraries/java/build-configuration.md
@@ -782,7 +782,7 @@ find ~/.gradle/caches/modules-2/files-2.1/com.google.guava/guava -name "*.jar" |
 Then copy the exact path to the jar and verify it with `chainctl`:
 
 ```bash
-chainctl libraries verify --parent your-org /full/path/to/guava-<version>.jar
+chainctl libraries verify /full/path/to/guava-<version>.jar
 ```
 
 > **Note**: Running `chainctl libraries verify` requires the `libraries.java.pull` permission or the Owner role.

--- a/content/chainguard/libraries/java/migration.md
+++ b/content/chainguard/libraries/java/migration.md
@@ -97,10 +97,10 @@ All dependencies should download from Central and tests should pass. This gives 
 You must be an Owner or have the `libraries.java.pull_token_creator` permission to create a pull token.
 You can [create a pull token in the Chainguard Console](/chainguard/libraries/introduction/access/#creating-pull-tokens-with-the-chainguard-console), or via `chainctl`.
 
-The following command creates the token and populates environment variables directly. Make sure to replace `example.org` with your own Chainguard org name:
+The following command creates the token and populates environment variables directly. If you have access to more than one Chainguard organization, add `--parent=<organization>` to choose which one the token belongs to:
 
 ```shell
-eval $(chainctl auth pull-token --parent=example.org --repository=java --name=my-java-token --output=env)
+eval $(chainctl auth pull-token --repository=java --name=my-java-token --output=env)
 ```
 
 This results in values for the `CHAINGUARD_JAVA_IDENTITY_ID` and `CHAINGUARD_JAVA_TOKEN` variables. The token is named `my-java-token`, with a default expiration of 30 days. To configure the expiration, use the `--ttl` flag.

--- a/content/chainguard/libraries/javascript/build-configuration.md
+++ b/content/chainguard/libraries/javascript/build-configuration.md
@@ -103,9 +103,10 @@ which requires authentication. Where it fetches from depends on your environment
 Authenticating to `libraries.cgr.dev` directly:
 
 - **Logged in locally**: Run the command while authenticated; if you have no
-  other credential it prompts for an organization and authenticates with a
-  [pull token](/chainguard/libraries/introduction/access/#pull-token). Pass
-  `--parent <organization>` to skip the prompt. To avoid the prompt entirely,
+  other credential it authenticates with a
+  [pull token](/chainguard/libraries/introduction/access/#pull-token) for your
+  organization, prompting for one only if you have access to more than one. Pass
+  `--parent <organization>` to skip that prompt. To avoid it entirely,
   scope your login to the libraries registry once with
   `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
   automatically. (`chainctl auth configure-npm` also sets up this
@@ -351,7 +352,7 @@ Before installing packages, you can verify that authentication is configured cor
 npm ping --userconfig .npmrc
 ```
 
-A successful respoonse looks like:
+A successful response looks like:
 
 ```bash
 npm notice PING https://libraries.cgr.dev/javascript/
@@ -516,7 +517,7 @@ pnpm install
 
 As an alternative, you can remove the `node_modules` directory _and_ the `pnpm-lock.yaml` file, then reinstall. This regenerates the lockfile and updates the hashes. Regenerating re-resolves your dependencies, so it can change your pinned versions, and any new versions published within your configured cooldown window will return an error. See [Update your lockfile](/chainguard/libraries/javascript/migration/#step-3-update-your-lockfile).
 
-**Clear pnpmn caches**
+**Clear pnpm caches**
 
 pnpm has three separate layers of cached data. If you encounter stale or corrupted package data, you can clear all of these caches:
 

--- a/content/chainguard/libraries/python/build-configuration.md
+++ b/content/chainguard/libraries/python/build-configuration.md
@@ -200,9 +200,10 @@ configuration](/chainguard/libraries/python/global-configuration/) page.
 which requires authentication. Choose whichever fits your environment:
 
 - **Logged in locally**: Run the command while authenticated; if you have no
-  other credential it prompts for an organization and authenticates with a
-  [pull token](/chainguard/libraries/introduction/access/#pull-token). Pass
-  `--parent <organization>` to skip the prompt. To avoid the prompt entirely,
+  other credential it authenticates with a
+  [pull token](/chainguard/libraries/introduction/access/#pull-token) for your
+  organization, prompting for one only if you have access to more than one. Pass
+  `--parent <organization>` to skip that prompt. To avoid it entirely,
   scope your login to the libraries registry once with
   `chainctl auth login --audience=libraries.cgr.dev` — that session is then used
   automatically.

--- a/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
+++ b/content/platform/administration/assumable-ids/identity-examples/gitlab-identity.md
@@ -36,7 +36,7 @@ Additionally, the Terraform method requires you to have `terraform` installed on
 
 You can create a new Chainguard identity that a GitLab CI/CD pipeline can assume by running the following command.
 
-Be sure to replace `<organization>` with the name of the Chainguard organization you want this identity to be used for. You'll also need to replace `<group_name>` and `<project_name>` with your actual GitLab group and project names.
+Be sure to replace `<group_name>` and `<project_name>` with your actual GitLab group and project names. If you have access to more than one Chainguard organization, add `--parent=<organization>` to choose where the identity is created.
 
 For example, if your GitLab project URL is `https://gitlab.com/mycompany/myproject`, then:
 
@@ -45,7 +45,6 @@ For example, if your GitLab project URL is `https://gitlab.com/mycompany/myproje
 
 ```shell
 chainctl iam identities create cg-gitlab-id \
-  --parent=<organization> \
   --identity-issuer="https://gitlab.com" \
   --subject="project_path:<group_name>/<project_name>:ref_type:branch:ref:main" \
   --audience="https://gitlab.com" \
@@ -82,7 +81,6 @@ For a private instance, pin the signing keys when you create the identity by pas
 
 ```shell
 chainctl iam identities create cg-gitlab-id \
-  --parent=<organization> \
   --identity-issuer="https://<your-gitlab-instance>" \
   --issuer-keys="$(curl -s https://<your-gitlab-instance>/oauth/discovery/keys)" \
   --subject="project_path:<group_name>/<project_name>:ref_type:branch:ref:main" \

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -167,14 +167,13 @@ chainctl auth login
 
 The bootstrap account can use any supported IdP -- for example you may choose to temporarily use a personal Google account. You can leave this account active as a [backup account](/platform/administration/custom-idps/custom-idps/#backup-accounts) or, if you prefer, you can delete the account by removing the role-binding after configuring the custom IdP.
 
-Create a new identity provider using the details you noted from your OIDC application. Replace `<application_client_id>`, `<client_secret>`, and `<issuer_url>` with the values from your own application, and `<organization_id>` with the UIDP of the organization where you want to install the identity provider.
+Create a new identity provider using the details you noted from your OIDC application. Replace `<application_client_id>`, `<client_secret>`, and `<issuer_url>` with the values from your own application.
 
 ```sh
 export NAME=my-sso-identity-provider
 export CLIENT_ID=<application_client_id>
 export CLIENT_SECRET=<client_secret>
 export ISSUER=<issuer_url>
-export ORG=<organization_id>
 chainctl iam identity-provider create \
   --configuration-type=OIDC \
   --oidc-client-id=${CLIENT_ID} \
@@ -182,17 +181,15 @@ chainctl iam identity-provider create \
   --oidc-issuer=${ISSUER} \
   --oidc-additional-scopes=email \
   --oidc-additional-scopes=profile \
-  --parent=${ORG} \
   --default-role=viewer \
   --name=${NAME}
 ```
 
+`chainctl` installs the provider in your organization automatically when you belong to only one. If you have access to more than one, add `--parent=<organization_id>` to choose where it is installed.
+
 The `oidc-issuer`, `oidc-client-id`, and `oidc-issuer-secret` values are required when setting up an OIDC configuration with `chainctl`. You must also include a unique name for each custom IdP account.
 
-Be aware that if you don't include the `--parent` or `--default-role` options in the command, you will be prompted to select these values interactively
-
-- The `--parent` option specifies which Chainguard IAM organization your identity provider will be installed under.
-- The `--default-role` option defines the default role granted to users registering with this identity provider. The previous example specifies the `viewer` role, but depending on your needs you might choose `editor` or `owner`. For more information, refer to the [IAM and Security section](#iam-and-security).
+If you omit the `--default-role` option, `chainctl` prompts you to select a value interactively. This option defines the default role granted to users registering with this identity provider. The previous example specifies the `viewer` role, but depending on your needs you might choose `editor` or `owner`. For more information, refer to the [IAM and Security section](#iam-and-security).
 
 You can retrieve a list of all your Chainguard organizations — along with their UIDPs — with the following command.
 

--- a/content/platform/administration/custom-idps/idp-providers/keycloak/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/keycloak/index.md
@@ -63,7 +63,7 @@ To configure Chainguard, make a note of the following details from your Keycloak
 * **Client Secret**: This can be found on the **Credentials** tab of the Keycloak Client.
 * **Issuer**: Your **Issuer** URL is defined by the following pattern `https://<keycloak_server_address>/realms/<realm_name>`
 
-You will also need the UIDP for the Chainguard organization under which you want to install the identity provider.  Your selection won’t affect how your users authenticate but will have implications on who has permission to modify the SSO configuration.
+If you belong to more than one Chainguard organization, you will also need the UIDP of the one under which you want to install the identity provider. Your selection won’t affect how your users authenticate but will have implications on who has permission to modify the SSO configuration.
 
 You can retrieve a list of all the Chainguard organizations you belong to — along with their UIDPs — with the following command.
 
@@ -80,13 +80,12 @@ chainctl iam organizations ls -o table
 
 Note down the `ID` value for your chosen organization.
 
-With this information in hand, create a new identity provider with the following commands. Replace `<client_id>` and `<client_secret>` with the values from your Keycloak client, `<keycloak_server_address>` and `<realm_name>` with your Keycloak server address and realm, and `<organization_id>` with the organization ID you just noted.
+With this information in hand, create a new identity provider with the following commands. Replace `<client_id>` and `<client_secret>` with the values from your Keycloak client, and `<keycloak_server_address>` and `<realm_name>` with your Keycloak server address and realm.
 
 ```sh
 export NAME=keycloak-idp
 export CLIENT_ID=<client_id>
 export CLIENT_SECRET=<client_secret>
-export ORG=<organization_id>
 export ISSUER="https://<keycloak_server_address>/realms/<realm_name>"
 chainctl iam identity-provider create \
   --configuration-type=OIDC \
@@ -95,10 +94,11 @@ chainctl iam identity-provider create \
   --oidc-issuer=${ISSUER} \
   --oidc-additional-scopes=email \
   --oidc-additional-scopes=profile \
-  --parent=${ORG} \
   --default-role=viewer \
   --name=${NAME}
 ```
+
+`chainctl` installs the provider in your organization automatically when you belong to only one. If you have access to more than one, add `--parent=<organization_id>` to choose where it is installed.
 
 Note the `--default-role` option. This defines the default role granted to users registering with this identity provider. This example specifies the `viewer` role, but depending on your needs you might choose `editor` or `owner`. If you don't include this option, you'll be prompted to specify the role interactively. For more information, refer to the [IAM and security section](/chainguard/administration/custom-idps/custom-idps/#iam-and-security) of our Introduction to Custom Identity Providers in Chainguard tutorial.
 

--- a/content/platform/administration/custom-idps/idp-providers/ms-entra-id/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/ms-entra-id/index.md
@@ -72,7 +72,7 @@ chainctl auth login
 
 Note that you can use this bootstrap account as a [backup account](/chainguard/administration/custom-idps/custom-idps/#backup-accounts) — that is, an account you can use to log in if you ever lose access to your primary account. However, if you prefer to remove this role-binding after configuring the custom IdP, you can do so.
 
-You also need the ID of the Chainguard organization where you want to install the identity provider. Your choice doesn't affect how your users authenticate, but it does determine who has permission to modify the SSO configuration.
+If you belong to more than one Chainguard organization, you also need the ID of the one where you want to install the identity provider. Your choice doesn't affect how your users authenticate, but it does determine who has permission to modify the SSO configuration.
 
 To retrieve a list of the Chainguard organizations you belong to, along with their IDs, run the following command.
 
@@ -89,18 +89,16 @@ chainctl iam organizations ls -o table
 
 Note the `ID` value for your chosen organization.
 
-With this information in hand, create a new identity provider with the following commands. Replace `<application_client_id>`, `<client_secret>`, and `<directory_tenant_id>` with the values from your Entra ID application, and `<organization_id>` with the organization ID you just noted.
+With this information in hand, create a new identity provider with the following commands. Replace `<application_client_id>`, `<client_secret>`, and `<directory_tenant_id>` with the values from your Entra ID application.
 
 ```sh
 export NAME=entra-id
 export CLIENT_ID=<application_client_id>
 export CLIENT_SECRET=<client_secret>
-export ORG=<organization_id>
 export TENANT_ID=<directory_tenant_id>
 export ISSUER="https://login.microsoftonline.com/${TENANT_ID}/v2.0"
 chainctl iam identity-providers create \
   --configuration-type=OIDC \
-  --parent=${ORG} \
   --name=${NAME} \
   --oidc-issuer=${ISSUER} \
   --oidc-client-id=${CLIENT_ID} \
@@ -109,6 +107,8 @@ chainctl iam identity-providers create \
   --oidc-additional-scopes=profile \
   --default-role=viewer
 ```
+
+`chainctl` installs the provider in your organization automatically when you belong to only one. If you have access to more than one, add `--parent=<organization_id>` to choose where it is installed.
 
 {{< note >}}
 Customers using Azure Government Cloud should set `ISSUER="https://login.microsoftonline.us/${TENANT_ID}/v2.0"` instead.

--- a/content/platform/administration/custom-idps/idp-providers/ping-id/index.md
+++ b/content/platform/administration/custom-idps/idp-providers/ping-id/index.md
@@ -84,7 +84,7 @@ To configure Chainguard make a note of the following settings from your Ping app
 * Client Secret
 * Issuer URL
 
-You will also need the UIDP for the Chainguard organization under which you want to install the identity provider.  Your selection won’t affect how your users authenticate but will have implications on who has permission to modify the SSO configuration.
+If you belong to more than one Chainguard organization, you will also need the UIDP of the one under which you want to install the identity provider. Your selection won’t affect how your users authenticate but will have implications on who has permission to modify the SSO configuration.
 
 You can retrieve a list of all the Chainguard organizations you belong to — along with their UIDPs — with the following command.
 
@@ -101,14 +101,13 @@ chainctl iam organizations ls -o table
 
 Note down the `ID` value for your chosen organization.
 
-With this information in hand, create a new identity provider with the following commands. Replace `<client_id>`, `<client_secret>`, and `<issuer_url>` with the values from your Ping Identity application, and `<organization_id>` with the organization ID you just noted.
+With this information in hand, create a new identity provider with the following commands. Replace `<client_id>`, `<client_secret>`, and `<issuer_url>` with the values from your Ping Identity application.
 
 ```sh
 export NAME=ping-id
 export CLIENT_ID=<client_id>
 export CLIENT_SECRET=<client_secret>
 export ISSUER=<issuer_url>
-export ORG=<organization_id>
 chainctl iam identity-provider create \
   --configuration-type=OIDC \
   --oidc-client-id=${CLIENT_ID} \
@@ -116,10 +115,11 @@ chainctl iam identity-provider create \
   --oidc-issuer=${ISSUER} \
   --oidc-additional-scopes=email \
   --oidc-additional-scopes=profile \
-  --parent=${ORG} \
   --default-role=viewer \
   --name=${NAME}
 ```
+
+`chainctl` installs the provider in your organization automatically when you belong to only one. If you have access to more than one, add `--parent=<organization_id>` to choose where it is installed.
 
 Note the `--default-role` option. This defines the default role granted to users registering with this identity provider. This example specifies the `viewer` role, but depending on your needs you might choose `editor` or `owner`. If you don't include this option, you'll be prompted to specify the role interactively. For more information, refer to the [IAM and security section](/chainguard/administration/custom-idps/custom-idps/#iam-and-security) of our Introduction to Custom Identity Providers in Chainguard tutorial.
 

--- a/content/platform/administration/custom-idps/scim-provisioning/ms-entra-id-scim/index.md
+++ b/content/platform/administration/custom-idps/scim-provisioning/ms-entra-id-scim/index.md
@@ -49,24 +49,22 @@ chainctl auth login
 
 This bootstrap account can serve as a [backup account](/platform/administration/custom-idps/custom-idps/#backup-accounts) if you ever lose access to your primary login.
 
-Retrieve the ID of the organization where you want to install the identity provider.
+If you belong to more than one organization, retrieve the ID of the one where you want to install the identity provider.
 
 ```sh
 chainctl iam organizations ls -o table
 ```
 
-Then create the identity provider. Replace `<application_client_id>`, `<client_secret>`, and `<directory_tenant_id>` with the three values from the previous step, and `<organization_id>` with the organization ID you just retrieved.
+Then create the identity provider. Replace `<application_client_id>`, `<client_secret>`, and `<directory_tenant_id>` with the three values from the previous step.
 
 ```sh
 export NAME=entra-id
 export CLIENT_ID=<application_client_id>
 export CLIENT_SECRET=<client_secret>
-export ORG=<organization_id>
 export TENANT_ID=<directory_tenant_id>
 export ISSUER="https://login.microsoftonline.com/${TENANT_ID}/v2.0"
 chainctl iam identity-providers create \
   --configuration-type=OIDC \
-  --parent=${ORG} \
   --name=${NAME} \
   --oidc-issuer=${ISSUER} \
   --oidc-client-id=${CLIENT_ID} \
@@ -77,6 +75,8 @@ chainctl iam identity-providers create \
   --default-role=viewer \
   -o json
 ```
+
+`chainctl` installs the provider in your organization automatically when you belong to only one. If you have access to more than one, add `--parent=<organization_id>` to choose where it is installed.
 
 This `create` command includes two options specific to SCIM linking with Entra ID:
 

--- a/content/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
+++ b/content/platform/administration/iam-organizations/roles-role-bindings/roles-role-bindings.md
@@ -42,9 +42,9 @@ The `owner`, `editor`, and `viewer` roles are useful for user profiles that requ
 
 Every role has at least one of four capabilities (`create`, `list`, `update`, `delete`) in relation to at least one Chainguard resource. For example, the `apk.pull` role only grants `list` access for APK packages and groups. This means identities with this role can pull the organization's APK packages and retrieve information about the organization, but won't have general access to the organization's [Chainguard registry](/chainguard/containers/registry/overview/) access.
 
-Chainguard's built-in default roles serve as building blocks and can be complemented with custom roles for specific use cases. Custom roles can extend or restrict default role capabilities, and offer or your organization greater flexibility, allowing you to mix default and custom roles based on your team's structure and needs.
+Chainguard's built-in default roles serve as building blocks and can be complemented with custom roles for specific use cases. Custom roles can extend or restrict default role capabilities, and offer your organization greater flexibility, allowing you to mix default and custom roles based on your team's structure and needs.
 
-When assigning a role, do so based on the principle of least privilege; assign only the role needed for the indentity's function. For example, CI systems should have a role like `registry.pull`, not `editor`.
+When assigning a role, do so based on the principle of least privilege; assign only the role needed for the identity's function. For example, CI systems should have a role like `registry.pull`, not `editor`.
 
 You can run `chainctl iam roles list` to retrieve a list of all the roles available to your organization and review each of their specific capabilities. This command will list all the built-in roles as well as any custom roles created for your organization. The next section outlines how to create and manage such custom roles.
 
@@ -65,18 +65,20 @@ chainctl iam roles create my-role
 
 After running this command, an interactive prompt will appear asking you to select what capabilities the new role should have and the organization under which the role should be created.
 
-You can avoid using the interactive prompt by including the `--parent` and `--capabilities` options in this command.
+You can avoid the interactive prompt by including the `--capabilities` option in this command.
 
 ```sh
-chainctl iam roles create new-role --parent=example-org --capabilities=roles.list
+chainctl iam roles create new-role --capabilities=roles.list
 ```
 
-This example creates a new role named `new-role` under an organization named `example-org`. The new role will only have the ability to list roles in the organization.
+This example creates a new role named `new-role` in your organization. The new role can only list roles in the organization.
+
+`chainctl` selects your organization automatically when you belong to only one. If you have access to more than one organization or folder, it prompts you to choose; add `--parent=<organization>` to skip the prompt.
 
 You can also grant multiple capabilities to a custom role with one command, as in this example:
 
 ```sh
-chainctl iam roles create puller-role --parent=example-org --capabilities=apk.list,groups.list,manifest.list,manifest.metadata.list,record_signatures.list,repo.list,sboms.list,tag.list,vuln.list
+chainctl iam roles create puller-role --capabilities=apk.list,groups.list,manifest.list,manifest.metadata.list,record_signatures.list,repo.list,sboms.list,tag.list,vuln.list
 ```
 
 This example command creates a role named `puller-role` that has the following capabilities:
@@ -140,13 +142,13 @@ chainctl iam role-bindings create
 
 This will start an interactive prompt where you can enter the appropriate details for this new role-binding. Specifically, you'll be prompted to specify the identity to bind, the role you want the identity bound to, and the organization that the role-binding should belong to.
 
-To avoid using the interactive prompt, you can add these details to the command by including the `--identity`, `--role`, and `--parent` options.
+To avoid the interactive prompt, add these details to the command by including the `--identity` and `--role` options.
 
 ```sh
-chainctl iam role-bindings create --identity=example-id --role=viewer --parent=example-org
+chainctl iam role-bindings create --identity=example-id --role=viewer
 ```
 
-This example creates a role-binding for the identity `example-id` with the built-in `viewer` role in an organization named `example-org`.
+This example creates a role-binding for the identity `example-id` with the built-in `viewer` role in your organization.
 
 Note that in order to use the `--identity` option like this, you will need to know the given identity's UIDP. You can find a list of all your identities' UIDPs by running `chainctl iam identities ls`. The identities' UIDPs will appear in the resulting `ID` column.
 

--- a/content/platform/chainctl-usage/chainctl-iam.md
+++ b/content/platform/chainctl-usage/chainctl-iam.md
@@ -70,7 +70,7 @@ This command can also create, delete, and update your organization's identity pr
 To tell chainctl about your OIDC provider and enable users to start using it, use create:
 
 ```shell
-chainctl iam identity-provider create --name=google --parent=example \
+chainctl iam identity-provider create --name=google \
 --oidc-issuer=https://accounts.google.com \
 --oidc-client-id=foo \
 --oidc-client-secret=bar \

--- a/content/platform/chainctl-usage/chainctl-images.md
+++ b/content/platform/chainctl-usage/chainctl-images.md
@@ -26,7 +26,7 @@ When you want to know which Chainguard Containers are available to your account,
 chainctl images list
 ```
 
-This will respond with a list of organizations available to your account. For most users, there will only be one entry in the list. This example shows an account with access to several organizations within the fictional MyCorp.
+If your account has access to more than one organization, the command asks which one to list images from. Most users belong to a single organization, and `chainctl` selects it automatically. This example shows an account with access to several organizations within the fictional MyCorp.
 
 ```output
     Which organization would you like to list images from?
@@ -80,16 +80,16 @@ chainctl images repos list
 
 To examine the history of an image tag in chainctl, like when it was updated and the associated digests for each update, use `chainctl images history`. This will also return information such as how many times a variant has been built and for which platforms, along with the time and digests for each.
 
-To examine the history without using the menu shown earlier, use the optional `--parent=$ORGANIZATION` switch to designate your org, like this:
+Pass the image and tag directly to skip the menu shown earlier:
 
 ```shell
-chainctl images history $IMAGE:$TAG --parent=$ORGANIZATION
+chainctl images history $IMAGE:$TAG
 ```
 
 For example, let's find the history of one of the `python` image variants from our previous list, `3.12.7`. So we enter:
 
 ```shell
-chainctl images history python:3.12.7 --parent=chainguard.edu
+chainctl images history python:3.12.7
 ```
 
 The returned list is longer than is shown here, but here's a useful excerpt:
@@ -131,7 +131,7 @@ The command returns a reverse-chronological history of when a specific tag was u
 When the release version tag is not provided, the command will present you with a menu that lets you select which tag you'd like to obtain the history for. For example, if you enter:
 
 ```shell
-chainctl images history python --parent=chainguard.edu
+chainctl images history python
 ```
 
 This will present you with a menu like this:

--- a/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
+++ b/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
@@ -100,10 +100,10 @@ This list contains columns with data about each image release, like the Pull URL
 
 ### Review container image history using chainctl
 
-To examine the history of an image using `chainctl`, enter this, replacing ORGANIZATION with your organization:
+To examine the history of an image using `chainctl`, enter this:
 
 ```sh
-chainctl image history kubectl:latest --parent=ORGANIZATION
+chainctl image history kubectl:latest
 ```
 
 This will return a reverse-chronological history of when a specific tag was update to point to a new manifest digest. This list can be long. Here's an excerpt:


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
**Documentation Update**
- Removes 109 unnecessary `--parent` flags from `chainctl` examples across 35 pages
- Trims surrounding prose to a short note for readers in more than one organization
- Keeps the flag where it is genuinely required, and in CI/automation examples
- Cleans up variables and placeholder prose the removals orphaned

### What should this PR do?
<!-- Does this PR resolve an issue? Please include a reference to it. -->
resolves https://linear.app/chainguard/issue/DOCS-25/audit-remove-parent-flag-from-chainctl-commands

Removes the `--parent` flag from `chainctl` examples outside the chainctl reference section, where it is optional for the single-organization case that describes most customers.

### Why are we making this change?
<!-- What larger problem does this PR address? -->
Most customers belong to exactly one organization, so `--parent` is noise in nearly every example — it lengthens commands and implies a required argument. `chainctl`'s interactive group resolver short-circuits when exactly one candidate is available, printing `One organization available, selecting <org>` and continuing without prompting. That path needs no TTY, so the shortened examples still work in scripts.

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
- `chainctl iam external-group-role-mappings list` keeps `--parent`; it is the only command that marks the flag required, and omitting it errors with `required flag(s) "parent" not set`
- CI and automation examples keep the flag, since a prompt would break a pipeline: `automating-chainctl.md`, the Custom Assembly GitOps workflow, and the GitHub identity workflow
- Commands that resolve against groups rather than organizations (`iam roles create`, `iam role-bindings create`, `images repos build *`) carry a note that they prompt when the org contains folders
- No organization variable is left set but unused, and no prose refers to a placeholder that no longer appears in its command

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

1. Check the preview link and ensure the changes look right
2. Run a shortened command as a single-org user and confirm it auto-selects, for example `chainctl policies binding list` or `chainctl auth pull-token list`
3. Confirm `chainctl iam external-group-role-mappings list` still fails without `--parent` in `platform/administration/custom-idps/grant-roles-from-groups/`
4. Review the Custom Assembly pages (`containers/custom-assembly/`) and the new `containers/building-and-modifying/adding-packages.md`, which carry the largest share of the removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)
