### PR TITLE
Fix two redirects that pointed at removed pages (DOCS-197)

### DIFF
--- a/content/open-source/wolfi/apk-package-manager.md
+++ b/content/open-source/wolfi/apk-package-manager.md
@@ -1,10 +1,12 @@
 ---
 title: "Why apk"
+aliases:
+- /open-source/apko/apk-package-manager
 type: "article"
 lead: "How apk-tools is different from other package managers"
 description: "How apk-tools is different from other package managers"
 date: 2022-07-06T08:49:31+00:00
-lastmod: 2026-07-27T16:03:25+00:00
+lastmod: 2026-09-11T15:52:58+00:00
 contributors: ["Ariadne Conill"]
 draft: false
 tags: ["apko", "Conceptual",]

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,14 @@ http {
         default "";
 
         # Add Hugo aliases as 301 redirects
+        #
+        # nginx takes the first match in a map, so every generated alias rule
+        # beats every hand-written rule below. A hand-written rule only wins
+        # where no alias matches the same URL, and a section root that carries
+        # an alias claims its whole subtree -- shadowing anything more
+        # specific written down here. Put that exception on the destination
+        # page's own "aliases:" instead: generated rules are sorted longest
+        # alias first, so the specific rule outranks the section root.
         include aliases;
 
         # individual URL redirects here
@@ -50,7 +58,6 @@ http {
         "~^/chainguard/chainguard-enforce/chainctl-docs(.+)?$" /chainguard/chainctl$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/chainguard-enforce-events(.+)?$" /chainguard/administration/cloudevents/events-reference$1;
         "~^/chainguard/chainguard-enforce/chainguard-enforce-events(.+)?$" /chainguard/administration/cloudevents/events-reference$1;
-        "~^/open-source/apko/apk-package-manager(.+)?$" /open-source/wolfi/apk-package-manager$1;
         # chainctl reference docs moved from /chainguard/chainctl/ to /platform/chainctl/.
         # The "(/.*)?" bound matches the chainctl subtree only, so this does NOT also
         # swallow /chainguard/chainctl-usage/... (which has its own aliases above).
@@ -117,7 +124,10 @@ http {
         "~^/chainguard/chainguard-enforce/cloudevents/(.+)?$"  /chainguard/administration/cloudevents/$1;
         "~^/chainguard/chainguard-enforce/iam-groups/identity-examples/(.+)?$"  /chainguard/chainguard-enforce/authentication/$1;
         "~^/chainguard/chainguard-enforce/authentication/identity-examples/(.+)?$"  /chainguard/administration/iam-groups/identity-examples/;
-        "~^/chainguard/chainguard-images/vulnerability-comparisons/(.+)?$"  /chainguard/chainguard-images/comparing-images/vulnerability-comparisons;
+        # This pointed at a vulnerability comparison page, which was removed
+        # along with the rest of that section, so it redirected to a 404.
+        # Send it to Containers, matching the vuln-comparison rules above.
+        "~^/chainguard/chainguard-images/vulnerability-comparisons(/.*)?$"  /chainguard/containers/;
         "~^/chainguard/administration/iam-groups/(.+)?$"  /chainguard/administration/iam-organizations/$1;
 
         # enforce docs turndown


### PR DESCRIPTION
## Summary

Two redirects delivered a 404. Both predate the query-string work and are independent of it; I found them sweeping redirect chains for DOCS-187.

Fixes DOCS-197.

## `/open-source/apko/apk-package-manager/`

```
before  -> /open-source/build-tools/apko/apk-package-manager/   404
after   -> /open-source/wolfi/apk-package-manager/              200
```

`content/open-source/build-tools/apko/_index.md` aliases `/open-source/apko`, which generates a rule claiming the entire subtree. That is right for every apko page except this one, which moved to `/open-source/wolfi/` rather than into `build-tools/`.

`nginx.conf` already carried a rule for it, and that rule has never run:

```nginx
"~^/open-source/apko/apk-package-manager(.+)?$" /open-source/wolfi/apk-package-manager$1;
```

nginx `map` takes the first matching regex, and this sits *below* `include aliases;`, so the generated section-root rule always wins. Same shadowing shape as DOCS-186, reached from the other side.

So the fix goes where the mechanism already works: the destination page gets its own `aliases:` entry, the way every sibling apko page that moved already has one. Generated rules are emitted longest alias first, so the specific rule outranks the section root — it lands at line 638 of `public/_aliases` against the section root's 720. The dead `nginx.conf` rule is removed.

I also added a comment above the include, because a hand-written rule that reads as correct and can never fire is worth warning about once rather than rediscovering.

## `/chainguard/chainguard-images/vulnerability-comparisons/`

```
before  -> /chainguard/chainguard-images/comparing-images/vulnerability-comparisons
        -> /platform/chainctl-usage/comparing-images/vulnerability-comparisons   404
after   -> /chainguard/containers/                                               200
```

The target was removed with the rest of the vulnerability comparison section. `nginx.conf` already sends the other `vuln-comparison` paths to `/chainguard/containers/`; this spelling was missed. Bound widened from `/(.+)?$` to `(/.*)?$` so the URL matches without a trailing slash too.

## Verification

Built the image from `main` and from this branch, then compared `Location` headers for all 820 generated aliases plus every hand-written rule across four trailing-slash and query variants — 3,064 requests per image.

**7 of 3,064 differ, and all 7 are the two intended fixes.** Nothing else changed. Following chains to a terminal response, `200`s went 751 → 753 and `404`s went 9 → 7, which is exactly these two.

## Note on ordering with #3989

One case here is only fully fixed once https://github.com/chainguard-dev/edu/pull/3989 lands: `/chainguard/chainguard-images/vulnerability-comparisons?utm_source=x`, with a query and no trailing slash, still misses because the map is keyed on `$request_uri`. It `404`s before and after this PR, so nothing regresses either way, and the two PRs touch different hunks and merge in either order.

---
Created in collaboration with Claude Code running Opus 5 on 2026-09-11.
