### PR TITLE
Document the Available in organization label on the Tags tab

### DIFF
--- a/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL grace period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2026-08-07T13:38:58+00:00
+lastmod: 2026-09-11T13:07:32+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -34,9 +34,9 @@ Chainguard's EOL grace period gives customers access to new builds of container 
 
 > **Note**: Chainguard is **not** able to offer any exceptions to the 6 month limit for the EOL grace period.
 
-You will be able to find the end date of a given container image version's grace period in the [Chainguard Console](https://console.chainguard.dev/). From the **Organization Images** tab, select an image. You'll be taken to that container image's **Versions** page, and the end date of each grace period will be listed under the respective version:
+You will be able to find the end date of a given container image version's grace period in the [Chainguard Console](https://console.chainguard.dev/). From the **Organization Images** tab, select an image. You'll be taken to that container image's **Tags** tab, and the end date of each grace period will be listed under the respective version:
 
-<center><img src="eol-gp-2.png" alt="Screenshot of a portion of an image's 'Versions' tab, showing the Grace Period end dates for several versions of the image." style="width:300px;"></center>
+<center><img src="eol-gp-2.png" alt="Screenshot of a portion of an image's 'Tags' tab, showing the Grace Period end dates for several versions of the image." style="width:300px;"></center>
 <br />
 
 As of this writing, a container image must meet four key requirements to be eligible for coverage under the EOL grace period:

--- a/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
+++ b/content/chainguard/containers/concepts/lifecycle-and-eol/eol-grace-period/index.md
@@ -4,7 +4,7 @@ linktitle: "EOL grace period"
 type: "article"
 description: "Understanding Chainguard's end-of-life (EOL) grace period."
 date: 2025-05-14T08:49:31+00:00
-lastmod: 2026-09-11T13:07:32+00:00
+lastmod: 2026-09-11T13:15:07+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -34,7 +34,7 @@ Chainguard's EOL grace period gives customers access to new builds of container 
 
 > **Note**: Chainguard is **not** able to offer any exceptions to the 6 month limit for the EOL grace period.
 
-You will be able to find the end date of a given container image version's grace period in the [Chainguard Console](https://console.chainguard.dev/). From the **Organization Images** tab, select an image. You'll be taken to that container image's **Tags** tab, and the end date of each grace period will be listed under the respective version:
+You will be able to find the end date of a given container image version's grace period in the [Chainguard Console](https://console.chainguard.dev/). From **Images**, select an image on the **Organization** tab. You'll be taken to that container image's **Tags** tab, and the end date of each grace period will be listed under the respective version:
 
 <center><img src="eol-gp-2.png" alt="Screenshot of a portion of an image's 'Tags' tab, showing the Grace Period end dates for several versions of the image." style="width:300px;"></center>
 <br />

--- a/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-visualizations/index.md
+++ b/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-visualizations/index.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "Getting started with the CVE visualization feature."
 date: 2024-12-19T11:07:52+02:00
-lastmod: 2026-08-21T12:27:26+00:00
+lastmod: 2026-09-11T13:07:32+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -62,13 +62,13 @@ The **Historical CVEs** tab has two boxes. The first box is labeled **Resolved C
 
 You can find this same comparison data when navigating to a specific container image in either the **Browse Containers** section or in your **Organization Containers**. After navigating to either of these sections, click on or search for any image you like.
 
-By default, you will be taken to the container image's **Versions** tab. Click on the **Comparison** tab at the far right. There, you'll be presented with the same comparison information found in the **Reports** section. At the top are some control menus, allowing you to select the date range for the comparison and, if available, the alternative you'd like to compare the Chainguard Container against.
+By default, you will be taken to the container image's **Tags** tab. Click on the **Comparison** tab at the far right. There, you'll be presented with the same comparison information found in the **Reports** section. At the top are some control menus, allowing you to select the date range for the comparison and, if available, the alternative you'd like to compare the Chainguard Container against.
 
 ## Accessing CVE visualizations in the Containers Directory
 
 Similar to the CVE reports found in the **Browse Containers** and **Organization Containers** section of the Chainguard Console, you can find CVE reports for every one of Chainguard's container images in the [Containers Directory](https://images.chainguard.dev/).
 
-After navigating to the directory, click on or search for any container image you like. Again, you will be taken to the image's **Versions** tab by default. Click on the **Comparison** tab at the right to view the CVE Comparison data.
+After navigating to the directory, click on or search for any container image you like. Again, you will be taken to the image's **Tags** tab by default. Click on the **Comparison** tab at the right to view the CVE Comparison data.
 
 ## Limitations
 

--- a/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-visualizations/index.md
+++ b/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-visualizations/index.md
@@ -10,7 +10,7 @@ aliases:
 type: "article"
 description: "Getting started with the CVE visualization feature."
 date: 2024-12-19T11:07:52+02:00
-lastmod: 2026-09-11T13:07:32+00:00
+lastmod: 2026-09-11T13:15:07+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -60,13 +60,13 @@ The **Historical CVEs** tab has two boxes. The first box is labeled **Resolved C
 
 ### Comparison tab
 
-You can find this same comparison data when navigating to a specific container image in either the **Browse Containers** section or in your **Organization Containers**. After navigating to either of these sections, click on or search for any image you like.
+You can find this same comparison data when navigating to a specific container image from **Images**, on either the **Organization** or **Chainguard catalog** tab. After navigating to either tab, click on or search for any image you like.
 
 By default, you will be taken to the container image's **Tags** tab. Click on the **Comparison** tab at the far right. There, you'll be presented with the same comparison information found in the **Reports** section. At the top are some control menus, allowing you to select the date range for the comparison and, if available, the alternative you'd like to compare the Chainguard Container against.
 
 ## Accessing CVE visualizations in the Containers Directory
 
-Similar to the CVE reports found in the **Browse Containers** and **Organization Containers** section of the Chainguard Console, you can find CVE reports for every one of Chainguard's container images in the [Containers Directory](https://images.chainguard.dev/).
+Similar to the CVE reports found under **Images** in the Chainguard Console, you can find CVE reports for every one of Chainguard's container images in the [Containers Directory](https://images.chainguard.dev/).
 
 After navigating to the directory, click on or search for any container image you like. Again, you will be taken to the image's **Tags** tab by default. Click on the **Comparison** tab at the right to view the CVE Comparison data.
 

--- a/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
+++ b/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-11T12:56:16+00:00
+lastmod: 2026-09-11T13:20:58+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -28,7 +28,7 @@ Browsing an image in the Directory doesn't mean your organization can pull it. F
 
 ## Find your situation
 
-Several of these situations turn on a label in the Console. On a container's **Tags** tab, the **Pull URL** column shows the pull URL for a version when your organization can pull that version. When it can't, the column shows a status label instead, and that label describes the repository rather than the version on that row. A label where you expected a URL means the version isn't available to you.
+You identify several of these situations from a label in the Console. On a container's **Tags** tab, the **Pull URL** column shows the pull URL for a version when your organization can pull that version. When it can't, the column shows a status label instead, and that label describes the repository rather than the version on that row. A label where you expected a URL means the version isn't available to you.
 
 Look up the image in the Directory, then match what you see to the following table:
 
@@ -83,13 +83,13 @@ When a container is added to an organization, only its actively supported tags c
 
 Those records outlive the images they name. A superseded tag can still appear in the Console with a pull URL beside it, and still be listed by `chainctl`, while pulling it returns `MANIFEST_UNKNOWN`. A tag's presence in a listing is a weaker signal than whether that tag is still active.
 
-So check against the active tags, which uses your default organization:
+So check against the active tags. This command reads your default organization:
 
 ```shell
 chainctl images tags list --repo=$IMAGE --active-only
 ```
 
-If the tag you want isn't in that output, treat it as unavailable, whatever the Directory or the Console shows for it. Drop `--active-only` to see everything your organization holds, including tags that are no longer maintained and may no longer pull.
+If the tag you want isn't in that output, treat it as unavailable, whatever the Directory or the Console shows for it. Drop `--active-only` to see everything your organization holds, including tags that are no longer maintained. Some of those will fail to pull.
 
 What you do next depends on which kind of tag it is:
 

--- a/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
+++ b/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-11T12:55:37+00:00
+lastmod: 2026-09-11T12:56:16+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -66,7 +66,7 @@ Some requests can't be fulfilled. Chainguard won't build resources from propriet
 
 The **Pull URL** column reads **Available in organization**, but `docker pull` on that exact tag returns not found.
 
-That label is about the repository: your organization has the container, and at least one of its versions is active. It says nothing about the version on the row where you read it. Because the column shows a pull URL whenever a version is pullable, a label in that position means this version has no pull URL for you. Two things cause that.
+That label is about the repository: your organization has the container, and at least one of its versions is active. It says nothing about the version on the row where you read it. The column falls back to a label only when it has no pull URL to show for that row, so seeing one tells you this version has no pull URL for you. Two things cause that.
 
 ### The container is still syncing
 

--- a/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
+++ b/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-11T12:52:54+00:00
+lastmod: 2026-09-11T12:55:37+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -79,15 +79,17 @@ Either message means the sync hasn't finished. Wait a few minutes, then reload t
 
 ### The tag isn't in your organization's registry
 
-When a container is added to an organization, only its actively supported tags come across. An organization that has carried a container for a long time also holds older tags, which were the supported ones when they arrived. What your registry contains therefore depends on when the container was added and how long you've had it, and the tag you want may not be there at all.
+When a container is added to an organization, only its actively supported tags come across. An organization that has carried a container for a long time also holds records of older tags, from back when those tags were the supported ones.
 
-List the tags your organization has, which uses your default organization:
+Those records outlive the images they name. A superseded tag can still appear in the Console with a pull URL beside it, and still be listed by `chainctl`, while pulling it returns `MANIFEST_UNKNOWN`. A tag's presence in a listing is a weaker signal than whether that tag is still active.
+
+So check against the active tags, which uses your default organization:
 
 ```shell
-chainctl images tags list --repo=$IMAGE
+chainctl images tags list --repo=$IMAGE --active-only
 ```
 
-Add `--active-only` to drop tags that are no longer maintained. Compare the result against the tags on the container's page in the Directory. A tag that appears in the Directory but not in this output isn't in your registry.
+If the tag you want isn't in that output, treat it as unavailable, whatever the Directory or the Console shows for it. Drop `--active-only` to see everything your organization holds, including tags that are no longer maintained and may no longer pull.
 
 What you do next depends on which kind of tag it is:
 

--- a/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
+++ b/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-11T12:37:43+00:00
+lastmod: 2026-09-11T12:52:54+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -79,9 +79,9 @@ Either message means the sync hasn't finished. Wait a few minutes, then reload t
 
 ### The tag isn't in your organization's registry
 
-Your organization receives the actively supported tags for a container, not every tag the Directory lists for it. A tag that has been superseded within its version stream was never synced to your registry, and it won't arrive on its own.
+When a container is added to an organization, only its actively supported tags come across. An organization that has carried a container for a long time also holds older tags, which were the supported ones when they arrived. What your registry contains therefore depends on when the container was added and how long you've had it, and the tag you want may not be there at all.
 
-List the tags your organization actually has:
+List the tags your organization has, which uses your default organization:
 
 ```shell
 chainctl images tags list --repo=$IMAGE

--- a/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
+++ b/content/chainguard/containers/troubleshooting/container-version-troubleshooting.md
@@ -6,7 +6,7 @@ aliases:
 type: "article"
 description: "When a container or version isn't available to you: how to identify which situation you're in, what to do about each, and when to open a support request."
 date: 2026-09-02T00:00:00+00:00
-lastmod: 2026-09-02T16:34:51+00:00
+lastmod: 2026-09-11T12:37:43+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -17,7 +17,7 @@ weight: 010
 toc: true
 ---
 
-You need a container image, or a particular version of one, and you can't pull it. The right next step depends on why it's missing, and there are four distinct reasons. This guide helps you tell them apart and resolve each one.
+You need a container image, or a particular version of one, and you can't pull it. The right next step depends on why it's missing, and there are five distinct reasons. This guide helps you tell them apart and resolve each one.
 
 First, distinguish between the public container registry and your organization's registry:
 
@@ -28,12 +28,15 @@ Browsing an image in the Directory doesn't mean your organization can pull it. F
 
 ## Find your situation
 
+Several of these situations turn on a label in the Console. On a container's **Tags** tab, the **Pull URL** column shows the pull URL for a version when your organization can pull that version. When it can't, the column shows a status label instead, and that label describes the repository rather than the version on that row. A label where you expected a URL means the version isn't available to you.
+
 Look up the image in the Directory, then match what you see to the following table:
 
 | What you find | Go to |
 | --- | --- |
 | The image is in the Directory, but the Console shows **Unavailable to organization**, **Add to organization for access**, or **Request image for access** | [The container isn't in your organization's catalog](#the-container-isnt-in-your-organizations-catalog) |
 | The image isn't in the Directory at all | [Chainguard doesn't build the container](#chainguard-doesnt-build-the-container) |
+| The version is listed and the Console shows **Available in organization**, but the pull fails | [The version shows as available but won't pull](#the-version-shows-as-available-but-wont-pull) |
 | The image is in the Directory, but not the version you need | [The version you need isn't listed](#the-version-you-need-isnt-listed) |
 | The version is listed with a pause icon, an **Expired** status, or an end-of-life date that has passed | [The version has reached end of life](#the-version-has-reached-end-of-life) |
 
@@ -58,6 +61,38 @@ If the image doesn't appear in the Directory, Chainguard doesn't build it yet, a
 Submitting requests requires membership in a [verified organization](/platform/administration/iam-organizations/verified-orgs/). The form asks for the resource type, the resource's existing public name, and a link to the upstream open source repository.
 
 Some requests can't be fulfilled. Chainguard won't build resources from proprietary code, won't build projects that no longer receive upstream updates, and can't always produce a FIPS variant. For the full process and the current limitations, see [Requesting new Chainguard resources](/chainguard/containers/reference/request-resources/).
+
+## The version shows as available but won't pull
+
+The **Pull URL** column reads **Available in organization**, but `docker pull` on that exact tag returns not found.
+
+That label is about the repository: your organization has the container, and at least one of its versions is active. It says nothing about the version on the row where you read it. Because the column shows a pull URL whenever a version is pullable, a label in that position means this version has no pull URL for you. Two things cause that.
+
+### The container is still syncing
+
+When a container is added to an organization, its tags take a few minutes to reach that organization's registry. While the sync runs, an upload icon appears alongside the filters above the version list. Hover over it to see which stage it's in:
+
+* `A new update for this image has been queued and will begin shortly.`
+* `This image is currently being updated with newly built tags.`
+
+Either message means the sync hasn't finished. Wait a few minutes, then reload the page. The icon appears only in your organization's view of the container, so not seeing it doesn't rule out a sync in progress. If the icon persists for more than a couple of hours, treat this as the next case.
+
+### The tag isn't in your organization's registry
+
+Your organization receives the actively supported tags for a container, not every tag the Directory lists for it. A tag that has been superseded within its version stream was never synced to your registry, and it won't arrive on its own.
+
+List the tags your organization actually has:
+
+```shell
+chainctl images tags list --repo=$IMAGE
+```
+
+Add `--active-only` to drop tags that are no longer maintained. Compare the result against the tags on the container's page in the Directory. A tag that appears in the Directory but not in this output isn't in your registry.
+
+What you do next depends on which kind of tag it is:
+
+* The tag is actively maintained and missing from your organization. [Open a support request](#open-a-support-request).
+* The tag has been superseded within its stream. Use that stream's current tag, or pin the exact build you need by digest, as described in [The version you need isn't listed](#the-version-you-need-isnt-listed).
 
 ## The version you need isn't listed
 
@@ -96,7 +131,7 @@ A digest identifies one build and keeps identifying that same build even after t
 
 When the Directory shows a tag as actively maintained but that tag isn't available in your organization's registry, that's worth reporting. [Open a support request](#open-a-support-request) with the image name and the exact tag.
 
-The Console makes the same point from the image's **Versions** tab. Below the tag table is a link labeled **Looking for older tags?**, which explains that only actively supported tags are available when an image is added to your organization, and asks you to try a supported tag before opening a request.
+The Console makes the same point from the image's **Tags** tab. Below the tag table is a link labeled **Looking for older tags?**, which explains that only actively supported tags are available when an image is added to your organization, and asks you to try a supported tag before opening a request.
 
 ## The version has reached end of life
 

--- a/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
+++ b/content/platform/chainctl-usage/comparing-chainctl-to-console/index.md
@@ -6,7 +6,7 @@ linktitle: "chainctl vs Console"
 type: "article"
 description: "Learn when to use chainctl CLI versus Chainguard Console for managing container security, with practical examples and use case recommendations"
 date: 2025-06-02T11:07:52+02:00
-lastmod: 2026-08-03T18:16:45+00:00
+lastmod: 2026-09-11T13:15:07+00:00
 draft: false
 tags: ["chainctl", "Chainguard Console"]
 images: []
@@ -42,8 +42,8 @@ To find the images available to you in the Console, do this:
 1. Open the [Console](https://console.chainguard.dev)
 ![Screenshot showing the Overview page in the Console.](console-overview.png)
 
-1. On the Overview page that opens, click **Organization Images** in the sidebar.
-![Screenshot showing the Organization Images page in the Console, which lists all of the images available along with data for each including Status, Latest tag, Pull URL, and when the image was last updated.](console-org-images.png)
+1. On the Overview page that opens, click **Images** in the sidebar.
+![Screenshot showing the Images page in the Console, which lists all of the images available along with data for each including Status, Latest tag, Pull URL, and when the image was last updated.](console-org-images.png)
 
 ### Find available images with chainctl
 

--- a/content/platform/console/images-directory/index.md
+++ b/content/platform/console/images-directory/index.md
@@ -7,7 +7,7 @@ aliases:
 type: "article"
 description: "A walkthrough of the Chainguard Console."
 date: 2024-02-23T11:07:52+02:00
-lastmod: 2026-09-02T13:31:42+00:00
+lastmod: 2026-09-11T12:38:00+00:00
 draft: false
 tags: ["Chainguard Containers"]
 images: []
@@ -84,7 +84,7 @@ Each container image details page has several tabs that provide information abou
 The default page for each image is the **Tags** tab which contains information about the version tags available for each image. This contains a table with columns:
 
 * **Tag**: this column lists each tag available for the container image
-* **Pull URL**: the URL you can use to download each version of the Container. In the Console, Production Containers you don't already have access to will show a message reading `Add to organization` if you're logged in under an organization with access to Production Containers; if you're logged in under an organization without entitlement, the message reads `Request image` or `Request chart`. For what to do about either message, refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
+* **Pull URL**: the URL you can use to download a version, shown when your organization can pull that version. When it can't, this column shows a status label in place of the URL: **Add to organization for access**, **Add image for access**, **Request image for access**, **Available in organization**, **Unavailable to organization**, or **Contact us for access**. These labels describe the repository rather than the version on that row, so **Available in organization** can appear beside a version you can't pull. For what each label means and what to do about it, refer to [Troubleshoot container and version availability](/chainguard/containers/troubleshooting/container-version-troubleshooting/).
 * **Compressed size**: the size of the image, in megabytes
 * **Last changed**: when each version of the image was last updated
 


### PR DESCRIPTION
Three users reported the same thing in August: the Console showed **Available in organization** beside a container version, `docker pull` returned not found, and one opened a support ticket titled "A version appears at images.chainguard.dev but is missing in our org." Kapa fielded six threads from five unique users on this and cited no edu page in four of them, because no page described what they were looking at. This adds the missing entry point.

## What the label actually means

`PullUrlCell` renders the real pull URL whenever a row has one. A status label is only the fallback for a row with **no** URL, and `sourceAccessType` is a single repository-level value handed identically to every row. So **Available in organization** in the Pull URL column means *this version has no pull URL for you, and the repository is in your organization* — phrased as reassurance, in a column whose heading implies a per-row statement.

The page now states that once, near the decision table, which disambiguates all six labels the column can show rather than only this one.

## Changes

**`container-version-troubleshooting.md`** — adds a decision-table row for the badge plus a failing pull, and a section covering the two causes: a sync still in flight, and a tag that isn't in the organization's registry. Quotes both sync-state tooltips verbatim from source. Corrects one stale "Versions tab" reference from DOCS-155; the tab routes to `/versions` but its visible label is **Tags**.

**`platform/console/images-directory/index.md`** — the Pull URL bullet listed two of the six labels, both truncated, and attributed `Request chart` to the container table. That string belongs to `helm/HelmTable.tsx`, and this page already covers Helm charts in its own section.

**Three more pages naming the same tab** — `cve-visualizations` (twice) and `eol-grace-period` sent readers to a **Versions** tab or page. Corrected to **Tags**, including one image alt text, so the screen reader description matches what is on screen.

**The Console's real names for the images views** — three pages sent readers to an **Organization Images** tab or sidebar item, and to a **Browse Containers** section. Neither string exists in `console-ui`'s translation catalog. The left navigation item is **Images**, and its two tabs are **Organization** and **Chainguard catalog** (`Navigation.tsx`, and the images route definitions in `ConsoleRouter.tsx`).

Rather than fix only the reported labels, I checked every bolded UI label on the edited pages against `app/src/locales/en.po`, which holds every translatable string the Console ships. That turned up more staleness in `cve-visualizations`' description of the **Reports** page — the **Compare Containers** and **Historical CVEs** tab names are absent from the catalog entirely, and two chart headings differ in case. **Those are left untouched here.** Correcting them means describing a UI as it is now, which needs eyes on the Console rather than a string lookup, and guessing would trade one wrong label for another. Tracked in [DOCS-195](https://linear.app/chainguard/issue/DOCS-195/audit-console-ui-labels-across-the-docs-against-console-uis), which carries the full scan: 103 label candidates across 21 Console pages, ranked, with the triage caveats.

## A finding that changed the recommendation

The draft told readers to check `chainctl images tags list --repo=$IMAGE`. Testing against a live organization killed that:

```
$ docker pull cgr.dev/$ORGANIZATION/ingress-nginx-controller:1.10.0
Error response from daemon: unknown: {"errors":[{"code":"MANIFEST_UNKNOWN","message":"Unknown manifest"}]}
```

For that tag, `chainctl` lists it with a digest, the Console renders a real pull URL on its row, and the registry refuses to serve the manifest. Tag records outlive the images they name, so the full listing overstates what an organization can pull — the check would have sent some readers away believing a tag was available when it is not. The page now recommends `--active-only` and says plainly that a tag's presence in a listing is a weaker signal than whether the tag is still active.

Tested across six superseded tags spanning 175 days to nearly three years old (`1.8.2`, `1.9.0`, `1.10.0`, `1.11.0`, `1.12.0`, `1.13.8`). All six are listed by `chainctl`; none pull. The page still says a superseded tag *can* fail rather than *will*, because six tags in one organization is a pattern and not a guarantee.

Worth flagging beyond this PR: any availability or freshness tooling that treats "the tag is listed" as "the tag is pullable" has the same hole. Why the manifest is gone while the record remains is not established, and the page does not speculate about it.

## Verification

* Console behavior read from `chainguard-dev/console-ui` at `main` on 2026-09-11: `getAccessType` in `self-service.ts`, `PullUrlCell` in `Versions.tsx`, tab titles in `ImageDetails.tsx`.
* `chainctl images tags list` exercised against a live organization. `--active-only` confirmed as a strict subset, keeping the current patch of each maintained stream plus the floating tags.
* `--public` returns `Error: no repositories found` for a paid-catalog image, so no public-versus-organization tag comparison is offered.
* `hugo --gc --minify` exit 0, 1689 pages. All 14 in-page anchors resolve against the built HTML.

Two claims in DOCS-193's original description did not survive source review and are corrected in comments on the issue: `IN_ORG_ADD_IMAGE` is not a distinct access state from `IN_ORG` (both come from `inOrg && hasActive`; the only discriminator is whether the viewing user holds the `ADD_IMAGE` capability), and `showInactive: true` suppresses the label on inactive rows rather than showing it.

Resolves DOCS-193.


---
Created in collaboration with Claude Code running Opus 5 on 2026-09-11.




