### PR TITLE
Stop redirects from duplicating the query string (DOCS-187)

### DIFF
--- a/layouts/index.aliases
+++ b/layouts/index.aliases
@@ -2,18 +2,17 @@
 Builds the nginx map that turns every Hugo alias into a 301. nginx.conf
 includes the result as /etc/nginx/aliases.
 
-The ([/?].*)? bound matches the alias itself, anything in its subtree, or a
-query string, but not a longer path segment that merely starts with the alias.
-An open-ended bound lets a rule feed itself: an alias of
-/pull-through-guides/artifactory on a page that now lives at
-/pull-through-guides/artifactory-containers-pull-through matches its own
-target and appends the suffix on every hop, so the URL never resolves
-(DOCS-186).
+The (/.*)? bound matches the alias itself or anything in its subtree, but not
+a longer path segment that merely starts with the alias. An open-ended bound
+lets a rule feed itself: an alias of /pull-through-guides/artifactory on a
+page that now lives at /pull-through-guides/artifactory-containers-pull-through
+matches its own target and appends the suffix on every hop, so the URL never
+resolves (DOCS-186).
 
-"?" belongs in the character class because nginx matches this map against
-$request_uri, which carries the query string. Bounding on "/" alone would
-stop matching an aliased URL written without a trailing slash but with a
-query, such as /chainguard/fips?utm_source=x, and send it to a 404.
+The bound needs no "?" because nginx.conf matches this map against a key with
+the query string already stripped (DOCS-187). Matching $request_uri directly
+would need "?" in a character class here, and the query would then land in $1
+and be duplicated by the rewrite that applies the map.
 
 nginx takes the first regex in a map that matches, so the rules are written
 longest alias first. An alias that is a prefix of another one would otherwise
@@ -32,5 +31,5 @@ the wrong page.
 {{- end -}}
 {{- end -}}
 {{- range sort $rules "length" "desc" -}}
-"~^{{ .alias }}([/?].*)?$" {{ .target }}$1;
+"~^{{ .alias }}(/.*)?$" {{ .target }}$1;
 {{ end -}}

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,8 +38,23 @@ http {
         image/svg+xml;
 
 
+    # Key the redirect map on the request path with the query string removed.
+    # $request_uri carries the query, and nearly every rule below ends in $1,
+    # so matching $request_uri put the query inside $redirect_url -- and the
+    # rewrite that applies the map appends the request arguments again,
+    # emitting "?utm_source=x?utm_source=x" (DOCS-187). A query-free key keeps
+    # $redirect_url query-free, so the append becomes the only source of a
+    # query on the Location, and it lands exactly once.
+    #
+    # $uri is the obvious key and is wrong: it is percent-decoded, so a request
+    # for %3F would put a literal "?" back into $redirect_url and reintroduce
+    # the duplication.
+    map $request_uri $request_path {
+        "~^(?<path_without_query>[^?]*)" $path_without_query;
+    }
+
     # add URLs after the `default` line that are moved and aren't redirecting via Hugo aliases
-    map $request_uri $redirect_url {
+    map $request_path $redirect_url {
         default "";
 
         # Add Hugo aliases as 301 redirects
@@ -154,20 +169,29 @@ http {
         server_name  localhost;
         root   /usr/share/nginx/html/;
 
-        # process $request_uri -> $redirect_url if url is absolute
+        # process $request_path -> $redirect_url if url is absolute
         if ($redirect_url ~ ^https://) {
             rewrite ^(.*)$ $redirect_url permanent;
         }
-        # process $request_uri -> $redirect_url, preserving https, and ensure URLs don't have any ports in them
+        # process $request_path -> $redirect_url, preserving https, and ensure URLs don't have any ports in them
         if ($redirect_url != "") {
             rewrite ^(.*)$ https://$http_host$redirect_url permanent;
         }
 
         # Redirect URLs without trailing slash to URLs with trailing slash
         # This ensures images in Hugo content directories display correctly
+        #
+        # "return" does not append the request arguments the way "rewrite"
+        # does, so $is_args$args carries the query string across this hop.
+        # Without it a campaign URL lost its parameters here (DOCS-187).
+        #
+        # The scheme is hardcoded for the same reason the redirect map above
+        # hardcodes it: Cloud Run terminates TLS at the load balancer, so
+        # $scheme is "http" and emitting it downgraded every one of these
+        # redirects to plaintext.
         location ~ ^([^.]*[^/])$ {
             if (-d $request_filename) {
-                return 301 $scheme://$host$uri/;
+                return 301 https://$host$uri/$is_args$args;
             }
         }
 


### PR DESCRIPTION
## Summary

Any URL that went through the nginx redirect map arrived at its destination with the query string repeated:

```
/chainguard/fips/?utm_source=test
  -> /platform/fips/?utm_source=test?utm_source=test
```

The second `?` is not a valid separator, so every UTM-tagged or referral link pointing at a redirected edu URL delivered one malformed parameter instead of two clean ones. Campaign attribution for those landings has been wrong for as long as the map has existed, which is what makes this worth fixing ahead of its priority: Marketing consumes those parameters, and no amount of correct tagging on their side survives the redirect.

Fixes DOCS-187.

## Cause

nginx decides whether to append the request arguments when it *parses* a `rewrite` replacement, by looking for a literal `?` in the config text. `$redirect_url` is a variable, so a `?` in its runtime value cannot suppress that append. Suppressing it per rule is therefore impossible, which rules out the approach DOCS-187 originally reached for — distinguishing rules that already carry the query from rules that do not.

This fixes the input instead of the output. The map is now keyed on the request path with the query string removed:

```nginx
map $request_uri $request_path {
    "~^(?<path_without_query>[^?]*)" $path_without_query;
}
```

No rule can capture a query, `$redirect_url` is query-free by construction, and nginx's append becomes the single source of the query string on the `Location`.

`$uri` is the obvious key and is wrong: it is percent-decoded, so a request for `%3F` would put a literal `?` back into `$redirect_url` and reintroduce the duplication.

With the key normalized, the generated alias bound no longer needs to match `?`, so `layouts/index.aliases` returns to `(/.*)?`.

## Three further defects the same key fixes

Sweeping every rule turned up more than duplication. All three reproduce on production today.

**Greedy absolute-URL rules captured the query into the middle of the path.** `reference/(.+)$` matched the query along with the image name:

```
/chainguard/chainguard-images/reference/nginx/overview/?utm_source=test
  before  https://images.chainguard.dev/directory/image/nginx/overview/?utm_source=test/overview?utm_source=test
  after   https://images.chainguard.dev/directory/image/nginx/overview?utm_source=test
```

**The one exact-match rule was shadowed whenever a query was present.** `/chainguard/api/openapi.json` missed its own rule and fell into a broader alias:

```
/chainguard/api/openapi.json?v=1
  before  /platform/api/openapi.json?v=1?v=1
  after   /api.json?v=1
```

**Rules anchored with `/?$` never matched a URL carrying a query at all.** The section roots added for DOCS-186 returned `403` rather than redirecting:

```
/chainguard/chainguard-images/?utm_source=test
  before  403, no Location
  after   /chainguard/containers/?utm_source=test
```

## Also in this PR: the trailing-slash hop

The same symptom reaches the `Location` from a second line. That hop uses `return`, which does not append arguments the way `rewrite` does, so it dropped the query outright — and it emitted `$scheme`, which is `http` behind the Cloud Run load balancer:

```
/platform/fips?utm_source=test
  before  http://edu.chainguard.dev/platform/fips/
  after   https://edu.chainguard.dev/platform/fips/?utm_source=test
```

Every trailing-slash redirect on the site has been downgrading to plaintext, and `edu.chainguard.dev` sends no HSTS header, so nothing mitigates it. One line, and the redirect map two blocks up already established the `https://` idiom in this file. Happy to split it out if reviewers would rather keep this PR to the query string.

## Verification

Built the site image before and after, then compared `Location` headers for all 721 generated aliases and every hand-written rule, across four trailing-slash and query variants — 3,068 requests per image, with the test port normalized out of the comparison.

All 1,503 differences are fixes:

| | count |
|---|---|
| Duplicate query collapsed to one | 1,476 |
| `404` → `301` (bare path + query never matched) | 11 |
| `403` → `301` (anchored `/?$` rules never matched) | 8 |
| Query now preserved | 6 |
| `http` → `https` | 2 |
| **Query-free redirect target changed** | **0** |

Following each chain to a terminal response: hops carrying more than one `?` went from **759 to 0**, no loops were introduced, `403`s went 4 → 0, and terminal `200`s went 747 → 751. Without a query string the two images behave identically — same 751/9/6 split over the same chains. The 9 remaining `404`s are pre-existing, unchanged by this PR, and mostly artifacts of the sweep appending `/` to paths that already end in one.

Two are genuine and worth separate issues: `/open-source/apko/apk-package-manager/` redirects to a target that 404s, and `/chainguard/chainguard-images/vulnerability-comparisons/` ends at `/platform/chainctl-usage/comparing-images/vulnerability-comparisons`, left over from the vuln-comparison removal.

`nginx -t` passes in the built container, and the regenerated `public/_aliases` is byte-identical to the file the sweep ran against.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-11.
