### PR TITLE
Fix broken anchor and stale melange paths in the images-advanced shortcode

### DIFF
--- a/layouts/shortcodes/blurb/images-advanced.html
+++ b/layouts/shortcodes/blurb/images-advanced.html
@@ -4,8 +4,8 @@
     <p><b>Note</b>: If you're building on top of a container image other than the wolfi-base container image, the image will run as a non-root user. Because of this, if you need to install packages with <code>apk add</code> you need to use the <code>USER root</code> directive.</p>
 </blockquote>
 
-<p>If the package is available, you can use the <a href="https://images.chainguard.dev/directory/image/wolfi-base/overview" title="Overview of wolfi-base image">wolfi-base</a> image in a Dockerfile and install what you need with <code>apk</code>, then use the resulting image as base for your app.
-Check the "<a href="/chainguard/containers/using-and-deploying/using-containers/#using-the-wolfi-base-image" title="using the wolfi-base image">Using the wolfi-base container</a>" section of our <a href="/chainguard/containers/using-and-deploying/using-containers/" title="How to use Chainguard Containers">images quickstart guide</a> for more information.
+<p>If the package is available, you can use the <a href="https://images.chainguard.dev/directory/image/wolfi-base/overview" title="Overview of wolfi-base image">wolfi-base</a> image in a Dockerfile and install what you need with <code>apk</code>, then use the resulting image as the base for your app.
+For a worked example, see the <a href="/chainguard/containers/using-and-deploying/using-containers/#using-the-wolfi-base-container-image-within-dockerfiles">Using the wolfi-base container image within Dockerfiles</a> section of our <a href="/chainguard/containers/using-and-deploying/using-containers/" title="How to use Chainguard Containers">guide to using Chainguard Containers</a>.
 </p>
 
-<p>If the packages you need are not available, you can build your own apks using <a href="/open-source/melange/overview">melange</a>. Please refer to <a href="/open-source/melange/tutorials/getting-started-with-melange">this guide</a> for more information.</p>
+<p>If the packages you need are not available, you can build your own apks using <a href="/open-source/build-tools/melange/overview/">melange</a>. To get started, see <a href="/open-source/build-tools/melange/getting-started-with-melange/">Getting started with melange</a>.</p>


### PR DESCRIPTION
Fixes [DOCS-172](https://linear.app/chainguard/issue/DOCS-172/fix-broken-anchor-and-pre-reorg-path-in-the-images-advanced-shortcode).

`layouts/shortcodes/blurb/images-advanced.html` carried three link defects. Fourteen getting-started pages render this shortcode, so all fourteen inherited them. One edit corrects all fourteen.

## What was wrong

**The anchor did not exist.** The shortcode asked for `#using-the-wolfi-base-image`. The target page has no such heading — it has "Using the wolfi-base container image" and "Using the wolfi-base container image within Dockerfiles", which goldmark renders as `using-the-wolfi-base-container-image` and `using-the-wolfi-base-container-image-within-dockerfiles`. Readers landed at the top of a long page instead of the section.

The surrounding sentence is about using `wolfi-base` in a Dockerfile and installing packages with `apk`, so the link now points at the Dockerfiles section, which contains exactly that worked example. The link text matches the heading, which also removes the old mismatch between "Using the wolfi-base container" and the real heading.

**Both melange links used pre-reorg paths.** `/open-source/melange/overview` and `/open-source/melange/tutorials/getting-started-with-melange` resolve only through alias redirects. They now use the canonical `/open-source/build-tools/melange/` paths.

**Two link-text problems.** "images quickstart guide" used the retired Chainguard Images product name, and "this guide" gave no clue about its destination.

Note: DOCS-172 also reported the quickstart links pointing at `/chainguard/containers/how-to-use-chainguard-images/`. A later reorg already moved them to `/chainguard/containers/using-and-deploying/using-containers/`, which is canonical, so only the fragment needed fixing there.

## Verification

Built the site and resolved every internal link the shortcode emits against `public/`, checking each fragment against a rendered heading ID.

Before:

```
BROKEN ANCHOR  /chainguard/containers/using-and-deploying/using-containers/#using-the-wolfi-base-image
ALIAS STUB     /open-source/melange/overview/  ->  /open-source/build-tools/melange/overview/
ALIAS STUB     /open-source/melange/tutorials/getting-started-with-melange/  ->  /open-source/build-tools/melange/getting-started-with-melange/
```

After:

```
OK anchor      /chainguard/containers/using-and-deploying/using-containers/#using-the-wolfi-base-container-image-within-dockerfiles
OK page        /chainguard/containers/using-and-deploying/using-containers/
OK page        /open-source/build-tools/melange/overview/
OK page        /open-source/build-tools/melange/getting-started-with-melange/
```

Also confirmed the corrected link renders on all 14 pages, and that the broken anchor no longer appears anywhere in the built site.

Build is clean: `hugo --gc --minify`, 1693 pages, exit 0.

## Follow-up, not in this PR

Nothing in CI resolves link fragments against built HTML. A source-only link check cannot see goldmark-generated heading IDs, so it reports false confidence in both directions — which is why this bug survived. Same gap recorded in the Kapa link-audit work.

Two stale-but-working melange paths remain on other pages, out of scope here:

- `content/open-source/build-tools/apko/getting-started-with-apko.md:165` — `/open-source/melange/`
- `content/open-source/wolfi/building-a-wolfi-package.md:367` — `https://edu.chainguard.dev/open-source/melange/troubleshooting/` (also an absolute URL where a relative one belongs)


---
Created in collaboration with Claude Code running Opus 5 on 2026-09-11.
