### PR TITLE
Add content about Go devel output and FIPS variants

### DIFF
--- a/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-status.md
+++ b/content/chainguard/containers/security-and-compliance/vulnerability-management/cve-status.md
@@ -4,7 +4,7 @@ linktitle: "Check CVEs in containers"
 type: "article"
 description: "Use chainctl images advisories list to compare a scanner's CVE findings with Chainguard's advisories for the APK packages in an image."
 date: 2026-09-10T00:00:00+00:00
-lastmod: 2026-09-10T00:00:00+00:00
+lastmod: 2026-09-11T18:53:42+00:00
 draft: false
 tags: ["Procedural", "Chainguard Containers", "CVE"]
 images: []
@@ -15,6 +15,17 @@ toc: true
 Use `chainctl images advisories list` to compare the advisories for the APK packages in an image with the CVEs reported by your scanner.
 
 > **Note:** This command checks **APK packages only**. It does not determine whether a CVE affects a Go module, Java dependency, or another non-APK component in the image.
+
+## FIPS variants
+
+FIPS variants use the same package-level advisory process as other Chainguard images. `chainctl images advisories list` does not determine coverage from the image name or the `-fips` suffix. It reads the APK package names and versions in the image SBOM, then looks up advisories for those APK packages. This means:
+
+- If a FIPS image contains the same APK package and version as a non-FIPS image, the same package advisory can apply.
+- If a FIPS image contains a FIPS-specific package name or version, that package needs a corresponding advisory record.
+- A FIPS image may have a different advisory result from its non-FIPS counterpart because its package set or versions differ.
+- An empty result does not by itself mean that the FIPS image is not affected or that the CVE is not covered.
+
+For a FIPS finding, use the exact image digest and platform, then compare the scanner’s package name and version with the APK package data in the image SBOM. Search the Security Advisories page for the exact package and CVE. If the APK package is present but no matching advisory exists, treat the result as an advisory-coverage question and include the image digest, package name and version, CVE, scanner and database versions, and scan output when contacting Support.
 
 ## Prerequisites
 

--- a/content/chainguard/containers/security-and-compliance/working-with-scanners/false-results.md
+++ b/content/chainguard/containers/security-and-compliance/working-with-scanners/false-results.md
@@ -14,7 +14,7 @@ description: "An overview of the formation of false positive and false negative 
 lead: "An overview of the formation of false positive and false negative vulnerability results in container image scanners"
 type: "article"
 date: 2023-09-14T16:59:04+00:00
-lastmod: 2026-08-31T15:18:48+00:00
+lastmod: 2026-09-11T17:42:16+00:00
 contributors: ["Michelle McAveety"]
 draft: false
 tags: ["CVE", "Overview", "Conceptual"]
@@ -61,6 +61,35 @@ It is worth noting that these false positive vulnerabilities could impact you if
 ### Missing or mismatched information
 
 Inconsistencies in package versioning conventions may cause scanners to fail in detecting the correct versions of your software components. Software vendors choose different version naming schemes for their products, so scanners may not easily detect what package versions are in use. Alternatively, missing or inconsistent data on vulnerable package versions in vulnerability databases can have a similar effect. In both cases, your scanner may struggle in correlating the package version in your container to package versions in vulnerability records, producing false positives and negatives where components are mismatched.
+
+### Go components reported as `(devel)`
+
+Some Go binaries report their module version as `(devel)` instead of a release version. This commonly occurs when a binary is built without release-version metadata. A component catalog can show the pattern like this:
+
+```output
+NAME          VERSION  TYPE
+cmd/addr2line  (devel)  go-module
+cmd/asm        (devel)  go-module
+cmd/buildid    (devel)  go-module
+cmd/cgo        (devel)  go-module
+cmd/compile    (devel)  go-module
+...
+```
+
+This is component-catalog output, not a list of confirmed vulnerabilities. The important signal is the combination of a Go component type and the literal `(devel)` version.
+
+When a scanner cannot map `(devel)` to a concrete module version, it may be unable to compare the component with fixed-version ranges. The scanner can then report every CVE known for that module, including CVEs that do not apply to the exact source revision or binary being scanned. Treat this pattern as a version-metadata limitation to investigate, not as proof that every reported CVE is present.
+
+#### How to investigate a `(devel)` result
+
+1. Confirm the component name, module path, and component type in the scanner or SBOM output.
+2. Confirm that the finding is a Go module or binary component, not an APK package with a similar name.
+3. Inspect the binary’s embedded Go build metadata, or the build configuration that produced it, to determine whether a release or commit version is available.
+4. Compare the scanner’s affected and fixed-version ranges with the source revision or release used to build the binary.
+5. Rebuild with version metadata when possible, then regenerate the SBOM and rescan.
+6. If the scanner still reports the CVEs, provide the image digest, binary or module name, reported `(devel)` version, scanner and database versions, and the relevant scan output when requesting support.
+
+Do not use `chainctl images advisories list` to validate this finding; that command checks APK packages only. For a Go-module finding, use the scanner’s language-package evidence and the dependency’s upstream advisory data.
 
 ### SCA vs SAST tools
 


### PR DESCRIPTION
[ ] Check if this is a typo or other quick fix and ignore the rest :)

## Type of change
Updates to:
- `/chainguard/containers/security-and-compliance/working-with-scanners/false-results.md`
- `/chainguard/security-and-compliance/vulnerability-management/cve-status.md`

### What should this PR do?
Add a section about Go components reported as `(devel)`
Add section about FIPS variants

### Why are we making this change?
Customers asked about this, as seen in the docs site's search tool data. Addresses [DOCS-192](https://linear.app/chainguard/issue/DOCS-192/document-how-to-check-whether-a-scanner-reported-cve-actually-affects)

### What are the acceptance criteria? 
Content should be clear and accurate

### How should this PR be tested?

Any documentation published to Chainguard Academy is reviewed carefully for accuracy. GUI procedures, API commands, and CLI code snippets in a draft are run and tested thoroughly — by both the author and the reviewer — to confirm they work exactly as written. This helps ensure that readers can follow along and get the same results. See the [`edu` repo's README](https://github.com/chainguard-dev/edu#testing).

<!-- What should your reviewer do to test this PR? Please list any steps that are additional to or different from the standard. If you outline steps in the console, include the console release version in this PR message. -->
