### PR TITLE
Head the OpenSSL table columns with the OpenSSL and FIPS provider versions

### DIFF
--- a/content/chainguard/chainguard-os/openssl-3.6.md
+++ b/content/chainguard/chainguard-os/openssl-3.6.md
@@ -23,7 +23,7 @@ only available with manual overrides, configuration, and reduction of
 default security level of 2, to a lower value. Those that are
 available in FIPS also require manual overrides and configuration.
 
-The Non-FIPS and FIPS columns read as follows:
+The v3.6 and FIPS v3.4 columns read as follows:
 
 - **Default**: negotiated by default under the shipped Chainguard OS
   crypto policy. For key exchange groups, **First** marks the most
@@ -55,7 +55,7 @@ For more information about Transport Layer Security (TLS) please see the followi
 
 ## TLS Cipher Suites
 
-| Value | Cipher Suite | Non-FIPS | FIPS | PQC |
+| Value | Cipher Suite | v3.6 | FIPS v3.4 | PQC |
 |---|---|---|---|---|
 | TLSv1.3 | | | | |
 | 0x13,0x01 | TLS_AES_128_GCM_SHA256 | Default | Default | Yes |
@@ -204,7 +204,7 @@ For more information about Transport Layer Security (TLS) please see the followi
 
 ## TLS Supported Groups
 
-| Value | Supported Group | Non-FIPS | FIPS | PQC |
+| Value | Supported Group | v3.6 | FIPS v3.4 | PQC |
 |---|---|---|---|---|
 | PQC TLSv1.3 | | | | |
 | 512 | MLKEM512 | Available |  | Yes |
@@ -240,7 +240,7 @@ The brainpool rows combine two codepoints each: the first one (`brainpoolP256r1`
 
 ## TLS SignatureScheme
 
-| Value | Signature Scheme | Non-FIPS | FIPS | PQC |
+| Value | Signature Scheme | v3.6 | FIPS v3.4 | PQC |
 |---|---|---|---|---|
 | PQC TLSv1.3 | | | | |
 | 0x0904 | mldsa44 | Default |  | Yes |
@@ -276,7 +276,7 @@ The brainpool rows combine two codepoints each: the first one (`brainpoolP256r1`
 
 ## Elliptic Curves
 
-| OID | Elliptic Curve | Non-FIPS | FIPS |
+| OID | Elliptic Curve | v3.6 | FIPS v3.4 |
 |---|---|---|---|
 | 1.2.840.10045.3.1.1 | prime192v1 (P-192, secp192r1) | Available | Verify only |
 | 1.2.840.10045.3.1.2 | prime192v2 | Non-TLS only |  |

--- a/content/chainguard/chainguard-os/openssl-3.6.md
+++ b/content/chainguard/chainguard-os/openssl-3.6.md
@@ -18,7 +18,7 @@ table_layout: auto
 This is a summary of available algorithms in Chainguard OpenSSL 3.6
 (non-fips) and Chainguard FIPS Provider for OpenSSL 3.4.
 
-The majority of the available algorithms are not enabled default and are
+The majority of the available algorithms are not enabled by default and are
 only available with manual overrides, configuration, and reduction of
 default security level of 2, to a lower value. Those that are
 available in FIPS also require manual overrides and configuration.

--- a/content/chainguard/chainguard-os/openssl-4.0.md
+++ b/content/chainguard/chainguard-os/openssl-4.0.md
@@ -23,7 +23,7 @@ only available with manual overrides, configuration, and reduction of
 default security level of 2, to a lower value. Those that are
 available in FIPS also require manual overrides and configuration.
 
-The Non-FIPS and FIPS columns read as follows:
+The v4.0 and FIPS v3.6 columns read as follows:
 
 - **Default**: negotiated by default under the shipped Chainguard OS
   crypto policy. For key exchange groups, **First** marks the most
@@ -53,7 +53,7 @@ For more information about Transport Layer Security (TLS) please see the followi
 
 ## TLS Cipher Suites
 
-| Value | Cipher Suite | Non-FIPS | FIPS | PQC |
+| Value | Cipher Suite | v4.0 | FIPS v3.6 | PQC |
 |---|---|---|---|---|
 | TLSv1.3 | | | | |
 | 0x13,0x01 | TLS_AES_128_GCM_SHA256 | Default | Default | Yes |
@@ -78,7 +78,7 @@ For more information about Transport Layer Security (TLS) please see the followi
 
 ## TLS Supported Groups
 
-| Value | Supported Group | Non-FIPS | FIPS | PQC |
+| Value | Supported Group | v4.0 | FIPS v3.6 | PQC |
 |---|---|---|---|---|
 | PQC TLSv1.3 | | | | |
 | 512 | MLKEM512 | Available | Available | Yes |
@@ -101,7 +101,7 @@ The brainpool rows combine two codepoints each: the first one (`brainpoolP256r1`
 
 ## TLS SignatureScheme
 
-| Value | Signature Scheme | Non-FIPS | FIPS | PQC |
+| Value | Signature Scheme | v4.0 | FIPS v3.6 | PQC |
 |---|---|---|---|---|
 | PQC TLSv1.3 | | | | |
 | 0x0904 | mldsa44 | Default | Default | Yes |
@@ -128,7 +128,7 @@ The brainpool rows combine two codepoints each: the first one (`brainpoolP256r1`
 
 ## Elliptic Curves
 
-| OID | Elliptic Curve | Non-FIPS | FIPS |
+| OID | Elliptic Curve | v4.0 | FIPS v3.6 |
 |---|---|---|---|
 | 1.2.840.10045.3.1.7 | prime256v1 (P-256, secp256r1) | Default | Default |
 | 1.3.36.3.3.2.8.1.1.7 | brainpoolP256r1 | Default |  |


### PR DESCRIPTION
On the OpenSSL configuration pages, head the two availability columns with the versions they describe instead of Non-FIPS / FIPS:

- OpenSSL 3.6 Configuration: **v3.6** and **FIPS v3.4**
- OpenSSL 4.0 Configuration: **v4.0** and **FIPS v3.6**

The legend sentence on each page is updated to match, and the 3.6 page picks up the "enabled by default" wording fix that #3978 applied to the 4.0 page.

Tables are regenerated by the generator in sandbox-of-power `xnox/tls-docs` (c11cc922), which now carries the header names per profile; no table content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)