### PR TITLE
Document how to change or reset your MFA device

### DIFF
--- a/content/get-started/_index.md
+++ b/content/get-started/_index.md
@@ -3,7 +3,7 @@ title: "Get started"
 lead: "New to Chainguard? Start here. Orient yourself, then pick the path that matches what you're trying to do — build with containers, build with libraries, evaluate trust, or migrate an organization."
 description: "Get started with Chainguard: orient yourself, then choose your path — build with containers, build with libraries, evaluate trust, or migrate an existing organization."
 date: 2026-06-09T08:48:23+00:00
-lastmod: 2026-09-01T16:18:53+00:00
+lastmod: 2026-09-11T14:07:20+00:00
 draft: false
 images: []
 weight: 1
@@ -33,4 +33,4 @@ Already convinced and ready to move existing workloads over? Step through the [m
 
 ## Get help
 
-Stuck on something the documentation doesn't cover? [Get support](/get-started/get-support/) explains what to check first, which channel handles your kind of request, and how to open a support ticket when you need one.
+Stuck on something the documentation doesn't cover? [Get support](/get-started/get-support/) explains what to check first, which channel handles your kind of request, and how to open a support ticket when you need one. If you're locked out because you replaced or lost the device running your authenticator app, start with [Change or reset your MFA device](/get-started/mfa-devices/).

--- a/content/get-started/get-support.md
+++ b/content/get-started/get-support.md
@@ -5,7 +5,7 @@ lead: "Chainguard offers several ways to get help, and the right one depends on 
 description: "Get help from Chainguard: check the self-service options, choose the right support channel, and open a ticket a support engineer can act on."
 type: "article"
 date: 2026-09-01T00:00:00+00:00
-lastmod: 2026-09-02T13:31:42+00:00
+lastmod: 2026-09-11T14:07:20+00:00
 draft: false
 tags: ["Getting Started"]
 images: []
@@ -31,7 +31,7 @@ The support portal handles most requests, but it isn't the only route, and for s
 
 - **You have a problem with a Chainguard product or with your organization's configuration.** Open a ticket in the [support portal](https://support.chainguard.dev/).
 
-- **You can't sign in to the Chainguard Console, and your organization uses single sign-on — for example, you've lost the device running your authenticator app.** Contact the identity provider administrator at your own organization. When you sign in through Google, GitHub, GitLab, or a corporate identity provider, that provider manages your multi-factor authentication, and Chainguard can neither see it nor change it.
+- **You need to move your multi-factor authentication to a new device, or you've lost the device running your authenticator app.** Where you make that change depends on how you sign in, and for most sign-in paths it isn't Chainguard that manages your MFA. See [Change or reset your MFA device](/get-started/mfa-devices/).
 
 - **You can't sign in at all, so you can't reach the portal.** Email [support@chainguard.dev](mailto:support@chainguard.dev).
 

--- a/content/get-started/mfa-devices.md
+++ b/content/get-started/mfa-devices.md
@@ -1,0 +1,74 @@
+---
+title: "Change or reset your MFA device"
+linktitle: "Change your MFA device"
+lead: "Moving your authenticator to a new phone, switching authenticator apps, or replacing a lost device all depend on the same thing: how you sign in to the Chainguard Console. This guide explains how to tell which sign-in path you use and where to change your MFA for each one."
+description: "Change or reset the multi-factor authentication device you use with the Chainguard Console, whether your MFA is managed by your identity provider or by Chainguard."
+type: "article"
+date: 2026-09-11T00:00:00+00:00
+lastmod: 2026-09-11T00:00:00+00:00
+draft: false
+tags: ["Getting Started"]
+images: []
+weight: 020
+toc: true
+---
+
+You might need to move your multi-factor authentication (MFA, also called 2FA) to a new device because you replaced your phone, changed authenticator apps, or lost the device that generates your codes. Where you make that change depends on how you sign in to the Chainguard Console, because Chainguard manages MFA for only one of the sign-in paths.
+
+## Find out which sign-in path you use
+
+The Console login screen has buttons for Google, GitHub, and GitLab, along with a single field that accepts either your email address or your organization name. What you click or enter there determines your path:
+
+- **You click Google, GitHub, or GitLab.** That provider signs you in.
+
+- **You enter your organization name.** The Console sends you to the identity provider your organization registered.
+
+- **You enter an email address whose domain your organization registered with a custom identity provider.** The Console sends you to that provider.
+
+- **You enter any other email address.** The Console sends you to Chainguard's email and password sign-in, which always asks for a one-time code from an authenticator app.
+
+Your path determines who holds your MFA enrollment:
+
+| How you sign in | Who manages your MFA | Where to change it |
+| --- | --- | --- |
+| Google, GitHub, or GitLab | That provider | Your account settings with that provider |
+| Your organization's identity provider, such as Okta, Microsoft Entra ID, Ping Identity, or Keycloak | Your own organization | Your internal IT or identity provider administrator |
+| Your email address and a password | Chainguard | A support ticket opened by an Owner in your organization |
+
+## Change MFA managed by an identity provider
+
+When you sign in through Google, GitHub, GitLab, or your organization's own identity provider, that provider holds your MFA enrollment. Chainguard can neither see it nor change it, so Chainguard support can't reset it for you. Change it where you manage the rest of that account:
+
+- **Google.** See [Turn on 2-Step Verification](https://support.google.com/accounts/answer/185839) in Google Account Help.
+
+- **GitHub.** See [Configuring two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication).
+
+- **GitLab.** See [Two-factor authentication](https://docs.gitlab.com/user/profile/account/two_factor_authentication/).
+
+- **A corporate identity provider.** Contact your internal IT helpdesk or the administrator who manages the provider.
+
+After you change MFA with your provider, sign in to the Console as usual. Nothing needs to change on the Chainguard side.
+
+## Change MFA for email and password sign-in
+
+Chainguard manages this path through Auth0, which hosts the sign-in screen at `auth.chainguard.dev` and holds your MFA enrollment. MFA is required here, so this path always asks for a code. You can't change or reset your own device: the Console has no MFA settings page, and Chainguard's sign-in configuration includes no self-service reset.
+
+If you still have your old device, check whether your authenticator app can move the entry for you. Some apps can transfer an existing entry to a new device, though whether yours can, and how, depends on the app. If it can't, or if you no longer have the old device, ask Chainguard to reset your enrollment.
+
+### Ask for a reset
+
+Chainguard doesn't act on an MFA reset requested from the account's own email address. Anyone who controlled your mailbox could already request a password reset, so treating an emailed request as proof of identity would defeat the purpose of the second factor.
+
+Instead, ask an Owner in your Chainguard organization to open a support ticket on your behalf. [Resetting your MFA device for the Chainguard Console](https://support.chainguard.dev/hc/en-us/articles/52523310297115-Resetting-your-MFA-device-for-the-Chainguard-Console) in the Chainguard knowledge base describes the process.
+
+Once support clears your enrollment, sign in to the Console again. The sign-in flow prompts you to enroll and displays a new QR code, which you scan with your authenticator app to finish. You won't receive an automatic notification when the reset happens, so watch your support ticket for the update.
+
+## One email address, two identities
+
+If your organization registered a custom identity provider after you had already created an email and password account, you might hold two separate Chainguard identities that share one email address. Chainguard identifies you by the provider that issued your login together with your ID at that provider, not by your email address, so the platform treats the two as distinct accounts. Each carries its own MFA, in a different place.
+
+When the Console asks for a code from an authenticator app and you expected to sign in through your organization's provider, you're on the email and password path. Enter your organization name in the login field instead of your email address to reach your provider.
+
+## Get more help
+
+If you can't sign in at all and therefore can't reach the support portal, see [Get support](/get-started/get-support/) for the right channel.

--- a/content/platform/administration/custom-idps/custom-idps/index.md
+++ b/content/platform/administration/custom-idps/custom-idps/index.md
@@ -8,7 +8,7 @@ lead: "Chainguard custom IdPs"
 description: "An introduction to and overview of Chainguard's custom IdP support features"
 type: "article"
 date: 2023-04-17T08:48:45+00:00
-lastmod: 2026-09-09T17:33:40+00:00
+lastmod: 2026-09-11T14:07:20+00:00
 draft: false
 tags: ["Chainguard Containers", "Overview"]
 images: []
@@ -92,7 +92,7 @@ To learn more about working with your `chainctl` config, you can read our doc on
 
 ### Authenticate with the Chainguard Console
 
-To authenticate with the Chainguard Console, [open the login screen](https://console.chainguard.dev?feature.emailAuth=true). Then, select one of the following options:
+To authenticate with the Chainguard Console, [open the login screen](https://console.chainguard.dev). Then, select one of the following options:
 
 - To use your organization's SSO, enter your Organization or email address and click **Continue**.
 - To use a third-party identity provider, click the corresponding option from the list.
@@ -101,6 +101,8 @@ To authenticate with the Chainguard Console, [open the login screen](https://con
 <center><img src="/platform/administration/custom-idps/custom-idps/cg-all-signin-24.png" alt="Screenshot showing an example Chainguard login box, with all described options shown." style="width:600px;"></center>
 
 In each of these cases, you will be redirected to an external identity provider to authenticate and then returned to the Chainguard Console. If you are using your email and a password, authentication is handled by and credentials are stored with [Auth0](https://auth0.com/).
+
+Multi-factor authentication follows the same split. Your own identity provider manages it for users who sign in through your SSO integration, while Chainguard manages it for users who sign in with an email address and a password. See [Change or reset your MFA device](/get-started/mfa-devices/) for what each group should do to move MFA to a new device.
 
 ## Setup and administration
 

--- a/content/platform/administration/custom-idps/disabling-social-logins/index.md
+++ b/content/platform/administration/custom-idps/disabling-social-logins/index.md
@@ -5,7 +5,7 @@ lead: ""
 description: "How to stop users from authenticating to Chainguard with social logins by blocking the Chainguard app in your identity provider, using Google Workspace as an example"
 type: "article"
 date: 2026-07-02T08:48:45+00:00
-lastmod: 2026-07-02T08:48:45+00:00
+lastmod: 2026-09-11T14:07:20+00:00
 draft: false
 tags: ["Chainguard Containers", "Procedural"]
 images: []
@@ -22,7 +22,9 @@ Chainguard doesn't currently offer a native setting to disable social logins. Ho
 
 ## Prerequisites
 
-Before blocking social logins, make sure you have a working custom identity provider and a recovery path in place. Some organizations intentionally keep a social login (or an email and password account) as a [backup, break-glass account](/chainguard/administration/custom-idps/custom-idps/#backup-accounts) in case they are ever locked out of their identity provider. If you block Google login without another recovery mechanism, an identity provider outage or misconfiguration could lock every user out of your organization.
+Before blocking social logins, make sure you have a working custom identity provider and a recovery path in place. Some organizations intentionally keep a social login (or an email and password account) as a [backup, break-glass account](/platform/administration/custom-idps/custom-idps/#backup-accounts) in case they are ever locked out of their identity provider. If you block Google login without another recovery mechanism, an identity provider outage or misconfiguration could lock every user out of your organization.
+
+Chainguard manages MFA for email and password accounts, so replacing a lost authenticator device on a break-glass account of that kind takes a support ticket rather than a self-service change. Factor that turnaround into your recovery plan, and see [Change or reset your MFA device](/get-started/mfa-devices/) for the process.
 
 We recommend confirming both of the following before proceeding:
 

--- a/content/platform/chainctl-usage/authentication-options.md
+++ b/content/platform/chainctl-usage/authentication-options.md
@@ -7,7 +7,7 @@ type: "article"
 description: "Learn the login flows chainctl supports, including interactive browser login, headless device-code login, social login providers, and assumable identities."
 lead: "chainctl supports several ways to authenticate to the Chainguard platform, so you can log in from a laptop, a browserless server, or a CI/CD pipeline."
 date: 2026-08-21T00:00:00+00:00
-lastmod: 2026-08-21T00:00:00+00:00
+lastmod: 2026-09-11T14:07:20+00:00
 draft: false
 tags: ["chainctl"]
 images: []
@@ -59,6 +59,8 @@ chainctl auth login --social-login github
 You can also set a default provider in your configuration with the `default.social-login` setting. See [Manage your chainctl configuration](/platform/chainctl-usage/manage-chainctl-config/).
 
 > Note: If your organization has configured a custom identity provider, authenticate with `--org-name` or `--identity-provider` instead. See [custom identity providers](/platform/administration/custom-idps/custom-idps/).
+
+Which provider you authenticate with also determines who manages your multi-factor authentication. To move it to a new device, see [Change or reset your MFA device](/get-started/mfa-devices/).
 
 ## Assumable identities for CI/CD
 


### PR DESCRIPTION
Documents where Console MFA actually lives, which is the one thing the August Kapa pass showed we had never said. "Managing 2FA/MFA Devices" was the worst-served cluster in that data — six threads from four unique users, with no edu page cited in five of them — and most of those askers sign in through a federated provider, so the reset they were asking Chainguard to perform was never ours to perform. Support now has a page to cite that tells each group where their MFA is and who can change it.

## Type of change

New page, plus cross-links and one stale-link removal. No existing procedure changes.

### What should this PR do?

Resolves [DOCS-191](https://linear.app/chainguard/issue/DOCS-191/document-how-to-change-or-reset-your-mfa-device).

Adds `/get-started/mfa-devices/`, structured by sign-in path, because the answer differs by path:

- **Google, GitHub, GitLab, or a corporate IdP.** That provider holds the enrollment, and Chainguard support can't reset it. Links each provider's own instructions and stops at the vendor boundary.
- **Email and password.** Chainguard manages this through Auth0, MFA is enforced, and there is no self-service reset. Routes the request through an Owner in the user's organization, per the knowledge base article.
- **One email address, two identities.** Identity is keyed on the issuer and subject pair rather than email, so an Auth0 email account and a custom-IdP account sharing an address are distinct accounts with MFA in different places. This is the root cause behind several support tickets and was undocumented.

Cross-links from Get support, Authentication options, the custom IdP overview, the Get started index, and Disable social logins. That last one matters for recovery planning: an email and password account kept as a break-glass account has Chainguard-managed MFA, so replacing its authenticator takes a support ticket rather than a self-service change.

Also drops `?feature.emailAuth=true` from the custom IdP page. The flag sits in `retiredFeatureFlags` in `console-ui`, so email sign-in is generally available and the link was making a shipped feature look experimental.

### Why are we making this change?

Four of the six Kapa askers wanted to rotate to a new device while still holding the old one, and Kapa's own coverage-gap summary named the reason it couldn't answer: the docs never said whether Chainguard manages MFA itself or defers to the identity provider. [Get support](https://edu.chainguard.dev/get-started/get-support/) covered only the federated lost-device case, and shipped after this data window.

### What are the acceptance criteria?

- The page routes a reader to the correct answer for each of the four sign-in paths the Console offers.
- It does not imply Chainguard can reset MFA for federated accounts, and it does not imply a self-service path exists for email and password accounts.
- The reset process matches the knowledge base article rather than restating a process Support may revise.
- Cross-links resolve without a redirect hop.

Two questions are open and deliberately out of scope, both recorded on DOCS-191:

1. The knowledge base article and Support's internal runbook both require the reset ticket to come from a different person holding Owner role, but Support has reset on self-requests in practice ([ZD 11576](https://chainguardhelp.zendesk.com/agent/tickets/11576), [customer-issues#3852](https://github.com/chainguard-dev/customer-issues/issues/3852)). This page documents the published policy. Someone outside docs needs to decide which is the rule.
2. Whether recovery codes are enabled in the prod Auth0 tenant. If they are, a user who saved one has a self-service path and this page understates what's possible.

### How should this PR be tested?

No CLI or GUI procedure to run, so the accuracy check is on the claims rather than the commands:

1. **The sign-in routing.** `app/src/pkg/auth/Login.tsx` in `console-ui`, function `verifyProviderWithEmail` — input containing `@` has its domain extracted and passed to `providerLookup`, and falls through to Auth0 Universal Login with the email as `login_hint` when no custom IdP matches. Confirms that the path follows from the email domain rather than from a button.
2. **That Chainguard manages MFA only for email and password.** The [Auth0 page](https://github.com/chainguard-dev/wiki/blob/main/content/docs/infrastructure/oauth/auth0.md) in the engineering wiki, and Julien Vermette and Colin Douglas in [#questions on 2026-04-14](https://chainguard-dev.slack.com/archives/C04PYHWPE1F/p1776206236297309). Custom-IdP users don't appear in Auth0 at all.
3. **That no self-service reset exists.** A `console-ui` code search returns no MFA settings UI, and Support's [MFA Reset process](https://chainguard.atlassian.net/wiki/spaces/Engineerin/pages/1321533470) page describes it as an admin action in the Auth0 dashboard.
4. **The retired flag.** `app/src/pkg/states/features.tsx` lists `emailAuth: RETIRED`.
5. **Build and lint.** `./node_modules/.bin/hugo` exits 0 and `pre-commit run --files <changed>` reports no failures. Both verified locally.

The four external provider links were checked for a 200 and for landing on the intended page.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-11.
